### PR TITLE
add pyproject.toml with build dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,10 @@
 clean_dist:
 	rm -rf dist/*
 
+# This step assumes there is already a virtualenv active.
 create_dist: clean_dist
-	python setup.py sdist
+	python -m pip install build
+	python -m build --sdist .
 
 upload_package: create_dist
 	twine upload dist/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "packaging", "psutil", "ninja", "torch", "wheel"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Adding this metadata means it is possible to `pip install flash-attn`
without pre-installing the packages imported in setup.py. It is still
possible to follow the existing manual instructions, too, but by not
requiring pre-installation it _also_ makes it easier for someone to
build from the source dist.