### PR TITLE
skip git commands when not inside a git repo

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,8 @@ ext_modules = []
 
 # We want this even if SKIP_CUDA_BUILD because when we run python setup.py sdist we want the .hpp
 # files included in the source distribution, in case the user compiles from source.
-subprocess.run(["git", "submodule", "update", "--init", "csrc/cutlass"])
+if os.path.exists(".git"):
+    subprocess.run(["git", "submodule", "update", "--init", "csrc/cutlass"])
 
 if not SKIP_CUDA_BUILD:
     print("\n\ntorch.__version__  = {}\n\n".format(torch.__version__))


### PR DESCRIPTION
 noticed in https://github.com/Dao-AILab/flash-attention/issues/509 logs there were some git warnings

>   fatal: not a git repository (or any of the parent directories): .git
