### PR TITLE
[AMD ROCm] Update backend to improve performance

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -348,7 +348,11 @@ elif not SKIP_CUDA_BUILD and IS_ROCM:
         archs = os.getenv("GPU_ARCHS", "native").split(";")
         validate_and_update_archs(archs)
 
-        cc_flag = [f"--offload-arch={arch}" for arch in archs]
+        if archs != ['native']:
+            cc_flag = [f"--offload-arch={arch}" for arch in archs]
+        else:
+            arch = torch.cuda.get_device_properties("cuda").gcnArchName.split(":")[0]
+            cc_flag = [f"--offload-arch={arch}"]
 
         # HACK: The compiler flag -D_GLIBCXX_USE_CXX11_ABI is set to be the same as
         # torch._C._GLIBCXX_USE_CXX11_ABI


### PR DESCRIPTION
In this PR
1. Update backend (composable kernel)
2. Detect AMD hardware explicitly, because some version of hipcc does not support arch=native