### PR TITLE
Add custom ops for compatibility with PT Compile

### DIFF
--- a/flash_attn/flash_attn_interface.py
+++ b/flash_attn/flash_attn_interface.py
@@ -881,7 +881,7 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
     ):
         if softmax_scale is None:
             softmax_scale = q.shape[-1] ** (-0.5)
-        head_size_og = q.size(3)
+        head_size_og = q.size(2)
         if head_size_og % 8 != 0:
             q = torch.nn.functional.pad(q, [0, 8 - head_size_og % 8])
             k = torch.nn.functional.pad(k, [0, 8 - head_size_og % 8])

--- a/flash_attn/flash_attn_interface.py
+++ b/flash_attn/flash_attn_interface.py
@@ -57,22 +57,16 @@ def _compile_wrapper(torch_op, func):
         return func
 
 
-def _torch_custom_op_wrapper():
-    if torch.__version__ >= "2.4.0":
-        return torch.library.custom_op
-    else:
-        def wrapper(name, fn, *, mutates_args, device_types, schema):
-            return fn
-        return wrapper
-    
-
-def _torch_register_fake_wrapper():
-    if torch.__version__ >= "2.4.0":
-        return torch.library.register_fake
-    else:
-        def wrapper(op, func, *, lib, _stacklevel):
-            return func
-        return wrapper
+if torch.__version__ >= "2.4.0":
+    _torch_custom_op_wrapper = torch.library.custom_op
+    _torch_register_fake_wrapper = torch.library.register_fake
+else:
+    def custom_op_wrapper(name, fn, *, mutates_args, device_types, schema):
+        return fn
+    def register_fake_wrapper(op, func, *, lib, _stacklevel):
+        return func
+    _torch_custom_op_wrapper = custom_op_wrapper
+    _torch_register_fake_wrapper = register_fake_wrapper
 
 
 @_torch_custom_op_wrapper("flashattn::_flash_attn_forward", mutates_args=("q", "k", "v"), device_types="cuda")

--- a/flash_attn/flash_attn_interface.py
+++ b/flash_attn/flash_attn_interface.py
@@ -131,7 +131,7 @@ def _flash_attn_forward_fake(
     p = torch.empty((0,), dtype=q.dtype, device=q.device, layout=q.layout)
     if return_softmax:
         p = torch.empty((batch_size, num_heads, round_multiple(seqlen_q, 128), round_multiple(seqlen_k, 128)), dtype=q.dtype, device=q.device, layout=q.layout)
-    rng_state = torch.empty((2,), dtype=torch.int64, device=q.device, requires_grad=False)
+    rng_state = torch.empty((2,), dtype=torch.int64, device=q.device)
 
     return out, softmax_lse, p, rng_state
 


### PR DESCRIPTION
This PR adds basic support for torch.compile() for the non-varlen variants of Flash Attention.

This essentially allows for models that use the `flash_attn_qkvpacked_func`, `flash_attn_kvpacked_func`, and `flash_attn_func` to compile without graph breaks.

I can add unit tests if it makes sense. I'll test it with our own training pipeline for performance measurements and I'll post them later.

This uses the new custom operators API in Pytorch 2.4. I can move to the older APIs if needed, or I can look up how to make both coexist