### PR TITLE
Support ARM builds

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ def get_platform():
     Returns the platform name as used in wheel filenames.
     """
     if sys.platform.startswith("linux"):
-        return "linux_x86_64"
+        return f'linux_{platform.uname().machine}'
     elif sys.platform == "darwin":
         mac_version = ".".join(platform.mac_ver()[0].split(".")[:2])
         return f"macosx_{mac_version}_x86_64"


### PR DESCRIPTION
This change allows flash attention to be built for the new NVIDIA GH 200 platform (aarch64). 