### PR TITLE
remove pyproject.toml to simplify installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,0 @@
-[tool.black]
-line-length = 100
-target-version = ['py38']

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[tool:brunette]
+line-length = 100
+target-version = py38


### PR DESCRIPTION
supercedes #493
fixes #453
cc #193 #209 

unfortunately black configuration can only be done via pyproject.toml:
- https://github.com/psf/black/issues/688
- https://github.com/psf/black/issues/683

this has the side-effect of enabling PEP517 as explained in https://github.com/Dao-AILab/flash-attention/pull/493#issuecomment-1693964407

instead of `black`, you can use https://github.com/odwyersoftware/brunette which can be configured via `setup.cfg` instead.