### PR TITLE
Make FA3 externally importable

### DIFF
--- a/hopper/setup.py
+++ b/hopper/setup.py
@@ -265,6 +265,7 @@ setup(
             "benchmarks",
         )
     ),
+    py_modules=["flash_attn_interface"],
     description="FlashAttention-3",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Library name to import is `flash_attn_interface`, which matches the test.

This makes it easier to experiment with FA3 as a library.