### PR TITLE
Change {q,k,v}_descale to be per-batch-element

### DIFF
--- a/hopper/flash_attn_interface.py
+++ b/hopper/flash_attn_interface.py
@@ -571,6 +571,9 @@ def flash_attn_with_kvcache(
     max_seqlen_q: Optional[int] = None,
     softmax_scale=None,
     causal=False,
+    q_descale=None,
+    k_descale=None,
+    v_descale=None,
     window_size=(-1, -1),  # -1 means infinite context window
     sink_token_length=0,
     softcap=0.0, # 0.0 means deactivated
@@ -694,7 +697,9 @@ def flash_attn_with_kvcache(
         max_seqlen_q,
         softmax_scale,
         causal,
-        None, None, None,  # qkv_descale
+        q_descale,
+        k_descale,
+        v_descale,
         window_size[0],
         window_size[1],
         sink_token_length,

--- a/hopper/mainloop_fwd_sm90_tma_gmma_ws.hpp
+++ b/hopper/mainloop_fwd_sm90_tma_gmma_ws.hpp
@@ -1000,7 +1000,7 @@ struct CollectiveMainloopFwd {
             if constexpr (RescaleOBeforeGemm) { softmax.rescale_o(tOrO, scores_scale); }
             consumer_wait(pipeline_v, smem_pipe_read);
             flash::gemm</*zero_init=*/false, /*wg_wait=*/-1>(tiled_mma1, tOrP, tOrV(_, _, _, smem_pipe_read.index()), tOrO);
-            cute::copy(softmax.finalize(!Is_FP8 || params.ptr_v_descale == nullptr ? 1.f : *params.ptr_v_descale), scores_scale);
+            cute::copy(softmax.finalize(!Is_FP8 || params.ptr_v_descale == nullptr ? 1.f : params.ptr_v_descale[(params.kv_batch_idx == nullptr ? bidb : params.kv_batch_idx[bidb])]), scores_scale);
             warpgroup_wait<0>();
             pipeline_v.consumer_release(smem_pipe_read);  // release V, otherwise producers will hang
             softmax.rescale_o(tOrO, scores_scale);


### PR DESCRIPTION
Previously {q,k,v}_descale were single floats multiplied by the entire q and {k,v}cache tensors. Now they are each vectors of floats. q_descale must be of size (batch_size,) and {k,v}_descale must be of size (cache_batch_size,).