### PR TITLE
Fix swiglu backwards return type

### DIFF
--- a/flash_attn/ops/activations.py
+++ b/flash_attn/ops/activations.py
@@ -110,7 +110,7 @@ template <typename T> T swiglu_fwd(T x, T y) {
 }
 """
 swiglu_bwd_codestring = """
-template <typename T> T swiglu_bwd(T x, T y, T g, T& dx, T& dy) {
+template <typename T> void swiglu_bwd(T x, T y, T g, T& dx, T& dy) {
     float x_sigmoid = 1.0f / (1.0f + ::exp(-float(x)));
     dx = x_sigmoid * (1 + float(x) * (1.0f - x_sigmoid)) * float(g) * float(y);
     dy = float(x) * x_sigmoid * float(g);


### PR DESCRIPTION
The return type of `swiglu_bwd_codestring` is incorrect, (specifies `T` not `void` despite the lack of returned value). While it doesn't appear to have an impact in CUDA, it does have an adverse effect in ROCm, resulting in incorrect gradients. Changing it to `void` resolves the issue.