### PR TITLE
Support dedicated compile[For Research]

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,11 @@ variable `MAX_JOBS`:
 MAX_JOBS=4 pip install flash-attn --no-build-isolation
 ```
 
+**Dedicated build(only for research):**
+```sh
+MAX_JOBS=8 HEADDIM=64 DTYPE=fp16 ENABLE_SM90=FALSE pip install -e . -v
+```
+
 **Interface:** `src/flash_attention_interface.py`
 
 ### NVIDIA CUDA Support

--- a/csrc/flash_attn/src/static_switch.h
+++ b/csrc/flash_attn/src/static_switch.h
@@ -76,39 +76,60 @@
   #define LOCAL_SWITCH BOOL_SWITCH
 #endif
 
-#define FP16_SWITCH(COND, ...)               \
-  [&] {                                      \
-    if (COND) {                              \
-      using elem_type = cutlass::half_t;     \
-      return __VA_ARGS__();                  \
-    } else {                                 \
-      using elem_type = cutlass::bfloat16_t; \
-      return __VA_ARGS__();                  \
-    }                                        \
-  }()
 
-#define HEADDIM_SWITCH(HEADDIM, ...)   \
-  [&] {                                    \
-    if (HEADDIM <= 32) {                   \
-      constexpr static int kHeadDim = 32;  \
-      return __VA_ARGS__();                \
-    } else if (HEADDIM <= 64) {            \
-      constexpr static int kHeadDim = 64;  \
-      return __VA_ARGS__();                \
-    } else if (HEADDIM <= 96) {            \
-      constexpr static int kHeadDim = 96;  \
-      return __VA_ARGS__();                \
-    } else if (HEADDIM <= 128) {           \
-      constexpr static int kHeadDim = 128; \
-      return __VA_ARGS__();                \
-    } else if (HEADDIM <= 160) {           \
-      constexpr static int kHeadDim = 160; \
-      return __VA_ARGS__();                \
-    } else if (HEADDIM <= 192) {           \
-      constexpr static int kHeadDim = 192; \
-      return __VA_ARGS__();                \
-    } else if (HEADDIM <= 256) {           \
-      constexpr static int kHeadDim = 256; \
-      return __VA_ARGS__();                \
-    }                                      \
+#define DTYPE(COND, cond, dtype, ...) \
+  else if (COND == cond) {using elem_type = dtype; return __VA_ARGS__();}
+
+#if defined(DTYPE_FP16)
+#define FP16_SWITCH(COND, ...)  [&] { if(false){} DTYPE(COND, true, cutlass::half_t, __VA_ARGS__)}()
+
+#elif defined(DTYPE_BF16)
+#define FP16_SWITCH(COND, ...)  [&] { if(false){} DTYPE(COND, false, cutlass::bfloat16_t, __VA_ARGS__)}()
+
+#else
+#define FP16_SWITCH(COND, ...)                             \
+  [&] {                                                    \
+    if (false) {}                                          \
+      DTYPE(COND, true, cutlass::half_t, __VA_ARGS__)      \
+      DTYPE(COND, false, cutlass::bfloat16_t, __VA_ARGS__) \
   }()
+#endif
+
+
+#define HEAD(HEADDIM, dim, ...) \
+    else if (HEADDIM <= dim) {constexpr static int kHeadDim = dim; return __VA_ARGS__();} \
+
+#if defined(HEADDIM_32)
+#define HEADDIM_SWITCH(HEADDIM, ...)  [&]{ if(false){} HEAD(HEADDIM, 32, __VA_ARGS__)}()
+
+#elif defined(HEADDIM_64)
+#define HEADDIM_SWITCH(HEADDIM, ...)  [&]{ if(false){} HEAD(HEADDIM, 64, __VA_ARGS__)}()
+
+#elif defined(HEADDIM_96)
+#define HEADDIM_SWITCH(HEADDIM, ...)  [&]{ if(false){} HEAD(HEADDIM, 96, __VA_ARGS__)}()
+
+#elif defined(HEADDIM_128)
+#define HEADDIM_SWITCH(HEADDIM, ...)  [&]{ if(false){} HEAD(HEADDIM, 128, __VA_ARGS__)}()
+
+#elif defined(HEADDIM_160)
+#define HEADDIM_SWITCH(HEADDIM, ...)  [&]{ if(false){} HEAD(HEADDIM, 160, __VA_ARGS__)}()
+
+#elif defined(HEADDIM_192)
+#define HEADDIM_SWITCH(HEADDIM, ...)  [&]{ if(false){} HEAD(HEADDIM, 192, __VA_ARGS__)}()
+
+#elif defined(HEADDIM_256)
+#define HEADDIM_SWITCH(HEADDIM, ...)  [&]{ if(false){} HEAD(HEADDIM, 256, __VA_ARGS__)}()
+
+#else
+#define HEADDIM_SWITCH(HEADDIM, ...)   \
+  [&] { \
+    if (false) {} \
+    HEAD(HEADDIM, 32, __VA_ARGS__) \
+    HEAD(HEADDIM, 64, __VA_ARGS__) \
+    HEAD(HEADDIM, 96, __VA_ARGS__) \
+    HEAD(HEADDIM, 128, __VA_ARGS__) \
+    HEAD(HEADDIM, 160, __VA_ARGS__) \
+    HEAD(HEADDIM, 192, __VA_ARGS__) \
+    HEAD(HEADDIM, 256, __VA_ARGS__) \
+  }()
+#endif


### PR DESCRIPTION
Support dedicated compile, HEADDIM=64 DTYPE=fp16 ENABLE_SM90=FALSE only build for headdim(64) fp16 and non-sm_90, this method is only for research, could reduce compile time from 50mins -> 5mins.

compile command
```
MAX_JOBS=8 NVCC_THREADS=2 HEADDIM=64 DTYPE=fp16 ENABLE_SM90=FALSE time pip install -e . -v
```
run tests
```
pytest tests/test_flash_attn.py -k test_flash_attn_kvcache -s
```