### PR TITLE
Fix(hopper): Correct C++ syntax in epilogue_fwd.hpp

### DIFF
--- a/hopper/epilogue_fwd.hpp
+++ b/hopper/epilogue_fwd.hpp
@@ -89,7 +89,7 @@ struct CollectiveEpilogueFwd {
     using ShapeLSEPacked = std::conditional_t<!PackGQA, cute::Shape<int32_t, int32_t, int32_t, int32_t>, cute::Shape<cute::Shape<int32_t, int32_t>, int32_t, int32_t, int32_t>>;
     using StrideLSEPacked = std::conditional_t<!PackGQA, StrideLSE, cute::Stride<cute::Stride<int64_t, _1>, int64_t, int64_t, int64_t>>;
 
-    using EpilogueTile_MN = decltype(select<0, 1>(TileShape_MNK_PV{})());
+    using EpilogueTile_MN = decltype(select<0, 1>(TileShape_MNK_PV{}));
     using CopyOpR2S = std::conditional_t<
         ArchTag::kMinComputeCapability >= 90,
         // cute::SM90_U32x4_STSM_N if Element size is 2 bytes (fp16, bf16)


### PR DESCRIPTION
This was causing a crash while compiling flash attention v3.