### PR TITLE
[Fix] Use CUDA 12.4 in the build system so that the current build system stops failing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,7 +45,7 @@ jobs:
           os: [ubuntu-20.04]
           python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
           torch-version: ['2.1.2', '2.2.2', '2.3.1', '2.4.0', '2.5.1']
-          cuda-version: ['11.8.0', '12.3.2']
+          cuda-version: ['11.8.0', '12.4.1']
           # We need separate wheels that either uses C++11 ABI (-D_GLIBCXX_USE_CXX11_ABI) or not.
           # Pytorch wheels currently don't use it, but nvcr images have Pytorch compiled with C++11 ABI.
           # Without this we get import error (undefined symbol: _ZN3c105ErrorC2ENS_14SourceLocationESs)

--- a/setup.py
+++ b/setup.py
@@ -436,9 +436,9 @@ def get_wheel_url():
         # We're using the CUDA version used to build torch, not the one currently installed
         # _, cuda_version_raw = get_cuda_bare_metal_version(CUDA_HOME)
         torch_cuda_version = parse(torch.version.cuda)
-        # For CUDA 11, we only compile for CUDA 11.8, and for CUDA 12 we only compile for CUDA 12.3
+        # For CUDA 11, we only compile for CUDA 11.8, and for CUDA 12 we only compile for CUDA 12.4
         # to save CI time. Minor versions should be compatible.
-        torch_cuda_version = parse("11.8") if torch_cuda_version.major == 11 else parse("12.3")
+        torch_cuda_version = parse("11.8") if torch_cuda_version.major == 11 else parse("12.4")
         # cuda_version = f"{cuda_version_raw.major}{cuda_version_raw.minor}"
         cuda_version = f"{torch_cuda_version.major}{torch_cuda_version.minor}"
 


### PR DESCRIPTION
Very recently, a pull request was merged to add PyTorch 2.5 support (https://github.com/Dao-AILab/flash-attention/pull/1284)

However, this pull request seems to have accidentally broken the build system, which I uncovered when trying to build wheels for PyTorch 2.5.

The problem is that the build system builds with CUDA 12.3, but PyTorch doesn't have any 12.3 
releases. See https://github.com/EthanSteinberg/flash-attention/actions/runs/11762473443/job/32765408364#step:8:56 for the failed run.

This PR simply changes the build system to build against 12.4.1 instead.

As an aside, if this PR gets accepted, I would really appreciate if you can do a flash-attention 2.6.4 release that has PyTorch 2.5 support.

I have prepared a cherry pick branch for a 2.6.4 that is the minimal change over 2.6.3 that only has the two commits needed for a PyTorch 2.5 release: https://github.com/EthanSteinberg/flash-attention/tree/cuda_124_rebase

https://github.com/EthanSteinberg/flash-attention/actions/runs/11762648654 is my test run that this appears to build. (Note that it still failed because I don't have permission to upload artifacts. But the wheel did build successfully).


