### PR TITLE
Paged Attention support for FA3

### DIFF
--- a/hopper/copy_paged_sm90_tma.hpp
+++ b/hopper/copy_paged_sm90_tma.hpp
@@ -1,0 +1,391 @@
+
+#pragma once
+
+#include <cute/arch/copy_sm90_tma.hpp>
+#include <cute/atom/copy_traits_sm90_tma.hpp>
+
+struct PagedCopyArgs {
+
+  CUTE_HOST_DEVICE
+  PagedCopyArgs() : block_table_batch_stride{0}, page_block_size(0), block_table(nullptr)  {
+  };
+
+  CUTE_HOST_DEVICE
+  PagedCopyArgs(int64_t const block_table_batch_stride_, int const page_block_size_, int32_t *block_table_) : block_table_batch_stride{block_table_batch_stride_}, page_block_size(page_block_size_), block_table(block_table_)  {
+  };
+
+  int64_t block_table_batch_stride; // The stride between block tables for different batches
+  int page_block_size; // The size of a page block in number of elements
+  int32_t* block_table; // The block table, must be properly sized or a nullptr
+};
+
+namespace cute {
+
+  struct SM90_TMA_LOAD_PAGED
+  {
+    using COPY_OP = SM90_TMA_LOAD; // The underlying copy operation that we delegate work to
+
+    CUTE_HOST_DEVICE static void
+    copy(void const* desc_ptr, uint64_t* mbar_ptr,
+        void      * smem_ptr,
+        int32_t const& crd0)
+    {
+      CUTE_INVALID_CONTROL_PATH("PAGED_COPY_OP not implemented for 1D");
+    }
+    CUTE_HOST_DEVICE static void
+    copy(void const* desc_ptr, uint64_t* mbar_ptr,
+        PagedCopyArgs const& pca,
+        void      * smem_ptr,
+        int32_t const& crd0, int32_t const& crd1)
+    {
+      CUTE_INVALID_CONTROL_PATH("PAGED_COPY_OP not implemented for 2D");
+    }
+    CUTE_HOST_DEVICE static void
+    copy(void const* desc_ptr, uint64_t* mbar_ptr,
+        PagedCopyArgs const& pca,
+        void      * smem_ptr,
+        int32_t const& crd0, int32_t const& crd1, int32_t const& crd2)
+    {
+      if (pca.block_table == nullptr) {
+        return SM90_TMA_LOAD_3D::copy(desc_ptr, mbar_ptr, smem_ptr, crd0, crd1, crd2);
+      }
+      CUTE_INVALID_CONTROL_PATH("PAGED_COPY_OP not implemented for 3D");
+    }
+    CUTE_HOST_DEVICE static void
+    copy(void const* desc_ptr, uint64_t* mbar_ptr,
+        PagedCopyArgs const& pca,
+        void      * smem_ptr,
+       // Index order reordered for TMA from PagedSeqLenTraits::get_kv_gmem_layout()
+       // via cute::make_tma_copy_atom ( see detail::construct_tma_gbasis )
+       // and detail::make_tma_copy_desc to create a TMA descriptor.
+       // The same reordering is aplied prior to calling via cute::tma_partition.
+
+       // Final order determined experimentally.
+       int32_t const& crdK, // embedding dim
+       int32_t const& crdM, // sequence dim
+       int32_t const& crdH, // head dim
+       int32_t const& crdB) // batch dim
+  {
+    //auto log = pca.debug_log->nextline();
+    //log.append_threadinfo();
+    //log.snprintf("SM_90_TMA_LOAD_PAGED::copy(%d, %d, %d, %d) ", (int)crdM, (int)crdK, (int)crdH, (int)crdB);
+    if (pca.block_table == nullptr) {
+        return SM90_TMA_LOAD_4D::copy(desc_ptr, mbar_ptr, smem_ptr, crdK, crdM, crdH, crdB);
+    }
+    int32_t const page_idx_offset = crdM / pca.page_block_size; // page index within the batch entry
+    int32_t const seq_pos_offset = crdM - page_idx_offset*pca.page_block_size; // == crd1 % page_block_size_ -> sequence position within the page
+    int32_t const page_idx = pca.block_table[page_idx_offset + crdB*pca.block_table_batch_stride]; // The page index for the given batch and sequence position
+    //if (cute::thread0()) {
+    //  printf("SM90_TMA_LOAD_PAGED::copy crdM=%d, crdB=%d, crdK=%d, crdH=%d, page_idx=%d, seq_pos_offset=%d, ptr=%p\n", (int)crdM, (int)crdB, (int) crdK, (int) crdH, (int)page_idx, (int)seq_pos_offset, (void*)desc_ptr);
+    //}
+    return SM90_TMA_LOAD_4D::copy(desc_ptr, mbar_ptr, smem_ptr, crdK, seq_pos_offset, crdH, page_idx);
+  }
+
+
+  CUTE_HOST_DEVICE static void
+  copy(void const* desc_ptr, uint64_t* mbar_ptr,
+      void      * smem_ptr,
+      int32_t const& crd0, int32_t const& crd1, int32_t const& crd2, int32_t const& crd3, int32_t const& crd4)
+  {
+    CUTE_INVALID_CONTROL_PATH("PAGED_COPY_OP not implemented for 5D");
+  }
+
+  };
+
+struct SM90_TMA_LOAD_MULTICAST_PAGED
+{
+  CUTE_HOST_DEVICE static void
+  copy(void const* desc_ptr, uint64_t* mbar_ptr, uint16_t multicast_mask,
+       void      * smem_ptr,
+       int32_t const& crd0)
+  {
+    CUTE_INVALID_CONTROL_PATH("not implemented");
+  }
+  CUTE_HOST_DEVICE static void
+  copy(void const* desc_ptr, uint64_t* mbar_ptr, uint16_t multicast_mask,
+       PagedCopyArgs const& pca,
+       void      * smem_ptr,
+       int32_t const& crd0, int32_t const& crd1)
+  {
+    CUTE_INVALID_CONTROL_PATH("not implemented");
+  }
+  CUTE_HOST_DEVICE static void
+  copy(void const* desc_ptr, uint64_t* mbar_ptr, uint16_t multicast_mask,
+       PagedCopyArgs const& pca,
+       void      * smem_ptr,
+       int32_t const& crd0, int32_t const& crd1, int32_t const& crd2)
+   {
+      if (pca.block_table == nullptr) {
+        return SM90_TMA_LOAD_MULTICAST_3D::copy(desc_ptr, mbar_ptr, multicast_mask, smem_ptr, crd0, crd1, crd2);
+      }
+      CUTE_INVALID_CONTROL_PATH("PAGED_COPY_OP not implemented for 3D");
+    }
+
+
+  CUTE_HOST_DEVICE static void
+  copy(void const* desc_ptr, uint64_t* mbar_ptr, uint16_t multicast_mask,
+       PagedCopyArgs const& pca,
+       void      * smem_ptr,
+       // Index order reordered for TMA from PagedSeqLenTraits::get_kv_gmem_layout()
+       // via cute::make_tma_copy_atom ( see detail::construct_tma_gbasis )
+       // and detail::make_tma_copy_desc to create a TMA descriptor.
+       // The same reordering is aplied prior to calling via cute::tma_partition.
+
+       // Final order determined experimentally.
+       int32_t const& crdK, // embedding dim
+       int32_t const& crdM, // sequence dim
+       int32_t const& crdH, // head dim
+       int32_t const& crdB) // batch dim
+  {
+    if (pca.block_table == nullptr) {
+        return SM90_TMA_LOAD_MULTICAST_4D::copy(desc_ptr, mbar_ptr, multicast_mask, smem_ptr, crdK, crdM, crdH, crdB);
+    }
+    int32_t const page_idx_offset = crdM / pca.page_block_size; // page index within the batch entry
+    int32_t const seq_pos_offset = crdM - page_idx_offset*pca.page_block_size; // == crd1 % page_block_size_ -> sequence position within the page
+    int32_t const page_idx = pca.block_table[page_idx_offset + crdB*pca.block_table_batch_stride]; // The page index for the given batch and sequence position
+    //if (cute::thread0()) {
+    //  printf("SM90_TMA_LOAD_MULTICAST_PAGED::copy crdM=%d, crdB=%d, crdK=%d, crdH=%d, page_idx=%d, seq_pos_offset=%d, ptr=%p\n", (int)crdM, (int)crdB, (int) crdK, (int) crdH, (int)page_idx, (int)seq_pos_offset, (void*)desc_ptr);
+    //}
+    return SM90_TMA_LOAD_MULTICAST_4D::copy(desc_ptr, mbar_ptr, multicast_mask, smem_ptr, crdK, seq_pos_offset, crdH, page_idx);
+  }
+};
+
+
+
+// We also need to specialize Copy_Traits for PAGED_COPY_OP, we can do this by inheriting from the traits of the underlying copy op
+
+//////////////////////////////////////////////////////////////////////////////
+///////////////////////////// TMA_LOAD ///////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////
+
+struct SM90_TMA_LOAD_PAGED_OP : SM90_TMA_LOAD_PAGED {};
+
+// The non-executable SM90_TMA_LOAD with tma_desc and no tma_mbar
+// Use .with(tma_mbar) to construct an executable version
+template <class NumBitsPerTMA, class AuxParams_>
+struct Copy_Traits<SM90_TMA_LOAD_PAGED, NumBitsPerTMA, AuxParams_>
+{
+  using ThrID     = Layout<_1>;
+  // Map from (src-thr,src-val) to bit
+  using SrcLayout = Layout<Shape<_1,NumBitsPerTMA>>;
+  // Map from (dst-thr,dst-val) to bit
+  using DstLayout = Layout<Shape<_1,NumBitsPerTMA>>;
+  // Reference map from (thr,val) to bit
+  using RefLayout = SrcLayout;
+
+  // SM90_TMA_LOAD arguments
+  TmaDescriptor tma_desc_;
+  using AuxParams = AuxParams_;
+  AuxParams aux_params_;
+
+  // Return TmaDescriptor/TensorMap
+  CUTE_HOST_DEVICE constexpr
+  TmaDescriptor const*
+  get_tma_descriptor() const {
+    return &tma_desc_;
+  }
+
+  // Construct an executable SM90_TMA_LOAD with tma_mbar
+  CUTE_HOST_DEVICE constexpr
+  Copy_Traits<SM90_TMA_LOAD_PAGED_OP, NumBitsPerTMA>
+  with(uint64_t& tma_mbar, [[maybe_unused]] uint16_t const& multicast_mask = 0) const {
+    // We accept multicast_mask here to keep the API for both atoms consistent
+    return {{}, {&tma_desc_, &tma_mbar, PagedCopyArgs{} }};
+  }
+
+  // Construct an executable SM90_TMA_LOAD with tma_mbar (temp. overloaded for grouped gemm/ptr array gemm)
+  CUTE_HOST_DEVICE constexpr
+  Copy_Traits<SM90_TMA_LOAD_PAGED_OP, NumBitsPerTMA>
+  with(TmaDescriptor const* new_tma_desc, uint64_t& tma_mbar, [[maybe_unused]] uint16_t const& multicast_mask = 0) const {
+    // We accept multicast_mask here to keep the API for both atoms consistent
+    return {{}, {new_tma_desc, &tma_mbar, PagedCopyArgs{} }};
+  }
+
+    CUTE_HOST_DEVICE constexpr
+  Copy_Traits<SM90_TMA_LOAD_PAGED_OP, NumBitsPerTMA>
+  with(uint64_t& tma_mbar, [[maybe_unused]] uint16_t const& multicast_mask, PagedCopyArgs const & paged_copy_args ) const {
+    // We accept multicast_mask here to keep the API for both atoms consistent
+    return {{}, {&tma_desc_, &tma_mbar, paged_copy_args }};
+  }
+
+  // Construct an executable SM90_TMA_LOAD with tma_mbar (temp. overloaded for grouped gemm/ptr array gemm)
+  CUTE_HOST_DEVICE constexpr
+  Copy_Traits<SM90_TMA_LOAD_PAGED_OP, NumBitsPerTMA>
+  with(TmaDescriptor const* new_tma_desc, uint64_t& tma_mbar, [[maybe_unused]] uint16_t const& multicast_mask,PagedCopyArgs const &paged_copy_args ) const {
+    // We accept multicast_mask here to keep the API for both atoms consistent
+    return {{}, {new_tma_desc, &tma_mbar, paged_copy_args }};
+  }
+
+  // Generate the TMA coord tensor
+  template <class GShape>
+  CUTE_HOST_DEVICE constexpr
+  auto
+  get_tma_tensor(GShape const& g_shape) const {
+    static_assert(is_congruent<decltype(g_shape), decltype(aux_params_.g_stride_)>::value);
+    return make_counting_tensor(make_layout(g_shape, aux_params_.g_stride_));
+  }
+
+  // Don't try to execute a copy with SM90_TMA_LOAD before calling .with()
+  template <class TS, class SLayout,
+            class TD, class DLayout>
+  CUTE_HOST_DEVICE friend constexpr void
+  copy_unpack(Copy_Traits        const& traits,
+              Tensor<TS,SLayout> const& src,
+              Tensor<TD,DLayout>      & dst) = delete;
+};
+
+// The executable SM90_TMA_LOAD with tma_desc and tma_mbar
+template <class NumBitsPerTMA>
+struct Copy_Traits<SM90_TMA_LOAD_PAGED_OP, NumBitsPerTMA>
+     : TMA_LOAD_Unpack<SM90_TMA_LOAD_PAGED_OP>
+{
+  using ThrID     = Layout<_1>;
+  // Map from (src-thr,src-val) to bit
+  using SrcLayout = Layout<Shape<_1,NumBitsPerTMA>>;
+  // Map from (dst-thr,dst-val) to bit
+  using DstLayout = Layout<Shape<_1,NumBitsPerTMA>>;
+  // Reference map from (thr,val) to bit
+  using RefLayout = SrcLayout;
+
+  // SM90_TMA_LOAD arguments
+  tuple<
+  TmaDescriptor const*,
+  uint64_t*, // smem mbarrier
+  PagedCopyArgs
+  > const opargs_;
+};
+
+
+//////////////////////////////////////////////////////////////////////////////
+///////////////////////////// TMA_LOAD_MULTICAST /////////////////////////////
+//////////////////////////////////////////////////////////////////////////////
+
+struct SM90_TMA_LOAD_MULTICAST_PAGED_OP : SM90_TMA_LOAD_MULTICAST_PAGED {};
+
+// The non-executable SM90_TMA_LOAD_MULTICAST with tma_desc and no tma_mbar
+// Use .with(tma_mbar, multicast_mask) to construct an executable version
+template <class NumBitsPerTMA, class AuxParams_>
+struct Copy_Traits<SM90_TMA_LOAD_MULTICAST_PAGED, NumBitsPerTMA, AuxParams_>
+{
+  using ThrID     = Layout<_1>;
+  // Map from (src-thr,src-val) to bit
+  using SrcLayout = Layout<Shape<_1,NumBitsPerTMA>>;
+  // Map from (dst-thr,dst-val) to bit
+  using DstLayout = Layout<Shape<_1,NumBitsPerTMA>>;
+  // Reference map from (thr,val) to bit
+  using RefLayout = SrcLayout;
+
+  // SM90_TMA_LOAD_MULTICAST arguments
+  TmaDescriptor tma_desc_;
+  using AuxParams = AuxParams_;
+  AuxParams aux_params_;
+
+  // Return TmaDescriptor/TensorMap
+  CUTE_HOST_DEVICE constexpr
+  TmaDescriptor const*
+  get_tma_descriptor() const {
+    return &tma_desc_;
+  }
+
+  // Construct an executable SM90_TMA_LOAD_MULTICAST with tma_mbar
+  CUTE_HOST_DEVICE constexpr
+  Copy_Traits<SM90_TMA_LOAD_MULTICAST_PAGED_OP, NumBitsPerTMA>
+  with(uint64_t& tma_load_mbar, uint16_t const& multicast_mask) const {
+    return {{}, {&tma_desc_, &tma_load_mbar, multicast_mask, PagedCopyArgs{} }};
+  }
+
+  // Construct an executable SM90_TMA_LOAD_MULTICAST_OP with tma_mbar (temp. overloaded for grouped gemm/ptr array gemm)
+  CUTE_HOST_DEVICE constexpr
+  Copy_Traits<SM90_TMA_LOAD_MULTICAST_PAGED_OP, NumBitsPerTMA>
+  with(TmaDescriptor const* new_tma_desc, uint64_t& tma_load_mbar, uint16_t const& multicast_mask) const {
+    return {{}, {new_tma_desc, &tma_load_mbar, multicast_mask, PagedCopyArgs{} }};
+  }
+
+    // Construct an executable SM90_TMA_LOAD_MULTICAST with tma_mbar
+  CUTE_HOST_DEVICE constexpr
+  Copy_Traits<SM90_TMA_LOAD_MULTICAST_PAGED_OP, NumBitsPerTMA>
+  with(uint64_t& tma_load_mbar, uint16_t const& multicast_mask, PagedCopyArgs const& paged_copy_args) const {
+    return {{}, {&tma_desc_, &tma_load_mbar, multicast_mask, paged_copy_args }};
+  }
+
+  // Construct an executable SM90_TMA_LOAD_MULTICAST_OP with tma_mbar (temp. overloaded for grouped gemm/ptr array gemm)
+  CUTE_HOST_DEVICE constexpr
+  Copy_Traits<SM90_TMA_LOAD_MULTICAST_PAGED_OP, NumBitsPerTMA>
+  with(TmaDescriptor const* new_tma_desc, uint64_t& tma_load_mbar, uint16_t const& multicast_mask, PagedCopyArgs const& paged_copy_args) const {
+    return {{}, {new_tma_desc, &tma_load_mbar, multicast_mask, paged_copy_args }};
+  }
+
+  // Generate the TMA coord tensor
+  template <class GShape>
+  CUTE_HOST_DEVICE constexpr
+  auto
+  get_tma_tensor(GShape const& g_shape) const {
+    static_assert(is_congruent<decltype(g_shape), decltype(aux_params_.g_stride_)>::value);
+    return make_counting_tensor(make_layout(g_shape, aux_params_.g_stride_));
+  }
+
+  // Don't try to execute a copy with SM90_TMA_LOAD_MULTICAST before calling .with()
+  template <class TS, class SLayout,
+            class TD, class DLayout>
+  CUTE_HOST_DEVICE friend constexpr void
+  copy_unpack(Copy_Traits        const& traits,
+              Tensor<TS,SLayout> const& src,
+              Tensor<TD,DLayout>      & dst) = delete;
+};
+
+// The executable SM90_TMA_LOAD_MULTICAST with tma_desc and tma_mbar and multicast_mask
+template <class NumBitsPerTMA>
+struct Copy_Traits<SM90_TMA_LOAD_MULTICAST_PAGED_OP, NumBitsPerTMA>
+     : TMA_LOAD_Unpack<SM90_TMA_LOAD_MULTICAST_PAGED_OP>
+{
+  using ThrID     = Layout<_1>;
+  // Map from (src-thr,src-val) to bit
+  using SrcLayout = Layout<Shape<_1,NumBitsPerTMA>>;
+  // Map from (dst-thr,dst-val) to bit
+  using DstLayout = Layout<Shape<_1,NumBitsPerTMA>>;
+  // Reference map from (thr,val) to bit
+  using RefLayout = SrcLayout;
+
+  // SM90_TMA_LOAD_MULTICAST arguments
+  tuple<
+  TmaDescriptor const*,
+  uint64_t*, // smem mbarrier
+  uint16_t,   // multicast mask
+  PagedCopyArgs,
+  > const opargs_;
+};
+
+
+template <class TmaInternalType = void,
+          class CopyOp,
+          class GEngine, class GLayout,
+          class VShape,
+          class SLayout,
+          class CTA_Tiler,
+          class Cluster_Size>
+CUTE_HOST_RTC
+auto
+make_virtualized_tma_copy(CopyOp                  const& copy_op,
+              Tensor<GEngine,GLayout> const& gtensor,
+              VShape                  const &virtual_shape,
+              SLayout                 const slayout,
+              CTA_Tiler               const& cta_tiler,
+              Cluster_Size            const& cluster_size)
+{
+    /**
+      Variant of cute::make_tma_copy which allows to separate a virtual tensor coordinate space and
+      a physical TMA tensor coordinate space. Used for Paged Attention with TMA.
+     */
+    auto cta_v_tile = make_identity_layout(virtual_shape).compose(cta_tiler);
+    auto cta_t_tile = make_layout(cluster_size);
+    //cute::print("\nVirtual Shape:"); cute::print(virtual_shape);
+    //cute::print("\nPhysical Shape:"); cute::print(gtensor.layout().shape()); cute::print("\n");
+    // Prefer TmaInternalType if specified. Fallback to GEngine::value_type
+    using TmaType = conditional_t<is_same<void, TmaInternalType>::value, typename GEngine::value_type, TmaInternalType>;
+    return detail::make_tma_copy_tiled<TmaType>(copy_op,
+                                                gtensor, slayout,
+                                                cta_t_tile, cta_v_tile);
+
+}
+
+}

