### PR TITLE
Fix common compilation issues by auto-adjusting ninja MAX_JOBS env var

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -282,6 +282,26 @@ class CachedWheelsCommand(_bdist_wheel):
             super().run()
 
 
+class NinjaBuildExtension(BuildExtension):
+    def __init__(self, *args, **kwargs) -> None:
+        # do not override env MAX_JOBS if already exists
+        if not os.environ.get("MAX_JOBS"):
+            import psutil
+
+            # calculate the maximum allowed NUM_JOBS based on cores
+            max_num_jobs_cores = max(1, os.cpu_count() // 2)
+
+            # calculate the maximum allowed NUM_JOBS based on free memory
+            free_memory_gb = psutil.virtual_memory().available / (1024 ** 3)  # free memory in GB
+            max_num_jobs_memory = int(free_memory_gb / 9)  # each JOB peak memory cost is ~8-9GB when threads = 4
+
+            # pick lower value of jobs based on cores vs memory metric to minimize oom and swap usage during compilation
+            max_jobs = max(1, min(max_num_jobs_cores, max_num_jobs_memory))
+            os.environ["MAX_JOBS"] = str(max_jobs)
+
+        super().__init__(*args, **kwargs)
+
+
 setup(
     name=PACKAGE_NAME,
     version=get_package_version(),
@@ -309,7 +329,7 @@ setup(
         "Operating System :: Unix",
     ],
     ext_modules=ext_modules,
-    cmdclass={"bdist_wheel": CachedWheelsCommand, "build_ext": BuildExtension}
+    cmdclass={"bdist_wheel": CachedWheelsCommand, "build_ext": NinjaBuildExtension}
     if ext_modules
     else {
         "bdist_wheel": CachedWheelsCommand,
@@ -320,5 +340,8 @@ setup(
         "einops",
         "packaging",
         "ninja",
+    ],
+    setup_requires=[
+        "psutil"
     ],
 )


### PR DESCRIPTION
Flash-attn takes a lot of ram and cpu cores to compile. Most users do not have 64 cores or over 96GB of ram and hand adjusting MAX_JOBS is trial-and-error and not to mention a waste of dev time. 

Problem this PR attempts to solve:

1. Ninja MAX_JOBS is unaware of threads=4 spawned by nvcc. 
2. Ninja MAX_JOBS is unaware of actual available memory in environment
3. Both 1 and 2 combined results in oom, heavy swap usage, oversubscribed threads to core count (thread starvation) and general reduced efficiency in compiling since ninja is not resource aware. 

Without this PR, `python setup install` will OOM on an Intel 14700k consumer machine with 96GB of ram (swap disabled). Using readme recommended MAX_JOBS=4 will lead to very slow compilation.  Both options are sub-optimal. This led to the reason I created this PR.  The problem becomes worse for consumer machines that generally have 32GB of ram especially for laptops.  Overall, the chance of you over-waiting for flash-attention to compile due to under-utilization or flat-out oom is extremely high for all environments. 

PR tries to solve most of the headaches and auto-adjusts ninja MAX_JOBS based on both cpu core count and available memory so that it will compile near max efficiency under both consumer and server environments.  There is no longer a need to manually adjust the MAX_JOBS value. 

Base logic is the code calculate max efficient MAX_JOBS based on 2 metrics: 1. cpu cores and 2. available memory and then take the min() value of the two.  Cores are real-cores / 2 since threads=4 and Memory is divided by a constant of 9GB since I observe each job uses from 8-9GB of ram during peak.  

Test Env:

```
Ubuntu 22.04
Torch 2.2
Intel 14700k + 96GB DDR5 6600 + swap disabled (to reproduce the worst possible oom situations). 
```