### PR TITLE
[FA3] Remove torchlib dependency from cpp files (except flash_api.h)

### DIFF
--- a/hopper/flash.h
+++ b/hopper/flash.h
@@ -7,14 +7,6 @@
 #include <cuda.h>
 #include <vector>
 
-#ifdef OLD_GENERATOR_PATH
-#include <ATen/CUDAGeneratorImpl.h>
-#else
-#include <ATen/cuda/CUDAGeneratorImpl.h>
-#endif
-
-#include <ATen/cuda/CUDAGraphsUtils.cuh> // For at::cuda::philox::unpack
-
 #include "cutlass/fast_math.h"  // For cutlass::FastDivmod
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -117,9 +109,6 @@ struct Flash_fwd_params : public Qkv_params {
 
     // Local window size
     int window_size_left, window_size_right;
-
-    // Random state.
-    at::PhiloxCudaState philox_args;
 
     // Pointer to the RNG seed (idx 0) and offset (idx 1).
     uint64_t * rng_state;

--- a/hopper/utils.h
+++ b/hopper/utils.h
@@ -21,6 +21,18 @@
 #include <cutlass/numeric_conversion.h>
 #include <cutlass/numeric_types.h>
 
+#define CHECK_CUDA(call)                                                                                  \
+    do {                                                                                                  \
+        cudaError_t status_ = call;                                                                       \
+        if (status_ != cudaSuccess) {                                                                     \
+            fprintf(stderr, "CUDA error (%s:%d): %s\n", __FILE__, __LINE__, cudaGetErrorString(status_)); \
+            exit(1);                                                                                      \
+        }                                                                                                 \
+    } while(0)
+
+#define CHECK_CUDA_KERNEL_LAUNCH() CHECK_CUDA(cudaGetLastError())
+
+
 namespace flash {
 
 using namespace cute;
@@ -62,7 +74,7 @@ struct Allreduce {
 
 template<>
 struct Allreduce<2> {
-template<typename T, typename Operator> 
+template<typename T, typename Operator>
 static __device__ __forceinline__ T run(T x, Operator &op) {
     x = op(x, __shfl_xor_sync(uint32_t(-1), x, 1));
     return x;


### PR DESCRIPTION
These make it so external C++ libraries can include `flash.h` without needing to depend on torchlib. The use case here is including FA3 in other C++ codebases, usually by either git submodules or CMake fetchcontent. Obviously `flash_api.cpp` needs to include torchlib to provide the torch interface, but the call stack below that can be done without needing it.

Changes are mainly just using native CUDA check macros rather than the ones from ATen. Another thing is I had to delete `philox_args` from `Flash_fwd_params`, which wasn't being used anywhere currently. If you have to add this back in at some point I hope it could be done without reintroducing the torchlib dependency.