### PR TITLE
fix a bug (issue #1390) caused by typo

### DIFF
--- a/flash_attn/flash_attn_interface.py
+++ b/flash_attn/flash_attn_interface.py
@@ -849,7 +849,7 @@ class FlashAttnFunc(torch.autograd.Function):
             ctx.softcap = softcap
             ctx.alibi_slopes = alibi_slopes
             ctx.deterministic = deterministic
-            out = out_padded[..., :head_size_og]
+        out = out_padded[..., :head_size_og]
         return out if not return_softmax else (out, softmax_lse, S_dmask)
 
     @staticmethod


### PR DESCRIPTION
move `flash_attn/flash_attn_interface.py` line 852 out of `if block`.