### PR TITLE
Fix spurious re-compilations of `rotary_kernel`

### DIFF
--- a/flash_attn/ops/triton/rotary.py
+++ b/flash_attn/ops/triton/rotary.py
@@ -8,15 +8,6 @@ import triton
 import triton.language as tl
 
 
-# @triton.autotune(
-#     configs=[
-#         triton.Config({"BLOCK_M": 2}),
-#         triton.Config({"BLOCK_M": 4}),
-#         triton.Config({"BLOCK_M": 8}),
-#         triton.Config({"BLOCK_M": 16}),
-#     ],
-#     key=["CACHE_KEY_SEQLEN", "BLOCK_K", "INTERLEAVED"],
-# )
 @triton.jit
 def rotary_kernel(
     OUT,  # Pointers to matrices
@@ -27,10 +18,8 @@ def rotary_kernel(
     SEQLEN_OFFSETS,  # this could be int or a pointer
     # Matrix dimensions
     seqlen,
-    nheads,
     rotary_dim,
     seqlen_ro,
-    CACHE_KEY_SEQLEN,
     # strides
     stride_out_batch,
     stride_out_seqlen,
@@ -218,10 +207,8 @@ def apply_rotary(
             cu_seqlens,
             seqlen_offsets,
             seqlen,  # shapes
-            nheads,
             rotary_dim,
             seqlen_ro,
-            seqlen // 128,  # key for triton cache (limit number of compilations)
             output.stride(0) if not is_varlen else 0,  # batch_strides if not varlen else 0
             output.stride(-3),  # seqlen_stride or total_seqlen_stride
             output.stride(-2),  # nheads_stride


### PR DESCRIPTION
All integer parameters in Triton kernels are [specialized](https://github.com/openai/triton/blob/release/2.2.x/python/triton/runtime/jit.py#L180) by default, meaning that (for the `2.2` version of Triton) a different kernel will be generated for the following mutually exclusive classes of parameter values:
  * divisible by 16
  * divisible by 8, but not by 16
  * not divisible by either 8 or 16, and not equal to 1
  * equal to 1

`nheads` and `CACHE_KEY_SEQLEN` are not used at all in `rotary_kernel`, but they still trigger re-compilation whenever their values move between classes. This is doubly ironic given that the comment in the code indicates that `CACHE_KEY_SEQLEN` was meant to `limit number of compilations` (probably when it was used for autotuning?).

I removed the unused parameters and autotuning setup, and added a simple test to verify that changing the class of `nheads` and/or `CACHE_KEY_SEQLEN` (i.e., `seqlen//128`) doesn't lead to re-compilations. The test is a little hackish because it relies on undocumented Triton internals, but at least it shows the problem clearly (e.g., when you run the test with Triton 2.2 and without the fix applied, it fails with `FAILED tests/test_rotary.py::test_compilation_count - assert 8 == 2`).

I also strongly suspect that some other parameters that *are* used in the kernel (such as `seqlen`) don't get any benefit from being specialized; that is, we just do a re-compile to get essentially the same kernel. However, this is trickier to prove, and I wanted to make only safe changes in this PR.