### PR TITLE
Enable CUDA graphs

### DIFF
--- a/csrc/flash_attn/flash_api.cpp
+++ b/csrc/flash_attn/flash_api.cpp
@@ -294,11 +294,16 @@ mha_fwd(const at::Tensor &q,         // batch_size x seqlen_q x num_heads x head
                      softmax_scale,
                      is_causal);
 
+    // number of times random will be generated per thread, to offset philox counter in thc random
+    // state
+    // We use a custom RNG that increases the offset by batch_size * nheads * 32.
+    int64_t counter_offset = params.b * params.h * 32;
+    auto options = torch::TensorOptions().dtype(torch::kFloat32).device(torch::kCUDA);
+    auto rng_state = torch::empty({2}, options.dtype(torch::kInt64));
+    // Forward kernel will populate memory with the seed and offset.
+    launch_params.params.rng_state = reinterpret_cast<uint64_t*>(rng_state.data_ptr());
+
     if (p_dropout > 0.0)  {
-        // number of times random will be generated per thread, to offset philox counter in thc random
-        // state
-        // We use a custom RNG that increases the offset by batch_size * nheads * 32.
-        int64_t counter_offset = params.b * params.h * 32;
         auto gen = at::get_generator_or_default<at::CUDAGeneratorImpl>(
             gen_, at::cuda::detail::getDefaultCUDAGenerator());
         // See Note [Acquire lock when using random generators]
@@ -315,7 +320,7 @@ mha_fwd(const at::Tensor &q,         // batch_size x seqlen_q x num_heads x head
         if (out_.has_value()) { out_.value().copy_(out); }
     }
 
-    return {out, q_padded, k_padded, v_padded, out_padded, softmax_lse, p};
+    return {out, q_padded, k_padded, v_padded, out_padded, softmax_lse, p, rng_state};
 }
 
 std::vector<at::Tensor>
@@ -448,11 +453,16 @@ mha_varlen_fwd(const at::Tensor &q,  // total_q x num_heads x head_size, total_q
                      softmax_scale,
                      is_causal);
 
