### PR TITLE
fix citation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ If you use this codebase, or otherwise found our work valuable, please cite:
   year={2022}
 }
 @article{dao2023flashattention2,
-  title={Flash{A}ttention-2: Faster Attention with Better Parallelism and Work Partitioning,
+  title={Flash{A}ttention-2: Faster Attention with Better Parallelism and Work Partitioning},
   author={Dao, Tri},
   year={2023}
 }


### PR DESCRIPTION
Very minor, but the Flash Attention 2 citation was missing a closing brace on the title (resulting in an error when copy/pasting into a paper 🙂 )