### PR TITLE
Create PEP 517 build metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=65", "wheel", "torch"]
+build-backend = ["setuptools.build_meta"]


### PR DESCRIPTION
Add pyproject.toml with the build system table.

The default doesn't work because the project has additional dependency on `torch` for build