### PR TITLE
[Build] Update version of setuptools used to generate core package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -203,7 +203,9 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install ninja packaging setuptools wheel twine
+          pip install ninja packaging wheel twine
+          # Install latest setuptools with support for pypi metadata 2.2 (improved compat w/ uv)
+          pip install setuptools==75.8.0
           # We don't want to download anything CUDA-related here
           pip install torch --index-url https://download.pytorch.org/whl/cpu
 


### PR DESCRIPTION
This updates `setuptools` version used in the build pipeline to v75.8.0, which includes https://github.com/pypa/setuptools/commit/f285d01e2661b01e4947a4dca7704790b65f2967 and generates `Metadata: 2.2` manifests for pypi

With this change, it becomes easier to manage flash-attn installation with `uv`. See https://github.com/astral-sh/uv/pull/6607#issuecomment-2308931562

>> for some reason, uv always tries to build flash-attn during sync, even though it was not requested
>
>This is expected _and_ required. `flash-attn` ships as a source distribution, and only at `Metadata-Version: 2.1`, so you _must_ ask the build backend for its dependencies per the spec -- which in turn requires that its build dependencies are already installed. There's really nothing we can do about this -- it's a problem with the package. They need to upgrade to `Metadata-Version: 2.2`.
 
For more details on the current workarounds, see the [uv docs](https://docs.astral.sh/uv/concepts/projects/config/#build-isolation) which feature a whole section on how to deal with issues trying to install flash-attn.

<img width="720" alt="Screenshot 2025-01-23 at 6 18 24 PM" src="https://github.com/user-attachments/assets/70587f0b-ef07-43fc-b5cc-8632bfb0a72b" />

cc @tridao @charliermarsh 