### PR TITLE
[AMD] Torch Compile Issues

### DIFF
--- a/flash_attn/flash_attn_interface.py
+++ b/flash_attn/flash_attn_interface.py
@@ -127,7 +127,10 @@ def _flash_attn_forward_fake(
     softmax_lse = torch.empty((batch_size, num_heads, seqlen_q), dtype=torch.float32, device=q.device, layout=q.layout)
     p = torch.empty((0,), dtype=q.dtype, device=q.device, layout=q.layout)
     if return_softmax:
-        p = torch.empty((batch_size, num_heads, round_multiple(seqlen_q, 128), round_multiple(seqlen_k, 128)), dtype=q.dtype, device=q.device, layout=q.layout)
+        if torch.cuda.is_available() and torch.version.hip:
+            p = torch.empty((batch_size, num_heads, seqlen_q, seqlen_k), dtype=q.dtype, device=q.device, layout=q.layout)
+        else:
+            p = torch.empty((batch_size, num_heads, round_multiple(seqlen_q, 128), round_multiple(seqlen_k, 128)), dtype=q.dtype, device=q.device, layout=q.layout)
     rng_state = torch.empty((2,), dtype=torch.int64, device=q.device)
 
     return out, softmax_lse, p, rng_state
@@ -220,10 +223,11 @@ def _flash_attn_varlen_forward_fake(
     out = torch.empty_like(q)
     softmax_lse = torch.empty((num_heads, total_q), dtype=torch.float32, device=q.device, layout=q.layout)
     p = torch.empty((0,), dtype=q.dtype, device=q.device, layout=q.layout)
-    seqlen_q_rounded = round_multiple(max_seqlen_q, 128)
-    seqlen_k_rounded = round_multiple(max_seqlen_k, 128)
     if return_softmax:
-        p = torch.empty((batch_size, num_heads, seqlen_q_rounded, seqlen_k_rounded), dtype=q.dtype, device=q.device, layout=q.layout)
+        if torch.cuda.is_available() and torch.version.hip:
+            p = torch.empty((batch_size, num_heads, max_seqlen_q, max_seqlen_k), dtype=q.dtype, device=q.device, layout=q.layout)
+        else:
+            p = torch.empty((batch_size, num_heads, round_multiple(max_seqlen_q, 128), round_multiple(max_seqlen_k, 128)), dtype=q.dtype, device=q.device, layout=q.layout)
     rng_state = torch.empty((2,), dtype=torch.int64, device=q.device)
     return out, softmax_lse, p, rng_state
 
@@ -315,7 +319,10 @@ def _flash_attn_backward_fake(
     if dv is None:
         dv = torch.empty_like(v)
     batch_size, seqlen_q, num_heads, _ = q.shape
-    softmax_d = torch.empty((batch_size, num_heads, round_multiple(seqlen_q, 128)), device=q.device, dtype=torch.float32)
+    if torch.cuda.is_available() and torch.version.hip:
+        softmax_d = torch.empty((batch_size, num_heads, seqlen_q, 128), device=q.device, dtype=torch.float32)
+    else:
+        softmax_d = torch.empty((batch_size, num_heads, round_multiple(seqlen_q, 128)), device=q.device, dtype=torch.float32)
     
     return softmax_d
 
@@ -426,7 +433,10 @@ def _flash_attn_varlen_backward_fake(
         dk = torch.empty_like(k)
     if dv is None:
         dv = torch.empty_like(v)
-    softmax_d = torch.empty((num_heads, total_q + 128 * batch_size), device=q.device, dtype=torch.float32)
+    if torch.cuda.is_available() and torch.version.hip:
+        softmax_d = torch.empty((num_heads, total_q), device=q.device, dtype=torch.float32)
+    else:
+        softmax_d = torch.empty((num_heads, total_q + 128 * batch_size), device=q.device, dtype=torch.float32)
     
     return softmax_d
 

--- a/flash_attn/flash_attn_interface.py
+++ b/flash_attn/flash_attn_interface.py
@@ -320,7 +320,7 @@ def _flash_attn_backward_fake(
         dv = torch.empty_like(v)
     batch_size, seqlen_q, num_heads, _ = q.shape
     if torch.cuda.is_available() and torch.version.hip:
-        softmax_d = torch.empty((batch_size, num_heads, seqlen_q, 128), device=q.device, dtype=torch.float32)
+        softmax_d = torch.empty((batch_size, num_heads, seqlen_q), device=q.device, dtype=torch.float32)
     else:
         softmax_d = torch.empty((batch_size, num_heads, round_multiple(seqlen_q, 128)), device=q.device, dtype=torch.float32)
     

--- a/flash_attn/flash_attn_triton_amd/bwd_prefill_split.py
+++ b/flash_attn/flash_attn_triton_amd/bwd_prefill_split.py
@@ -1161,7 +1161,7 @@ def attention_prefill_backward_triton_split_impl(
     delta = torch.zeros_like(softmax_lse)
     if IS_VARLEN:
         stride_deltab = 0
-        stride_deltam, stride_deltah = delta.stride()
+        stride_deltah, stride_deltam = delta.stride()
     else:
         stride_deltab, stride_deltah, stride_deltam = delta.stride()
     pre_grid = (triton.cdiv(max_seqlen_q_final, PRE_BLOCK), batch, nheads_q)

--- a/flash_attn/flash_attn_triton_amd/fwd_prefill.py
+++ b/flash_attn/flash_attn_triton_amd/fwd_prefill.py
@@ -621,8 +621,9 @@ def attention_prefill_forward_triton_impl(
 
     # stores LSE the log of the normalization constant / sum of expoential score(unnormalzied probablities)
     if is_varlen:
-        softmax_lse = torch.zeros((q.shape[0], nheads_q), device=q.device, dtype=torch.float32)
-        stride_lse_m, stride_lse_h = softmax_lse.stride()
+        total_seqlen_q, _, _ = q.shape
+        softmax_lse = torch.zeros((nheads_q, total_seqlen_q), device=q.device, dtype=torch.float32)
+        stride_lse_h, stride_lse_m = softmax_lse.stride()
         stride_lse_z = 0
     else:
         softmax_lse = torch.zeros((batch, nheads_q, max_seqlens_q), device=q.device, dtype=torch.float32)

--- a/flash_attn/flash_attn_triton_amd/interface_fa.py
+++ b/flash_attn/flash_attn_triton_amd/interface_fa.py
@@ -74,11 +74,9 @@ def fwd(q: torch.Tensor,
     if alibi_slopes is not None:
         metadata.need_alibi(alibi_slopes, batch, nheads_q)
 
-    if dropout_p > 0.0:
-        metadata.need_dropout(dropout_p)
-        rng_state = torch.as_tensor([metadata.philox_seed, metadata.philox_offset]) # as_tensors uses the underlying data and doesnot cast
-    else:
-        rng_state = None
+    # store rng state
+    metadata.need_dropout(dropout_p, return_softmax)
+    rng_state = torch.as_tensor([metadata.philox_seed, metadata.philox_offset]) # as_tensors uses the underlying data and doesnot cast
 
     # check arguments
     metadata.check_args(q, k, v, out)
@@ -212,8 +210,7 @@ def bwd(
     dk = torch.zeros_like(k) if dk is None else dk.zero_()
     dv = torch.zeros_like(v) if dv is None else dv.zero_()
 
-    if dropout_p > 0.0:
-        assert rng_state is not None
+    if rng_state is not None:
         philox_seed, philox_offset = rng_state[0].item(), rng_state[1].item()
     else:
         philox_seed, philox_offset = None, None
@@ -423,11 +420,9 @@ def varlen_fwd(
     if alibi_slopes is not None:
         metadata.need_alibi(alibi_slopes, batch, nheads_q)
 
-    if dropout_p > 0.0:
-        metadata.need_dropout(dropout_p)
-        rng_state = torch.as_tensor([metadata.philox_seed, metadata.philox_offset]) # as_tensors uses the underlying data and doesnot cast
-    else:
-        rng_state = None
+    # store rng state
+    metadata.need_dropout(dropout_p, return_softmax)
+    rng_state = torch.as_tensor([metadata.philox_seed, metadata.philox_offset]) # as_tensors uses the underlying data and doesnot cast
 
     # Check arguments
     metadata.check_args(q, k, v, out)
@@ -563,8 +558,7 @@ def varlen_bwd(
     dk = torch.zeros_like(k) if dk is None else dk.zero_()
     dv = torch.zeros_like(v) if dv is None else dv.zero_()
 
-    if dropout_p > 0.0:
-        assert rng_state is not None
+    if rng_state is not None:
         philox_seed, philox_offset = rng_state[0].item(), rng_state[1].item()
     else:
         philox_seed, philox_offset = None, None

--- a/flash_attn/flash_attn_triton_amd/utils.py
+++ b/flash_attn/flash_attn_triton_amd/utils.py
@@ -112,11 +112,10 @@ class MetaData():
         self.rotary_interleaved = rotary_interleaved
         self.rotary_conjunction = rotary_conjunction
 
-    def need_dropout(self, dropout_p, return_scores = True):
-        if dropout_p > 0.0:
-            self.dropout_p = dropout_p
-            self.return_scores = return_scores
-            self.philox_seed, self.philox_offset = 0x1BF58, 0x1D4B49
+    def need_dropout(self, dropout_p, return_softmax):
+        self.dropout_p = dropout_p
+        self.return_softmax = return_softmax
+        self.philox_seed, self.philox_offset = 0x1BF58, 0x1D4B49
 
     def check_args(self, q, k, v, o):
         assert q.dim() == k.dim() and q.dim() == v.dim()

--- a/flash_attn/flash_attn_triton_amd/utils.py
+++ b/flash_attn/flash_attn_triton_amd/utils.py
@@ -112,7 +112,7 @@ class MetaData():
         self.rotary_interleaved = rotary_interleaved
         self.rotary_conjunction = rotary_conjunction
 
-    def need_dropout(self, dropout_p, return_softmax):
+    def need_dropout(self, dropout_p, return_softmax = True):
         self.dropout_p = dropout_p
         self.return_softmax = return_softmax
         self.philox_seed, self.philox_offset = 0x1BF58, 0x1D4B49


### PR DESCRIPTION
A few users encountered issues when using flash attention with torch compile on AMD. The code similar to the one below would run into asserts because our output didnot match what the op registerations where expecting.

```
q = torch.randn((BATCH, N_CTX_Q, HQ, D_HEAD))
k = torch.randn((BATCH, N_CTX_K, HK, D_HEAD))
v = torch.randn((BATCH, N_CTX_K, HK, D_HEAD))

flash_attn_func_compiled = torch.compile(flash_attn_func)
o = flash_attn_func_compiled(q, k, v, causal=True)
o.sum().backward()
```

The first issue was that op was expecting certain dimensions to be a factor of 128 which seems to be a detail of the Nvidia backend. Both the AMD CK and Triton don't have that limitation. We conditionaly change the op registration so that for AMD we expect the dimension to be match the input dimesinosns. Another issue was that the triton backend, when using varlen, was returning an lse value which was transposed shape. We have fixed that as well.


The Triton AMD Backend Tests pass.

<img width="726" height="224" alt="image" src="https://github.com/user-attachments/assets/3a9ca259-ab3d-4bdd-85cb-03d76534b207" />
        