### PR TITLE
Fix random state for dropout_layer_norm

### DIFF
--- a/csrc/layer_norm/ln_api.cpp
+++ b/csrc/layer_norm/ln_api.cpp
@@ -229,11 +229,6 @@ std::vector<at::Tensor> dropout_add_ln_fwd(const at::Tensor &x0,      // Input: 
     // Request the kernel launcher.
     auto launcher = get_fwd_launcher(wtype, itype, rtype, otype, ctype, round_multiple(hidden_size, multiple));
 
-    // Query the kernel-specific launch parameters.
-    launcher(launch_params, true);
-
-    at::Tensor workspace, barrier;
-
     // Set the kernel runtime parameters.
     layer_norm::FwdParams &params = launch_params.params;
     params.rows = rows;
@@ -251,6 +246,11 @@ std::vector<at::Tensor> dropout_add_ln_fwd(const at::Tensor &x0,      // Input: 
     params.inverse_cols = 1.f / float(params.cols);
     params.rowscale_const = rowscale_const;
     params.is_rms_norm = is_rms_norm;
+
+    // Query the kernel-specific launch parameters.
+    launcher(launch_params, true);
+
+    at::Tensor workspace, barrier;
 
     if (dropout_p > 0.f) {
         // number of times random will be generated per thread, to offset philox counter in thc random
@@ -594,11 +594,6 @@ std::vector<at::Tensor> dropout_add_ln_parallel_residual_fwd(
     // Request the kernel launcher.
     auto launcher = get_parallel_fwd_launcher(wtype, itype, rtype, otype, ctype, round_multiple(hidden_size, multiple));
 
-    // Query the kernel-specific launch parameters.
-    launcher(launch_params, true);
-
-    at::Tensor workspace, barrier;
-
     // Set the kernel runtime parameters.
     layer_norm::FwdParams &params = launch_params.params;
     params.rows = rows;
@@ -620,6 +615,11 @@ std::vector<at::Tensor> dropout_add_ln_parallel_residual_fwd(
     params.dropout_scale = 1.f / (1.f - dropout_p);
     params.inverse_cols = 1.f / float(params.cols);
     params.is_rms_norm = is_rms_norm;
+
+    // Query the kernel-specific launch parameters.
+    launcher(launch_params, true);
+
+    at::Tensor workspace, barrier;
 
     if (dropout_p > 0.f) {
         // number of times random will be generated per thread, to offset philox counter in thc random


### PR DESCRIPTION
Fixes #314 

See #314. Moving the `launcher` call ensures `params.rows` is defined and fixes the counter value, I think it shouldn't have any other effect.

Running the script
```


import torch
import dropout_layer_norm

kwargs={"device":"cuda", "dtype":torch.float16}
d=4096
torch.cuda.init()
torch.cuda.manual_seed(0)
gen=torch.cuda.default_generators[torch.cuda.current_device()]
print("START",gen.get_state()[-8:].tolist())
x=torch.randn([d,d], **kwargs)
r=torch.randn([d,d], **kwargs)
gamma=torch.randn([d], **kwargs)
beta=torch.randn([d], **kwargs)

print("BEFORE DROPOUT LN",gen.get_state()[-8:].tolist())
y1, *rest = dropout_layer_norm.dropout_add_ln_fwd(
        x, r, gamma, beta, None, None, None, None, 0.1, 1e-5,
        1.0, 0, None, False, False
    )
print("AFTER DROPOUT LN 1",gen.get_state()[-8:].tolist())
y2, *rest=dropout_layer_norm.dropout_add_ln_fwd(
        x, r, gamma, beta, None, None, None, None, 0.1, 1e-5,
        1.0, 0, None, False, False
    )
print("AFTER DROPOUT LN 1",gen.get_state()[-8:].tolist())
print("MATCHING", torch.equal(y1,y2))
y3=torch.dropout(x, 0.1, True)
print("AFTER DROPOUT 1",gen.get_state()[-8:].tolist())
y4=torch.dropout(x, 0.1, True)
print("AFTER DROPOUT 2",gen.get_state()[-8:].tolist())
print("MATCHING", torch.equal(y3,y4))
```

Before fix (random state unchanged, 2nd call identical; dropout for reference)
```
START [0, 0, 0, 0, 0, 0, 0, 0]
BEFORE DROPOUT LN [160, 0, 0, 0, 0, 0, 0, 0]
AFTER DROPOUT LN 1 [160, 0, 0, 0, 0, 0, 0, 0]
AFTER DROPOUT LN 1 [160, 0, 0, 0, 0, 0, 0, 0]
MATCHING True
AFTER DROPOUT 1 [236, 0, 0, 0, 0, 0, 0, 0]
AFTER DROPOUT 2 [56, 1, 0, 0, 0, 0, 0, 0]
MATCHING False
```

After fix (random state changed, 2nd call different
```
START [0, 0, 0, 0, 0, 0, 0, 0]
BEFORE DROPOUT LN [160, 0, 0, 0, 0, 0, 0, 0]
AFTER DROPOUT LN 1 [224, 1, 0, 0, 0, 0, 0, 0]
AFTER DROPOUT LN 2 [32, 3, 0, 0, 0, 0, 0, 0]
MATCHING False
AFTER DROPOUT 1 [108, 3, 0, 0, 0, 0, 0, 0]
AFTER DROPOUT 2 [184, 3, 0, 0, 0, 0, 0, 0]
MATCHING False
```