+    // number of times random will be generated per thread, to offset philox counter in thc random
+    // state
+    // We use a custom RNG that increases the offset by batch_size * nheads * 32.
+    int64_t counter_offset = params.b * params.h * 32;
+    auto options = torch::TensorOptions().dtype(torch::kFloat32).device(torch::kCUDA);
+    auto rng_state = torch::empty({2}, options.dtype(torch::kInt64));
+    // Forward kernel will populate memory with the seed and offset.
+    launch_params.params.rng_state = reinterpret_cast<uint64_t*>(rng_state.data_ptr());
+
     if (p_dropout > 0.0)  {
-        // number of times random will be generated per thread, to offset philox counter in thc random
-        // state
-        // We use a custom RNG that increases the offset by batch_size * nheads * 32.
-        int64_t counter_offset = params.b * params.h * 32;
         auto gen = at::get_generator_or_default<at::CUDAGeneratorImpl>(
             gen_, at::cuda::detail::getDefaultCUDAGenerator());
         // See Note [Acquire lock when using random generators]
@@ -469,7 +479,7 @@ mha_varlen_fwd(const at::Tensor &q,  // total_q x num_heads x head_size, total_q
         if (out_.has_value()) { out_.value().copy_(out); }
     }
 
-    return {out, q_padded, k_padded, v_padded, out_padded, softmax_lse, p};
+    return {out, q_padded, k_padded, v_padded, out_padded, softmax_lse, p, rng_state};
 }
 
 void run_mha_bwd(Flash_bwd_params &params, cudaStream_t stream, const bool configure) {

--- a/csrc/flash_attn/flash_api.cpp
+++ b/csrc/flash_attn/flash_api.cpp
@@ -301,7 +301,7 @@ mha_fwd(const at::Tensor &q,         // batch_size x seqlen_q x num_heads x head
     auto options = torch::TensorOptions().dtype(torch::kFloat32).device(torch::kCUDA);
     auto rng_state = torch::empty({2}, options.dtype(torch::kInt64));
     // Forward kernel will populate memory with the seed and offset.
-    launch_params.params.rng_state = reinterpret_cast<uint64_t*>(rng_state.data_ptr());
+    params.rng_state = reinterpret_cast<uint64_t*>(rng_state.data_ptr());
 
     if (p_dropout > 0.0)  {
         auto gen = at::get_generator_or_default<at::CUDAGeneratorImpl>(
@@ -460,7 +460,7 @@ mha_varlen_fwd(const at::Tensor &q,  // total_q x num_heads x head_size, total_q
     auto options = torch::TensorOptions().dtype(torch::kFloat32).device(torch::kCUDA);
     auto rng_state = torch::empty({2}, options.dtype(torch::kInt64));
     // Forward kernel will populate memory with the seed and offset.
-    launch_params.params.rng_state = reinterpret_cast<uint64_t*>(rng_state.data_ptr());
+    params.rng_state = reinterpret_cast<uint64_t*>(rng_state.data_ptr());
 
     if (p_dropout > 0.0)  {
         auto gen = at::get_generator_or_default<at::CUDAGeneratorImpl>(

--- a/csrc/flash_attn/src/flash.h
+++ b/csrc/flash_attn/src/flash.h
@@ -91,6 +91,9 @@ struct Flash_fwd_params : public Qkv_params {
     // Random state.
     at::PhiloxCudaState philox_args;
 
+    // Pointer to the RNG seed (idx 0) and offset (idx 1).
+    uint64_t * rng_state;
+
     bool is_bf16;
     bool is_causal;
 };

--- a/csrc/flash_attn/src/flash_bwd_kernel.h
+++ b/csrc/flash_attn/src/flash_bwd_kernel.h
@@ -1300,9 +1300,8 @@ inline __device__ void compute_dq_dk_dv_1rowblock(const Params &params, const in
     #pragma unroll
     for (int mi = 0; mi < size(dP_sum); ++mi) { dP_sum(mi) = sdPsum(get<0>(taccScS_row(mi))); }
 
-    auto seeds = at::cuda::philox::unpack(params.philox_args);
-    unsigned long long seed = std::get<0>(seeds);
-    unsigned long long offset = std::get<1>(seeds) + (bidb * params.h + bidh) * 32 + tidx % 32;
+    auto seed = params.rng_state[0];
+    auto offset = params.rng_state[1];
 
     clear(acc_dq);
 

--- a/csrc/flash_attn/src/flash_bwd_kernel.h
+++ b/csrc/flash_attn/src/flash_bwd_kernel.h
@@ -756,7 +756,7 @@ inline __device__ void compute_dq_dk_dv_1colblock(const Params &params, const in
     }
 
     auto seed = params.rng_state[0];
-    auto offset = params.rng_state[1];
+    auto offset = params.rng_state[1] + (bidb * params.h + bidh) * 32 + tidx % 32;
 
     clear(acc_dv);
     clear(acc_dk);
@@ -1301,7 +1301,7 @@ inline __device__ void compute_dq_dk_dv_1rowblock(const Params &params, const in
     for (int mi = 0; mi < size(dP_sum); ++mi) { dP_sum(mi) = sdPsum(get<0>(taccScS_row(mi))); }
 
     auto seed = params.rng_state[0];
-    auto offset = params.rng_state[1];
+    auto offset = params.rng_state[1] + (bidb * params.h + bidh) * 32 + tidx % 32;
 
     clear(acc_dq);
 

--- a/csrc/flash_attn/src/flash_bwd_kernel.h
+++ b/csrc/flash_attn/src/flash_bwd_kernel.h
@@ -755,9 +755,8 @@ inline __device__ void compute_dq_dk_dv_1colblock(const Params &params, const in
         copy(smem_thr_copy_KV, tdPsV, tdPrV_copy_view);
     }
 
-    auto seeds = at::cuda::philox::unpack(params.philox_args);
-    unsigned long long seed = std::get<0>(seeds);
-    unsigned long long offset = std::get<1>(seeds) + (bidb * params.h + bidh) * 32 + tidx % 32;
+    auto seed = params.rng_state[0];
+    auto offset = params.rng_state[1];
 
     clear(acc_dv);
     clear(acc_dk);

--- a/csrc/flash_attn/src/flash_fwd_kernel.h
+++ b/csrc/flash_attn/src/flash_fwd_kernel.h
@@ -308,6 +308,10 @@ inline __device__ void compute_attn_1rowblock(const Params &params, const int bi
     unsigned long long seed = std::get<0>(seeds);
     unsigned long long offset = std::get<1>(seeds) + (bidb * params.h + bidh) * 32 + tidx % 32;
 
+    // Save seed and offset for backward.
+    params.rng_state[0] = seed;
+    params.rng_state[1] = offset;
+
     clear(acc_o);
 
     // For performance reason, we separate out two kinds of iterations:

--- a/csrc/flash_attn/src/flash_fwd_kernel.h
+++ b/csrc/flash_attn/src/flash_fwd_kernel.h
@@ -130,8 +130,8 @@ inline __device__ void compute_attn_1rowblock(const Params &params, const int bi
 
     // The thread index.
     const int tidx = threadIdx.x;
-    // The block index.
-    const int bidx = gridDim.x * bidh + bidb;
+    // The global block index.
+    const int block_id = blockIdx.x + blockIdx.y * gridDim.x + gridDim.x * gridDim.y * blockIdx.z;
 
     constexpr int kBlockM = Kernel_traits::kBlockM;
     constexpr int kBlockN = Kernel_traits::kBlockN;
@@ -311,7 +311,7 @@ inline __device__ void compute_attn_1rowblock(const Params &params, const int bi
     unsigned long long offset = std::get<1>(seeds) + (bidb * params.h + bidh) * 32 + tidx % 32;
 
     // Save seed and offset for backward.
-    if (bidx == 0 && tidx == 0) {
+    if (block_id == 0 && tidx == 0) {
         params.rng_state[0] = seed;
         params.rng_state[1] = std::get<1>(seeds);
     }

--- a/csrc/flash_attn/src/flash_fwd_kernel.h
+++ b/csrc/flash_attn/src/flash_fwd_kernel.h
@@ -313,7 +313,7 @@ inline __device__ void compute_attn_1rowblock(const Params &params, const int bi
     // Save seed and offset for backward.
     if (bidx == 0 && tidx == 0) {
         params.rng_state[0] = seed;
-        params.rng_state[1] = offset;
+        params.rng_state[1] = std::get<1>(seeds);
     }
 
     clear(acc_o);

--- a/csrc/flash_attn/src/flash_fwd_kernel.h
+++ b/csrc/flash_attn/src/flash_fwd_kernel.h
@@ -130,6 +130,8 @@ inline __device__ void compute_attn_1rowblock(const Params &params, const int bi
 
     // The thread index.
     const int tidx = threadIdx.x;
+    // The block index.
+    const int bidx = gridDim.x * bidh + bidb;
 
     constexpr int kBlockM = Kernel_traits::kBlockM;
     constexpr int kBlockN = Kernel_traits::kBlockN;
@@ -309,8 +311,10 @@ inline __device__ void compute_attn_1rowblock(const Params &params, const int bi
     unsigned long long offset = std::get<1>(seeds) + (bidb * params.h + bidh) * 32 + tidx % 32;
 
     // Save seed and offset for backward.
-    params.rng_state[0] = seed;
-    params.rng_state[1] = offset;
+    if (bidx == 0 && tidx == 0) {
+        params.rng_state[0] = seed;
+        params.rng_state[1] = offset;
+    }
 
     clear(acc_o);
 


### PR DESCRIPTION
Fixes #379 

Flash attention 2 broke the CUDA graphs support that was previously added, this PR mostly re-implements the changes in #166 (that PR description explains the changes) in order to enable CUDA graph capture.

All tests under `tests/test_flash_attn.py` are passing except few race condition checks that fail even outside this PR.