### PR TITLE
A100 FAv2 not working

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -156,7 +156,7 @@ jobs:
           export PATH=/usr/local/nvidia/bin:/usr/local/nvidia/lib64:$PATH
           export LD_LIBRARY_PATH=/usr/local/nvidia/lib64:/usr/local/cuda/lib64:$LD_LIBRARY_PATH
           # Currently for this setting the runner goes OOM if we pass --threads 4 to nvcc
-          if [[ ( ${MATRIX_CUDA_VERSION} == "121" || ${MATRIX_CUDA_VERSION} == "122" ) && ${MATRIX_TORCH_VERSION} == "2.1" ]]; then
+          if [[ ( ${MATRIX_CUDA_VERSION} == "12.1" || ${MATRIX_CUDA_VERSION} == "12.2" ) && ${MATRIX_TORCH_VERSION} == "2.1" ]]; then
             export FLASH_ATTENTION_FORCE_SINGLE_THREAD="TRUE"
           fi
           # Limit MAX_JOBS otherwise the github runner goes OOM


### PR DESCRIPTION
Running `import flash_attn` on A100 gives the following error:

```
ImportError: /usr/local/lib/python3.8/dist-packages/flash_attn_2_cuda.cpython-38-x86_64-linux-gnu.so: undefined symbol: _ZN3c104cuda9SetDeviceE
```

A bisect of the versions shows that [this](https://github.com/Dao-AILab/flash-attention/commit/f8dccfc90a115ce797fed7d5eaf8b066f2753d34) is the offending commit. I have confirmed that installing from source using the uploaded wheels (via `pip install .`) results in the error for all newer versions whereas locally building via `python setup.py install` works, indicating that this change results in erroneous wheels for ampere (h100 works, haven't looked at other devices).