### PR TITLE
Fix: check the type of max_seqlen_k instead of checking max_seqlen twice

### DIFF
--- a/flash_attn/modules/mha.py
+++ b/flash_attn/modules/mha.py
@@ -196,7 +196,7 @@ class FlashCrossAttention(nn.Module):
             assert cu_seqlens_k is not None
             assert cu_seqlens_k.dtype == torch.int32
             assert max_seqlen_k is not None
-            assert isinstance(max_seqlen, int)
+            assert isinstance(max_seqlen_k, int)
             return flash_attn_varlen_kvpacked_func(
                 q,
                 kv,


### PR DESCRIPTION
In FlashCrossAttention, `isinstance(max_seqlen, int)` is executed twice, but `max_seqlen_k` is not checked