### PR TITLE
Fix FA3 Varlen Performance regression

### DIFF
--- a/hopper/copy_paged_sm90_tma_cutlass36.hpp
+++ b/hopper/copy_paged_sm90_tma_cutlass36.hpp
@@ -14,12 +14,12 @@ struct PagedCopyArgs {
   };
 
   CUTE_HOST_DEVICE
-  PagedCopyArgs(int64_t const block_table_batch_stride_, int const page_block_size_, int32_t *block_table_) : block_table_batch_stride{block_table_batch_stride_}, page_block_size(page_block_size_), block_table(block_table_)  {
+  PagedCopyArgs(int64_t const block_table_batch_stride_, int const page_block_size_, const int32_t *const block_table_) : block_table_batch_stride{block_table_batch_stride_}, page_block_size(page_block_size_), block_table(block_table_)  {
   };
 
-  int64_t block_table_batch_stride; // The stride between block tables for different batches
-  int page_block_size; // The size of a page block in number of elements
-  int32_t* block_table; // The block table, must be properly sized or a nullptr
+  const int64_t block_table_batch_stride; // The stride between block tables for different batches
+  const int page_block_size; // The size of a page block in number of elements
+  const int32_t *const block_table; // The block table, must be properly sized or a nullptr
 };
 
 namespace cute {
@@ -29,34 +29,35 @@ namespace cute {
     using COPY_OP = SM90_TMA_LOAD; // The underlying copy operation that we delegate work to
 
     CUTE_HOST_DEVICE static void
-    copy(void const* desc_ptr, uint64_t* mbar_ptr, uint64_t cache_hint,
+    copy(void const* desc_ptr, uint64_t* mbar_ptr,
         void      * smem_ptr,
         int32_t const& crd0)
     {
       CUTE_INVALID_CONTROL_PATH("PAGED_COPY_OP not implemented for 1D");
     }
     CUTE_HOST_DEVICE static void
-    copy(void const* desc_ptr, uint64_t* mbar_ptr, uint64_t cache_hint,
-        PagedCopyArgs const& pca,
+    copy(void const* desc_ptr, uint64_t* mbar_ptr,
+        PagedCopyArgs const* pca,
         void      * smem_ptr,
         int32_t const& crd0, int32_t const& crd1)
     {
       CUTE_INVALID_CONTROL_PATH("PAGED_COPY_OP not implemented for 2D");
     }
     CUTE_HOST_DEVICE static void
-    copy(void const* desc_ptr, uint64_t* mbar_ptr, uint64_t cache_hint,
-        PagedCopyArgs const& pca,
+    copy(void const* desc_ptr, uint64_t* mbar_ptr, 
+        PagedCopyArgs const* pca,
         void      * smem_ptr,
         int32_t const& crd0, int32_t const& crd1, int32_t const& crd2)
     {
-      if (pca.block_table == nullptr) {
-        return SM90_TMA_LOAD_3D::copy(desc_ptr, mbar_ptr, cache_hint, smem_ptr, crd0, crd1, crd2);
-      }
-      CUTE_INVALID_CONTROL_PATH("PAGED_COPY_OP not implemented for 3D");
+      // WARNING: Do not place anything else here, or a performance regression will occur
+      // look out for ptxas build warnings like "Potential Performance Loss: wgmma.mma_async instructions are serialized"
+      // asserts that pca==nullptr, but even an assert would kill performance
+      return SM90_TMA_LOAD_3D::copy(desc_ptr, mbar_ptr, static_cast<uint64_t>(TMA::CacheHintSm90::EVICT_NORMAL), smem_ptr, crd0, crd1, crd2);
     }
-    CUTE_HOST_DEVICE static void
-    copy(void const* desc_ptr, uint64_t* mbar_ptr, uint64_t cache_hint,
-        PagedCopyArgs const& pca,
+
+    CUTE_HOST_DEVICE  static void
+    copy(void const* desc_ptr, uint64_t* mbar_ptr, 
+        PagedCopyArgs const* pca,
         void      * smem_ptr,
        // Index order reordered for TMA from PagedSeqLenTraits::get_kv_gmem_layout()
        // via cute::make_tma_copy_atom ( see detail::construct_tma_gbasis )
@@ -72,21 +73,24 @@ namespace cute {
     //auto log = pca.debug_log->nextline();
     //log.append_threadinfo();
     //log.snprintf("SM_90_TMA_LOAD_PAGED::copy(%d, %d, %d, %d) ", (int)crdM, (int)crdK, (int)crdH, (int)crdB);
-    if (pca.block_table == nullptr) {
-        return SM90_TMA_LOAD_4D::copy(desc_ptr, mbar_ptr, cache_hint, smem_ptr, crdK, crdM, crdH, crdB);
+    if (pca == nullptr) {
+        return SM90_TMA_LOAD_4D::copy(desc_ptr, mbar_ptr, static_cast<uint64_t>(TMA::CacheHintSm90::EVICT_NORMAL), smem_ptr, crdK, crdM, crdH, crdB);
     }
-    int32_t const page_idx_offset = crdM / pca.page_block_size; // page index within the batch entry
-    int32_t const seq_pos_offset = crdM - page_idx_offset*pca.page_block_size; // == crd1 % page_block_size_ -> sequence position within the page
-    int32_t const page_idx = pca.block_table[page_idx_offset + crdB*pca.block_table_batch_stride]; // The page index for the given batch and sequence position
+    auto const page_block_size = pca->page_block_size;
+    int32_t const page_idx_offset = crdM / page_block_size; // page index within the batch entry
+    int32_t const seq_pos_offset = crdM - page_idx_offset * page_block_size; // == crd1 % page_block_size_ -> sequence position within the page
+    int32_t const page_idx = pca->block_table[page_idx_offset + crdB*pca->block_table_batch_stride]; // The page index for the given batch and sequence position
     //if (cute::thread0()) {
     //  printf("SM90_TMA_LOAD_PAGED::copy crdM=%d, crdB=%d, crdK=%d, crdH=%d, page_idx=%d, seq_pos_offset=%d, ptr=%p\n", (int)crdM, (int)crdB, (int) crdK, (int) crdH, (int)page_idx, (int)seq_pos_offset, (void*)desc_ptr);
     //}
-    return SM90_TMA_LOAD_4D::copy(desc_ptr, mbar_ptr, cache_hint, smem_ptr, crdK, seq_pos_offset, crdH, page_idx);
+    
+    return SM90_TMA_LOAD_4D::copy(desc_ptr, mbar_ptr, static_cast<uint64_t>(TMA::CacheHintSm90::EVICT_NORMAL), smem_ptr, crdK, seq_pos_offset, crdH, page_idx);
+
   }
 
 
   CUTE_HOST_DEVICE static void
-  copy(void const* desc_ptr, uint64_t* mbar_ptr, uint64_t cache_hint,
+  copy(void const* desc_ptr, uint64_t* mbar_ptr, 
       void      * smem_ptr,
       int32_t const& crd0, int32_t const& crd1, int32_t const& crd2, int32_t const& crd3, int32_t const& crd4)
   {
@@ -98,36 +102,36 @@ namespace cute {
 struct SM90_TMA_LOAD_MULTICAST_PAGED
 {
   CUTE_HOST_DEVICE static void
-  copy(void const* desc_ptr, uint64_t* mbar_ptr, uint16_t multicast_mask, uint64_t cache_hint,
+  copy(void const* desc_ptr, uint64_t* mbar_ptr, uint16_t multicast_mask,
        void      * smem_ptr,
        int32_t const& crd0)
   {
     CUTE_INVALID_CONTROL_PATH("not implemented");
   }
   CUTE_HOST_DEVICE static void
-  copy(void const* desc_ptr, uint64_t* mbar_ptr, uint16_t multicast_mask, uint64_t cache_hint,
-       PagedCopyArgs const& pca,
+  copy(void const* desc_ptr, uint64_t* mbar_ptr, uint16_t multicast_mask,
+       PagedCopyArgs const* pca,
        void      * smem_ptr,
        int32_t const& crd0, int32_t const& crd1)
   {
     CUTE_INVALID_CONTROL_PATH("not implemented");
   }
-  CUTE_HOST_DEVICE static void
-  copy(void const* desc_ptr, uint64_t* mbar_ptr, uint16_t multicast_mask, uint64_t cache_hint,
-       PagedCopyArgs const& pca,
+  CUTE_HOST_DEVICE  static void
+  copy(void const* desc_ptr, uint64_t* mbar_ptr, uint16_t multicast_mask,
+       PagedCopyArgs const* pca,
        void      * smem_ptr,
        int32_t const& crd0, int32_t const& crd1, int32_t const& crd2)
    {
-      if (pca.block_table == nullptr) {
-        return SM90_TMA_LOAD_MULTICAST_3D::copy(desc_ptr, mbar_ptr, multicast_mask, cache_hint, smem_ptr, crd0, crd1, crd2);
-      }
-      CUTE_INVALID_CONTROL_PATH("PAGED_COPY_OP not implemented for 3D");
+      // WARNING: Do not place anything else here, or a performance regression will occur
+      // look out for ptxas build warnings like "Potential Performance Loss: wgmma.mma_async instructions are serialized"
+      // asserts that pca==nullptr, but even an assert would kill performance
+      return SM90_TMA_LOAD_MULTICAST_3D::copy(desc_ptr, mbar_ptr, multicast_mask, static_cast<uint64_t>(TMA::CacheHintSm90::EVICT_NORMAL), smem_ptr, crd0, crd1, crd2);
     }
 
 
   CUTE_HOST_DEVICE static void
-  copy(void const* desc_ptr, uint64_t* mbar_ptr, uint16_t multicast_mask,  uint64_t cache_hint,
-       PagedCopyArgs const& pca,
+  copy(void const* desc_ptr, uint64_t* mbar_ptr, uint16_t multicast_mask, 
+       PagedCopyArgs const* pca,
        void      * smem_ptr,
        // Index order reordered for TMA from PagedSeqLenTraits::get_kv_gmem_layout()
        // via cute::make_tma_copy_atom ( see detail::construct_tma_gbasis )
@@ -140,17 +144,20 @@ struct SM90_TMA_LOAD_MULTICAST_PAGED
        int32_t const& crdH, // head dim
        int32_t const& crdB) // batch dim
   {
-    if (pca.block_table == nullptr) {
-        return SM90_TMA_LOAD_MULTICAST_4D::copy(desc_ptr, mbar_ptr, multicast_mask, cache_hint, smem_ptr, crdK, crdM, crdH, crdB);
+    if (pca == nullptr) {
+        return SM90_TMA_LOAD_MULTICAST_4D::copy(desc_ptr, mbar_ptr, multicast_mask, static_cast<uint64_t>(TMA::CacheHintSm90::EVICT_NORMAL), smem_ptr, crdK, crdM, crdH, crdB);
     }
-    int32_t const page_idx_offset = crdM / pca.page_block_size; // page index within the batch entry
-    int32_t const seq_pos_offset = crdM - page_idx_offset*pca.page_block_size; // == crd1 % page_block_size_ -> sequence position within the page
-    int32_t const page_idx = pca.block_table[page_idx_offset + crdB*pca.block_table_batch_stride]; // The page index for the given batch and sequence position
+    auto const page_block_size = pca->page_block_size;
+    int32_t const page_idx_offset = crdM / page_block_size; // page index within the batch entry
+    int32_t const seq_pos_offset = crdM - page_idx_offset*page_block_size; // == crd1 % page_block_size_ -> sequence position within the page
+    int32_t const page_idx = pca->block_table[page_idx_offset + crdB*pca->block_table_batch_stride]; // The page index for the given batch and sequence position
     //if (cute::thread0()) {
     //  printf("SM90_TMA_LOAD_MULTICAST_PAGED::copy crdM=%d, crdB=%d, crdK=%d, crdH=%d, page_idx=%d, seq_pos_offset=%d, ptr=%p\n", (int)crdM, (int)crdB, (int) crdK, (int) crdH, (int)page_idx, (int)seq_pos_offset, (void*)desc_ptr);
     //}
-    return SM90_TMA_LOAD_MULTICAST_4D::copy(desc_ptr, mbar_ptr, multicast_mask, cache_hint, smem_ptr, crdK, seq_pos_offset, crdH, page_idx);
+    return SM90_TMA_LOAD_MULTICAST_4D::copy(desc_ptr, mbar_ptr, multicast_mask, static_cast<uint64_t>(TMA::CacheHintSm90::EVICT_NORMAL), smem_ptr, crdK, seq_pos_offset, crdH, page_idx);
+    
   }
+
 };
 
 
@@ -193,7 +200,7 @@ struct Copy_Traits<SM90_TMA_LOAD_PAGED, NumBitsPerTMA, AuxParams_>
   Copy_Traits<SM90_TMA_LOAD_PAGED_OP, NumBitsPerTMA>
   with(uint64_t& tma_mbar, [[maybe_unused]] uint16_t const& multicast_mask = 0, TMA::CacheHintSm90 const& cache_hint = TMA::CacheHintSm90::EVICT_NORMAL) const {
     // We accept multicast_mask here to keep the API for both atoms consistent
-    return {{}, {&tma_desc_, &tma_mbar, static_cast<uint64_t>(cache_hint), PagedCopyArgs{} }};
+    return {{}, {&tma_desc_, &tma_mbar, nullptr}};
   }
 
   // Construct an executable SM90_TMA_LOAD with tma_mbar (temp. overloaded for grouped gemm/ptr array gemm)
@@ -201,22 +208,22 @@ struct Copy_Traits<SM90_TMA_LOAD_PAGED, NumBitsPerTMA, AuxParams_>
   Copy_Traits<SM90_TMA_LOAD_PAGED_OP, NumBitsPerTMA>
   with(TmaDescriptor const* new_tma_desc, uint64_t& tma_mbar, [[maybe_unused]] uint16_t const& multicast_mask = 0, TMA::CacheHintSm90 const& cache_hint = TMA::CacheHintSm90::EVICT_NORMAL) const {
     // We accept multicast_mask here to keep the API for both atoms consistent
-    return {{}, {new_tma_desc, &tma_mbar, static_cast<uint64_t>(cache_hint), PagedCopyArgs{} }};
+    return {{}, {new_tma_desc, &tma_mbar, nullptr }};
   }
 
     CUTE_HOST_DEVICE constexpr
   Copy_Traits<SM90_TMA_LOAD_PAGED_OP, NumBitsPerTMA>
   with(uint64_t& tma_mbar, [[maybe_unused]] uint16_t const& multicast_mask, PagedCopyArgs const & paged_copy_args, TMA::CacheHintSm90 const& cache_hint = TMA::CacheHintSm90::EVICT_NORMAL) const {
     // We accept multicast_mask here to keep the API for both atoms consistent
-    return {{}, {&tma_desc_, &tma_mbar, static_cast<uint64_t>(cache_hint), paged_copy_args }};
+    return {{}, {&tma_desc_, &tma_mbar, (paged_copy_args.block_table==nullptr) ? nullptr : &paged_copy_args }};
   }
 
   // Construct an executable SM90_TMA_LOAD with tma_mbar (temp. overloaded for grouped gemm/ptr array gemm)
   CUTE_HOST_DEVICE constexpr
   Copy_Traits<SM90_TMA_LOAD_PAGED_OP, NumBitsPerTMA>
-  with(TmaDescriptor const* new_tma_desc, uint64_t& tma_mbar, [[maybe_unused]] uint16_t const& multicast_mask, PagedCopyArgs const &paged_copy_args, TMA::CacheHintSm90 const& cache_hint = TMA::CacheHintSm90::EVICT_NORMAL) const {
+  with(TmaDescriptor const* new_tma_desc, uint64_t& tma_mbar, [[maybe_unused]] uint16_t const& multicast_mask, PagedCopyArgs const & paged_copy_args, TMA::CacheHintSm90 const& cache_hint = TMA::CacheHintSm90::EVICT_NORMAL) const {
     // We accept multicast_mask here to keep the API for both atoms consistent
-    return {{}, {new_tma_desc, &tma_mbar, static_cast<uint64_t>(cache_hint), paged_copy_args }};
+    return {{}, {new_tma_desc, &tma_mbar, (paged_copy_args.block_table==nullptr) ? nullptr : &paged_copy_args }};
   }
 
   // Generate the TMA coord tensor
@@ -254,8 +261,7 @@ struct Copy_Traits<SM90_TMA_LOAD_PAGED_OP, NumBitsPerTMA>
   tuple<
   TmaDescriptor const*,
   uint64_t*, // smem mbarrier
-  uint64_t,   // cache hint
-  PagedCopyArgs
+  PagedCopyArgs const*
   > const opargs_;
 };
 
@@ -295,28 +301,28 @@ struct Copy_Traits<SM90_TMA_LOAD_MULTICAST_PAGED, NumBitsPerTMA, AuxParams_>
   CUTE_HOST_DEVICE constexpr
   Copy_Traits<SM90_TMA_LOAD_MULTICAST_PAGED_OP, NumBitsPerTMA>
   with(uint64_t& tma_load_mbar, uint16_t const& multicast_mask,  TMA::CacheHintSm90 const& cache_hint = TMA::CacheHintSm90::EVICT_NORMAL) const {
-    return {{}, {&tma_desc_, &tma_load_mbar, multicast_mask, static_cast<uint64_t>(cache_hint),  PagedCopyArgs{} }};
+    return {{}, {&tma_desc_, &tma_load_mbar, multicast_mask,  nullptr }};
   }
 
   // Construct an executable SM90_TMA_LOAD_MULTICAST_OP with tma_mbar (temp. overloaded for grouped gemm/ptr array gemm)
   CUTE_HOST_DEVICE constexpr
   Copy_Traits<SM90_TMA_LOAD_MULTICAST_PAGED_OP, NumBitsPerTMA>
   with(TmaDescriptor const* new_tma_desc, uint64_t& tma_load_mbar, uint16_t const& multicast_mask, TMA::CacheHintSm90 const& cache_hint = TMA::CacheHintSm90::EVICT_NORMAL) const {
-    return {{}, {new_tma_desc, &tma_load_mbar, multicast_mask, static_cast<uint64_t>(cache_hint), PagedCopyArgs{} }};
+    return {{}, {new_tma_desc, &tma_load_mbar, multicast_mask,  nullptr }};
   }
 
     // Construct an executable SM90_TMA_LOAD_MULTICAST with tma_mbar
   CUTE_HOST_DEVICE constexpr
   Copy_Traits<SM90_TMA_LOAD_MULTICAST_PAGED_OP, NumBitsPerTMA>
-  with(uint64_t& tma_load_mbar, uint16_t const& multicast_mask, PagedCopyArgs const& paged_copy_args,  TMA::CacheHintSm90 const& cache_hint = TMA::CacheHintSm90::EVICT_NORMAL) const {
-    return {{}, {&tma_desc_, &tma_load_mbar, multicast_mask, static_cast<uint64_t>(cache_hint), paged_copy_args }};
+  with(uint64_t& tma_load_mbar, uint16_t const& multicast_mask, PagedCopyArgs const & paged_copy_args,  TMA::CacheHintSm90 const& cache_hint = TMA::CacheHintSm90::EVICT_NORMAL) const {
+    return {{}, {&tma_desc_, &tma_load_mbar, multicast_mask,  (paged_copy_args.block_table==nullptr) ? nullptr :  &paged_copy_args }};
   }
 
   // Construct an executable SM90_TMA_LOAD_MULTICAST_OP with tma_mbar (temp. overloaded for grouped gemm/ptr array gemm)
   CUTE_HOST_DEVICE constexpr
   Copy_Traits<SM90_TMA_LOAD_MULTICAST_PAGED_OP, NumBitsPerTMA>
   with(TmaDescriptor const* new_tma_desc, uint64_t& tma_load_mbar, uint16_t const& multicast_mask, PagedCopyArgs const& paged_copy_args,  TMA::CacheHintSm90 const& cache_hint = TMA::CacheHintSm90::EVICT_NORMAL) const {
-    return {{}, {new_tma_desc, &tma_load_mbar, multicast_mask, static_cast<uint64_t>(cache_hint), paged_copy_args }};
+    return {{}, {new_tma_desc, &tma_load_mbar, multicast_mask, (paged_copy_args.block_table==nullptr) ? nullptr :  &paged_copy_args }};
   }
 
   // Generate the TMA coord tensor
@@ -355,8 +361,7 @@ struct Copy_Traits<SM90_TMA_LOAD_MULTICAST_PAGED_OP, NumBitsPerTMA>
   TmaDescriptor const*,
   uint64_t*, // smem mbarrier
   uint16_t,   // multicast mask
-  uint64_t,   // cache hint
-  PagedCopyArgs
+  PagedCopyArgs const*
   > const opargs_;
 };
 


### PR DESCRIPTION
This fixes an issue in the varlen Flash Attention 3 Varlen Kernel, leading ptxas to serialize wgmma instructions, obviously having a drastic performance impact that was hidden by the fact that varlen performance is still better in the degraded version than in the non-varlen case
With this fix, ptxas build warnings like this are gone: "ptxas info    : ([C7510](https://www.internalfb.com/cases/7510)) Potential Performance Loss: wgmma.mma_async instructions are serialized due to wgmma pipeline crossing function boundary ..."  and the performance for FA3 varlen kernels improves drastically in benchmarks. ( non-public ) - Overall, performance improved almost 2 x in some edge cases with these changes. 

Approach:

 * Use less registers or use registers for a shorter amount of steps than previously when calling the tma load operations. 
 * Remove runtime branch from a function, which seems to have led to nvcc not inlining this function, which in turn led ptxas to serialize all wgmma instructions ( ptxas warning "wgmma.mma_async instructions are serialized due to wgmma pipeline crossing function boundary " )
