### PR TITLE
[feat] deterministic backward atomicAdd version

### DIFF
--- a/csrc/flash_attn/flash_api.cpp
+++ b/csrc/flash_attn/flash_api.cpp
@@ -956,11 +956,17 @@ mha_bwd(const at::Tensor &dout,  // batch_size x seqlen_q x num_heads, x head_si
                      window_size_right,
                      is_deterministic);
 
-    if(is_deterministic) {
+    if (is_deterministic) {
         // TODO: workaround this limitation later
-        TORCH_CHECK(workspace_.has_value(), "If Is_deterministic is true, extra workspace needed.");
         TORCH_CHECK(window_size_left == -1 && window_size_right <= 0, "If Is_deterministic is true, Is_local should be false.");
-        at::Tensor workspace = workspace_.value();
+        at::Tensor workspace;
+        if (workspace_.has_value()) {
+            workspace = workspace_.value();
+        } else {
+            TORCH_WARN("If is_deterministic is true, extra workspace needed.");
+            size_t workspace_size = get_mha_bwd_workspace_size(params);
+            workspace = torch::zeros({workspace_size}, opts.dtype(at::kInt));
+        }
         params.workspace = static_cast<int *>(workspace.data_ptr());
     }
 
@@ -1199,11 +1205,17 @@ mha_varlen_bwd(const at::Tensor &dout,  // total_q x num_heads, x head_size
                      window_size_right,
                      is_deterministic);
 
-    if(is_deterministic) {
+    if (is_deterministic) {
         // TODO: workaround this limitation later
-        TORCH_CHECK(workspace_.has_value(), "If Is_deterministic is true, extra workspace needed.");
         TORCH_CHECK(window_size_left == -1 && window_size_right <= 0, "If Is_deterministic is true, Is_local should be false.");
-        at::Tensor workspace = workspace_.value();
+        at::Tensor workspace;
+        if (workspace_.has_value()) {
+            workspace = workspace_.value();
+        } else {
+            TORCH_WARN("If is_deterministic is true, extra workspace needed.");
+            size_t workspace_size = get_mha_bwd_workspace_size(params);
+            workspace = torch::zeros({workspace_size}, opts.dtype(at::kInt));
+        }
         params.workspace = static_cast<int *>(workspace.data_ptr());
     }
 

--- a/csrc/flash_attn/flash_api.cpp
+++ b/csrc/flash_attn/flash_api.cpp
@@ -639,6 +639,8 @@ size_t mha_bwd_workspace_size(const int blockM, Flash_bwd_params &params) {
 }
 
 size_t get_mha_bwd_workspace_size_hdim32(Flash_bwd_params &params) {
+    return mha_bwd_workspace_size(128, params);
+    /*
     constexpr static int Headdim = 32;
     int device;
     cudaGetDevice(&device);
@@ -651,6 +653,7 @@ size_t get_mha_bwd_workspace_size_hdim32(Flash_bwd_params &params) {
     } else {  // 96 KB
         return mha_bwd_workspace_size(128, params);
     }
+    */
 }
 
 size_t get_mha_bwd_workspace_size_hdim64(Flash_bwd_params &params) {
@@ -669,7 +672,9 @@ size_t get_mha_bwd_workspace_size_hdim64(Flash_bwd_params &params) {
 }
 
 size_t get_mha_bwd_workspace_size_hdim96(Flash_bwd_params &params) {
-    // constexpr static int Headdim = 96;
+    return mha_bwd_workspace_size(64, params);
+    /*
+    constexpr static int Headdim = 96;
     int device;
     cudaGetDevice(&device);
     int max_smem_per_block;
@@ -682,10 +687,13 @@ size_t get_mha_bwd_workspace_size_hdim96(Flash_bwd_params &params) {
     } else {
         return mha_bwd_workspace_size(64, params);
     }
+    */
 }
 
 size_t get_mha_bwd_workspace_size_hdim128(Flash_bwd_params &params) {
-    // constexpr static int Headdim = 128;
+    return mha_bwd_workspace_size(64, params);
+    /*
+    constexpr static int Headdim = 128;
     int device;
     cudaGetDevice(&device);
     int max_smem_per_block;
@@ -697,10 +705,13 @@ size_t get_mha_bwd_workspace_size_hdim128(Flash_bwd_params &params) {
     } else {
         return mha_bwd_workspace_size(64, params);
     }
+    */
 }
 
 size_t get_mha_bwd_workspace_size_hdim160(Flash_bwd_params &params) {
-    // constexpr static int Headdim = 160;
+    return mha_bwd_workspace_size(64, params);
+    /*
+    constexpr static int Headdim = 160;
     int device;
     cudaGetDevice(&device);
     int max_smem_per_block;
@@ -712,10 +723,13 @@ size_t get_mha_bwd_workspace_size_hdim160(Flash_bwd_params &params) {
     } else {
         return mha_bwd_workspace_size(64, params);
     }
+    */
 }
 
 size_t get_mha_bwd_workspace_size_hdim192(Flash_bwd_params &params) {
-    // constexpr static int Headdim = 192;
+    return mha_bwd_workspace_size(64, params);
+    /*
+    constexpr static int Headdim = 192;
     int device;
     cudaGetDevice(&device);
     int max_smem_per_block;
@@ -726,6 +740,7 @@ size_t get_mha_bwd_workspace_size_hdim192(Flash_bwd_params &params) {
     } else {
         return mha_bwd_workspace_size(64, params);
     }
+    */
 }
 
 size_t get_mha_bwd_workspace_size_hdim224(Flash_bwd_params &params) {
@@ -734,7 +749,9 @@ size_t get_mha_bwd_workspace_size_hdim224(Flash_bwd_params &params) {
 }
 
 size_t get_mha_bwd_workspace_size_hdim256(Flash_bwd_params &params) {
-    // constexpr static int Headdim = 256;
+    return mha_bwd_workspace_size(64, params);
+    /*
+    constexpr static int Headdim = 256;
     int device;
     cudaGetDevice(&device);
     int max_smem_per_block;
@@ -745,6 +762,7 @@ size_t get_mha_bwd_workspace_size_hdim256(Flash_bwd_params &params) {
     } else {  // A100, we don't do double buffering to save smem
         return mha_bwd_workspace_size(64, params);
     }
+    */
 }
 
 size_t get_mha_bwd_workspace_size(Flash_bwd_params &params) {

--- a/csrc/flash_attn/src/flash.h
+++ b/csrc/flash_attn/src/flash.h
@@ -169,6 +169,10 @@ struct Flash_bwd_params : public Flash_fwd_params {
 
     // The pointer to the softmax d sum.
     void *__restrict__ dsoftmax_sum;
+    // The pointer to the workspace needed by semaphore.
+    int *workspace;
+
+    bool is_deterministic;
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/csrc/flash_attn/src/flash_bwd_kernel.h
+++ b/csrc/flash_attn/src/flash_bwd_kernel.h
@@ -997,7 +997,7 @@ inline __device__ void compute_dq_dk_dv_1colblock(const Params &params, const in
                 // if (cute::thread0()) { print(acc_dq.layout()); printf("\n"); print(acc_dq_reshaped.layout()); printf("\n"); print(tdQgdQaccum.layout()); printf("\n"); }
                 CUTE_STATIC_ASSERT_V(size(acc_dq) == size(tdQgdQaccum));
                 if (Is_deterministic) {
-                    int storage_id = (bidb * cute::ceil_div(params.seqlen_q_rounded, kBlockM) + m_block) * params.h + bidh;
+                    int storage_id = (bidb * m_block_max + m_block) * params.h + bidh;
                     // Fetch the synchronization lock initially but do not block.
                     semaphore.fetch(params.workspace + storage_id);
                     semaphore.wait(params.workspace + storage_id, blockIdx.x);

--- a/csrc/flash_attn/src/flash_bwd_kernel.h
+++ b/csrc/flash_attn/src/flash_bwd_kernel.h
@@ -997,7 +997,7 @@ inline __device__ void compute_dq_dk_dv_1colblock(const Params &params, const in
                 // if (cute::thread0()) { print(acc_dq.layout()); printf("\n"); print(acc_dq_reshaped.layout()); printf("\n"); print(tdQgdQaccum.layout()); printf("\n"); }
                 CUTE_STATIC_ASSERT_V(size(acc_dq) == size(tdQgdQaccum));
                 if (Is_deterministic) {
-                    int storage_id = (bidb * m_block_max + m_block) * params.h + bidh;
+                    int storage_id = (bidb * cute::ceil_div(params.seqlen_q_rounded, kBlockM) + m_block) * params.h + bidh;
                     // Fetch the synchronization lock initially but do not block.
                     semaphore.fetch(params.workspace + storage_id);
                     semaphore.wait(params.workspace + storage_id, blockIdx.x);

--- a/csrc/flash_attn/src/flash_bwd_kernel.h
+++ b/csrc/flash_attn/src/flash_bwd_kernel.h
@@ -674,6 +674,7 @@ inline __device__ void compute_dq_dk_dv_1colblock(const Params &params, const in
     // Otherwise we get wrong result for the case where we don't enter the for loop.
     // And we might read OOB elements from gQ and gdO.
     // This also covers the case where actual_seqlen_q == 0
+
     if ((Is_local || !Is_even_MN) && m_block < m_block_min) {
         const index_t row_offset_dk = binfo.k_offset(params.dk_batch_stride, params.dk_row_stride, bidb)
           + n_block * kBlockN * params.dk_row_stride + bidh * params.dk_head_stride;
@@ -1005,10 +1006,11 @@ inline __device__ void compute_dq_dk_dv_1colblock(const Params &params, const in
                     for (int i = 0; i < size(acc_dq); ++i) { atomicAdd(&tdQgdQaccum(i), acc_dq(i)); }
                     // If the workspace data is not initialized to zero,
                     // then this commented-out code needs to be executed.
-                    // if (blockIdx.x == (gridDim.x - 1)) { //
+                    // if (blockIdx.x == (gridDim.x - 1)) {
                     //     semaphore.release(params.workspace + storage_id, 0);
                     // } else {
-                        semaphore.release(params.workspace + storage_id, blockIdx.x + 1); 
+                        semaphore.release(params.workspace + storage_id, blockIdx.x + 1);
+                    // }
                 } else {
                     #pragma unroll
                     for (int i = 0; i < size(acc_dq); ++i) { atomicAdd(&tdQgdQaccum(i), acc_dq(i)); }

--- a/csrc/flash_attn/src/flash_bwd_launch_template.h
+++ b/csrc/flash_attn/src/flash_bwd_launch_template.h
@@ -23,10 +23,10 @@ __global__ void flash_bwd_dq_dk_dv_loop_kernel(Flash_bwd_params params) {
     flash::compute_dq_dk_dv<Kernel_traits, Is_dropout, Is_causal, Is_even_M, Is_even_K>(params);
 }
 
-template<typename Kernel_traits, bool Is_dropout, bool Is_causal, bool Is_local, bool Is_even_MN, bool Is_even_K>
+template<typename Kernel_traits, bool Is_dropout, bool Is_causal, bool Is_local, bool Is_even_MN, bool Is_even_K, bool Is_deterministic>
 __global__ void flash_bwd_dq_dk_dv_loop_seqk_parallel_kernel(Flash_bwd_params params) {
     static_assert(!(Is_causal && Is_local));  // If Is_local is true, Is_causal should be false
-    flash::compute_dq_dk_dv_seqk_parallel<Kernel_traits, Is_dropout, Is_causal, Is_local, Is_even_MN, Is_even_K>(params);
+    flash::compute_dq_dk_dv_seqk_parallel<Kernel_traits, Is_dropout, Is_causal, Is_local, Is_even_MN, Is_even_K, Is_deterministic>(params);
 }
 
 template<typename Kernel_traits, bool Is_dropout, bool Is_causal, bool Is_even_N, bool Is_even_K>
@@ -60,21 +60,23 @@ void run_flash_bwd_seqk_parallel(Flash_bwd_params &params, cudaStream_t stream, 
     const bool is_even_K = params.d == Kernel_traits::kHeadDim;
     constexpr int smem_size_dq_dk_dv = Kernel_traits::kSmemSize1colblock;
     // printf("smem_size_dq_dk_dv = %d\n", smem_size_dq_dk_dv);
-    BOOL_SWITCH(params.is_causal, Is_causal, [&] {
-        BOOL_SWITCH(is_even_MN, IsEvenMNConst, [&] {
-            BOOL_SWITCH(is_even_K, IsEvenKConst, [&] {
-                BOOL_SWITCH((params.window_size_left >= 0 || params.window_size_right >= 0) && !params.is_causal, Is_local, [&] {
-                    // If not IsEvenKConst, we also set IsEvenMNConst to false to reduce number of templates.
-                    // If head dim > 128, set IsEvenMNConst to false to reduce number of templates
-                    // If Is_local, set Is_causal to false
-                    auto kernel = &flash_bwd_dq_dk_dv_loop_seqk_parallel_kernel<Kernel_traits, Is_dropout, Is_causal, Is_local && !Is_causal, IsEvenMNConst && IsEvenKConst && !Is_local && Kernel_traits::kHeadDim <= 128, IsEvenKConst>;
-                    // auto kernel = &flash_bwd_dq_dk_dv_loop_seqk_parallel_kernel<Kernel_traits, Is_dropout, Is_causal, IsEvenMNConst, true>;
-                    if (smem_size_dq_dk_dv >= 48 * 1024)  {
-                        C10_CUDA_CHECK(cudaFuncSetAttribute(
-                            kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size_dq_dk_dv));
-                    }
-                    kernel<<<grid_n, Kernel_traits::kNThreads, smem_size_dq_dk_dv, stream>>>(params);
-                    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    BOOL_SWITCH(params.is_deterministic, IsDeterministic, [&] {
+        BOOL_SWITCH(params.is_causal, Is_causal, [&] {
+            BOOL_SWITCH(is_even_MN, IsEvenMNConst, [&] {
+                BOOL_SWITCH(is_even_K, IsEvenKConst, [&] {
+                    BOOL_SWITCH((params.window_size_left >= 0 || params.window_size_right >= 0) && !params.is_causal, Is_local, [&] {
+                        // If not IsEvenKConst, we also set IsEvenMNConst to false to reduce number of templates.
+                        // If head dim > 128, set IsEvenMNConst to false to reduce number of templates
+                        // If Is_local, set Is_causal to false
+                        auto kernel = &flash_bwd_dq_dk_dv_loop_seqk_parallel_kernel<Kernel_traits, Is_dropout, Is_causal, Is_local && !Is_causal, IsEvenMNConst && IsEvenKConst && !Is_local && Kernel_traits::kHeadDim <= 128, IsEvenKConst, IsDeterministic>;
+                        // auto kernel = &flash_bwd_dq_dk_dv_loop_seqk_parallel_kernel<Kernel_traits, Is_dropout, Is_causal, IsEvenMNConst, true>;
+                        if (smem_size_dq_dk_dv >= 48 * 1024)  {
+                            C10_CUDA_CHECK(cudaFuncSetAttribute(
+                                kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size_dq_dk_dv));
+                        }
+                        kernel<<<grid_n, Kernel_traits::kNThreads, smem_size_dq_dk_dv, stream>>>(params);
+                        C10_CUDA_KERNEL_LAUNCH_CHECK();
+                    });
                 });
             });
         });

--- a/csrc/flash_attn/src/flash_semaphore.h
+++ b/csrc/flash_attn/src/flash_semaphore.h
@@ -1,0 +1,61 @@
+// modify from: cutass/include/cutlass/semaphore.h
+
+#include "cuda_runtime.h"
+
+namespace flash {
+
+/// CTA-wide semaphore for inter-CTA synchronization.
+class FlashSemaphore { 
+public:
+
+  bool wait_thread;
+  int state;
+
+public:
+
+  /// Implements a semaphore to wait for a flag to reach a given value
+  inline __device__ FlashSemaphore(int thread_id): 
+    wait_thread(thread_id < 0 || thread_id == 0),
+    state(-1) {
+
+  }
+
+  /// Permit fetching the synchronization mechanism early
+  inline __device__ void fetch(int* lock) {
+    if (wait_thread) {
+      #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 700
+      asm volatile ("ld.global.acquire.gpu.b32 %0, [%1];\n" : "=r"(state) : "l"(lock));  
+      #else
+      asm volatile ("ld.global.cg.b32 %0, [%1];\n" : "=r"(state) : "l"(lock));  
+      #endif
+    }
+  }
+
+  /// Gets the internal state
+  inline __device__ int get_state() const {
+    return state;
+  }
+
+  /// Waits until the semaphore is equal to the given value
+  inline __device__ void wait(int* lock, int status = 0) {
+    while( __syncthreads_and(state != status) ) {
+        fetch(lock);
+    }
+    __syncthreads();
+  }
+
+  /// Updates the lock with the given result
+  inline __device__ void release(int* lock, int status = 0) {
+    __syncthreads();
+
+    if (wait_thread) {
+      #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 700
+      asm volatile ("st.global.release.gpu.b32 [%0], %1;\n" : : "l"(lock), "r"(status));
+      #else
+      asm volatile ("st.global.cg.b32 [%0], %1;\n" : : "l"(lock), "r"(status));
+      #endif
+    }
+  }
+};
+
+} // namespace flash

--- a/flash_attn/__init__.py
+++ b/flash_attn/__init__.py
@@ -8,4 +8,5 @@ from flash_attn.flash_attn_interface import (
     flash_attn_varlen_kvpacked_func,
     flash_attn_varlen_qkvpacked_func,
     flash_attn_with_kvcache,
+    flash_get_bwd_workspace_size_func,
 )

--- a/flash_attn/flash_attn_interface.py
+++ b/flash_attn/flash_attn_interface.py
@@ -1104,5 +1104,5 @@ def flash_attn_with_kvcache(
     )
     return out
 
-def flash_get_bwd_workspace_size():
-    return flash_attn_cuda.get_bwd_workspace_size()
+def flash_get_bwd_workspace_size_func(b, n, s, h):
+    return flash_attn_cuda.get_bwd_workspace_size(b, n, s, h)


### PR DESCRIPTION
FA2 Supports deterministic Computation Feature, fix this issue https://github.com/Dao-AILab/flash-attention/issues/429

- Add one deterministic flag like FA1 to control whether the results are deterministic.
- This feature needs extra worksapce for semaphores.
- For convenience, users are allowed not to allocate extra workspace, it will be allocated automatically and throws one warning message.
- We do not support deterministic=True and local=True at the same time, will workaround this limitation later.

Example(for usage and test):
 
        workspace = torch.zeros(flash_get_bwd_workspace_size_func(batch_size, nheads, seqlen_q, d), device=device, dtype=torch.int32)
        q = torch.randn(batch_size, seqlen_q, nheads, d, device=device, dtype=dtype, requires_grad=True)
        k = torch.randn(batch_size, seqlen_k, nheads, d, device=device, dtype=dtype, requires_grad=True)
        v = torch.randn(batch_size, seqlen_k, nheads, d, device=device, dtype=dtype, requires_grad=True)
        out = flash_attn_func(q, k, v, 0.0, causal=causal, window_size=window_size, workspace=workspace, deterministic=True)
        g = torch.randn_like(out)

        (
            dq,
            dk,
            dv,
         ) = torch.autograd.grad(out, (q, k, v), g, retain_graph=True)

        (
            dq1,
            dk1,
            dv1,
        ) = torch.autograd.grad(out, (q, k, v), g)
	assert (dq - dq1).abs().max().item() == 0

By this way, result of dq is deterministic. We run twice backward, get dq and dq1, The results of these two are completely identical.