### PR TITLE
Move packaging and ninja from install_requires to setup_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -344,10 +344,10 @@ setup(
     install_requires=[
         "torch",
         "einops",
-        "packaging",
-        "ninja",
     ],
     setup_requires=[
-        "psutil"
+        "packaging",
+        "psutil",
+        "ninja",
     ],
 )


### PR DESCRIPTION
Set `packaging` and `ninja` as build time dependencies rather than runtime dependencies.

Xref https://github.com/conda-forge/staged-recipes/pull/26239#discussion_r1590048101 where we're trying to package `flash-attn` on conda-forge, and would like the setup.py metadata to be correct so that running `pip check` would work.