### PR TITLE
FA3 FP8 qkv descales + restore max offset for h128 causal + added sync for producer WG

### DIFF
--- a/hopper/flash.h
+++ b/hopper/flash.h
@@ -64,9 +64,6 @@ struct Flash_fwd_params : public Qkv_params {
     float scale_softmax_log2;
     uint32_t scale_softmax_log2_half2;
 
-    // scale_q and scale_k are multiplied into scale_softmax
-    float scale_v;
-
     // array of length b+1 holding starting offset of each sequence.
     int * __restrict__ cu_seqlens_q;
     int * __restrict__ cu_seqlens_k;
@@ -134,6 +131,9 @@ struct Flash_fwd_params : public Qkv_params {
     bool unpadded_lse; // For varlen paths: LSE is in [nheads, total_seqlen_q] format instead of [b, nheads, seqlen_q].
 
     int * __restrict__ tile_count_semaphore;
+    float * __restrict__ descale_q_ptr;
+    float * __restrict__ descale_k_ptr;
+    float * __restrict__ descale_v_ptr;
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/hopper/flash.h
+++ b/hopper/flash.h
@@ -64,6 +64,9 @@ struct Flash_fwd_params : public Qkv_params {
     float scale_softmax_log2;
     uint32_t scale_softmax_log2_half2;
 
+    // scale_q and scale_k are multiplied into scale_softmax
+    float scale_v;
+
     // array of length b+1 holding starting offset of each sequence.
     int * __restrict__ cu_seqlens_q;
     int * __restrict__ cu_seqlens_k;

--- a/hopper/flash_attn_interface.py
+++ b/hopper/flash_attn_interface.py
@@ -14,7 +14,7 @@ import flashattn_hopper_cuda
 def maybe_contiguous(x):
     return x.contiguous() if x is not None and x.stride(-1) != 1 else x
 
-def _flash_attn_forward(q, k, v, softmax_scale, causal, descale_q = 1.0, descale_k = 1.0, descale_v = 1.0):
+def _flash_attn_forward(q, k, v, softmax_scale, causal, descale_q = None, descale_k = None, descale_v = None):
     q, k, v = [maybe_contiguous(x) for x in (q, k, v)]
     out, q, k, v, out_padded, softmax_lse, S_dmask = flashattn_hopper_cuda.fwd(
         q,

--- a/hopper/flash_attn_interface.py
+++ b/hopper/flash_attn_interface.py
@@ -14,7 +14,7 @@ import flashattn_hopper_cuda
 def maybe_contiguous(x):
     return x.contiguous() if x is not None and x.stride(-1) != 1 else x
 
-def _flash_attn_forward(q, k, v, softmax_scale, causal):
+def _flash_attn_forward(q, k, v, softmax_scale, causal, descale_q = 1.0, descale_k = 1.0, descale_v = 1.0):
     q, k, v = [maybe_contiguous(x) for x in (q, k, v)]
     out, q, k, v, out_padded, softmax_lse, S_dmask = flashattn_hopper_cuda.fwd(
         q,
@@ -22,6 +22,9 @@ def _flash_attn_forward(q, k, v, softmax_scale, causal):
         v,
         None,
         softmax_scale,
+        descale_q,
+        descale_k,
+        descale_v,
         causal,
     )
     return out, q, k, v, out_padded, softmax_lse, S_dmask

--- a/hopper/flash_fwd_kernel.h
+++ b/hopper/flash_fwd_kernel.h
@@ -212,9 +212,7 @@ __global__ void __launch_bounds__(Ktraits::kNWarps * cutlass::NumThreadsPerWarp,
     static constexpr int kBlockM = Ktraits::kBlockM;
     // static constexpr int kBlockN = Ktraits::kBlockN;
     // static constexpr int kHeadDim = Ktraits::kHeadDim;
-    static constexpr bool Delay_V_release = Is_causal && Ktraits::kHeadDim == 128;  
-    // for now, disable for hdim 128 causal to avoid perf regression with register spilling
-    // static constexpr bool Use_max_offset = !(Is_causal && Ktraits::kHeadDim == 128);    
+    static constexpr bool Delay_V_release = Is_causal && Ktraits::kHeadDim == 128;    
     static constexpr bool Use_max_offset = true;
 
     using CollectiveMainloop = CollectiveMainloopFwd<Ktraits, Is_causal, Seqlen_traits>;

--- a/hopper/flash_fwd_kernel.h
+++ b/hopper/flash_fwd_kernel.h
@@ -214,7 +214,8 @@ __global__ void __launch_bounds__(Ktraits::kNWarps * cutlass::NumThreadsPerWarp,
     // static constexpr int kHeadDim = Ktraits::kHeadDim;
     static constexpr bool Delay_V_release = Is_causal && Ktraits::kHeadDim == 128;  
     // for now, disable for hdim 128 causal to avoid perf regression with register spilling
-    static constexpr bool Use_max_offset = !(Is_causal && Ktraits::kHeadDim == 128);    
+    // static constexpr bool Use_max_offset = !(Is_causal && Ktraits::kHeadDim == 128);    
+    static constexpr bool Use_max_offset = true;
 
     using CollectiveMainloop = CollectiveMainloopFwd<Ktraits, Is_causal, Seqlen_traits>;
     using CollectiveEpilogue = CollectiveEpilogueFwd<Ktraits, Seqlen_traits>;

--- a/hopper/flash_fwd_kernel.h
+++ b/hopper/flash_fwd_kernel.h
@@ -157,7 +157,7 @@ __global__ void __launch_bounds__(Ktraits::kNWarps * cutlass::NumThreadsPerWarp,
              work_tile_info = scheduler.template get_next_work</*IsProducer=*/false>(scheduler_params, work_tile_info)) {
             // Attention output (GEMM-II) accumulator.
             Tensor tOrO = partition_fragment_C(tiled_mma1, select<0, 2>(TileShape_MNK{}));
-            flash::Softmax<2 * (2 * kBlockM / NumMmaThreads)> softmax;
+            flash::Softmax<2 * (2 * kBlockM / NumMmaThreads)> softmax(mainloop_params.softmax_scale_log2);
 
             auto block_coord = work_tile_info.get_block_coord(scheduler_params);
             auto [m_block, bidh, bidb] = block_coord;
@@ -268,6 +268,12 @@ __global__ void __launch_bounds__(Ktraits::kNWarps * cutlass::NumThreadsPerWarp,
     CollectiveMainloop collective_mainloop;
     CollectiveEpilogue collective_epilogue;
 
+    float descale_q = *mainloop_params.descale_q_ptr;
+    float descale_k = *mainloop_params.descale_k_ptr;
+    float descale_v = *mainloop_params.descale_v_ptr;
+    shared_storage.softmax_scale_qk_log2 = mainloop_params.softmax_scale_log2 * descale_q * descale_k;
+    shared_storage.descale_v = descale_v;
+
     // We need this to guarantee that the Pipeline init is visible to all producers and consumer blocks in the Cluster
     if constexpr (size(ClusterShape{}) > 1) {
         cute::cluster_arrive_relaxed();
@@ -340,7 +346,7 @@ __global__ void __launch_bounds__(Ktraits::kNWarps * cutlass::NumThreadsPerWarp,
              work_tile_info = scheduler.template get_next_work</*IsProducer=*/false>(scheduler_params, work_tile_info)) {
             // Attention output (GEMM-II) accumulator.
             Tensor tOrO = partition_fragment_C(tiled_mma1, select<0, 2>(TileShape_MNK{}));
-            flash::Softmax<2 * (2 * kBlockM / NumMmaThreads), Use_max_offset> softmax;
+            flash::Softmax<2 * (2 * kBlockM / NumMmaThreads), Use_max_offset> softmax(shared_storage.softmax_scale_qk_log2);
 
             auto block_coord = work_tile_info.get_block_coord(scheduler_params);
             auto [m_block, bidh, bidb] = block_coord;

--- a/hopper/flash_fwd_launch_template.h
+++ b/hopper/flash_fwd_launch_template.h
@@ -58,7 +58,9 @@ void run_flash_fwd(Flash_fwd_params &params, cudaStream_t stream) {
                 params.v_row_stride, params.v_head_stride, params.v_batch_stride
             ),  // layout_V
             params.scale_softmax_log2,
-            params.scale_v
+            params.descale_q_ptr,
+            params.descale_k_ptr,
+            params.descale_v_ptr
         });
     typename CollectiveEpilogue::Params epilogue_params =
         CollectiveEpilogue::to_underlying_arguments({
@@ -161,16 +163,26 @@ void run_mha_fwd_hdim64_fp8(Flash_fwd_params &params, cudaStream_t stream) {
     constexpr static int kBlockN = 128;
     constexpr static int kNWarps = 4 + kBlockM/16;
     constexpr static int kStages = 4;    
-    BOOL_SWITCH(params.is_causal, Is_causal, [&] {
-        SEQLEN_SWITCH(params.cu_seqlens_q, Seqlen_traits, [&] {
-            // Only use Cluster if number of tiles along seqlen_q is even
-            BOOL_SWITCH(cutlass::ceil_div(params.seqlen_q, kBlockM) % 2 == 0 && !Is_causal &&
-                        !Seqlen_traits::kUseVarSeqLen, UseCluster, [&] {
-                run_flash_fwd<Flash_fwd_kernel_traits_fp8<Headdim, kBlockM, kBlockN, kNWarps, kStages,
-                              false, UseCluster ? 2 : 1, T>, Is_causal, Seqlen_traits>(params, stream);            
-            });
+    using Seqlen_traits = flash::FixedSeqLenTraits;
+    if(params.is_causal) {
+        run_flash_fwd<Flash_fwd_kernel_traits_fp8<Headdim, kBlockM, kBlockN, kNWarps, kStages,
+                        false, 1, T>, /*Is_causal=*/true, Seqlen_traits>(params, stream);
+    } else {
+        BOOL_SWITCH(cutlass::ceil_div(params.seqlen_q, kBlockM) % 2 == 0, UseCluster, [&] {
+            run_flash_fwd<Flash_fwd_kernel_traits_fp8<Headdim, kBlockM, kBlockN, kNWarps, kStages,
+                            false, UseCluster ? 2 : 1, T>, /*Is_causal=*/false, Seqlen_traits>(params, stream);
         });
-    });    
+    }
+    // BOOL_SWITCH(params.is_causal, Is_causal, [&] {
+        // SEQLEN_SWITCH(params.cu_seqlens_q, Seqlen_traits, [&] {
+            // Only use Cluster if number of tiles along seqlen_q is even
+            // BOOL_SWITCH(cutlass::ceil_div(params.seqlen_q, kBlockM) % 2 == 0 && !Is_causal &&
+            //             !Seqlen_traits::kUseVarSeqLen, UseCluster, [&] {
+            //     run_flash_fwd<Flash_fwd_kernel_traits_fp8<Headdim, kBlockM, kBlockN, kNWarps, kStages,
+            //                   false, UseCluster ? 2 : 1, T>, Is_causal, Seqlen_traits>(params, stream);            
+            // });
+        // });
+    // });
 }
 
 template<typename T>
@@ -179,17 +191,27 @@ void run_mha_fwd_hdim128_fp8(Flash_fwd_params &params, cudaStream_t stream) {
     constexpr static int kBlockM = 128;
     constexpr static int kBlockN = 256;
     constexpr static int kNWarps = 4 + kBlockM/16;
-    constexpr static int kStages = 2;    
-    BOOL_SWITCH(params.is_causal, Is_causal, [&] {
-        SEQLEN_SWITCH(params.cu_seqlens_q, Seqlen_traits, [&] {
-            // Only use Cluster if number of tiles along seqlen_q is even
-            BOOL_SWITCH(cutlass::ceil_div(params.seqlen_q, kBlockM) % 2 == 0 && !Is_causal &&
-                        !Seqlen_traits::kUseVarSeqLen, UseCluster, [&] {
-                run_flash_fwd<Flash_fwd_kernel_traits_fp8<Headdim, kBlockM, kBlockN, kNWarps, kStages,
-                              false, UseCluster ? 2 : 1, T>, Is_causal, Seqlen_traits>(params, stream);
-            });
+    constexpr static int kStages = 2;
+    using Seqlen_traits = flash::FixedSeqLenTraits;
+    if(params.is_causal) {
+        run_flash_fwd<Flash_fwd_kernel_traits_fp8<Headdim, kBlockM, kBlockN, kNWarps, kStages,
+                        false, 1, T>, /*Is_causal=*/true, Seqlen_traits>(params, stream);
+    } else {
+        BOOL_SWITCH(cutlass::ceil_div(params.seqlen_q, kBlockM) % 2 == 0, UseCluster, [&] {
+            run_flash_fwd<Flash_fwd_kernel_traits_fp8<Headdim, kBlockM, kBlockN, kNWarps, kStages,
+                            false, UseCluster ? 2 : 1, T>, /*Is_causal=*/false, Seqlen_traits>(params, stream);
         });
-    });    
+    }
+    // BOOL_SWITCH(params.is_causal, Is_causal, [&] {
+        // SEQLEN_SWITCH(params.cu_seqlens_q, Seqlen_traits, [&] {
+            // Only use Cluster if number of tiles along seqlen_q is even
+            // BOOL_SWITCH(cutlass::ceil_div(params.seqlen_q, kBlockM) % 2 == 0 && !Is_causal &&
+            //             !Seqlen_traits::kUseVarSeqLen, UseCluster, [&] {
+            //     run_flash_fwd<Flash_fwd_kernel_traits_fp8<Headdim, kBlockM, kBlockN, kNWarps, kStages,
+            //                   false, UseCluster ? 2 : 1, T>, Is_causal, Seqlen_traits>(params, stream);
+            // });
+        // });
+    // });
 }
 
 template<typename T>
@@ -198,15 +220,25 @@ void run_mha_fwd_hdim256_fp8(Flash_fwd_params &params, cudaStream_t stream) {
     constexpr static int kBlockM = 128;
     constexpr static int kBlockN = 128;
     constexpr static int kNWarps = 4 + kBlockM/16;
-    constexpr static int kStages = 2;    
-    BOOL_SWITCH(params.is_causal, Is_causal, [&] {
-        SEQLEN_SWITCH(params.cu_seqlens_q, Seqlen_traits, [&] {
-            // Only use Cluster if number of tiles along seqlen_q is even
-            BOOL_SWITCH(cutlass::ceil_div(params.seqlen_q, kBlockM) % 2 == 0 && !Is_causal &&
-                        !Seqlen_traits::kUseVarSeqLen, UseCluster, [&] {
-                run_flash_fwd<Flash_fwd_kernel_traits_fp8<Headdim, kBlockM, kBlockN, kNWarps, kStages,
-                              false, UseCluster ? 2 : 1, T>, Is_causal, Seqlen_traits>(params, stream);
-            });
+    constexpr static int kStages = 2;
+    using Seqlen_traits = flash::FixedSeqLenTraits;
+    if(params.is_causal) {
+        run_flash_fwd<Flash_fwd_kernel_traits_fp8<Headdim, kBlockM, kBlockN, kNWarps, kStages,
+                        false, 1, T>, /*Is_causal=*/true, Seqlen_traits>(params, stream);
+    } else {
+        BOOL_SWITCH(cutlass::ceil_div(params.seqlen_q, kBlockM) % 2 == 0, UseCluster, [&] {
+            run_flash_fwd<Flash_fwd_kernel_traits_fp8<Headdim, kBlockM, kBlockN, kNWarps, kStages,
+                            false, UseCluster ? 2 : 1, T>, /*Is_causal=*/false, Seqlen_traits>(params, stream);
         });
-    });    
+    }
+    // BOOL_SWITCH(params.is_causal, Is_causal, [&] {
+        // SEQLEN_SWITCH(params.cu_seqlens_q, Seqlen_traits, [&] {
+            // Only use Cluster if number of tiles along seqlen_q is even
+            // BOOL_SWITCH(cutlass::ceil_div(params.seqlen_q, kBlockM) % 2 == 0 && !Is_causal &&
+            //             !Seqlen_traits::kUseVarSeqLen, UseCluster, [&] {
+            //     run_flash_fwd<Flash_fwd_kernel_traits_fp8<Headdim, kBlockM, kBlockN, kNWarps, kStages,
+            //                   false, UseCluster ? 2 : 1, T>, Is_causal, Seqlen_traits>(params, stream);
+            // });
+        // });
+    // });
 }

--- a/hopper/flash_fwd_launch_template.h
+++ b/hopper/flash_fwd_launch_template.h
@@ -57,7 +57,8 @@ void run_flash_fwd(Flash_fwd_params &params, cudaStream_t stream) {
                 params.seqlen_k, params.d, params.h_k, params.b, 
                 params.v_row_stride, params.v_head_stride, params.v_batch_stride
             ),  // layout_V
-            params.scale_softmax_log2
+            params.scale_softmax_log2,
+            params.scale_v
         });
     typename CollectiveEpilogue::Params epilogue_params =
         CollectiveEpilogue::to_underlying_arguments({

--- a/hopper/kernel_traits.h
+++ b/hopper/kernel_traits.h
@@ -52,6 +52,8 @@ struct SharedStorageQKVOVt {
     typename cutlass::PipelineTmaAsync<kStages>::SharedStorage pipeline_v;
     typename cutlass::PipelineAsync<kStages>::SharedStorage pipeline_vt;
     int tile_count_semaphore;
+    float softmax_scale_qk_log2;
+    float descale_v;
   };
 };
 

--- a/hopper/mainloop_fwd_sm90_tma_gmma_ws.hpp
+++ b/hopper/mainloop_fwd_sm90_tma_gmma_ws.hpp
@@ -369,6 +369,7 @@ struct CollectiveMainloopFwd {
                                 flatten(sVt_divide(_, i, j, stage)));
                 }
             }
+            cutlass::arch::NamedBarrier::sync(cutlass::NumThreadsPerWarpGroup, static_cast<int>(FwdNamedBarriers::ProducerWG) /*id*/);
         };
 
         Tensor mQ = mainloop_params.tma_load_Q.get_tma_tensor(mainloop_params.layout_Q.shape());

--- a/hopper/softmax.h
+++ b/hopper/softmax.h
@@ -137,11 +137,12 @@ struct Softmax {
 
     using TensorT = decltype(make_tensor<float>(Shape<Int<kNRows>>{}));
     TensorT row_max, row_sum;
+    const float softmax_scale_log2;
 
-    CUTLASS_DEVICE Softmax() {};
+    CUTLASS_DEVICE Softmax(float scale_ = 1.f) : softmax_scale_log2(scale_) {};
 
     template<bool Is_first, bool Check_inf=false, typename Tensor0>
-    __forceinline__ __device__ TensorT max(Tensor0 &acc_s, float softmax_scale_log2) {
+    __forceinline__ __device__ TensorT max(Tensor0 &acc_s) {
         // Reshape acc_s from ((2, 2, V), MMA_M, MMA_N) to (nrow=(2, MMA_M), ncol=(2, V, MMA_N))
         Tensor scores = make_tensor(acc_s.data(), flash::convert_layout_acc_rowcol(acc_s.layout()));
         static_assert(decltype(size<0>(scores))::value == kNRows);
@@ -166,7 +167,7 @@ struct Softmax {
     };
 
     template<bool Is_first, bool Check_inf=false, typename Tensor0>
-    __forceinline__ __device__ TensorT online_softmax(Tensor0 &acc_s, float softmax_scale_log2) {
+    __forceinline__ __device__ TensorT online_softmax(Tensor0 &acc_s) {
         // Reshape acc_s from ((2, 2, V), MMA_M, MMA_N) to (nrow=(2, MMA_M), ncol=(2, V, MMA_N))
         Tensor scores = make_tensor(acc_s.data(), flash::convert_layout_acc_rowcol(acc_s.layout()));
         static_assert(decltype(size<0>(scores))::value == kNRows);
@@ -197,9 +198,9 @@ struct Softmax {
         }
         return scores_scale;
     };
-    
+
     template<bool Is_dropout=false, bool Split=false, typename Tensor0>
-    __forceinline__ __device__ TensorT finalize(Tensor0 &acc_s, float softmax_scale_log2, float scale_v = 1.f, float rp_dropout=1.f) {
+    __forceinline__ __device__ TensorT finalize(Tensor0 &acc_s, float descale_v = 1.f, float rp_dropout=1.f) {
         constexpr static float max_offset_E = Use_max_offset ? 8.f * float(M_LN2) : 0.f;
         // Reshape acc_s from ((2, 2, V), MMA_M, MMA_N) to (nrow=(2, MMA_M), ncol=(2, V, MMA_N))
         Tensor scores = make_tensor(acc_s.data(), flash::convert_layout_acc_rowcol(acc_s.layout()));
@@ -210,7 +211,7 @@ struct Softmax {
         #pragma unroll
         for (int mi = 0; mi < size(row_max); ++mi) {
             float sum = row_sum(mi);
-            float inv_sum = (sum == 0.f || sum != sum) ? 0.f : scale_v / sum;
+            float inv_sum = (sum == 0.f || sum != sum) ? 0.f : descale_v / sum;
             row_sum(mi) = (sum == 0.f || sum != sum) ? (Split ? -INFINITY : INFINITY) : (row_max(mi) * softmax_scale_log2) * float(M_LN2) - max_offset_E + __logf(sum);
             scores_scale(mi) = !Is_dropout ? inv_sum : inv_sum * rp_dropout;
         }


### PR DESCRIPTION
This PR adds qkv descales for the fp8 kernel, added warpgroup sync in producer in do_transpose_V lambda, and slightly altered schedule for h128 causal fp8 that allows for using max offset to fill fp8 range before 2nd gemm with minimal perf penalty (<10 tflops measured on my H100 PCIe, log attached).

[new_fp8_h128_times_0823.log](https://github.com/user-attachments/files/16734356/new_fp8_h128_times_0823.log)