--- a/hopper/flash.h
+++ b/hopper/flash.h
@@ -105,6 +105,7 @@ struct Flash_fwd_params : public Qkv_params {
     int * __restrict__ block_table;
     index_t block_table_batch_stride;
     int page_block_size;
+    int page_num_blocks;
 
     // The dropout probability (probability of keeping an activation).
     float p_dropout;

--- a/hopper/static_switch.h
+++ b/hopper/static_switch.h
@@ -55,14 +55,23 @@
     }                                                                          \
   }()
 
-#define SEQLEN_SWITCH(USE_VAR_SEQ_LEN, NAME, ...)                              \
+#define SEQLEN_SWITCH(PARAMS, NAME, NAME_Q, ...)                               \
   [&] {                                                                        \
-    bool useSeqLen = USE_VAR_SEQ_LEN;                                          \
+    const bool useSeqLen = PARAMS.cu_seqlens_q;                                \
+    const bool usePagedKV = PARAMS.page_block_size>0;                          \
     if (useSeqLen) {                                                           \
-      using NAME = flash::VarSeqLenTraits;                                     \
-      return __VA_ARGS__();                                                    \
+      if (usePagedKV) {                                                        \
+        using NAME = flash::PagedSeqLenTraits;                                 \
+        using NAME_Q = flash::VarSeqLenTraits;                                 \
+        return __VA_ARGS__();                                                  \
+      } else {                                                                 \
+        using NAME = flash::VarSeqLenTraits;                                   \
+        using NAME_Q = flash::VarSeqLenTraits;                                 \
+        return __VA_ARGS__();                                                  \
+      }                                                                        \
     } else {                                                                   \
       using NAME = flash::FixedSeqLenTraits;                                   \
+      using NAME_Q = flash::FixedSeqLenTraits;                                 \
       return __VA_ARGS__();                                                    \
     }                                                                          \
   }()

