### PR TITLE
Fix illegal memory access through off-by-one error in num_splits_dynamic_ptr init

### DIFF
--- a/hopper/flash_api.cpp
+++ b/hopper/flash_api.cpp
@@ -972,7 +972,10 @@ mha_fwd(at::Tensor q,   // (b, s_q, h, d) or (total_q, h, d) if there is cu_seql
             tile_count_semaphore.zero_();  // If varlen we'll manually do the zero-ing
         }
         params.tile_count_semaphore = scheduler_needs_semaphore ? tile_count_semaphore.data_ptr<int>() : nullptr;
-        params.num_splits_dynamic_ptr = use_dynamic_split ? tile_count_semaphore.data_ptr<int>() + 1 : nullptr;
+
+        params.num_splits_dynamic_ptr = use_dynamic_split ?
+                                        tile_count_semaphore.data_ptr<int>() + int(scheduler_needs_semaphore)
+                                        : nullptr;
     }
 
     if (q_v_.has_value()) {


### PR DESCRIPTION
There is an off-by-one error in flash_api.cpp / set_params_fprop() which can lead to memory access violations in our codebase. 

### Error description

in set_params_fprop, if scheduler_needs_semaphore == False and use_dynamic_split == True, the size of the tile_count_semaphore tensor is initialized here to be equal to the batch size. Which is theoretically sufficient:  https://github.com/Dao-AILab/flash-attention/blob/adf27d1db38223288981c4dc3509efafbddd3422/hopper/flash_api.cpp#L959

But on line 975 a bit further below, even if  scheduler_needs_semaphore==False, there is an offset of 1 being used to initialize num_splits_dynamic_ptr based off the raw data of the tile_count_semaphore tensor. 

If num_splits_dynamic_ptr is now again being accessed at it's supposedly last valid element at an index equal to the batch size - 1, an illegal memory access occurs. Since it's just an off-by-one error, this might rarely be detectable, but it led to (rare) crashes and numerical issues in our CI. It could be detected by running some of our tests with "compute-sanitizer --padding 128 ... " while setting PYTORCH_NO_CUDA_MEMORY_CACHING=1 to disable pytorch's caching allocator ( without that, the access usually still hit memory that belonged to a valid allocation even if it was out of bounds ).

https://github.com/Dao-AILab/flash-attention/blob/adf27d1db38223288981c4dc3509efafbddd3422/hopper/flash_api.cpp#L975
