### PR TITLE
feat: ALiBi for the non-flash code path

### DIFF
--- a/flash_attn/modules/mha.py
+++ b/flash_attn/modules/mha.py
@@ -277,8 +277,8 @@ class SelfAttention(nn.Module):
             scores = scores + rearrange(padding_mask, "b s -> b 1 1 s")
         if self.alibi_slopes is not None:
             if seqlen > self.linear_biases.shape[-1]:
-                self.linear_biases = self._build_linear_biases(seqlen).to(scores.device)
-            cropped_biases = self.linear_biases[..., :seqlen, :seqlen].to(scores.device)
+                self.linear_biases = self._build_linear_biases(seqlen)
+            cropped_biases = self.linear_biases[..., :seqlen, :seqlen]
             scores = scores - cropped_biases
         if causal:
             # "triu_tril_cuda_template" not implemented for 'BFloat16'

--- a/flash_attn/modules/mha.py
+++ b/flash_attn/modules/mha.py
@@ -243,7 +243,7 @@ class SelfAttention(nn.Module):
         if alibi_slopes is not None:
             self.register_buffer('linear_biases', self._build_linear_biases(16), persistent=False)
         else:
-            self.alibi_tensor = None
+            self.linear_biases = None
 
     def _build_linear_biases(self, seqlen):
         context_position = torch.arange(seqlen, device=self.alibi_slopes.device)[:, None]
@@ -251,8 +251,8 @@ class SelfAttention(nn.Module):
         # distance tensor is of shape (seqlen, seqlen)
         distance = torch.abs(memory_position - context_position)
         # alibi tensor is of shape (1, H, seqlen, seqlen)
-        alibi_tensor = (distance[None, ...] * self.alibi_slopes[:, None, None])[None, ...]
-        return alibi_tensor
+        linear_biases = (distance[None, ...] * self.alibi_slopes[:, None, None])[None, ...]
+        return linear_biases
 
     def forward(self, qkv, causal=None, key_padding_mask=None):
         """Implements the multihead softmax attention.


### PR DESCRIPTION
Currently, ALiBi is only implemented for the flash code-path. This PR implements ALiBi also for the non-flash code path.

Here is a short script to verify that the behaviour matches the behaviour of the implementation with flash attention. To run this, one needs to merge the changes from #846 

```python
import torch
from flash_attn.modules.mha import get_alibi_slopes , FlashSelfAttention, SelfAttention

CAUSAL = False
qkv = torch.randn((16, 55, 3, 4, 32)).to('cuda', torch.float16)

module = SelfAttention(alibi_slopes=torch.tensor(get_alibi_slopes(4)), causal=CAUSAL).to('cuda', torch.float16)
module_flash = FlashSelfAttention(alibi_slopes=torch.tensor(get_alibi_slopes(4)), causal=CAUSAL).to('cuda', torch.float16)
result = module(qkv)
result_flash = module_flash(qkv)
print((result - result_flash) / result_flash * 100)
``` 