--- a/hopper/test_flash_attn.py
+++ b/hopper/test_flash_attn.py
@@ -1,15 +1,26 @@
 import math
 
+import einops
+
 import pytest
 import torch
 import torch.nn.functional as F
-
 from einops import rearrange, repeat
-from flash_attn_interface import flash_attn_func, flash_attn_varlen_func, _flash_attn_forward
-from tests.test_util import generate_random_padding_mask, generate_qkv, construct_local_mask, attention_ref
+from flash_attn_interface import (
+    _flash_attn_forward,
+    flash_attn_func,
+    flash_attn_varlen_func,
+)
+from tests.test_util import (
+    attention_ref,
+    construct_local_mask,
+    generate_qkv,
+    generate_random_padding_mask,
+)
 
 ABS_TOL = 5e-3
 REL_TOL = 1e-1
+
 
 def print_diffs(out, out_ref):
     out_1d = out.flatten()
@@ -55,14 +66,23 @@ def print_diffs(out, out_ref):
     ],
 )
 def test_flash_attn_output_fp8(
-    seqlen_q, seqlen_k, d, causal, local, deterministic, mha_type, dtype, descale, gqa_parallel
+    seqlen_q,
+    seqlen_k,
+    d,
+    causal,
+    local,
+    deterministic,
+    mha_type,
+    dtype,
+    descale,
+    gqa_parallel,
 ):
     device = "cuda"
     dtype_init = torch.bfloat16
     print(dtype)
