### PR TITLE
[CI] Use torch 2.2.0 nightly build dev20231106

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,7 +44,7 @@ jobs:
           # manylinux docker image, but I haven't figured out how to install CUDA on manylinux.
           os: [ubuntu-20.04]
           python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
-          torch-version: ['1.12.1', '1.13.1', '2.0.1', '2.1.2', '2.2.0.dev20231130', '2.3.0.dev20240126']
+          torch-version: ['1.12.1', '1.13.1', '2.0.1', '2.1.2', '2.2.0.dev20231106', '2.3.0.dev20240126']
           cuda-version: ['11.8.0', '12.2.2']
           # We need separate wheels that either uses C++11 ABI (-D_GLIBCXX_USE_CXX11_ABI) or not.
           # Pytorch wheels currently don't use it, but nvcr images have Pytorch compiled with C++11 ABI.
@@ -61,7 +61,7 @@ jobs:
               python-version: '3.7'
             - torch-version: '2.1.2'
               python-version: '3.7'
-            - torch-version: '2.2.0.dev20231130'
+            - torch-version: '2.2.0.dev20231106'
               python-version: '3.7'
             - torch-version: '2.3.0.dev20240126'
               python-version: '3.7'


### PR DESCRIPTION

Tying up loose ends :-)

@tridao

> nvcr 24.01 is out and still uses torch2.2.20231106. I'll merge this and fix that later.

_Originally posted by @tridao in https://github.com/Dao-AILab/flash-attention/issues/793#issuecomment-1915919111_
