### PR TITLE
Add how to import FA3 to documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,11 @@ To run the test:
 export PYTHONPATH=$PWD
 pytest -q -s test_flash_attn.py
 ```
-
-
+Once the package is installed, you can import it as follows:
+```python
+import flash_attn_interface
+flash_attn_interface.flash_attn_func()
+```
 
 ## Installation and features
 


### PR DESCRIPTION
I've had this issue and also seen many people questioning how to use FA3.

usually people try to 
`import as flash_attn.hopper `
or as
`import flashattn_hopper
`
but it should be 
`import flash_attn_interface`