### PR TITLE
add blocksparse support for flash forward

### DIFF
--- a/csrc/flash_attn/flash_api.cpp
+++ b/csrc/flash_attn/flash_api.cpp
@@ -195,34 +195,21 @@ void run_mha_fwd(Flash_fwd_params &params, cudaStream_t stream, bool force_split
     FP16_SWITCH(!params.is_bf16, [&] {
         FWD_HEADDIM_SWITCH(params.d, [&] {
             if (params.num_splits <= 1 && !force_split_kernel) {  // If we don't set it num_splits == 0
-                // add by JXGuo
-                printf("[run_mha_fwd] run_mha_fwd_ \n");
-                printf("[run_mha_fwd] kHeadDim = %d \n", kHeadDim);
                 run_mha_fwd_<elem_type, kHeadDim>(params, stream);
             } else {
-                // add by JXGuo
-                printf("[run_mha_fwd] run_mha_fwd_splitkv_dispatch \n");
                 run_mha_fwd_splitkv_dispatch<elem_type, kHeadDim>(params, stream);
             }
         });
     });
 }
 
-// add by JXGuo
+
 void run_mha_fwd_block(Flash_fwd_params &params, cudaStream_t stream, bool force_split_kernel=false) {
     FP16_SWITCH(!params.is_bf16, [&] {
         FWD_BLOCK_HEADDIM_SWITCH(params.d, [&] {
-            if (params.num_splits <= 1 && !force_split_kernel) {  // If we don't set it num_splits == 0
-                // add by JXGuo
-                printf("[run_mha_fwd_block] run_mha_fwd_block_ \n");
-                printf("[run_mha_fwd_block] kHeadDim = %d \n", kHeadDim);
+            if (params.num_splits <= 1 && !force_split_kernel) {  // If we don't set it num_splits == 
                 run_mha_fwd_block_<elem_type, kHeadDim>(params, stream);
             }
-            //  else {
-            //     // add by JXGuo
-            //     printf("[run_mha_fwd] run_mha_fwd_splitkv_dispatch, this branch is illegal\n");
-            //     // run_mha_fwd_splitkv_dispatch<elem_type, kHeadDim>(params, stream);
-            // }
         });
     });
 }
@@ -1318,7 +1305,7 @@ mha_fwd_kvcache(at::Tensor &q,                 // batch_size x seqlen_q x num_he
 
 
 
-// add by JXGuo
+
 std::vector<at::Tensor>
 mha_fwd_block(const at::Tensor &q,         
 // total_q x num_heads x head_size, total := \sum_{i=0}^{b} s_i
@@ -1336,8 +1323,6 @@ mha_fwd_block(const at::Tensor &q,
               const bool is_causal,
               const bool return_softmax,
               c10::optional<at::Generator> gen_){
-    // add by JXGuo
-    printf("[mha_fwd_block] start\n");
     auto dprops = at::cuda::getCurrentDeviceProperties();
     // bool is_sm75 = dprops->major == 7 && dprops->minor == 5;
     bool is_sm8x = dprops->major == 8 && dprops->minor >= 0;
@@ -1487,7 +1472,6 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
     m.def("bwd", &mha_bwd, "Backward pass");
     m.def("varlen_bwd", &mha_varlen_bwd, "Backward pass (variable length)");
     m.def("fwd_kvcache", &mha_fwd_kvcache, "Forward pass, with KV-cache");
-
-    // add by JXGuo
+  
     m.def("fwd_block", &mha_fwd_block, "Forward pass, with blockmask");
 }

--- a/csrc/flash_attn/src/block_info.h
+++ b/csrc/flash_attn/src/block_info.h
@@ -19,7 +19,7 @@ struct BlockInfo {
         // If is_seqlens_k_cumulative, then seqlen_k is cu_seqlens_k[bidb + 1] - cu_seqlens_k[bidb].
         // Otherwise it's cu_seqlens_k[bidb], i.e., we use cu_seqlens_k to store the sequence lengths of K.
         , seqlen_k_cache(!Varlen || params.cu_seqlens_k == nullptr ? params.seqlen_k : (params.is_seqlens_k_cumulative ? params.cu_seqlens_k[bidb + 1] - sum_s_k : params.cu_seqlens_k[bidb]))
-        , actual_seqlen_k(params.seqused_k ? params.seqused_k[bidb] : seqlen_k_cache + (params.knew_ptr == nullptr ? 0 : params.seqlen_knew))
+        , actual_seqlen_k(seqlen_k_cache + (params.knew_ptr == nullptr ? 0 : params.seqlen_knew))
         {
         }
 

--- a/csrc/flash_attn/src/flash.h
+++ b/csrc/flash_attn/src/flash.h
@@ -175,5 +175,5 @@ template<typename T, int Headdim> void run_mha_fwd_splitkv_dispatch(Flash_fwd_pa
 
 template<typename T, int Headdim> void run_mha_bwd_(Flash_bwd_params &params, cudaStream_t stream, const bool configure);
 
-// add by JXGuo
+
 template<typename T, int Headdim> void run_mha_fwd_block_(Flash_fwd_params &params, cudaStream_t stream);

--- a/csrc/flash_attn/src/flash.h
+++ b/csrc/flash_attn/src/flash.h
@@ -77,9 +77,6 @@ struct Flash_fwd_params : public Qkv_params {
     int * __restrict__ cu_seqlens_q;
     int * __restrict__ cu_seqlens_k;
 
-    // If provided, the actual length of each k sequence.
-    int * __restrict__ seqused_k;
-
     int *__restrict__ blockmask;
 
     // The K_new and V_new matrices.
@@ -177,3 +174,6 @@ template<typename T, int Headdim> void run_mha_fwd_(Flash_fwd_params &params, cu
 template<typename T, int Headdim> void run_mha_fwd_splitkv_dispatch(Flash_fwd_params &params, cudaStream_t stream);
 
 template<typename T, int Headdim> void run_mha_bwd_(Flash_bwd_params &params, cudaStream_t stream, const bool configure);
+
+// add by JXGuo
+template<typename T, int Headdim> void run_mha_fwd_block_(Flash_fwd_params &params, cudaStream_t stream);

--- a/csrc/flash_attn/src/flash_blockmask.h
+++ b/csrc/flash_attn/src/flash_blockmask.h
@@ -1,0 +1,50 @@
+/******************************************************************************
+ * Copyright (c) 2011-2021, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+#pragma once
+
+namespace flash {
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+struct Blockmask {
+
+    template<typename Params>
+    __device__ Blockmask(const Params &params, int loop_step_idx) :
+        blockmask_ptr(params.blockmask + loop_step_idx * params.seqlen_q / 16) {
+    }
+
+    __device__ int mask_val(int block_row_idx) const {
+        return blockmask_ptr[block_row_idx];
+    }
+
+    const int *blockmask_ptr;
+};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+}  // namespace flash

--- a/csrc/flash_attn/src/flash_blockmask.h
+++ b/csrc/flash_attn/src/flash_blockmask.h
@@ -32,16 +32,22 @@ namespace flash {
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 struct Blockmask {
+    
 
     template<typename Params>
-    __device__ Blockmask(const Params &params, int loop_step_idx) :
-        blockmask_ptr(params.blockmask + loop_step_idx * params.seqlen_q / 64) {
+    __device__ Blockmask(const Params &params, int loop_step_idx) {
+        Is_blocksparse = params.blockmask != nullptr;
+        blockmask_ptr = Is_blocksparse ? params.blockmask + loop_step_idx * params.seqlen_q / 64 : nullptr;
     }
 
     __device__ int mask_val(int block_row_idx) const {
+        if (!Is_blocksparse) {
+            return -2;
+        }
         return blockmask_ptr[block_row_idx];
     }
 
+    bool Is_blocksparse = false;
     const int *blockmask_ptr;
 };
 

--- a/csrc/flash_attn/src/flash_blockmask.h
+++ b/csrc/flash_attn/src/flash_blockmask.h
@@ -35,7 +35,7 @@ struct Blockmask {
 
     template<typename Params>
     __device__ Blockmask(const Params &params, int loop_step_idx) :
-        blockmask_ptr(params.blockmask + loop_step_idx * params.seqlen_q / 16) {
+        blockmask_ptr(params.blockmask + loop_step_idx * params.seqlen_q / 64) {
     }
 
     __device__ int mask_val(int block_row_idx) const {

--- a/csrc/flash_attn/src/flash_blockmask.h
+++ b/csrc/flash_attn/src/flash_blockmask.h
@@ -42,7 +42,7 @@ struct Blockmask {
 
     __device__ int mask_val(int block_row_idx) const {
         if (!Is_blocksparse) {
-            return -2;
+            return -1;
         }
         return blockmask_ptr[block_row_idx];
     }

--- a/csrc/flash_attn/src/flash_bwd_launch_template.h
+++ b/csrc/flash_attn/src/flash_bwd_launch_template.h
@@ -60,15 +60,15 @@ void run_flash_bwd_seqk_parallel(Flash_bwd_params &params, cudaStream_t stream, 
     const bool is_even_K = params.d == Kernel_traits::kHeadDim;
     constexpr int smem_size_dq_dk_dv = Kernel_traits::kSmemSize1colblock;
     // printf("smem_size_dq_dk_dv = %d\n", smem_size_dq_dk_dv);
-    BOOL_SWITCH(params.is_causal, Is_causal, [&] {
+    BOOL_SWITCH(params.is_causal, IsCausalConst, [&] {
         BOOL_SWITCH(is_even_MN, IsEvenMNConst, [&] {
             BOOL_SWITCH(is_even_K, IsEvenKConst, [&] {
-                BOOL_SWITCH((params.window_size_left >= 0 || params.window_size_right >= 0) && !params.is_causal, Is_local, [&] {
+                BOOL_SWITCH(params.window_size_left >= 0 || params.window_size_right >= 0, Is_local, [&] {
                     // If not IsEvenKConst, we also set IsEvenMNConst to false to reduce number of templates.
                     // If head dim > 128, set IsEvenMNConst to false to reduce number of templates
                     // If Is_local, set Is_causal to false
-                    auto kernel = &flash_bwd_dq_dk_dv_loop_seqk_parallel_kernel<Kernel_traits, Is_dropout, Is_causal, Is_local && !Is_causal, IsEvenMNConst && IsEvenKConst && !Is_local && Kernel_traits::kHeadDim <= 128, IsEvenKConst>;
-                    // auto kernel = &flash_bwd_dq_dk_dv_loop_seqk_parallel_kernel<Kernel_traits, Is_dropout, Is_causal, IsEvenMNConst, true>;
+                    auto kernel = &flash_bwd_dq_dk_dv_loop_seqk_parallel_kernel<Kernel_traits, Is_dropout, IsCausalConst && !Is_local, Is_local, IsEvenMNConst && IsEvenKConst && !Is_local && Kernel_traits::kHeadDim <= 128, IsEvenKConst>;
+                    // auto kernel = &flash_bwd_dq_dk_dv_loop_seqk_parallel_kernel<Kernel_traits, Is_dropout, IsCausalConst, IsEvenMNConst, true>;
                     if (smem_size_dq_dk_dv >= 48 * 1024)  {
                         C10_CUDA_CHECK(cudaFuncSetAttribute(
                             kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size_dq_dk_dv));
@@ -104,11 +104,11 @@ void run_flash_bwd_seqq_parallel(Flash_bwd_params &params, cudaStream_t stream, 
     const bool is_even_K = params.d == Kernel_traits::kHeadDim;
     constexpr int smem_size_dq_dk_dv = Kernel_traits::kSmemSize1rowblock;
     // printf("smem_size_dq_dk_dv = %d\n", smem_size_dq_dk_dv);
-    BOOL_SWITCH(params.is_causal, Is_causal, [&] {
+    BOOL_SWITCH(params.is_causal, IsCausalConst, [&] {
         BOOL_SWITCH(is_even_N, IsEvenNConst, [&] {
             BOOL_SWITCH(is_even_K, IsEvenKConst, [&] {
                 // If not IsEvenKConst, we also set IsEvenMNConst to false to reduce number of templates.
-                auto kernel = &flash_bwd_dq_dk_dv_loop_seqq_parallel_kernel<Kernel_traits, Is_dropout, Is_causal, IsEvenNConst && IsEvenKConst, IsEvenKConst>;
+                auto kernel = &flash_bwd_dq_dk_dv_loop_seqq_parallel_kernel<Kernel_traits, Is_dropout, IsCausalConst, IsEvenNConst && IsEvenKConst, IsEvenKConst>;
                 // auto kernel = &flash_bwd_dq_dk_dv_loop_seqq_parallel_kernel<Kernel_traits, false, false, IsEvenNConst, IsEvenKConst>;
                 if (smem_size_dq_dk_dv >= 48 * 1024)  {
                     C10_CUDA_CHECK(cudaFuncSetAttribute(

--- a/csrc/flash_attn/src/flash_fwd_block_hdim128_bf16_sm80.cu
+++ b/csrc/flash_attn/src/flash_fwd_block_hdim128_bf16_sm80.cu
@@ -1,0 +1,10 @@
+// Copyright (c) 2023, Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+
+#include "flash_fwd_launch_template.h"
+
+template<>
+void run_mha_fwd_block_<cutlass::bfloat16_t, 128>(Flash_fwd_params &params, cudaStream_t stream) {
+    run_mha_fwd_block_hdim128<cutlass::bfloat16_t>(params, stream);
+}

--- a/csrc/flash_attn/src/flash_fwd_block_hdim128_fp16_sm80.cu
+++ b/csrc/flash_attn/src/flash_fwd_block_hdim128_fp16_sm80.cu
@@ -1,0 +1,10 @@
+// Copyright (c) 2023, Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+
+#include "flash_fwd_launch_template.h"
+
+template<>
+void run_mha_fwd_block_<cutlass::half_t, 128>(Flash_fwd_params &params, cudaStream_t stream) {
+    run_mha_fwd_block_hdim128<cutlass::half_t>(params, stream);
+}

--- a/csrc/flash_attn/src/flash_fwd_block_hdim32_bf16_sm80.cu
+++ b/csrc/flash_attn/src/flash_fwd_block_hdim32_bf16_sm80.cu
@@ -5,8 +5,6 @@
 #include "flash_fwd_launch_template.h"
 
 template<>
-void run_mha_fwd_<cutlass::half_t, 32>(Flash_fwd_params &params, cudaStream_t stream) {
-    // add by JXGuo
-    printf("[run_mha_fwd_hdim32] half_t \n");
-    run_mha_fwd_hdim32<cutlass::half_t>(params, stream);
+void run_mha_fwd_block_<cutlass::bfloat16_t, 32>(Flash_fwd_params &params, cudaStream_t stream) {
+    run_mha_fwd_block_hdim32<cutlass::bfloat16_t>(params, stream);
 }

--- a/csrc/flash_attn/src/flash_fwd_block_hdim32_fp16_sm80.cu
+++ b/csrc/flash_attn/src/flash_fwd_block_hdim32_fp16_sm80.cu
@@ -6,6 +6,5 @@
 
 template<>
 void run_mha_fwd_block_<cutlass::half_t, 32>(Flash_fwd_params &params, cudaStream_t stream) {
-    printf("[run_mha_fwd_block_]<cutlass::half_t, 32> \n");
     run_mha_fwd_block_hdim32<cutlass::half_t>(params, stream);
 }

--- a/csrc/flash_attn/src/flash_fwd_block_hdim32_fp16_sm80.cu
+++ b/csrc/flash_attn/src/flash_fwd_block_hdim32_fp16_sm80.cu
@@ -5,8 +5,7 @@
 #include "flash_fwd_launch_template.h"
 
 template<>
-void run_mha_fwd_<cutlass::half_t, 32>(Flash_fwd_params &params, cudaStream_t stream) {
-    // add by JXGuo
-    printf("[run_mha_fwd_hdim32] half_t \n");
-    run_mha_fwd_hdim32<cutlass::half_t>(params, stream);
+void run_mha_fwd_block_<cutlass::half_t, 32>(Flash_fwd_params &params, cudaStream_t stream) {
+    printf("[run_mha_fwd_block_]<cutlass::half_t, 32> \n");
+    run_mha_fwd_block_hdim32<cutlass::half_t>(params, stream);
 }

--- a/csrc/flash_attn/src/flash_fwd_block_hdim64_bf16_sm80.cu
+++ b/csrc/flash_attn/src/flash_fwd_block_hdim64_bf16_sm80.cu
@@ -5,8 +5,6 @@
 #include "flash_fwd_launch_template.h"
 
 template<>
-void run_mha_fwd_<cutlass::half_t, 32>(Flash_fwd_params &params, cudaStream_t stream) {
-    // add by JXGuo
-    printf("[run_mha_fwd_hdim32] half_t \n");
-    run_mha_fwd_hdim32<cutlass::half_t>(params, stream);
+void run_mha_fwd_block_<cutlass::bfloat16_t, 64>(Flash_fwd_params &params, cudaStream_t stream) {
+    run_mha_fwd_block_hdim64<cutlass::bfloat16_t>(params, stream);
 }

--- a/csrc/flash_attn/src/flash_fwd_block_hdim64_fp16_sm80.cu
+++ b/csrc/flash_attn/src/flash_fwd_block_hdim64_fp16_sm80.cu
@@ -5,8 +5,6 @@
 #include "flash_fwd_launch_template.h"
 
 template<>
-void run_mha_fwd_<cutlass::half_t, 32>(Flash_fwd_params &params, cudaStream_t stream) {
-    // add by JXGuo
-    printf("[run_mha_fwd_hdim32] half_t \n");
-    run_mha_fwd_hdim32<cutlass::half_t>(params, stream);
+void run_mha_fwd_block_<cutlass::half_t, 64>(Flash_fwd_params &params, cudaStream_t stream) {
+    run_mha_fwd_block_hdim64<cutlass::half_t>(params, stream);
 }

--- a/csrc/flash_attn/src/flash_fwd_kernel.h
+++ b/csrc/flash_attn/src/flash_fwd_kernel.h
@@ -15,7 +15,7 @@
 #include "utils.h"
 #include "softmax.h"
 
-// add by JXGuo
+
 #include "flash_blockmask.h"
 
 namespace flash {
@@ -106,7 +106,7 @@ inline __device__ void compute_attn_1rowblock(const Params &params, const int bi
         // }
     }
 
-    // add by JXGuo: add blocksparse support
+    
     Blockmask blockmask(params, m_block);
     bool Is_blocksparse = blockmask.Is_blocksparse;
     if(Is_blocksparse && blockmask.mask_val(0) == -1){ //add by JXGuo: 此处处理全为-1的情况，即不需要计算的情况
@@ -523,7 +523,6 @@ inline __device__ void compute_attn_1rowblock(const Params &params, const int bi
         cute::cp_async_fence();
 
 
-        // add by JXGuo: todo: add skip
         if(!is_skip){
            flash::gemm</*A_in_regs=*/Kernel_traits::Is_Q_in_regs>(
                 acc_s, tSrQ, tSrK, tSsQ, tSsK, tiled_mma, smem_tiled_copy_Q, smem_tiled_copy_K,
@@ -588,7 +587,6 @@ inline __device__ void compute_attn_1rowblock(const Params &params, const int bi
         }
 
 
-        // add by JXGuo: todo: add skip
         if(!is_skip){
             flash::gemm_A_in_regs(acc_o, tOrP, tOrVt, tOsVt, tiled_mma, smem_tiled_copy_V, smem_thr_copy_V);
         }

--- a/csrc/flash_attn/src/flash_fwd_kernel.h
+++ b/csrc/flash_attn/src/flash_fwd_kernel.h
@@ -346,9 +346,9 @@ inline __device__ void compute_attn_1rowblock(const Params &params, const int bi
     }
 
     // add by JXGuo
-    printf("[compute_attn_1rowblock] before clear2, acc_o(0) = %d, threadIdx.x = %d, m_block = %d\n", acc_o(0), threadIdx.x, m_block);
+    printf("[compute_attn_1rowblock] before clear1, acc_o(0) = %d, threadIdx.x = %d, m_block = %d\n", acc_o(0), threadIdx.x, m_block);
     clear(acc_o);
-    printf("[compute_attn_1rowblock] after clear2, acc_o(0) = %d, threadIdx.x = %d, m_block = %d\n", acc_o(0), threadIdx.x, m_block);
+    printf("[compute_attn_1rowblock] after clear1, acc_o(0) = %d, threadIdx.x = %d, m_block = %d\n", acc_o(0), threadIdx.x, m_block);
 
     clear(acc_o);
 
@@ -365,111 +365,111 @@ inline __device__ void compute_attn_1rowblock(const Params &params, const int bi
         : ((Is_even_MN && Is_causal) ? cute::ceil_div(kBlockM, kBlockN) : cute::ceil_div(kBlockM, kBlockN) + 1);
 
     // add by JXGuo: blocksparse is not supported for causal, so will not enter this loop
-    #pragma unroll
-    for (int masking_step = 0; masking_step < n_masking_steps; ++masking_step, --n_block) {
-        Tensor acc_s = partition_fragment_C(tiled_mma, Shape<Int<kBlockM>, Int<kBlockN>>{});  // (MMA=4, MMA_M, MMA_N) // add by JXGuo: 猜测是 softmax 中间值
-        clear(acc_s);
-        flash::cp_async_wait<0>();
-        __syncthreads();
+    // #pragma unroll
+    // for (int masking_step = 0; masking_step < n_masking_steps; ++masking_step, --n_block) {
+    //     Tensor acc_s = partition_fragment_C(tiled_mma, Shape<Int<kBlockM>, Int<kBlockN>>{});  // (MMA=4, MMA_M, MMA_N) // add by JXGuo: 猜测是 softmax 中间值
+    //     clear(acc_s);
+    //     flash::cp_async_wait<0>();
+    //     __syncthreads();
 
-        // Advance gV
-        if (masking_step > 0) {
-            tVgV.data() = tVgV.data() + (-int(kBlockN * params.v_row_stride));
-            flash::copy</*Is_even_MN=*/true, Is_even_K>(gmem_tiled_copy_QKV, tVgV, tVsV, tKVcKV, tKVpKV);
-        } else {
-            // Clear the smem tiles to account for predicated off loads
-            flash::copy<Is_even_MN, Is_even_K, /*Clear_OOB_MN=*/true>(
-                gmem_tiled_copy_QKV, tVgV, tVsV, tKVcKV, tKVpKV, binfo.actual_seqlen_k - n_block * kBlockN
-            );
-        }
-        cute::cp_async_fence();
+    //     // Advance gV
+    //     if (masking_step > 0) {
+    //         tVgV.data() = tVgV.data() + (-int(kBlockN * params.v_row_stride));
+    //         flash::copy</*Is_even_MN=*/true, Is_even_K>(gmem_tiled_copy_QKV, tVgV, tVsV, tKVcKV, tKVpKV);
+    //     } else {
+    //         // Clear the smem tiles to account for predicated off loads
+    //         flash::copy<Is_even_MN, Is_even_K, /*Clear_OOB_MN=*/true>(
+    //             gmem_tiled_copy_QKV, tVgV, tVsV, tKVcKV, tKVpKV, binfo.actual_seqlen_k - n_block * kBlockN
+    //         );
+    //     }
+    //     cute::cp_async_fence();
 
-        flash::gemm</*A_in_regs=*/Kernel_traits::Is_Q_in_regs>(
-            acc_s, tSrQ, tSrK, tSsQ, tSsK, tiled_mma, smem_tiled_copy_Q, smem_tiled_copy_K,
-            smem_thr_copy_Q, smem_thr_copy_K
-        );
-        // if (cute::thread0()) { print(acc_s); }
+    //     flash::gemm</*A_in_regs=*/Kernel_traits::Is_Q_in_regs>(
+    //         acc_s, tSrQ, tSrK, tSsQ, tSsK, tiled_mma, smem_tiled_copy_Q, smem_tiled_copy_K,
+    //         smem_thr_copy_Q, smem_thr_copy_K
+    //     );
+    //     // if (cute::thread0()) { print(acc_s); }
 
-        // Reshape acc_s from (MMA=4, MMA_M, MMA_N) to (nrow=(2, MMA_M), ncol=(2, MMA_N))
-        Tensor scores = make_tensor(acc_s.data(), flash::convert_layout_acc_rowcol(acc_s.layout()));
-        // if (cute::thread0()) { print_tensor(scores); }
-        // We don't put the masking before the matmul S = Q K^T because we don't clear sK
-        // for rows outside actual_seqlen_k. So those rows could have Inf / NaN, and the matmul
-        // can produce Inf / NaN.
-        if (!Is_causal && !Is_local) {
-            if (!Is_even_MN) { flash::apply_mask(scores, binfo.actual_seqlen_k - n_block * kBlockN); }
-        } else {
-            // Tensor caccS = make_identity_tensor(Shape<Int<kBlockM>, Int<kBlockN>>{});    // (BLK_M,BLK_N) -> (blk_m,blk_n)
-            // Tensor taccScS = thr_mma.partition_C(caccS);                           // (MMA,MMA_M,MMA_N)
-            // static_assert(decltype(size<0>(taccScS))::value == 4);
-            // // Convert to ((2, 2), MMA_M, MMA_N) then take only the row indices.
-            // Tensor idx_row = logical_divide(taccScS, Shape<_2>{})(make_coord(0, _), _, 0);
-            // Tensor idx_rowcol = make_tensor(taccScS.data(), flash::convert_layout_acc_rowcol(taccScS.layout()));
-            // flash::apply_mask_causal_w_idx(scores, idx_rowcol, n_block * kBlockN, binfo.actual_seqlen_k,
-            //                               m_block * kBlockM);
-            // Idk why it's get<1> and not get<0> of the stride.
-            // if (cute::thread0()) { print(idx_row.layout()); print(stride<1>(idx_row)); printf("stride = %d \n", get<1>(stride<1>(idx_row))); }
-            // I can't get the stride from idx_row
-            flash::apply_mask_local</*HasWSLeft=*/Is_local>(
-                scores, n_block * kBlockN, binfo.actual_seqlen_k,
-                // m_block * kBlockM + get<0>(idx_row(0)),
-                m_block * kBlockM + (tidx / 32) * 16 + (tidx % 32) / 4,
-                binfo.actual_seqlen_q, kNWarps * 16,
-                params.window_size_left, params.window_size_right
-                // m_block * kBlockM + (tidx / 32) * 16, kNWarps * 16
-                // m_block * kBlockM + (tidx / 32) * (kBlockM / kNWarps), 16
-            );
-            // if (cute::thread0()) { print_tensor(scores); }
-        }
+    //     // Reshape acc_s from (MMA=4, MMA_M, MMA_N) to (nrow=(2, MMA_M), ncol=(2, MMA_N))
+    //     Tensor scores = make_tensor(acc_s.data(), flash::convert_layout_acc_rowcol(acc_s.layout()));
+    //     // if (cute::thread0()) { print_tensor(scores); }
+    //     // We don't put the masking before the matmul S = Q K^T because we don't clear sK
+    //     // for rows outside actual_seqlen_k. So those rows could have Inf / NaN, and the matmul
+    //     // can produce Inf / NaN.
+    //     if (!Is_causal && !Is_local) {
+    //         if (!Is_even_MN) { flash::apply_mask(scores, binfo.actual_seqlen_k - n_block * kBlockN); }
+    //     } else {
+    //         // Tensor caccS = make_identity_tensor(Shape<Int<kBlockM>, Int<kBlockN>>{});    // (BLK_M,BLK_N) -> (blk_m,blk_n)
+    //         // Tensor taccScS = thr_mma.partition_C(caccS);                           // (MMA,MMA_M,MMA_N)
+    //         // static_assert(decltype(size<0>(taccScS))::value == 4);
+    //         // // Convert to ((2, 2), MMA_M, MMA_N) then take only the row indices.
+    //         // Tensor idx_row = logical_divide(taccScS, Shape<_2>{})(make_coord(0, _), _, 0);
+    //         // Tensor idx_rowcol = make_tensor(taccScS.data(), flash::convert_layout_acc_rowcol(taccScS.layout()));
+    //         // flash::apply_mask_causal_w_idx(scores, idx_rowcol, n_block * kBlockN, binfo.actual_seqlen_k,
+    //         //                               m_block * kBlockM);
+    //         // Idk why it's get<1> and not get<0> of the stride.
+    //         // if (cute::thread0()) { print(idx_row.layout()); print(stride<1>(idx_row)); printf("stride = %d \n", get<1>(stride<1>(idx_row))); }
+    //         // I can't get the stride from idx_row
+    //         flash::apply_mask_local</*HasWSLeft=*/Is_local>(
+    //             scores, n_block * kBlockN, binfo.actual_seqlen_k,
+    //             // m_block * kBlockM + get<0>(idx_row(0)),
+    //             m_block * kBlockM + (tidx / 32) * 16 + (tidx % 32) / 4,
+    //             binfo.actual_seqlen_q, kNWarps * 16,
+    //             params.window_size_left, params.window_size_right
+    //             // m_block * kBlockM + (tidx / 32) * 16, kNWarps * 16
+    //             // m_block * kBlockM + (tidx / 32) * (kBlockM / kNWarps), 16
+    //         );
+    //         // if (cute::thread0()) { print_tensor(scores); }
+    //     }
 
-        flash::cp_async_wait<0>();
-        __syncthreads();
-        if (n_block > n_block_min) {
-            // Advance gK
-            tKgK.data() = tKgK.data() + (-int(kBlockN * params.k_row_stride));
-            flash::copy</*Is_even_MN=*/true, Is_even_K>(gmem_tiled_copy_QKV, tKgK, tKsK, tKVcKV, tKVpKV);
-            // This cp_async_fence needs to be in the if block, otherwise the synchronization
-            // isn't right and we get race conditions.
-            cute::cp_async_fence();
-        }
+    //     flash::cp_async_wait<0>();
+    //     __syncthreads();
+    //     if (n_block > n_block_min) {
+    //         // Advance gK
+    //         tKgK.data() = tKgK.data() + (-int(kBlockN * params.k_row_stride));
+    //         flash::copy</*Is_even_MN=*/true, Is_even_K>(gmem_tiled_copy_QKV, tKgK, tKsK, tKVcKV, tKVpKV);
+    //         // This cp_async_fence needs to be in the if block, otherwise the synchronization
+    //         // isn't right and we get race conditions.
+    //         cute::cp_async_fence();
+    //     }
 
-        // TODO: when we have key_padding_mask we'll need to Check_inf
-        masking_step == 0
-            ? softmax_rescale_o</*Is_first=*/true,  /*Check_inf=*/Is_causal || Is_local>(scores, scores_max, scores_sum, acc_o, params.scale_softmax_log2)
-            : softmax_rescale_o</*Is_first=*/false, /*Check_inf=*/Is_causal || Is_local>(scores, scores_max, scores_sum, acc_o, params.scale_softmax_log2);
+    //     // TODO: when we have key_padding_mask we'll need to Check_inf
+    //     masking_step == 0
+    //         ? softmax_rescale_o</*Is_first=*/true,  /*Check_inf=*/Is_causal || Is_local>(scores, scores_max, scores_sum, acc_o, params.scale_softmax_log2)
+    //         : softmax_rescale_o</*Is_first=*/false, /*Check_inf=*/Is_causal || Is_local>(scores, scores_max, scores_sum, acc_o, params.scale_softmax_log2);
 
-        // Convert scores from fp32 to fp16/bf16
-        Tensor rP = flash::convert_type<Element>(scores);
-        // Reshape rP from (nrow=(2, MMA_M), ncol=(2, MMA_N)) to ((2, 2, 2), MMA_M, MMA_N / 2)
-        // if using m16n8k16 or ((2, 2, 1), MMA_M, MMA_N) if using m16n8k8.
-        Tensor tOrP = make_tensor(rP.data(), flash::convert_layout_rowcol_Aregs<Kernel_traits::TiledMma>(rP.layout()));
-        int block_row_idx = m_block * (kBlockM / 16) + tidx / 32;
-        int block_col_idx = n_block * (kBlockN / 32);
-        if (Return_softmax) {
-            Tensor tOrP_copy = make_fragment_like(tOrP);
-            cute::copy(tOrP, tOrP_copy);
-            flash::apply_dropout</*encode_dropout_in_sign_bit=*/true>(
-                tOrP_copy, params.p_dropout_in_uint8_t, seed, offset,
-                block_row_idx, block_col_idx, kNWarps
-            );
-            flash::write_softmax_to_gmem(tOrP_copy, tPgP, gmem_tiled_copy_P);
-            tPgP.data() = tPgP.data() + (-kBlockN);
-        }
-        if (Is_dropout) {
-            flash::apply_dropout(tOrP, params.p_dropout_in_uint8_t, seed, offset,
-                                 block_row_idx, block_col_idx, kNWarps);
-        }
-        // if (cute::thread0()) { print(tOrP); }
+    //     // Convert scores from fp32 to fp16/bf16
+    //     Tensor rP = flash::convert_type<Element>(scores);
+    //     // Reshape rP from (nrow=(2, MMA_M), ncol=(2, MMA_N)) to ((2, 2, 2), MMA_M, MMA_N / 2)
+    //     // if using m16n8k16 or ((2, 2, 1), MMA_M, MMA_N) if using m16n8k8.
+    //     Tensor tOrP = make_tensor(rP.data(), flash::convert_layout_rowcol_Aregs<Kernel_traits::TiledMma>(rP.layout()));
+    //     int block_row_idx = m_block * (kBlockM / 16) + tidx / 32;
+    //     int block_col_idx = n_block * (kBlockN / 32);
+    //     if (Return_softmax) {
+    //         Tensor tOrP_copy = make_fragment_like(tOrP);
+    //         cute::copy(tOrP, tOrP_copy);
+    //         flash::apply_dropout</*encode_dropout_in_sign_bit=*/true>(
+    //             tOrP_copy, params.p_dropout_in_uint8_t, seed, offset,
+    //             block_row_idx, block_col_idx, kNWarps
+    //         );
+    //         flash::write_softmax_to_gmem(tOrP_copy, tPgP, gmem_tiled_copy_P);
+    //         tPgP.data() = tPgP.data() + (-kBlockN);
+    //     }
+    //     if (Is_dropout) {
+    //         flash::apply_dropout(tOrP, params.p_dropout_in_uint8_t, seed, offset,
+    //                              block_row_idx, block_col_idx, kNWarps);
+    //     }
+    //     // if (cute::thread0()) { print(tOrP); }
 
-        flash::gemm_A_in_regs(acc_o, tOrP, tOrVt, tOsVt, tiled_mma, smem_tiled_copy_V, smem_thr_copy_V);
-        // if (cute::thread0()) { print(scores); }
+    //     flash::gemm_A_in_regs(acc_o, tOrP, tOrVt, tOsVt, tiled_mma, smem_tiled_copy_V, smem_thr_copy_V);
+    //     // if (cute::thread0()) { print(scores); }
 
-        // This check is at the end of the loop since we always have at least 1 iteration
-        if (n_masking_steps > 1 && n_block <= n_block_min) {
-            --n_block;
-            break;
-        }
-    }
+    //     // This check is at the end of the loop since we always have at least 1 iteration
+    //     if (n_masking_steps > 1 && n_block <= n_block_min) {
+    //         --n_block;
+    //         break;
+    //     }
+    // }
 
     
 

--- a/csrc/flash_attn/src/flash_fwd_kernel.h
+++ b/csrc/flash_attn/src/flash_fwd_kernel.h
@@ -346,9 +346,9 @@ inline __device__ void compute_attn_1rowblock(const Params &params, const int bi
     }
 
     // add by JXGuo
-    printf("[compute_attn_1rowblock] before clear2, acc_o(0) = %d, tidx = %d, m_block = %d\n", acc_o(0), tidx, m_block);
+    printf("[compute_attn_1rowblock] before clear2, acc_o(0) = %d, threadIdx.x = %d, m_block = %d\n", acc_o(0), threadIdx.x, m_block);
     clear(acc_o);
-    printf("[compute_attn_1rowblock] after clear2, acc_o(0) = %d, tidx = %d, m_block = %d\n", acc_o(0), tidx, m_block);
+    printf("[compute_attn_1rowblock] after clear2, acc_o(0) = %d, threadIdx.x = %d, m_block = %d\n", acc_o(0), threadIdx.x, m_block);
 
     clear(acc_o);
 
@@ -551,9 +551,9 @@ inline __device__ void compute_attn_1rowblock(const Params &params, const int bi
     }
 
     // add by JXGuo
-    printf("[compute_attn_1rowblock] before clear2, acc_o(0) = %d, tidx = %d, m_block = %d\n", acc_o(0), tidx, m_block);
+    printf("[compute_attn_1rowblock] before clear2, acc_o(0) = %d, threadIdx.x = %d, m_block = %d\n", acc_o(0), threadIdx.x, m_block);
     clear(acc_o);
-    printf("[compute_attn_1rowblock] after clear2, acc_o(0) = %d, tidx = %d, m_block = %d\n", acc_o(0), tidx, m_block);
+    printf("[compute_attn_1rowblock] after clear2, acc_o(0) = %d, threadIdx.x = %d, m_block = %d\n", acc_o(0), threadIdx.x, m_block);
 
     // Epilogue
 

--- a/csrc/flash_attn/src/flash_fwd_kernel.h
+++ b/csrc/flash_attn/src/flash_fwd_kernel.h
@@ -109,7 +109,7 @@ inline __device__ void compute_attn_1rowblock(const Params &params, const int bi
     
     Blockmask blockmask(params, m_block);
     bool Is_blocksparse = blockmask.Is_blocksparse;
-    if(Is_blocksparse && blockmask.mask_val(0) == -1){ //add by JXGuo: 此处处理全为-1的情况，即不需要计算的情况
+    if(Is_blocksparse && blockmask.mask_val(0) == -1){ //add by JXGuo: deal with the case that need no calculation
         n_block_max = n_block_min;
     }
 
@@ -585,7 +585,6 @@ inline __device__ void compute_attn_1rowblock(const Params &params, const int bi
             flash::apply_dropout(tOrP, params.p_dropout_in_uint8_t, seed, offset,
                                  block_row_idx, block_col_idx, kNWarps);
         }
-
 
         if(!is_skip){
             flash::gemm_A_in_regs(acc_o, tOrP, tOrVt, tOsVt, tiled_mma, smem_tiled_copy_V, smem_thr_copy_V);

--- a/csrc/flash_attn/src/flash_fwd_launch_template.h
+++ b/csrc/flash_attn/src/flash_fwd_launch_template.h
@@ -415,3 +415,40 @@ void run_mha_fwd_block_hdim64(Flash_fwd_params &params, cudaStream_t stream) {
         });
     });
 }
+
+template<typename T>
+void run_mha_fwd_block_hdim128(Flash_fwd_params &params, cudaStream_t stream) {
+    constexpr static int Headdim = 128;
+    auto dprops = at::cuda::getCurrentDeviceProperties();
+    bool is_sm8x = dprops->major == 8 && dprops->minor > 0;
+    BOOL_SWITCH(params.p_dropout < 1.f, Is_dropout, [&] {
+        BOOL_SWITCH(params.is_causal, Is_causal, [&] {
+            if constexpr(!Is_dropout) {
+                // For sm86 or sm89, 64 x 64 is the fastest for causal (because it's square),
+                // and 128 x 32 (48 KB smem) is the fastest for non-causal since we get 2 CTAs per SM.
+                if (is_sm8x) {
+                    if constexpr(!Is_causal) {
+                        run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 64, 64, 4, false, false, T>, Is_dropout, Is_causal>(params, stream);
+                    } else {
+                        run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 64, 64, 4, false, false, T>, Is_dropout, Is_causal>(params, stream);
+                    }
+                } else {
+                    run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 64, 64, 4, false, false, T>, Is_dropout, Is_causal>(params, stream);
+                }
+                // run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 128, 64, 4, true, false, T>, Is_dropout, Is_causal>(params, stream);
+                // run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 128, 64, 4, true, true, T>, Is_dropout, Is_causal>(params, stream);
+                // run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 64, 128, 4, false, false, T>, Is_dropout, Is_causal>(params, stream);
+                // Using 8 warps (128 x 128 and 256 x 64) is 28% slower for seqlen=2k
+                // run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 128, 128, 8, false, false, T>, Is_dropout, Is_causal>(params, stream);
+                // run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 128, 64, 8, false, false, T>, Is_dropout, Is_causal>(params, stream);
+                // 1st ones are good for H100, A100
+                // 2nd one is good for A6000 bc we get slightly better occupancy
+            } else {
+                run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 64, 64, 4, false, false, T>, Is_dropout, Is_causal>(params, stream);
+                // run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 64, 64, 4, false, false, T>, Is_dropout, Is_causal>(params, stream);
+                // run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 128, 32, 4, true, false, T>, Is_dropout, Is_causal>(params, stream);
+                // run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 128, 32, 4, true, true, T>, Is_dropout, Is_causal>(params, stream);
+            }
+        });
+    });
+}

--- a/csrc/flash_attn/src/flash_fwd_launch_template.h
+++ b/csrc/flash_attn/src/flash_fwd_launch_template.h
@@ -384,11 +384,11 @@ void run_mha_fwd_hdim256(Flash_fwd_params &params, cudaStream_t stream) {
 template<typename T>
 void run_mha_fwd_block_hdim32(Flash_fwd_params &params, cudaStream_t stream) {
     // add by JXGuo
-    printf("[run_mha_fwd_block_hdim32] start\n");
+    // printf("[run_mha_fwd_block_hdim32] start\n");
     constexpr static int Headdim = 32;
     BOOL_SWITCH(params.p_dropout < 1.f, Is_dropout, [&] {
         BOOL_SWITCH(params.is_causal, Is_causal, [&] {
-            printf("[run_mha_fwd_block_hdim32] is_causal = %d\n", (int)Is_causal);
+            // printf("[run_mha_fwd_block_hdim32] is_causal = %d\n", (int)Is_causal);
             run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 64, 64, 4, false, false, T>, Is_dropout, Is_causal>(params, stream);
         });
     });
@@ -399,19 +399,7 @@ void run_mha_fwd_block_hdim64(Flash_fwd_params &params, cudaStream_t stream) {
     constexpr static int Headdim = 64;
     BOOL_SWITCH(params.p_dropout < 1.f, Is_dropout, [&] {
         BOOL_SWITCH(params.is_causal, Is_causal, [&] {
-            if constexpr(!Is_dropout) {
-                // Using 8 warps is 18% slower for seqlen=2k, 2 warps is 5% slower
-                // Using block size (64 x 256) is 27% slower for seqlen=2k
-                // Using block size (256 x 64) is 85% slower for seqlen=2k, because of register spilling
-                run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 64, 64, 4, false, false, T>, Is_dropout, Is_causal>(params, stream);
-                // run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 128, 64, 4, true, false, T>, Is_dropout, Is_causal>(params, stream);
-                // run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 128, 64, 4, true, true, T>, Is_dropout, Is_causal>(params, stream);
-            } else {
-                run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 64, 64, 4, false, false, T>, Is_dropout, Is_causal>(params, stream);
-                // run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 128, 64, 4, true, true, T>, Is_dropout, Is_causal>(params, stream);
-                // run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 128, 64, 4, true, false, T>, Is_dropout, Is_causal>(params, stream);
-                // run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 128, 128, 4, false, false, T>, Is_dropout, Is_causal>(params, stream);
-            }
+            run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 64, 64, 4, false, false, T>, Is_dropout, Is_causal>(params, stream);
         });
     });
 }
@@ -423,32 +411,7 @@ void run_mha_fwd_block_hdim128(Flash_fwd_params &params, cudaStream_t stream) {
     bool is_sm8x = dprops->major == 8 && dprops->minor > 0;
     BOOL_SWITCH(params.p_dropout < 1.f, Is_dropout, [&] {
         BOOL_SWITCH(params.is_causal, Is_causal, [&] {
-            if constexpr(!Is_dropout) {
-                // For sm86 or sm89, 64 x 64 is the fastest for causal (because it's square),
-                // and 128 x 32 (48 KB smem) is the fastest for non-causal since we get 2 CTAs per SM.
-                if (is_sm8x) {
-                    if constexpr(!Is_causal) {
-                        run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 64, 64, 4, false, false, T>, Is_dropout, Is_causal>(params, stream);
-                    } else {
-                        run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 64, 64, 4, false, false, T>, Is_dropout, Is_causal>(params, stream);
-                    }
-                } else {
-                    run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 64, 64, 4, false, false, T>, Is_dropout, Is_causal>(params, stream);
-                }
-                // run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 128, 64, 4, true, false, T>, Is_dropout, Is_causal>(params, stream);
-                // run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 128, 64, 4, true, true, T>, Is_dropout, Is_causal>(params, stream);
-                // run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 64, 128, 4, false, false, T>, Is_dropout, Is_causal>(params, stream);
-                // Using 8 warps (128 x 128 and 256 x 64) is 28% slower for seqlen=2k
-                // run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 128, 128, 8, false, false, T>, Is_dropout, Is_causal>(params, stream);
-                // run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 128, 64, 8, false, false, T>, Is_dropout, Is_causal>(params, stream);
-                // 1st ones are good for H100, A100
-                // 2nd one is good for A6000 bc we get slightly better occupancy
-            } else {
-                run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 64, 64, 4, false, false, T>, Is_dropout, Is_causal>(params, stream);
-                // run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 64, 64, 4, false, false, T>, Is_dropout, Is_causal>(params, stream);
-                // run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 128, 32, 4, true, false, T>, Is_dropout, Is_causal>(params, stream);
-                // run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 128, 32, 4, true, true, T>, Is_dropout, Is_causal>(params, stream);
-            }
+            run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 64, 64, 4, false, false, T>, Is_dropout, Is_causal>(params, stream);
         });
     });
 }

--- a/csrc/flash_attn/src/flash_fwd_launch_template.h
+++ b/csrc/flash_attn/src/flash_fwd_launch_template.h
@@ -388,7 +388,7 @@ void run_mha_fwd_block_hdim32(Flash_fwd_params &params, cudaStream_t stream) {
     constexpr static int Headdim = 32;
     BOOL_SWITCH(params.p_dropout < 1.f, Is_dropout, [&] {
         BOOL_SWITCH(params.is_causal, Is_causal, [&] {
-            run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 64, 64, 4, false, false, T>, Is_dropout, Is_causal>(params, stream);
+            run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 128, 128, 4, false, false, T>, Is_dropout, Is_causal>(params, stream);
         });
     });
 }

--- a/csrc/flash_attn/src/flash_fwd_launch_template.h
+++ b/csrc/flash_attn/src/flash_fwd_launch_template.h
@@ -389,7 +389,7 @@ void run_mha_fwd_block_hdim32(Flash_fwd_params &params, cudaStream_t stream) {
     BOOL_SWITCH(params.p_dropout < 1.f, Is_dropout, [&] {
         BOOL_SWITCH(params.is_causal, Is_causal, [&] {
             printf("[run_mha_fwd_block_hdim32] is_causal = %d\n", (int)Is_causal);
-            run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 128, 128, 4, false, false, T>, Is_dropout, Is_causal>(params, stream);
+            run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 64, 64, 4, false, false, T>, Is_dropout, Is_causal>(params, stream);
         });
     });
 }
@@ -403,11 +403,11 @@ void run_mha_fwd_block_hdim64(Flash_fwd_params &params, cudaStream_t stream) {
                 // Using 8 warps is 18% slower for seqlen=2k, 2 warps is 5% slower
                 // Using block size (64 x 256) is 27% slower for seqlen=2k
                 // Using block size (256 x 64) is 85% slower for seqlen=2k, because of register spilling
-                run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 128, 128, 4, false, false, T>, Is_dropout, Is_causal>(params, stream);
+                run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 64, 64, 4, false, false, T>, Is_dropout, Is_causal>(params, stream);
                 // run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 128, 64, 4, true, false, T>, Is_dropout, Is_causal>(params, stream);
                 // run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 128, 64, 4, true, true, T>, Is_dropout, Is_causal>(params, stream);
             } else {
-                run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 128, 64, 4, false, false, T>, Is_dropout, Is_causal>(params, stream);
+                run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 64, 64, 4, false, false, T>, Is_dropout, Is_causal>(params, stream);
                 // run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 128, 64, 4, true, true, T>, Is_dropout, Is_causal>(params, stream);
                 // run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 128, 64, 4, true, false, T>, Is_dropout, Is_causal>(params, stream);
                 // run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 128, 128, 4, false, false, T>, Is_dropout, Is_causal>(params, stream);

--- a/csrc/flash_attn/src/softmax.h
+++ b/csrc/flash_attn/src/softmax.h
@@ -116,18 +116,18 @@ inline __device__ void max_scale_exp2_sum(Tensor<Engine0, Layout0> &tensor, Tens
 }
 
 
-// add by JXGuo: todo 目前还不完全理解这个函数的作用
+
 
 template <typename Engine, typename Layout>
 inline __device__ void apply_mask(Tensor<Engine, Layout> &tensor, const int max_seqlen_k,
                                   const int col_idx_offset_ = 0) {
-    // tensor has shape (ncol=(2, MMA_M), nrow=(2, MMA_N)) // add by JXGuo: 此处基本理解了
+    // tensor has shape (ncol=(2, MMA_M), nrow=(2, MMA_N))
     static_assert(Layout::rank == 2, "Only support 2D Tensor");
     const int lane_id = threadIdx.x % 32;
     const int col_idx_offset = col_idx_offset_ + (lane_id % 4) * 2;
     #pragma unroll
     for (int nj = 0; nj < size<1, 1>(tensor); ++nj) {
-        const int col_idx_base = col_idx_offset + nj * 8; // add by JXGuo: 为什么乘8不是乘4
+        const int col_idx_base = col_idx_offset + nj * 8;
         #pragma unroll
         for (int j = 0; j < size<1, 0>(tensor); ++j) {
             const int col_idx = col_idx_base + j;
@@ -227,7 +227,7 @@ inline __device__ void apply_dropout(Tensor<Engine, Layout> &tensor, uint8_t p_d
     auto encode_dropout = [](bool keep, T val) {
         return keep ? val : (encode_dropout_in_sign_bit ? -val : T(0));
     };
-    static_assert(decltype(size<2>(tensor))::value % 2 == 0); // add by JXGuo: 用于检查tensor的第二个维度大小是否为偶数
+    static_assert(decltype(size<2>(tensor))::value % 2 == 0);
     const uint16_t p_dropout_8bit_in_uint16_t = uint16_t(p_dropout_in_uint8_t);
     const uint32_t p_dropout_8bit_in_uint32_t = (uint32_t(p_dropout_8bit_in_uint16_t) << 16) | uint32_t(p_dropout_8bit_in_uint16_t);
     // if (cute::thread0()) { printf("threshold2 = 0x%x\n", p_dropout_8bit_in_uint32_t); }

--- a/csrc/flash_attn/src/softmax.h
+++ b/csrc/flash_attn/src/softmax.h
@@ -115,16 +115,19 @@ inline __device__ void max_scale_exp2_sum(Tensor<Engine0, Layout0> &tensor, Tens
     }
 }
 
+
+// add by JXGuo: todo 目前还不完全理解这个函数的作用
+
 template <typename Engine, typename Layout>
 inline __device__ void apply_mask(Tensor<Engine, Layout> &tensor, const int max_seqlen_k,
                                   const int col_idx_offset_ = 0) {
-    // tensor has shape (ncol=(2, MMA_M), nrow=(2, MMA_N))
+    // tensor has shape (ncol=(2, MMA_M), nrow=(2, MMA_N)) // add by JXGuo: 此处基本理解了
     static_assert(Layout::rank == 2, "Only support 2D Tensor");
     const int lane_id = threadIdx.x % 32;
     const int col_idx_offset = col_idx_offset_ + (lane_id % 4) * 2;
     #pragma unroll
     for (int nj = 0; nj < size<1, 1>(tensor); ++nj) {
-        const int col_idx_base = col_idx_offset + nj * 8;
+        const int col_idx_base = col_idx_offset + nj * 8; // add by JXGuo: 为什么乘8不是乘4
         #pragma unroll
         for (int j = 0; j < size<1, 0>(tensor); ++j) {
             const int col_idx = col_idx_base + j;

--- a/csrc/flash_attn/src/softmax.h
+++ b/csrc/flash_attn/src/softmax.h
@@ -224,7 +224,7 @@ inline __device__ void apply_dropout(Tensor<Engine, Layout> &tensor, uint8_t p_d
     auto encode_dropout = [](bool keep, T val) {
         return keep ? val : (encode_dropout_in_sign_bit ? -val : T(0));
     };
-    static_assert(decltype(size<2>(tensor))::value % 2 == 0);
+    static_assert(decltype(size<2>(tensor))::value % 2 == 0); // add by JXGuo: 用于检查tensor的第二个维度大小是否为偶数
     const uint16_t p_dropout_8bit_in_uint16_t = uint16_t(p_dropout_in_uint8_t);
     const uint32_t p_dropout_8bit_in_uint32_t = (uint32_t(p_dropout_8bit_in_uint16_t) << 16) | uint32_t(p_dropout_8bit_in_uint16_t);
     // if (cute::thread0()) { printf("threshold2 = 0x%x\n", p_dropout_8bit_in_uint32_t); }

--- a/csrc/flash_attn/src/static_switch.h
+++ b/csrc/flash_attn/src/static_switch.h
@@ -74,5 +74,9 @@
     } else if (HEADDIM <= 64) {               \
       constexpr static int kHeadDim = 64;     \
       return __VA_ARGS__();                   \
+    } else if (HEADDIM <= 128) {           \
+      constexpr static int kHeadDim = 128; \
+      return __VA_ARGS__();                \
     }                                         \
   }()
+  

--- a/csrc/flash_attn/src/static_switch.h
+++ b/csrc/flash_attn/src/static_switch.h
@@ -64,3 +64,15 @@
       return __VA_ARGS__();                \
     }                                      \
   }()
+
+// add by JXGuo
+#define FWD_BLOCK_HEADDIM_SWITCH(HEADDIM, ...)\
+  [&] {                                       \
+    if (HEADDIM <= 32) {                      \
+      constexpr static int kHeadDim = 32;     \
+      return __VA_ARGS__();                   \
+    } else if (HEADDIM <= 64) {               \
+      constexpr static int kHeadDim = 64;     \
+      return __VA_ARGS__();                   \
+    }                                         \
+  }()

--- a/csrc/flash_attn/src/static_switch.h
+++ b/csrc/flash_attn/src/static_switch.h
@@ -65,7 +65,7 @@
     }                                      \
   }()
 
-// add by JXGuo
+
 #define FWD_BLOCK_HEADDIM_SWITCH(HEADDIM, ...)\
   [&] {                                       \
     if (HEADDIM <= 32) {                      \

--- a/flash_attn/flash_blocksparse_attn_interface.py
+++ b/flash_attn/flash_blocksparse_attn_interface.py
@@ -1,9 +1,9 @@
 # Adapted from https://github.com/mlcommons/training_results_v1.1/blob/main/NVIDIA/benchmarks/bert/implementations/pytorch/fmha.py
-import flash_attn_cuda
+import flash_attn_2_cuda
 import torch
 import torch.nn as nn
 
-
+# modified by JXGuo
 def convert_blockmask(blockmask, causal):
     """Convert from the 0-1 format to the format used by the CUDA code.
     0 means the block is skipped.
@@ -22,7 +22,10 @@ def convert_blockmask(blockmask, causal):
     nrow, ncol = blockmask.shape
     # Sort does not support bool on CUDA
     blockmask = blockmask.to(dtype=torch.uint8)
-    nonzero_val, nonzero_sorted_rowidx = blockmask.sort(dim=0, stable=True, descending=True)
+    nonzero_val, nonzero_sorted_rowidx = blockmask.sort(dim=0, stable=True, ascending=True)
+    print("nonzero_val: ", nonzero_val)
+    print("nonzero_sorted_rowidx: ", nonzero_sorted_rowidx)
+    
     nonzero_unsorted_rowidx = nonzero_sorted_rowidx.argsort(dim=0)
     last_nonzero_col_per_row = blockmask.sort(dim=-1, stable=True).indices[:, -1]
     last_nonzero_col_per_row_after_sort = nonzero_unsorted_rowidx[
@@ -33,16 +36,48 @@ def convert_blockmask(blockmask, causal):
         torch.arange(nrow, device=blockmask.device), first_nonzero_col_per_row
     ]
     nonzero_idx = nonzero_sorted_rowidx * 4
-    nonzero_idx[last_nonzero_col_per_row_after_sort, last_nonzero_col_per_row] += 2
-    nonzero_idx[first_nonzero_col_per_row_after_sort, first_nonzero_col_per_row] += 1
+    nonzero_idx[last_nonzero_col_per_row_after_sort, last_nonzero_col_per_row] += 1
+    nonzero_idx[first_nonzero_col_per_row_after_sort, first_nonzero_col_per_row] += 2
     nonzero_idx[nonzero_val == 0] = -1
+    return nonzero_idx.T.contiguous().to(dtype=torch.int32)
+
+
+def convert_blockmask_reverse(blockmask, causal):
+    assert not causal
+    # TD [2022-05-13]: The indexing and sorting is very tricky
+    nrow, ncol = blockmask.shape
+    # Sort does not support bool on CUDA
+    blockmask = blockmask.to(dtype=torch.uint8)
+    nonzero_val, nonzero_sorted_rowidx = blockmask.sort(dim=0, stable=True, descending=False)
+    # print("nonzero_val: ", nonzero_val)
+    # print("nonzero_sorted_rowidx: ", nonzero_sorted_rowidx)
+    
+    nonzero_unsorted_rowidx = nonzero_sorted_rowidx.argsort(dim=0)
+    last_nonzero_col_per_row = blockmask.sort(dim=-1, stable=True).indices[:, -1]
+    last_nonzero_col_per_row_after_sort = nonzero_unsorted_rowidx[
+        torch.arange(nrow, device=blockmask.device), last_nonzero_col_per_row
+    ]
+    first_nonzero_col_per_row = blockmask.sort(dim=-1, stable=True, descending=True).indices[:, 0]
+    first_nonzero_col_per_row_after_sort = nonzero_unsorted_rowidx[
+        torch.arange(nrow, device=blockmask.device), first_nonzero_col_per_row
+    ]
+    nonzero_idx = nonzero_sorted_rowidx * 4
+    nonzero_idx[last_nonzero_col_per_row_after_sort, last_nonzero_col_per_row] += 1
+    nonzero_idx[first_nonzero_col_per_row_after_sort, first_nonzero_col_per_row] += 2
+    nonzero_idx[nonzero_val == 0] = -1
+    
+    # print ("nonzero_idx: ", nonzero_idx)
+    
+    nonzero_idx = torch.flip(nonzero_idx, dims=[0])
+    # print("nonzero_idx: ", nonzero_idx)
+    
     return nonzero_idx.T.contiguous().to(dtype=torch.int32)
 
 
 def _flash_blocksparse_attn_forward(
     qkv, cu_seqlens, blockmask, dropout_p, max_s, softmax_scale, causal, return_softmax
 ):
-    context, softmax_lse, *rest = flash_attn_cuda.fwd_block(
+    context, softmax_lse, *rest = flash_attn_2_cuda.fwd_block(
         qkv, cu_seqlens, blockmask, dropout_p, max_s, softmax_scale, causal, return_softmax, None
     )
     # if context.isnan().any() or softmax_lse.isnan().any():
@@ -64,23 +99,24 @@ def _flash_blocksparse_attn_backward(
     softmax_scale,
     causal,
 ):
-    dqkv, dp, softmax_d = flash_attn_cuda.bwd_block(
-        dout,
-        qkv,
-        out,
-        S_dmask,
-        softmax_lse,
-        cu_seqlens,
-        blockmask,
-        dropout_p,
-        softmax_scale,
-        max_s,
-        causal,
-        None,
-    )
-    # if dqkv.isnan().any() or softmax_d.isnan().any():
-    #     breakpoint()
-    return dqkv
+    # dqkv, dp, softmax_d = flash_attn_2_cuda.bwd_block(
+    #     dout,
+    #     qkv,
+    #     out,
+    #     S_dmask,
+    #     softmax_lse,
+    #     cu_seqlens,
+    #     blockmask,
+    #     dropout_p,
+    #     softmax_scale,
+    #     max_s,
+    #     causal,
+    #     None,
+    # )
+    # # if dqkv.isnan().any() or softmax_d.isnan().any():
+    # #     breakpoint()
+    # return dqkv
+    return None
 
 
 class FlashBlocksparseAttnFun(torch.autograd.Function):

--- a/flash_attn/flash_blocksparse_attn_interface.py
+++ b/flash_attn/flash_blocksparse_attn_interface.py
@@ -62,8 +62,8 @@ def convert_blockmask_reverse(blockmask, causal):
         torch.arange(nrow, device=blockmask.device), first_nonzero_col_per_row
     ]
     nonzero_idx = nonzero_sorted_rowidx * 4
-    nonzero_idx[last_nonzero_col_per_row_after_sort, last_nonzero_col_per_row] += 1
-    nonzero_idx[first_nonzero_col_per_row_after_sort, first_nonzero_col_per_row] += 2
+    nonzero_idx[last_nonzero_col_per_row_after_sort, last_nonzero_col_per_row] += 2
+    nonzero_idx[first_nonzero_col_per_row_after_sort, first_nonzero_col_per_row] += 1
     nonzero_idx[nonzero_val == 0] = -1
     
     # print ("nonzero_idx: ", nonzero_idx)

--- a/setup.py
+++ b/setup.py
@@ -189,10 +189,10 @@ if not SKIP_CUDA_BUILD:
                 "csrc/flash_attn/src/flash_fwd_block_hdim64_bf16_sm80.cu",
             ],
             extra_compile_args={
-                "cxx": ["-O0", "-std=c++17"] + generator_flag,
+                "cxx": ["-O3", "-std=c++17"] + generator_flag,
                 "nvcc": append_nvcc_threads(
                     [
-                        "-O0",
+                        "-O3",
                         "-std=c++17",
                         "-U__CUDA_NO_HALF_OPERATORS__",
                         "-U__CUDA_NO_HALF_CONVERSIONS__",

--- a/setup.py
+++ b/setup.py
@@ -187,12 +187,14 @@ if not SKIP_CUDA_BUILD:
                 "csrc/flash_attn/src/flash_fwd_block_hdim32_bf16_sm80.cu",
                 "csrc/flash_attn/src/flash_fwd_block_hdim64_fp16_sm80.cu",
                 "csrc/flash_attn/src/flash_fwd_block_hdim64_bf16_sm80.cu",
+                "csrc/flash_attn/src/flash_fwd_block_hdim128_fp16_sm80.cu",
+                "csrc/flash_attn/src/flash_fwd_block_hdim128_bf16_sm80.cu",
             ],
             extra_compile_args={
-                "cxx": ["-O3", "-std=c++17"] + generator_flag,
+                "cxx": ["-O0", "-std=c++17"] + generator_flag,
                 "nvcc": append_nvcc_threads(
                     [
-                        "-O3",
+                        "-O0",
                         "-std=c++17",
                         "-U__CUDA_NO_HALF_OPERATORS__",
                         "-U__CUDA_NO_HALF_CONVERSIONS__",

--- a/setup.py
+++ b/setup.py
@@ -182,6 +182,11 @@ if not SKIP_CUDA_BUILD:
                 "csrc/flash_attn/src/flash_fwd_split_hdim224_bf16_sm80.cu",
                 "csrc/flash_attn/src/flash_fwd_split_hdim256_fp16_sm80.cu",
                 "csrc/flash_attn/src/flash_fwd_split_hdim256_bf16_sm80.cu",
+                # add by JXGuo
+                "csrc/flash_attn/src/flash_fwd_block_hdim32_fp16_sm80.cu",
+                "csrc/flash_attn/src/flash_fwd_block_hdim32_bf16_sm80.cu",
+                "csrc/flash_attn/src/flash_fwd_block_hdim64_fp16_sm80.cu",
+                "csrc/flash_attn/src/flash_fwd_block_hdim64_bf16_sm80.cu",
             ],
             extra_compile_args={
                 "cxx": ["-O3", "-std=c++17"] + generator_flag,

--- a/setup.py
+++ b/setup.py
@@ -191,10 +191,10 @@ if not SKIP_CUDA_BUILD:
                 "csrc/flash_attn/src/flash_fwd_block_hdim128_bf16_sm80.cu",
             ],
             extra_compile_args={
-                "cxx": ["-O3", "-std=c++17"] + generator_flag,
+                "cxx": ["-O0", "-std=c++17"] + generator_flag,
                 "nvcc": append_nvcc_threads(
                     [
-                        "-O3",
+                        "-O0",
                         "-std=c++17",
                         "-U__CUDA_NO_HALF_OPERATORS__",
                         "-U__CUDA_NO_HALF_CONVERSIONS__",

--- a/setup.py
+++ b/setup.py
@@ -191,10 +191,10 @@ if not SKIP_CUDA_BUILD:
                 "csrc/flash_attn/src/flash_fwd_block_hdim128_bf16_sm80.cu",
             ],
             extra_compile_args={
-                "cxx": ["-O0", "-std=c++17"] + generator_flag,
+                "cxx": ["-O3", "-std=c++17"] + generator_flag,
                 "nvcc": append_nvcc_threads(
                     [
-                        "-O0",
+                        "-O3",
                         "-std=c++17",
                         "-U__CUDA_NO_HALF_OPERATORS__",
                         "-U__CUDA_NO_HALF_CONVERSIONS__",

--- a/setup.py
+++ b/setup.py
@@ -189,10 +189,10 @@ if not SKIP_CUDA_BUILD:
                 "csrc/flash_attn/src/flash_fwd_block_hdim64_bf16_sm80.cu",
             ],
             extra_compile_args={
-                "cxx": ["-O3", "-std=c++17"] + generator_flag,
+                "cxx": ["-O0", "-std=c++17"] + generator_flag,
                 "nvcc": append_nvcc_threads(
                     [
-                        "-O3",
+                        "-O0",
                         "-std=c++17",
                         "-U__CUDA_NO_HALF_OPERATORS__",
                         "-U__CUDA_NO_HALF_CONVERSIONS__",


### PR DESCRIPTION
I try to add the blocksparse support for flash attention2, and I test the correctness by comparing the output of my code and the output of the blocksparse feature provided in flash attention1. And I use the following code to test:
```{python}
from flash_attn1.flash_blocksparse_attn_interface import convert_blockmask
from flash_attn1.flash_blocksparse_attn_interface import flash_attn_cuda
from flash_attn.flash_blocksparse_attn_interface import flash_attn_2_cuda
from flash_attn.flash_blocksparse_attn_interface import convert_blockmask_reverse

import numpy as np
np.set_printoptions(threshold=np.inf)
import torch



def run():
    shape = (1, 2048, 1, 64)
    dropout = 0.0
    scale = shape[-1] ** (-0.5)
    is_causal = False
    
    q = torch.randn(shape, dtype=torch.float16).to(device="cuda:0")
    q.requires_grad = True
    batch_size, seqlen, num_head, head_dim = q.shape
    qt = q.reshape((batch_size * seqlen, q.shape[2], q.shape[3]))
    
    cu_seqlens = torch.arange(0, (batch_size + 1) * seqlen, step=seqlen, dtype=torch.int32, device=q.device)
    
    
    base_blockmask = torch.randint(0, 2, (seqlen // 64, seqlen // 256), dtype=torch.int32)
    
    
    blockmask1 = torch.zeros((seqlen//16, seqlen//256), dtype=torch.int32)
    for i in range(blockmask1.shape[0]):
        for j in range(blockmask1.shape[1]):
            blockmask1[i, j] = base_blockmask[i//4, j]
    blockmask1 = blockmask1.to(device="cuda:0")
    
    print("blockmask1: ", blockmask1)
    blockmask1 = convert_blockmask(blockmask1, is_causal)
    
    blockmask2 = torch.zeros((seqlen//64, seqlen//64), dtype=torch.int32)
    for i in range(blockmask2.shape[0]):
        for j in range(blockmask2.shape[1]):
            blockmask2[i, j] = base_blockmask[i, j // 4]
    blockmask2 = blockmask2.to(device="cuda:0")
    print("[blockmask2] ", blockmask2)
    blockmask2 = convert_blockmask_reverse(blockmask2, is_causal)
    
    

    
    out1, lse1 = flash_attn_cuda.fwd_block(qt, qt, qt, cu_seqlens, cu_seqlens, blockmask1, seqlen, seqlen, dropout, scale, is_causal, False, None)
    out2, lse2 = flash_attn_2_cuda.fwd_block(qt, qt, qt, cu_seqlens, cu_seqlens, blockmask2, seqlen, seqlen, dropout, scale, is_causal, False, None)
    
    
    out1_base = torch.empty_like(out1)
    lse =  lse, _ = flash_attn_cuda.fwd(qt, qt, qt, out1_base, cu_seqlens, cu_seqlens, seqlen, seqlen, dropout, scale, False, False, False, 1, None)
    out2_base = torch.empty_like(out2)
    lse = flash_attn_2_cuda.varlen_fwd(qt, qt, qt, out2_base, cu_seqlens, cu_seqlens, seqlen, seqlen, dropout, scale, False,  is_causal, -1, -1, False, None)


    def print_diff(a, b, name="OK"):
        print("--"*10)
        try:
            np.testing.assert_allclose(a, b)
            print(name, "OK")
        except Exception as e:
            print(name, e)

        
        
    print("[diff]: ")
    
    hold = np.array(out2.cpu()) - np.array(out1.cpu())
    for i in range (hold.shape[0]):
        print("[diff %d row]: " % i, hold[i])

    
    print_diff(out1_base.cpu(), out2_base.cpu(), "out1b2b")
    print_diff(out1.cpu(), out2.cpu(), "out12")
    # print_diff(out1_base.cpu(), out1.cpu(), "out1b1")
    # print_diff(out2_base.cpu(), out2.cpu(), "out2b2")
    
    # print("base_blockmask: ", base_blockmask)
    print("[blockmask1] ", blockmask1)
    print("[blockmask2] ", blockmask2)

run()
```

For hdim=32 or hdim=64, the difference between the output of my code and the counterpart in flash attention1 is similar to that between the output of flash attention1 and flash attention2 (as is shown below). And for hdim=128, I did not test myself.

<img width="481" alt="image" src="https://github.com/Dao-AILab/flash-attention/assets/92502485/7347751a-0dbf-4b76-af6b-5c5bf9e2091b">


