### PR TITLE
Validate that `git` is available and `CUDA_HOME` is set in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -135,14 +135,21 @@ def validate_and_update_archs(archs):
 
 cmdclass = {}
 ext_modules = []
+git_available = shutil.which("git") is not None
 
 # We want this even if SKIP_CUDA_BUILD because when we run python setup.py sdist we want the .hpp
 # files included in the source distribution, in case the user compiles from source.
-if IS_ROCM:
-    if not USE_TRITON_ROCM:
-        subprocess.run(["git", "submodule", "update", "--init", "csrc/composable_kernel"])
-else:
-    subprocess.run(["git", "submodule", "update", "--init", "csrc/cutlass"])
+if git_available:
+    if IS_ROCM:
+        if not USE_TRITON_ROCM:
+            subprocess.run(["git", "submodule", "update", "--init", "csrc/composable_kernel"])
+    else:
+        subprocess.run(["git", "submodule", "update", "--init", "csrc/cutlass"])
+
+# SKIP_CUDA_BUILD if build tools not available
+if CUDA_HOME is None or not git_available:
+    print("CUDA_HOME not set and/or git not available, skipping CUDA build")
+    SKIP_CUDA_BUILD = True
 
 if not SKIP_CUDA_BUILD and not IS_ROCM:
     print("\n\ntorch.__version__  = {}\n\n".format(torch.__version__))


### PR DESCRIPTION
This PR addresses #1379. It checks that `git` is available and that `CUDA_HOME` is not `None`. This enables falling back to pre-built wheels for environments that just have torch installed.
