### PR TITLE
Fix deprecation warnings

### DIFF
--- a/flash_attn/fused_softmax.py
+++ b/flash_attn/fused_softmax.py
@@ -58,12 +58,12 @@ def scaled_upper_triang_masked_softmax(inputs, _, scale):
     # Reshaping input to 3D tensor (attn_batches, sq, sk)
     inputs = inputs.view(-1, sq, sk)
     args = _cast_if_autocast_enabled(inputs, scale)
-    with torch.cuda.amp.autocast(enabled=False):
+    with torch.amp.autocast(device_type="cuda", enabled=False):
         probs = ScaledUpperTriangMaskedSoftmax.apply(*args)
     return probs.view(b, np, sq, sk)
 
 
-# NOTE (mkozuki): `ScaledMaskedSoftmax` somehow doesn't work well with `torch.cuda.amp.custom_fwd`.
+# NOTE (mkozuki): `ScaledMaskedSoftmax` somehow doesn't work well with `torch.amp.custom_fwd`.
 # Without `cast_inputs` kwarg, somehow inputs are not cast to dtype used in the autocast context.
 # So I needed to manually write two `torch.autograd.Function` inheritances.
 # Fused operation which performs following three operations in sequence
@@ -88,7 +88,7 @@ class ScaledMaskedSoftmax(torch.autograd.Function):
 def scaled_masked_softmax(inputs, mask, scale):
     # input is 4D tensor (b, np, sq, sk)
     args = _cast_if_autocast_enabled(inputs, mask, scale)
-    with torch.cuda.amp.autocast(enabled=False):
+    with torch.amp.autocast(device_type="cuda", enabled=False):
         return ScaledMaskedSoftmax.apply(*args)
 
 

--- a/flash_attn/ops/triton/layer_norm.py
+++ b/flash_attn/ops/triton/layer_norm.py
@@ -10,7 +10,7 @@ import math
 
 import torch
 import torch.nn.functional as F
-from torch.cuda.amp import custom_fwd, custom_bwd
+from torch.amp import custom_fwd, custom_bwd
 
 import triton
 import triton.language as tl
@@ -981,7 +981,7 @@ class RMSNorm(torch.nn.Module):
 
 class LayerNormLinearFn(torch.autograd.Function):
     @staticmethod
-    @custom_fwd
+    @custom_fwd(device_type="cuda")
     def forward(
         ctx,
         x,
@@ -1040,7 +1040,7 @@ class LayerNormLinearFn(torch.autograd.Function):
         return out if not prenorm else (out, residual_out.reshape(x_shape_og))
 
     @staticmethod
-    @custom_bwd
+    @custom_bwd(device_type="cuda")
     def backward(ctx, dout, *args):
         x, norm_weight, norm_bias, linear_weight, mean, rstd = ctx.saved_tensors
         dout = dout.reshape(-1, dout.shape[-1])

--- a/flash_attn/ops/triton/mlp.py
+++ b/flash_attn/ops/triton/mlp.py
@@ -4,7 +4,7 @@ import fused_dense_lib as fused_dense_cuda
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from torch.cuda.amp import custom_bwd, custom_fwd
+from torch.amp import custom_bwd, custom_fwd
 
 from flash_attn.ops.activations import sqrelu_bwd, sqrelu_fwd
 from flash_attn.ops.triton.linear import triton_dgrad_act, triton_linear_act
@@ -12,7 +12,7 @@ from flash_attn.ops.triton.linear import triton_dgrad_act, triton_linear_act
 
 class FusedDenseSqreluDenseFunc(torch.autograd.Function):
     @staticmethod
-    @custom_fwd
+    @custom_fwd(device_type="cuda")
     def forward(ctx, x, weight1, bias1, weight2, bias2, checkpoint_lvl=0):
         """checkpoint_lvl:
         0: no recomputation in the bwd
@@ -62,7 +62,7 @@ class FusedDenseSqreluDenseFunc(torch.autograd.Function):
         return output2.reshape(*batch_shape, output2.shape[-1])
 
     @staticmethod
-    @custom_bwd
+    @custom_bwd(device_type="cuda")
     def backward(ctx, grad_output):
         grad_output = grad_output.contiguous()
         checkpoint_lvl = ctx.checkpoint_lvl


### PR DESCRIPTION
A couple of torch calls are deprecated:
```
fused_dense.py:30: FutureWarning: `torch.cuda.amp.custom_fwd(args...)` is deprecated. Please use `torch.amp.custom_fwd(args..., device_type='cuda')` instead.
fused_dense.py:71: FutureWarning: `torch.cuda.amp.custom_bwd(args...)` is deprecated. Please use `torch.amp.custom_bwd(args..., device_type='cuda')` instead.
```
