### PR TITLE
Remove ninja runtime dependency

### DIFF
--- a/hopper/setup.py
+++ b/hopper/setup.py
@@ -631,6 +631,5 @@ setup(
         "torch",
         "einops",
         "packaging",
-        "ninja",
     ],
 )


### PR DESCRIPTION
Fixes https://github.com/Dao-AILab/flash-attention/issues/1470

This section is for runtime dependencies and `ninja` is more necessary at build time, not at run time. I'm not sure why adding it is causing the error in the linked issue but removing it resolves the error.