-    print('causal',causal)
-    print('local',local)
-    print('gqa_parallel',gqa_parallel)
+    print("causal", causal)
+    print("local", local)
+    print("gqa_parallel", gqa_parallel)
     # set seed
     torch.random.manual_seed(42)
     # batch_size = 40
@@ -74,21 +94,55 @@ def test_flash_attn_output_fp8(
     # batch_size = 9
     # nheads = 6
     window_size = (-1, -1) if not local else torch.randint(0, seqlen_k, (2,))
-    q = torch.randn(batch_size, seqlen_q, nheads, d, device=device, dtype=dtype_init, requires_grad=True)
-    k = torch.randn(batch_size, seqlen_k, nheads_kv, d, device=device, dtype=dtype_init, requires_grad=True)
-    v = torch.randn(batch_size, seqlen_k, nheads_kv, d, device=device, dtype=dtype_init, requires_grad=True)
+    q = torch.randn(
+        batch_size,
+        seqlen_q,
+        nheads,
+        d,
+        device=device,
+        dtype=dtype_init,
+        requires_grad=True,
+    )
+    k = torch.randn(
+        batch_size,
+        seqlen_k,
+        nheads_kv,
+        d,
+        device=device,
+        dtype=dtype_init,
+        requires_grad=True,
+    )
+    v = torch.randn(
+        batch_size,
+        seqlen_k,
+        nheads_kv,
+        d,
+        device=device,
+        dtype=dtype_init,
+        requires_grad=True,
+    )
 
     q = q.to(dtype)
     k = k.to(dtype)
     v = v.to(dtype)
 
     softmax_scale = q.shape[-1] ** (-0.5)
-    descale_q = torch.tensor([descale], dtype=torch.float32, device='cuda')
-    descale_k = torch.tensor([descale], dtype=torch.float32, device='cuda')
-    descale_v = torch.tensor([descale], dtype=torch.float32, device='cuda')
+    descale_q = torch.tensor([descale], dtype=torch.float32, device="cuda")
+    descale_k = torch.tensor([descale], dtype=torch.float32, device="cuda")
+    descale_v = torch.tensor([descale], dtype=torch.float32, device="cuda")
 
-    out, lse = flash_attn_func(q, k, v, causal=causal, window_size=window_size, deterministic=deterministic, gqa_parallel=gqa_parallel,
-                                descale_q=descale_q, descale_k=descale_k, descale_v=descale_v)
+    out, lse = flash_attn_func(
+        q,
+        k,
+        v,
+        causal=causal,
+        window_size=window_size,
+        deterministic=deterministic,
+        gqa_parallel=gqa_parallel,
+        descale_q=descale_q,
+        descale_k=descale_k,
+        descale_v=descale_v,
+    )
 
     q = q.to(dtype_init)
     k = k.to(dtype_init)
@@ -145,7 +199,7 @@ def test_flash_attn_output_fp8(
     # dV = torch.einsum('bhts,bthd->bshd', P, g.float())
     # dK = torch.einsum('bhts,bthd->bshd', dP, q.float())
     # breakpoint()
-    
+
     # assert (out - out_ref).abs().max().item() <= 4 * (out_pt - out_ref).abs().max().item() + 1e-2
     atol = 4 * (out_pt - out_ref).abs().max().item() + 1e-2
     torch.testing.assert_close(out, out_ref, rtol=1e-2, atol=atol, check_dtype=False)
@@ -197,17 +251,26 @@ def test_flash_attn_output_fp8(
 )
 # @pytest.mark.parametrize('seqlen_q,seqlen_k', [(128, 128)])
 def test_flash_attn_output(
-    seqlen_q, seqlen_k, d, causal, local, deterministic, mha_type, dtype, descale, gqa_parallel
+    seqlen_q,
+    seqlen_k,
+    d,
+    causal,
+    local,
+    deterministic,
+    mha_type,
+    dtype,
+    descale,
+    gqa_parallel,
 ):
     device = "cuda"
-    if(dtype == torch.float8_e4m3fn):
+    if dtype == torch.float8_e4m3fn:
         dtype_init = torch.bfloat16
     else:
         dtype_init = dtype
     print(dtype)
-    print('causal',causal)
-    print('local',local)
-    print('gqa_parallel',gqa_parallel)
+    print("causal", causal)
+    print("local", local)
+    print("gqa_parallel", gqa_parallel)
     # set seed
     torch.random.manual_seed(42)
     # batch_size = 40
@@ -219,30 +282,72 @@ def test_flash_attn_output(
     # batch_size = 9
     # nheads = 6
     window_size = (-1, -1) if not local else torch.randint(0, seqlen_k, (2,))
-    q = torch.randn(batch_size, seqlen_q, nheads, d, device=device, dtype=dtype_init, requires_grad=True)
-    k = torch.randn(batch_size, seqlen_k, nheads_kv, d, device=device, dtype=dtype_init, requires_grad=True)
-    v = torch.randn(batch_size, seqlen_k, nheads_kv, d, device=device, dtype=dtype_init, requires_grad=True)
+    q = torch.randn(
+        batch_size,
+        seqlen_q,
+        nheads,
+        d,
+        device=device,
+        dtype=dtype_init,
+        requires_grad=True,
+    )
+    k = torch.randn(
+        batch_size,
+        seqlen_k,
+        nheads_kv,
+        d,
+        device=device,
+        dtype=dtype_init,
+        requires_grad=True,
+    )
+    v = torch.randn(
+        batch_size,
+        seqlen_k,
+        nheads_kv,
+        d,
+        device=device,
+        dtype=dtype_init,
+        requires_grad=True,
+    )
 
     q = q.to(dtype)
     k = k.to(dtype)
     v = v.to(dtype)
 
     softmax_scale = q.shape[-1] ** (-0.5)
-    descale_q = torch.tensor([descale], dtype=torch.float32, device='cuda')
-    descale_k = torch.tensor([descale], dtype=torch.float32, device='cuda')
-    descale_v = torch.tensor([descale], dtype=torch.float32, device='cuda')
+    descale_q = torch.tensor([descale], dtype=torch.float32, device="cuda")
+    descale_k = torch.tensor([descale], dtype=torch.float32, device="cuda")
+    descale_v = torch.tensor([descale], dtype=torch.float32, device="cuda")
 
-    if(dtype != torch.float8_e4m3fn):
-        out, lse = flash_attn_func(q, k, v, causal=causal, window_size=window_size, deterministic=deterministic, gqa_parallel=gqa_parallel)
+    if dtype != torch.float8_e4m3fn:
+        out, lse = flash_attn_func(
+            q,
+            k,
+            v,
+            causal=causal,
+            window_size=window_size,
+            deterministic=deterministic,
+            gqa_parallel=gqa_parallel,
+        )
     else:
-        out, lse = flash_attn_func(q, k, v, causal=causal, window_size=window_size, deterministic=deterministic, gqa_parallel=gqa_parallel,
-                                   descale_q=descale_q, descale_k=descale_k, descale_v=descale_v)
+        out, lse = flash_attn_func(
+            q,
+            k,
+            v,
+            causal=causal,
+            window_size=window_size,
+            deterministic=deterministic,
+            gqa_parallel=gqa_parallel,
+            descale_q=descale_q,
+            descale_k=descale_k,
+            descale_v=descale_v,
+        )
 
     q = q.to(dtype_init)
     k = k.to(dtype_init)
     v = v.to(dtype_init)
 
-    if(dtype == torch.float8_e4m3fn):
+    if dtype == torch.float8_e4m3fn:
         descale_q = descale_q.to(dtype_init)
         descale_k = descale_k.to(dtype_init)
         descale_v = descale_v.to(dtype_init)
@@ -317,16 +422,26 @@ def test_flash_attn_output(
     # Check that FlashAttention's numerical error is at most twice the numerical error
     # of a Pytorch implementation.
     # breakpoint()
-    if(dtype != torch.float8_e4m3fn):
-        assert (out - out_ref).abs().max().item() <= 2 * (out_pt - out_ref).abs().max().item() + 3e-5
+    if dtype != torch.float8_e4m3fn:
+        assert (out - out_ref).abs().max().item() <= 2 * (
+            out_pt - out_ref
+        ).abs().max().item() + 3e-5
     else:
         # just test correctness of fp8 kernel w/o further quantization techniques
-        assert (out - out_ref).abs().max().item() <= 4 * (out_pt - out_ref).abs().max().item() + 2e-2
+        assert (out - out_ref).abs().max().item() <= 4 * (
+            out_pt - out_ref
+        ).abs().max().item() + 2e-2
 
     if d <= 128 and dtype != torch.float8_e4m3fn:
-        assert (dq - dq_ref).abs().max().item() <= 2 * (dq_pt - dq_ref).abs().max().item() + 3e-5
-        assert (dk - dk_ref).abs().max().item() <= 2 * (dk_pt - dk_ref).abs().max().item() + 3e-5
-        assert (dv - dv_ref).abs().max().item() <= 2 * (dv_pt - dv_ref).abs().max().item() + 3e-5
+        assert (dq - dq_ref).abs().max().item() <= 2 * (
+            dq_pt - dq_ref
+        ).abs().max().item() + 3e-5
+        assert (dk - dk_ref).abs().max().item() <= 2 * (
+            dk_pt - dk_ref
+        ).abs().max().item() + 3e-5
+        assert (dv - dv_ref).abs().max().item() <= 2 * (
+            dv_pt - dv_ref
+        ).abs().max().item() + 3e-5
 
 
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
@@ -392,30 +507,54 @@ def test_flash_attn_varlen_output(
 
     window_size = (-1, -1) if not local else torch.randint(0, seqlen_k, (2,))
 
-    q = torch.randn(batch_size, seqlen_q, nheads, d, device=device, dtype=dtype, requires_grad=True)
+    q = torch.randn(
+        batch_size, seqlen_q, nheads, d, device=device, dtype=dtype, requires_grad=True
+    )
     k = torch.randn(
-        batch_size, seqlen_k, nheads_kv, d, device=device, dtype=dtype, requires_grad=True
+        batch_size,
+        seqlen_k,
+        nheads_kv,
+        d,
+        device=device,
+        dtype=dtype,
+        requires_grad=True,
     )
     v = torch.randn(
-        batch_size, seqlen_k, nheads_kv, d, device=device, dtype=dtype, requires_grad=True
+        batch_size,
+        seqlen_k,
+        nheads_kv,
+        d,
+        device=device,
+        dtype=dtype,
+        requires_grad=True,
     )
 
-    query_padding_mask = generate_random_padding_mask(seqlen_q, batch_size, device, mode="random", zero_lengths=False)
-    key_padding_mask = generate_random_padding_mask(seqlen_k, batch_size, device, mode="random", zero_lengths=True)
+    query_padding_mask = generate_random_padding_mask(
+        seqlen_q, batch_size, device, mode="random", zero_lengths=False
+    )
+    key_padding_mask = generate_random_padding_mask(
+        seqlen_k, batch_size, device, mode="random", zero_lengths=True
+    )
     # key_padding_mask = generate_random_padding_mask(seqlen_k, batch_size, device, mode='full')
 
     def _gen_unused_masks(padding_mask, add_unused, max_seq_len, bs, device):
         if add_unused:
             another_mask = generate_random_padding_mask(max_seq_len, bs, device)
             attn_mask = torch.logical_and(padding_mask, another_mask)
-            unused_mask = torch.logical_xor(torch.logical_or(padding_mask, another_mask), attn_mask)
+            unused_mask = torch.logical_xor(
+                torch.logical_or(padding_mask, another_mask), attn_mask
+            )
         else:
             attn_mask = padding_mask
             unused_mask = None
         return attn_mask, unused_mask
 
-    query_padding_mask, query_unused_mask = _gen_unused_masks(query_padding_mask, add_unused_qkv, seqlen_q, batch_size, q.device)
-    key_padding_mask, key_unused_mask = _gen_unused_masks(key_padding_mask, add_unused_qkv, seqlen_k, batch_size, k.device)
+    query_padding_mask, query_unused_mask = _gen_unused_masks(
+        query_padding_mask, add_unused_qkv, seqlen_q, batch_size, q.device
+    )
+    key_padding_mask, key_unused_mask = _gen_unused_masks(
+        key_padding_mask, add_unused_qkv, seqlen_k, batch_size, k.device
+    )
 
     (
         q_unpad,
@@ -433,7 +572,16 @@ def test_flash_attn_varlen_output(
         output_pad_fn,
         dq_pad_fn,
         dk_pad_fn,
-    ) = generate_qkv(q, k, v, query_padding_mask, key_padding_mask, kvpacked=False, query_unused_mask=query_unused_mask, key_unused_mask=key_unused_mask)
+    ) = generate_qkv(
+        q,
+        k,
+        v,
+        query_padding_mask,
+        key_padding_mask,
+        kvpacked=False,
+        query_unused_mask=query_unused_mask,
+        key_unused_mask=key_unused_mask,
+    )
     # print("cu_seqlens_q: ", cu_seqlens_q)
     # print("cu_seqlens_k: ", cu_seqlens_k)
     # print("q_unpad, shape: ", q_unpad.shape)
@@ -503,7 +651,9 @@ def test_flash_attn_varlen_output(
             dk_ref,
             dv_ref,
         ) = torch.autograd.grad(out_ref, (q, k, v), g)
-        zero_masking = rearrange(torch.logical_not(torch.any(key_padding_mask, 1)), "b -> b 1 1 1")
+        zero_masking = rearrange(
+            torch.logical_not(torch.any(key_padding_mask, 1)), "b -> b 1 1 1"
+        )
         dk_ref.masked_fill_(zero_masking, 0.0)
         dv_ref.masked_fill_(zero_masking, 0.0)
         (
@@ -531,9 +681,507 @@ def test_flash_attn_varlen_output(
 
     # Check that FlashAttention's numerical error is at most twice the numerical error
     # of a Pytorch implementation.
-    assert (out - out_ref).abs().max().item() <= 2 * (out_pt - out_ref).abs().max().item()
+    assert (out - out_ref).abs().max().item() <= 2 * (
+        out_pt - out_ref
+    ).abs().max().item()
 
     if d <= 128:
-        assert (dq - dq_ref).abs().max().item() < 1e-4 or (dq - dq_ref).abs().max().item() <= 3 * (dq_pt - dq_ref).abs().max().item()
-        assert (dk - dk_ref).abs().max().item() < 1e-4 or (dk - dk_ref).abs().max().item() <= 3 * (dk_pt - dk_ref).abs().max().item()
-        assert (dv - dv_ref).abs().max().item() < 1e-4 or (dv - dv_ref).abs().max().item() <= 3 * (dv_pt - dv_ref).abs().max().item()
+        assert (dq - dq_ref).abs().max().item() < 1e-4 or (
+            dq - dq_ref
+        ).abs().max().item() <= 3 * (dq_pt - dq_ref).abs().max().item()
+        assert (dk - dk_ref).abs().max().item() < 1e-4 or (
+            dk - dk_ref
+        ).abs().max().item() <= 3 * (dk_pt - dk_ref).abs().max().item()
+        assert (dv - dv_ref).abs().max().item() < 1e-4 or (
+            dv - dv_ref
+        ).abs().max().item() <= 3 * (dv_pt - dv_ref).abs().max().item()
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+# @pytest.mark.parametrize("dtype", [torch.float16])
+@pytest.mark.parametrize("mha_type", ["mha", "mqa", "gqa"])
+@pytest.mark.parametrize("causal", [False, True])
+# @pytest.mark.parametrize("causal", [False])
+@pytest.mark.parametrize("deterministic", [True, False])
+# @pytest.mark.parametrize("deterministic", [False])
+# @pytest.mark.parametrize("d", [32, 59, 64, 80, 96, 111, 128, 160, 192, 224, 256])
+# @pytest.mark.parametrize("d", [32, 64, 96, 128, 160, 192, 224, 256])
+# @pytest.mark.parametrize('d', [128])
+# @pytest.mark.parametrize("d", [64, 128, 256])
+@pytest.mark.parametrize("d", [128, 64])
+# @pytest.mark.parametrize("d", [128])
+@pytest.mark.parametrize(
+    "seqlen_q,seqlen_k",
+    [
+        # (1, 1),
+        # (1, 3),
+        # (2, 1),
+        # (511, 1),
+        # (3, 513),
+        # (64, 128),
+        # (113, 203),
+        # (128, 128),
+        # (128, 217),
+        # (113, 211),
+        # (108, 256),
+        (256, 512),
+        # (384, 256),
+        (768, 512),
+        #  (512, 256),
+        # (640, 128),
+        (1024, 1024),
+        # (1023, 1024),
+        # (1024, 1023),
+        # (2048, 2048),
+    ],
+)
+@pytest.mark.parametrize("add_unused_qkv", [False])
+@pytest.mark.parametrize("shuffle_pages", [True, False])
+# @pytest.mark.parametrize('seqlen_q,seqlen_k', [(128, 128)])
+def test_flash_attn_paged1(
+    seqlen_q,
+    seqlen_k,
+    d,
+    causal,
+    deterministic,
+    add_unused_qkv,
+    mha_type,
+    dtype,
+    shuffle_pages,
+):
+    run_conf = locals()
+    if (
+        max(seqlen_q, seqlen_k) >= 2048
+        and torch.cuda.get_device_properties("cuda").total_memory <= 16 * 2**30
+    ):
+        pytest.skip()  # Reference implementation OOM
+    device = "cuda"
+    # set seed
+    torch.random.manual_seed(0)
+    # batch_size = 1
+    # nheads = 1
+    batch_size = 9
+    nheads = 6
+    nheads_kv = 6 if mha_type == "mha" else (2 if mha_type == "gqa" else 1)
+
+    q = torch.randn(
+        batch_size, seqlen_q, nheads, d, device=device, dtype=dtype, requires_grad=True
+    )
+
+    page_size = 256
+    num_pages = batch_size * seqlen_k // page_size
+    assert seqlen_k % page_size == 0, "Max seqlen must be divisible by page size"
+    block_table = torch.reshape(
+        torch.arange(num_pages, dtype=torch.int32, device=device), (batch_size, -1)
+    )
+
+    k_paged = torch.randn(
+        num_pages,
+        page_size,
+        nheads_kv,
+        d,
+        device=device,
+        dtype=dtype,
+        requires_grad=True,
+    )
+    v_paged = torch.randn(
+        num_pages,
+        page_size,
+        nheads_kv,
+        d,
+        device=device,
+        dtype=dtype,
+        requires_grad=True,
+    )
+
+    if shuffle_pages:
+        block_table = torch.randperm(num_pages, dtype=torch.int32, device=device).view(
+            batch_size, -1
+        )
+        k = torch.index_select(k_paged, 0, block_table.view(-1)).view(
+            batch_size, seqlen_k, nheads_kv, d
+        )
+        v = torch.index_select(v_paged, 0, block_table.view(-1)).view(
+            batch_size, seqlen_k, nheads_kv, d
+        )
+    else:
+        k = torch.reshape(k_paged, (batch_size, seqlen_k, nheads_kv, d))
+        v = torch.reshape(v_paged, (batch_size, seqlen_k, nheads_kv, d))
+
+    query_padding_mask = generate_random_padding_mask(
+        seqlen_q, batch_size, device, mode="random"
+    )
+    key_padding_mask = generate_random_padding_mask(
+        seqlen_k, batch_size, device, mode="random"
+    )
+    # key_padding_mask = generate_random_padding_mask(seqlen_k, batch_size, device, mode='full')
+
+    def _gen_unused_masks(padding_mask, add_unused, max_seq_len, bs, device):
+        if add_unused:
+            another_mask = generate_random_padding_mask(max_seq_len, bs, device)
+            attn_mask = torch.logical_and(padding_mask, another_mask)
+            unused_mask = torch.logical_xor(
+                torch.logical_or(padding_mask, another_mask), attn_mask
+            )
+        else:
+            attn_mask = padding_mask
+            unused_mask = None
+        return attn_mask, unused_mask
+
+    query_padding_mask, query_unused_mask = _gen_unused_masks(
+        query_padding_mask, add_unused_qkv, seqlen_q, batch_size, q.device
+    )
+    key_padding_mask, key_unused_mask = _gen_unused_masks(
+        key_padding_mask, add_unused_qkv, seqlen_k, batch_size, k.device
+    )
+
+    (
+        q_unpad,
+        k_unpad,
+        v_unpad,
+        cu_seqlens_q,
+        cu_seqlens_k,
+        seqused_q,
+        seqused_k,
+        max_seqlen_q,
+        max_seqlen_k,
+        q,
+        k,
+        v,
+        output_pad_fn,
+        dq_pad_fn,
+        dk_pad_fn,
+    ) = generate_qkv(
+        q,
+        k,
+        v,
+        query_padding_mask,
+        key_padding_mask,
+        kvpacked=False,
+        query_unused_mask=query_unused_mask,
+        key_unused_mask=key_unused_mask,
+    )
+    # print("cu_seqlens_q: ", cu_seqlens_q)
+    # print("cu_seqlens_k: ", cu_seqlens_k)
+    # print("q_unpad, shape: ", q_unpad.shape)
+    # print("k_unpad, shape: ", k_unpad.shape)
+    # print("v_unpad, shape: ", v_unpad.shape)
+
+    out_unpad, sm_lse = flash_attn_varlen_func(
+        q_unpad,
+        k_paged,
+        v_paged,
+        cu_seqlens_q,
+        cu_seqlens_k,
+        max_seqlen_q,
+        max_seqlen_k,
+        causal=causal,
+        deterministic=deterministic,
+        block_table=block_table,
+    )
+    out = output_pad_fn(out_unpad)
+
+    out_unpaged_unpad, sm_unpaged_lse = flash_attn_varlen_func(
+        q_unpad,
+        k_unpad,
+        v_unpad,
+        cu_seqlens_q,
+        cu_seqlens_k,
+        max_seqlen_q,
+        max_seqlen_k,
+        causal=causal,
+        deterministic=deterministic,
+    )
+    out_unpaged = output_pad_fn(out_unpaged_unpad)
+
+    dropout_mask = None
+
+    out_ref, attn_ref = attention_ref(
+        q,
+        k,
+        v,
+        query_padding_mask,
+        key_padding_mask,
+        causal=causal,
+    )
+    out_pt, attn_pt = attention_ref(
+        q,
+        k,
+        v,
+        query_padding_mask,
+        key_padding_mask,
+        causal=causal,
+        upcast=False,
+        reorder_ops=True,
+    )
+    # print(f"{k.stride()=}, {v.stride()=}, {k_paged.stride()=}, {v_paged.stride()=}, {block_table.stride()=}")
+    print(f"Output max diff: {(out - out_ref).abs().max().item()}")
+    print(f"Output mean diff: {(out - out_ref).abs().mean().item()}")
+    print(f"Pytorch max diff: {(out_pt - out_ref).abs().max().item()}")
+    print(f"Pytorch mean diff: {(out_pt - out_ref).abs().mean().item()}")
+
+    print(f"Output max diff paged vs varlen: {(out - out_unpaged).abs().max().item()}")
+    print(
+        f"Output mean diff paged vs varlen: {(out - out_unpaged).abs().mean().item()}"
+    )
+
+    # Check that FlashAttention's numerical error is at most twice the numerical error
+    # of a Pytorch implementation.
+    # import fbvscode; fbvscode.set_trace()
+    assert (out - out_ref).abs().max().item() <= 2 * (
+        out_pt - out_ref
+    ).abs().max().item()
+
+
+@pytest.mark.parametrize("dtype", ([torch.bfloat16]))
+# @pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.parametrize("local", [False])
+# @pytest.mark.parametrize("local", [True])
+@pytest.mark.parametrize(
+    "d", [128, 64]
+)  # [32, 40, 59, 64, 80, 96, 111, 128, 160, 192, 224, 256])
+# @pytest.mark.parametrize("d", [32, 64, 96, 128, 160, 192, 224, 256])
+# @pytest.mark.parametrize('d', [32, 40, 64, 80, 96, 128, 160, 192])
+# @pytest.mark.parametrize('d', [32, 64, 96, 128, 160, 192])
+# @pytest.mark.parametrize('d', [56, 80])
+# @pytest.mark.parametrize("d", [64])
+@pytest.mark.parametrize("swap_sq_sk", [False, True])
+# @pytest.mark.parametrize("swap_sq_sk", [True])
+@pytest.mark.parametrize(
+    "seqlen_q,seqlen_k",
+    [
+        (1, 239),
+        (3, 799),
+        (127, 512),
+        (127, 513),
+        (113, 203),
+        (128, 217),
+        (113, 211),
+        (108, 256),
+        (256, 512),
+        (1023, 1024),
+    ],
+)
+# TODO: add smaller page sizes when https://github.com/Dao-AILab/flash-attention/pull/824 is merged
+@pytest.mark.parametrize("paged_kv_block_size", [256, 512])
+# @pytest.mark.parametrize("seqlen_q,seqlen_k", [(256, 128)])
+def test_flash_attn_varlen_paged2(
+    seqlen_q, seqlen_k, swap_sq_sk, d, local, paged_kv_block_size, dtype
+):
+    # Test ported from FlashAttention V2 test test_flash_attn_varlen_causal
+
+    def _generate_block_kvcache(
+        seqlen_k, paged_kv_block_size, batch_size, nheads_k, d, device, dtype
+    ):
+        num_blocks = math.ceil(seqlen_k / paged_kv_block_size) * batch_size * 3
+        k_cache_paged = torch.randn(
+            num_blocks, paged_kv_block_size, nheads_k, d, device=device, dtype=dtype
+        )
+        v_cache_paged = torch.randn(
+            num_blocks, paged_kv_block_size, nheads_k, d, device=device, dtype=dtype
+        )
+        block_table = rearrange(
+            torch.randperm(num_blocks, dtype=torch.int32, device=device),
+            "(b nblocks) -> b nblocks",
+            b=batch_size,
+        )
+        k_cache = rearrange(
+            # pytorch 1.12 doesn't have indexing with int32
+            k_cache_paged[block_table.to(dtype=torch.long).flatten()],
+            "(b nblocks) block_size ... -> b (nblocks block_size) ...",
+            b=batch_size,
+        )[:, :seqlen_k]
+        v_cache = rearrange(
+            v_cache_paged[block_table.to(dtype=torch.long).flatten()],
+            "(b nblocks) block_size ... -> b (nblocks block_size) ...",
+            b=batch_size,
+        )[:, :seqlen_k]
+        return k_cache, v_cache, block_table, k_cache_paged, v_cache_paged, num_blocks
+
+    if (
+        max(seqlen_q, seqlen_k) >= 2048
+        and torch.cuda.get_device_properties("cuda").total_memory <= 16 * 2**30
+    ):
+        pytest.skip()  # Reference implementation OOM
+    if swap_sq_sk:
+        seqlen_q, seqlen_k = seqlen_k, seqlen_q
+    device = "cuda"
+    causal = True
+    # set seed
+    torch.random.manual_seed(0)
+    batch_size = 8
+    nheads = 9
+    window_size = (-1, -1) if not local else torch.randint(0, seqlen_k, (2,))
+    q = torch.randn(
+        batch_size, seqlen_q, nheads, d, device=device, dtype=dtype, requires_grad=True
+    )
+
+    if paged_kv_block_size is None:
+        k = torch.randn(
+            batch_size,
+            seqlen_k,
+            nheads,
+            d,
+            device=device,
+            dtype=dtype,
+            requires_grad=True,
+        )
+        v = torch.randn(
+            batch_size,
+            seqlen_k,
+            nheads,
+            d,
+            device=device,
+            dtype=dtype,
+            requires_grad=True,
+        )
+        block_table = None
+    else:
+        k, v, block_table, k_cache_paged, v_cache_paged, num_blocks = (
+            _generate_block_kvcache(
+                seqlen_k, paged_kv_block_size, batch_size, nheads, d, device, dtype
+            )
+        )
+
+    query_padding_mask = generate_random_padding_mask(
+        seqlen_q, batch_size, device, mode="random"
+    )
+    key_padding_mask = generate_random_padding_mask(
+        seqlen_k, batch_size, device, mode="random"
+    )
+
+    def _gen_unused_masks(padding_mask, add_unused, max_seq_len, bs, device):
+        if add_unused:
+            another_mask = generate_random_padding_mask(max_seq_len, bs, device)
+            attn_mask = torch.logical_and(padding_mask, another_mask)
+            unused_mask = torch.logical_xor(
+                torch.logical_or(padding_mask, another_mask), attn_mask
+            )
+        else:
+            attn_mask = padding_mask
+            unused_mask = None
+        return attn_mask, unused_mask
+
+    query_padding_mask, query_unused_mask = _gen_unused_masks(
+        query_padding_mask, False, seqlen_q, batch_size, q.device
+    )
+    key_padding_mask, key_unused_mask = _gen_unused_masks(
+        key_padding_mask, False, seqlen_k, batch_size, k.device
+    )
+    (
+        q_unpad,
+        k_unpad,
+        v_unpad,
+        cu_seqlens_q,
+        cu_seqlens_k,
+        seqused_q,
+        seqused_k,
+        max_seqlen_q,
+        max_seqlen_k,
+        q,
+        k,
+        v,
+        output_pad_fn,
+        dq_pad_fn,
+        dk_pad_fn,
+    ) = generate_qkv(q, k, v, query_padding_mask, key_padding_mask, kvpacked=False)
+
+    out_unpad, sm_lse = flash_attn_varlen_func(
+        q_unpad,
+        k_unpad if paged_kv_block_size is None else k_cache_paged,
+        v_unpad if paged_kv_block_size is None else v_cache_paged,
+        cu_seqlens_q,
+        cu_seqlens_k,
+        max_seqlen_q,
+        max_seqlen_k,
+        causal=causal,
+        block_table=block_table,
+    )
+    out = output_pad_fn(out_unpad)
+    out_ref, attn_ref = attention_ref(
+        q,
+        k,
+        v,
+        query_padding_mask,
+        key_padding_mask,
+        None,
+        0.0,
+        None,
+        causal=causal,
+        window_size=window_size,
+    )
+    out_pt, attn_pt = attention_ref(
+        q,
+        k,
+        v,
+        query_padding_mask,
+        key_padding_mask,
+        None,
+        0.0,
+        None,
+        causal=causal,
+        window_size=window_size,
+        upcast=False,
+        reorder_ops=True,
+    )
+
+    print(f"Output max diff: {(out - out_ref).abs().max().item()}")
+    print(f"Output mean diff: {(out - out_ref).abs().mean().item()}")
+    print(f"Pytorch max diff: {(out_pt - out_ref).abs().max().item()}")
+    print(f"Pytorch mean diff: {(out_pt - out_ref).abs().mean().item()}")
+
+    g = torch.randn_like(out)
+    do_o = (g.float() * out.float()).sum(-1)
+    test_backward = block_table is None
+    if test_backward:
+        (
+            dq_unpad,
+            dk_unpad,
+            dv_unpad,
+        ) = torch.autograd.grad(out, (q_unpad, k_unpad, v_unpad), g)
+        dq = dq_pad_fn(dq_unpad)
+        dk = dk_pad_fn(dk_unpad)
+        dv = dk_pad_fn(dv_unpad)
+        (
+            dq_ref,
+            dk_ref,
+            dv_ref,
+        ) = torch.autograd.grad(out_ref, (q, k, v), g)
+        (
+            dq_pt,
+            dk_pt,
+            dv_pt,
+        ) = torch.autograd.grad(out_pt, (q, k, v), g)
+        print(f"dQ max diff: {(dq - dq_ref).abs().max().item()}")
+        print(f"dK max diff: {(dk - dk_ref).abs().max().item()}")
+        print(f"dV max diff: {(dv - dv_ref).abs().max().item()}")
+        print(f"dQ mean diff: {(dq - dq_ref).abs().mean().item()}")
+        print(f"dK mean diff: {(dk - dk_ref).abs().mean().item()}")
+        print(f"dV mean diff: {(dv - dv_ref).abs().mean().item()}")
+        print(f"dQ Pytorch max diff: {(dq_pt - dq_ref).abs().max().item()}")
+        print(f"dK Pytorch max diff: {(dk_pt - dk_ref).abs().max().item()}")
+        print(f"dV Pytorch max diff: {(dv_pt - dv_ref).abs().max().item()}")
+        print(f"dQ Pytorch mean diff: {(dq_pt - dq_ref).abs().mean().item()}")
+        print(f"dK Pytorch mean diff: {(dk_pt - dk_ref).abs().mean().item()}")
+        print(f"dV Pytorch mean diff: {(dv_pt - dv_ref).abs().mean().item()}")
+
+    # Check that FlashAttention's numerical error is at most twice the numerical error
+    # of a Pytorch implementation.
+    assert (out - out_ref).abs().max().item() <= 2 * (
+        out_pt - out_ref
+    ).abs().max().item() + 1e-5
+
+    if test_backward:
+        assert (dq - dq_ref).abs().max().item() <= 2 * (
+            dq_pt - dq_ref
+        ).abs().max().item() + 1e-5
+        assert (dk - dk_ref).abs().max().item() <= 2 * (
+            dk_pt - dk_ref
+        ).abs().max().item() + 1e-5
+        assert (dv - dv_ref).abs().max().item() <= 2 * (
+            dv_pt - dv_ref
+        ).abs().max().item() + 1e-5
+
+
+if __name__ == "__main__":
+    test_flash_attn_varlen_causal(512, 768, False, 128, False, 256, torch.bfloat16)


### PR DESCRIPTION
Adding support for Paged Attention / block table to the Flash-Attention 3 Kernel.

 Limits:
  - ~~Not yet integrated with #1236 which modifes the same code (and more).~~
  - No fp8 support yet - as that support also seems missing in the non-paged varlen version so far.

Test Plan:

```
cd hopper
pytest test_flash_attn.py -k "test_flash_attn_varlen_paged"  -s
```


**Update**
 - Rebased on top of main, which includes #1236 now
 - Original version of this PR ( not rebased ) still available on [this branch](https://github.com/kadeng/flash-attention/tree/fa3-paged-original)