### PR TITLE
fix: fa3 backward check qkv with qkv_scale and dqkv

### DIFF
--- a/hopper/flash_attn_interface.py
+++ b/hopper/flash_attn_interface.py
@@ -351,7 +351,8 @@ class FlashAttnFunc(torch.autograd.Function):
         dq = dq[..., : q.shape[-1]]  # We could have padded the head dimension
         dk = dk[..., : k.shape[-1]]
         dv = dv[..., : v.shape[-1]]
-        return dq, dk, dv, None, None, None, None, None, None, None, None, None, None, None, None, None, None
+        # return dq, dk, dv, None, None, None, None, None, None, None, None, None, None, None, None, None, None
+        return dq, dk, dv, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None
 
 
 class FlashAttnVarlenFunc(torch.autograd.Function):


### PR DESCRIPTION
# Task background
Lora training Wan2.1

# Problem description
When I use FA3 and train it with FP8 quantization, forward has the scale parameter of q k v, and can input data in torch.float8_e4m3fn format.

But backward will display "RuntimeError: FlashAttention only supports fp16 and bf16 data type", and dq qk qv is also created in the format of torch.float8_e4m3fn because of the input q k v.

Backward will not save the scale parameter to restore q k v, so I need to manually change the format of dq dk dv to fp16 or bf16, and manually dequantize FP8 q k v to bf16 when entering backward.

In addition, I also need to modify the forward parameter save and save the scale for use before backward.

# Fix method
Check qkv_scale, dequantize qkv, and check the data type of dqkv


# Error log
```
[rank4]:   File "/root/miniconda3/lib/python3.10/site-packages/flash_attn_3-3.0.0b1-py3.10-linux-x86_64.egg/flash_attn_interface.py", line 317, in backward
[rank4]:     _flash_attn_backward(
[rank4]:   File "/root/miniconda3/lib/python3.10/site-packages/flash_attn_3-3.0.0b1-py3.10-linux-x86_64.egg/flash_attn_interface.py", line 132, in _flash_attn_backward
[rank4]:     dq, dk, dv, softmax_d, *rest = flash_attn_3_cuda.bwd(
[rank4]:   File "/root/miniconda3/lib/python3.10/site-packages/torch/_ops.py", line 1123, in __call__
[rank4]:     return self._op(*args, **(kwargs or {}))
[rank4]: RuntimeError: FlashAttention only support fp16 and bf16 data type
```
