### PR TITLE
Fix FAv3 compilation with MSVC

### DIFF
--- a/hopper/setup.py
+++ b/hopper/setup.py
@@ -146,6 +146,13 @@ if not SKIP_CUDA_BUILD:
         "-DCUTLASS_DEBUG_TRACE_LEVEL=0",  # Can toggle for debugging
         "-DNDEBUG",  # Important, otherwise performance is severely impacted
     ]
+    if get_platform() == "win_amd64":
+        nvcc_flags.extend(
+            [
+                "-D_USE_MATH_DEFINES",  # for M_LN2
+                "-Xcompiler=/Zc:__cplusplus",  # sets __cplusplus correctly, CUTLASS_CONSTEXPR_IF_CXX17 needed for cutlass::gcd
+            ]
+        )
     include_dirs = [
         # Path(this_dir) / "fmha-pipeline",
         # repo_dir / "lib",


### PR DESCRIPTION
This PR fixes FAv3 compilation with MSVC.

There are 2 issues:
- `-D_USE_MATH_DEFINES` is needed for [Math constants](https://learn.microsoft.com/en-us/cpp/c-runtime-library/math-constants?view=msvc-170) in MSVC, specifically `M_LN2` used in `hopper/softmax.h`.
- `-Xcompiler=/Zc:__cplusplus` sets `__cplusplus` correctly, in turn this enables `CUTLASS_CONSTEXPR_IF_CXX17` in Cutlass which is used by `cutlass::gcd`.

These options are added to `nvcc_flags` when `get_platform() == "win_amd64"`.
