### PR TITLE
feat: change minimal supported CUDA version to 11.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ MAX_JOBS=4 pip install flash-attn --no-build-isolation
 
 ### NVIDIA CUDA Support
 **Requirements:**
-- CUDA 11.6 and above.
+- CUDA 11.7 and above.
 
 We recommend the
 [Pytorch](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/pytorch)

--- a/setup.py
+++ b/setup.py
@@ -156,9 +156,9 @@ if not SKIP_CUDA_BUILD and not IS_ROCM:
     cc_flag = []
     if CUDA_HOME is not None:
         _, bare_metal_version = get_cuda_bare_metal_version(CUDA_HOME)
-        if bare_metal_version < Version("11.6"):
+        if bare_metal_version < Version("11.7"):
             raise RuntimeError(
-                "FlashAttention is only supported on CUDA 11.6 and above.  "
+                "FlashAttention is only supported on CUDA 11.7 and above.  "
                 "Note: make sure nvcc has a supported version by running nvcc -V."
             )
     # cc_flag.append("-gencode")


### PR DESCRIPTION
As `__grid_constant__` was introduced in CUDA 11.7, the minimal supported CUDA version must change from `11.6` to `11.7`. The project is failed to build from tag `v2.4.0` with CUDA 11.6 and shows the errors as follow. (I just test building from the latest tag back to `v2.4.0`, which does not mean older versions can pass.)

```
  /usr/local/cuda/bin/nvcc -I/workspace/flash-attention/csrc/flash_attn -I/workspace/flash-attention/csrc/flash_attn/src -I/workspace/flash-attention/csrc/cutlass/include -I/usr/local/lib/python3.8/dist-packages/torch/include -I/usr/local/lib/python3.8/dist-packages/torch/include/torch/csrc/api/include -I/usr/local/lib/python3.8/dist-packages/torch/include/TH -I/usr/local/lib/python3.8/dist-packages/torch/include/THC -I/usr/local/cuda/include -I/usr/include/python3.8 -c csrc/flash_attn/src/flash_bwd_hdim128_bf16_causal_sm80.cu -o build/temp.linux-x86_64-3.8/csrc/flash_attn/src/flash_bwd_hdim128_bf16_causal_sm80.o -D__CUDA_NO_HALF_OPERATORS__ -D__CUDA_NO_HALF_CONVERSIONS__ -D__CUDA_NO_BFLOAT16_CONVERSIONS__ -D__CUDA_NO_HALF2_OPERATORS__ --expt-relaxed-constexpr --compiler-options '-fPIC' -O3 -std=c++17 -U__CUDA_NO_HALF_OPERATORS__ -U__CUDA_NO_HALF_CONVERSIONS__ -U__CUDA_NO_HALF2_OPERATORS__ -U__CUDA_NO_BFLOAT16_CONVERSIONS__ --expt-relaxed-constexpr --expt-extended-lambda --use_fast_math -gencode arch=compute_80,code=sm_80 --threads 4 -DTORCH_API_INCLUDE_EXTENSION_H -DPYBIND11_COMPILER_TYPE=\"_gcc\" -DPYBIND11_STDLIB=\"_libstdcpp\" -DPYBIND11_BUILD_ABI=\"_cxxabi1011\" -DTORCH_EXTENSION_NAME=flash_attn_2_cuda -D_GLIBCXX_USE_CXX11_ABI=0
  csrc/flash_attn/src/flash_bwd_launch_template.h(30): warning #1835-D: attribute "__global__" does not apply here

  csrc/flash_attn/src/flash_bwd_launch_template.h(30): error: incomplete type is not allowed

  csrc/flash_attn/src/flash_bwd_launch_template.h(30): error: identifier "__grid_constant__" is undefined

  csrc/flash_attn/src/flash_bwd_launch_template.h(30): error: expected a ")"

  csrc/flash_attn/src/flash_bwd_launch_template.h(30): error: expected a ";"

  At end of source: error: expected a ";"

  5 errors detected in the compilation of "csrc/flash_attn/src/flash_bwd_hdim128_bf16_causal_sm80.cu".
  error: command '/usr/local/cuda/bin/nvcc' failed with exit code 255
  error: subprocess-exited-with-error

  × python setup.py bdist_wheel did not run successfully.
  │ exit code: 1
  ╰─> See above for output.
```