### PR TITLE
Fix: bwd may need to first allocate cuda mem for rng_state

### DIFF
--- a/csrc/flash_attn/flash_api.cpp
+++ b/csrc/flash_attn/flash_api.cpp
@@ -997,6 +997,8 @@ mha_bwd(const at::Tensor &dout,  // batch_size x seqlen_q x num_heads, x head_si
         std::lock_guard<std::mutex> lock(gen->mutex_);
         params.philox_args = gen->philox_cuda_state(counter_offset);
         auto seeds = at::cuda::philox::unpack(params.philox_args);
+        auto rng_state = torch::empty({2}, opts.dtype(torch::kInt64));
+        params.rng_state = reinterpret_cast<uint64_t*>(rng_state.data_ptr());
         params.rng_state[0] = std::get<0>(seeds);
         params.rng_state[1] = std::get<1>(seeds);
     }
@@ -1251,6 +1253,8 @@ mha_varlen_bwd(const at::Tensor &dout,  // total_q x num_heads, x head_size
         std::lock_guard<std::mutex> lock(gen->mutex_);
         params.philox_args = gen->philox_cuda_state(counter_offset);
         auto seeds = at::cuda::philox::unpack(params.philox_args);
+        auto rng_state = torch::empty({2}, opts.dtype(torch::kInt64));
+        params.rng_state = reinterpret_cast<uint64_t*>(rng_state.data_ptr());
         params.rng_state[0] = std::get<0>(seeds);
         params.rng_state[1] = std::get<1>(seeds);
     }


### PR DESCRIPTION
When calling bwd function without passing into a rng_state, we may need to first allocate 2 uint64 on GPU memory and then assign upacked seeds to rng_state 0 and 1.