### PR TITLE
[BugFix] Ensure tensor contiguity.

### DIFF
--- a/flash_attn/flash_attn_interface.py
+++ b/flash_attn/flash_attn_interface.py
@@ -17,7 +17,7 @@ else:
 # isort: on
 
 def maybe_contiguous(x):
-    return x.contiguous() if x is not None and x.stride(-1) != 1 else x
+    return x.contiguous() if x is not None else x
 
 
 def _get_block_size_n(device, head_dim, is_dropout, is_causal):

--- a/hopper/flash_attn_interface.py
+++ b/hopper/flash_attn_interface.py
@@ -13,7 +13,7 @@ import flash_attn_3_cuda
 
 
 def maybe_contiguous(x):
-    return x.contiguous() if x is not None and x.stride(-1) != 1 else x
+    return x.contiguous() if x is not None else x
 
 
 def _flash_attn_forward(


### PR DESCRIPTION
maybe_contiguous() fails to correct non-contiguous view tensors because of an incomplete condition. This has been observed breaking Hunyuan video generation model on AMD GPUs with ROCm stack.

Since torch.Tensor.contiguous() already checks for contiguity and does nothing unless it is needed, there are no downsides to invoking it unconditionally. This simple fix resolves the observed Hunyuan issues.