### PR TITLE
Fix CUDA 12.1 build

### DIFF
--- a/hopper/mainloop_fwd_sm90_tma_gmma_ws.hpp
+++ b/hopper/mainloop_fwd_sm90_tma_gmma_ws.hpp
@@ -994,7 +994,7 @@ struct CollectiveMainloopFwdSm90 {
             if constexpr (LargeHeadDimV) {
                 return make_tensor(make_smem_ptr(shared_storage.tensors.mainloop.smem_scale.data()), SmemLayoutScale{});
             } else { // won't be used, just a placeholder
-                return make_tensor(make_smem_ptr(shared_storage.tensors.mainloop.smem_q.data()), SmemLayoutScale{});
+                return make_tensor(make_smem_ptr(static_cast<float*>(nullptr)), SmemLayoutScale{});
             }
         }();
         Tensor sQv = make_tensor(make_smem_ptr(shared_storage.tensors.mainloop.smem_qv.data()), SmemLayoutQv{});


### PR DESCRIPTION
Building using CUDA 12.1 was resulting in:
```
.../hopper/mainloop_fwd_sm90_tma_gmma_ws.hpp(1068): error: no operator "=" matches these operands
  operand types are: cutlass::bfloat16_t = float
    sScale(get<0>(taccOcO_row(mi)), stage) = scales(mi);
```
which appears to be from slight differences in template type deduction