### PR TITLE
Useuful command to install flash faster on behamoth clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ Alternatively you can compile from source:
 ```sh
 python setup.py install
 ```
+To fully utilize high-performance AI clusters with 1 TiB RAM and over 100 CPU cores:
+```
+MAX_JOBS=$(nproc) python3 setup.py install
+```
 
 If your machine has less than 96GB of RAM and lots of CPU cores, `ninja` might
 run too many parallel compilation jobs that could exhaust the amount of RAM. To


### PR DESCRIPTION
In HPC and behemoth clusters where it can use 1TiB RAM and over 100 CPU cores (largely server grade CPUs), and 8xA100s or 8xH100s combination a better useful command can be used that I have added. It uses all resources to install flash-atten2 in 30-40 minutes cutting it from 1-1.5 hours. Where it was utilising 7-10% of the CPU before. 