### PR TITLE
[CI] build upon manylinux, improve compatibility

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,28 +13,8 @@ on:
       - v*
 
 jobs:
-
-  setup_release:
-    name: Create Release
-    runs-on: ubuntu-latest
-    steps:
-      - name: Get the tag version
-        id: extract_branch
-        run: echo ::set-output name=branch::${GITHUB_REF#refs/tags/}
-        shell: bash
-
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ steps.extract_branch.outputs.branch }}
-          release_name: ${{ steps.extract_branch.outputs.branch }}
-
   build_wheels:
     name: Build Wheel
-    needs: setup_release
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -68,10 +48,26 @@ jobs:
 
       - name: Set CUDA and PyTorch versions
         run: |
-          echo "MATRIX_CUDA_VERSION=$(echo ${{ matrix.cuda-version }} | awk -F \. {'print $1 $2'})" >> $GITHUB_ENV
-          echo "MATRIX_TORCH_VERSION=$(echo ${{ matrix.torch-version }} | awk -F \. {'print $1 "." $2'})" >> $GITHUB_ENV
-          echo "WHEEL_CUDA_VERSION=$(echo ${{ matrix.cuda-version }} | awk -F \. {'print $1'})" >> $GITHUB_ENV
-          echo "MATRIX_PYTHON_VERSION=$(echo ${{ matrix.python-version }} | awk -F \. {'print $1 $2'})" >> $GITHUB_ENV
+          # export variables into the hostedrunner environment
+          export MATRIX_CUDA_VERSION=$(echo ${{ matrix.cuda-version }} | awk -F \. {'print $1 $2'})
+          export MATRIX_TORCH_VERSION=$(echo ${{ matrix.torch-version }} | awk -F \. {'print $1 "." $2'})
+          export WHEEL_CUDA_VERSION=$(echo ${{ matrix.cuda-version }} | awk -F \. {'print $1'})
+          export MATRIX_PYTHON_VERSION=$(echo ${{ matrix.python-version }} | awk -F \. {'print $1 $2'})
+          export TORCH_CUDA_VERSION=$(python -c "from os import environ as env; \
+              minv = {'2.4': 118, '2.5': 118, '2.6': 118, '2.7': 118}['${MATRIX_TORCH_VERSION}']; \
+              maxv = {'2.4': 124, '2.5': 124, '2.6': 126, '2.7': 128}['${MATRIX_TORCH_VERSION}']; \
+              print(minv if int(${MATRIX_CUDA_VERSION}) < 120 else maxv)" \
+            )
+          export MAX_JOBS=$([ "$MATRIX_CUDA_VERSION" == "129" ] && echo 1 || echo 2)
+          export FLASH_ATTN_LOCAL_VERSION="cu${WHEEL_CUDA_VERSION}torch$(echo ${{ matrix.torch-version }} | awk -F \. {'print $1 $2'})cxx11abi${{ matrix.cxx11_abi }}"
+          # Write variables to the GitHub environment
+          echo "MATRIX_CUDA_VERSION=${MATRIX_CUDA_VERSION}" >> $GITHUB_ENV
+          echo "MATRIX_TORCH_VERSION=${MATRIX_TORCH_VERSION}" >> $GITHUB_ENV
+          echo "WHEEL_CUDA_VERSION=${WHEEL_CUDA_VERSION}" >> $GITHUB_ENV
+          echo "MATRIX_PYTHON_VERSION=${MATRIX_PYTHON_VERSION}" >> $GITHUB_ENV
+          echo "TORCH_CUDA_VERSION=${TORCH_CUDA_VERSION}" >> $GITHUB_ENV
+          echo "MAX_JOBS=$MAX_JOBS" >> $GITHUB_ENV
+          echo "FLASH_ATTN_LOCAL_VERSION=${FLASH_ATTN_LOCAL_VERSION}" >> $GITHUB_ENV
 
       - name: Free up disk space
         if: ${{ runner.os == 'Linux' }}
@@ -88,94 +84,108 @@ jobs:
         with:
           swap-size-gb: 10
 
-      - name: Install CUDA ${{ matrix.cuda-version }}
-        if: ${{ matrix.cuda-version != 'cpu' }}
-        uses: Jimver/cuda-toolkit@v0.2.26
-        id: cuda-toolkit
-        with:
-          cuda: ${{ matrix.cuda-version }}
-          linux-local-args: '["--toolkit"]'
-          # default method is "local", and we're hitting some error with caching for CUDA 11.8 and 12.1
-          # method: ${{ (matrix.cuda-version == '11.8.0' || matrix.cuda-version == '12.1.0') && 'network' || 'local' }}
-          method: 'network'
-          sub-packages: '["nvcc"]'
-
-      - name: Install PyTorch ${{ matrix.torch-version }}+cu${{ matrix.cuda-version }}
-        run: |
-          pip install --upgrade pip
-          # With python 3.13 and torch 2.5.1, unless we update typing-extensions, we get error
-          # AttributeError: attribute '__default__' of 'typing.ParamSpec' objects is not writable
-          pip install typing-extensions==4.12.2
-          # We want to figure out the CUDA version to download pytorch
-          # e.g. we can have system CUDA version being 11.7 but if torch==1.12 then we need to download the wheel from cu116
-          # see https://github.com/pytorch/pytorch/blob/main/RELEASE.md#release-compatibility-matrix
-          # This code is ugly, maybe there's a better way to do this.
-          export TORCH_CUDA_VERSION=$(python -c "from os import environ as env; \
-            minv = {'2.4': 118, '2.5': 118, '2.6': 118, '2.7': 118}[env['MATRIX_TORCH_VERSION']]; \
-            maxv = {'2.4': 124, '2.5': 124, '2.6': 126, '2.7': 128}[env['MATRIX_TORCH_VERSION']]; \
-            print(minv if int(env['MATRIX_CUDA_VERSION']) < 120 else maxv)" \
-          )
-          if [[ ${{ matrix.torch-version }} == *"dev"* ]]; then
-            # pip install --no-cache-dir --pre torch==${{ matrix.torch-version }} --index-url https://download.pytorch.org/whl/nightly/cu${TORCH_CUDA_VERSION}
-            # Can't use --no-deps because we need cudnn etc.
-            # Hard-coding this version of pytorch-triton for torch 2.6.0.dev20241001
-            pip install jinja2
-            pip install https://download.pytorch.org/whl/nightly/pytorch_triton-3.1.0%2Bcf34004b8a-cp${MATRIX_PYTHON_VERSION}-cp${MATRIX_PYTHON_VERSION}-linux_x86_64.whl
-            pip install --no-cache-dir --pre https://download.pytorch.org/whl/nightly/cu${TORCH_CUDA_VERSION}/torch-${{ matrix.torch-version }}%2Bcu${TORCH_CUDA_VERSION}-cp${MATRIX_PYTHON_VERSION}-cp${MATRIX_PYTHON_VERSION}-linux_x86_64.whl
-          else
-            pip install --no-cache-dir torch==${{ matrix.torch-version }} --index-url https://download.pytorch.org/whl/cu${TORCH_CUDA_VERSION}
-          fi
-          nvcc --version
-          python --version
-          python -c "import torch; print('PyTorch:', torch.__version__)"
-          python -c "import torch; print('CUDA:', torch.version.cuda)"
-          python -c "from torch.utils import cpp_extension; print (cpp_extension.CUDA_HOME)"
-        shell:
-          bash
-
       - name: Build wheel
-        run: |
-          # We want setuptools >= 49.6.0 otherwise we can't compile the extension if system CUDA version is 11.7 and pytorch cuda version is 11.6
-          # https://github.com/pytorch/pytorch/blob/664058fa83f1d8eede5d66418abff6e20bd76ca8/torch/utils/cpp_extension.py#L810
-          # However this still fails so I'm using a newer version of setuptools
-          pip install setuptools==75.8.0
-          pip install ninja packaging wheel
-          export PATH=/usr/local/nvidia/bin:/usr/local/nvidia/lib64:$PATH
-          export LD_LIBRARY_PATH=/usr/local/nvidia/lib64:/usr/local/cuda/lib64:$LD_LIBRARY_PATH
-          # Limit MAX_JOBS otherwise the github runner goes OOM
-          # nvcc 11.8 can compile with 2 jobs, but nvcc 12.3 goes OOM
-          MAX_JOBS=$([ "$MATRIX_CUDA_VERSION" == "129" ] && echo 1 || echo 2) NVCC_THREADS=2 FLASH_ATTENTION_FORCE_BUILD="TRUE" FLASH_ATTENTION_FORCE_CXX11_ABI=${{ matrix.cxx11_abi}} python setup.py bdist_wheel --dist-dir=dist
-          tmpname=cu${WHEEL_CUDA_VERSION}torch${MATRIX_TORCH_VERSION}cxx11abi${{ matrix.cxx11_abi }}
-          wheel_name=$(ls dist/*whl | xargs -n 1 basename | sed "s/-/+$tmpname-/2")
-          ls dist/*whl |xargs -I {} mv {} dist/${wheel_name}
-          echo "wheel_name=${wheel_name}" >> $GITHUB_ENV
-
-      - name: Log Built Wheels
-        run: |
-          ls dist
-
-      - name: Get the tag version
-        id: extract_branch
-        run: echo ::set-output name=branch::${GITHUB_REF#refs/tags/}
-
-      - name: Get Release with tag
-        id: get_current_release
-        uses: joutvhu/get-release@v1
-        with:
-          tag_name: ${{ steps.extract_branch.outputs.branch }}
+        uses: pypa/cibuildwheel@v3.1.1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CIBW_DEBUG_TRACEBACK: 1
+          CIBW_BUILD_VERBOSITY: 3
+          CIBW_MANYLINUX_X86_64_IMAGE: "manylinux_2_28"
+          CIBW_BUILD: "cp${{ env.MATRIX_PYTHON_VERSION }}-manylinux_x86_64"
+          CIBW_SKIP: "cp${{ env.MATRIX_PYTHON_VERSION }}-win* cp${{ env.MATRIX_PYTHON_VERSION }}-musl* cp${{ env.MATRIX_PYTHON_VERSION }}-macosx*"
+          CIBW_ENVIRONMENT_PASS_LINUX: "MATRIX_CUDA_VERSION MATRIX_TORCH_VERSION WHEEL_CUDA_VERSION MATRIX_PYTHON_VERSION TORCH_CUDA_VERSION FLASH_ATTN_LOCAL_VERSION MAX_JOBS"
+          CIBW_ENVIRONMENT: "FLASH_ATTENTION_FORCE_BUILD=TRUE FLASH_ATTENTION_FORCE_CXX11_ABI=${{ matrix.cxx11_abi }} NVCC_THREADS=2"
+          CIBW_BUILD_FRONTEND: "pip"
+          CIBW_BEFORE_ALL: |
+            set -x
+            # Check environment variables
+            echo "========Checking environment variables========"
+            echo "MATRIX_CUDA_VERSION=${MATRIX_CUDA_VERSION}"
+            echo "MATRIX_TORCH_VERSION=${MATRIX_TORCH_VERSION}"
+            echo "WHEEL_CUDA_VERSION=${WHEEL_CUDA_VERSION}"
+            echo "MATRIX_PYTHON_VERSION=${MATRIX_PYTHON_VERSION}"
+            echo "TORCH_CUDA_VERSION=${TORCH_CUDA_VERSION}"
+            echo "FLASH_ATTN_LOCAL_VERSION=${FLASH_ATTN_LOCAL_VERSION}"
+            echo "MAX_JOBS=${MAX_JOBS}"
+            echo "FLASH_ATTENTION_FORCE_BUILD=${FLASH_ATTENTION_FORCE_BUILD}"
+            echo "FLASH_ATTENTION_FORCE_CXX11_ABI=${FLASH_ATTENTION_FORCE_CXX11_ABI}"
+            echo "========Checking environment variables========"
+            # Install CUDA toolkit
+            dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo
+            dnf clean all
+            RETRIES=5
+            COUNT=0
+            # install full cuda-toolkit, maybe cuda-nvcc enough
+            until dnf -y install cuda-toolkit; do
+              if [[ $COUNT -ge $RETRIES ]]; then
+                echo "Failed after $RETRIES attempts, aborting."
+                exit 1
+              fi
+              COUNT=$((COUNT+1))
+              echo "Retrying CUDA installation($COUNT/$RETRIES)..."
+              sleep 10
+            done
+            ls -al /usr/local
+            export PATH=$PATH:/usr/local/cuda/bin
+            nvcc --version
+          CIBW_BEFORE_BUILD: |
+            # Install PyTorch ${{ matrix.torch-version }}+cu${{ matrix.cuda-version }}
+            pip install --upgrade pip
 
-      - name: Upload Release Asset
+            # With python 3.13 and torch 2.5.1, unless we update typing-extensions, we get error
+            # AttributeError: attribute '__default__' of 'typing.ParamSpec' objects is not writable
+            pip install typing-extensions==4.12.2
+            # We want to figure out the CUDA version to download pytorch
+            # e.g. we can have system CUDA version being 11.7 but if torch==1.12 then we need to download the wheel from cu116
+            # see https://github.com/pytorch/pytorch/blob/main/RELEASE.md#release-compatibility-matrix
+            # This code is ugly, maybe there's a better way to do this.
+            
+            if [[ ${{ matrix.torch-version }} == *"dev"* ]]; then
+              # pip install --no-cache-dir --pre torch==${{ matrix.torch-version }} --index-url https://download.pytorch.org/whl/nightly/cu${TORCH_CUDA_VERSION}
+              # Can't use --no-deps because we need cudnn etc.
+              # Hard-coding this version of pytorch-triton for torch 2.6.0.dev20241001
+              pip install jinja2
+              pip install https://download.pytorch.org/whl/nightly/pytorch_triton-3.1.0%2Bcf34004b8a-cp${MATRIX_PYTHON_VERSION}-cp${MATRIX_PYTHON_VERSION}-linux_x86_64.whl
+              pip install --no-cache-dir --pre https://download.pytorch.org/whl/nightly/cu${TORCH_CUDA_VERSION}/torch-${{ matrix.torch-version }}%2Bcu${TORCH_CUDA_VERSION}-cp${MATRIX_PYTHON_VERSION}-cp${MATRIX_PYTHON_VERSION}-linux_x86_64.whl
+            else
+              pip install --no-cache-dir torch==${{ matrix.torch-version }} --index-url https://download.pytorch.org/whl/cu${TORCH_CUDA_VERSION}
+            fi
+            # We want setuptools >= 49.6.0 otherwise we can't compile the extension if system CUDA version is 11.7 and pytorch cuda version is 11.6
+            # https://github.com/pytorch/pytorch/blob/664058fa83f1d8eede5d66418abff6e20bd76ca8/torch/utils/cpp_extension.py#L810
+            # However this still fails so I'm using a newer version of setuptools
+            pip install 'numpy<2.0'
+            pip install ninja packaging wheel setuptools
+            export PATH=/usr/local/cuda/bin:/usr/local/cuda/lib64:/usr/local/nvidia/bin:/usr/local/nvidia/lib64:$PATH
+            export LD_LIBRARY_PATH=/usr/local/nvidia/lib64:/usr/local/cuda/lib64:$LD_LIBRARY_PATH
+            nvcc --version
+            python --version
+            python -c "import torch; print('PyTorch:', torch.__version__)"
+            python -c "import torch; print('CUDA:', torch.version.cuda)"
+            python -c "from torch.utils import cpp_extension; print (cpp_extension.CUDA_HOME)"
+          CIBW_REPAIR_WHEEL_COMMAND_LINUX: |
+            auditwheel repair --exclude 'libcuda.so*' --exclude 'libtorch.so*' --exclude 'libc10.so*' --exclude 'libtorch_python.so*' --exclude 'libc10_cuda.so*' --exclude 'libtorch_cuda.so*' --exclude 'libtorch_cpu.so*' --exclude 'libcudart.so.*' -w {dest_dir} {wheel}
+        with:
+          output-dir: dist
+
+      - name: List built wheels
+        if: ${{ always() }}
+        run: |
+          ls -lh dist/
+
+      - name: Release
         id: upload_release_asset
-        uses: actions/upload-release-asset@v1
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.get_current_release.outputs.upload_url }}
-          asset_path: ./dist/${{env.wheel_name}}
-          asset_name: ${{env.wheel_name}}
-          asset_content_type: application/*
+          files: dist/*.whl
+      
+      # TODO: upload wheels to pypi
+      # - name: Deploy package
+      #   env:
+      #     TWINE_USERNAME: "__token__"
+      #     TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+      #   run: |
+      #     python -m twine upload dist/*.whl
 
   publish_package:
     name: Publish package

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,16 @@ FORCE_CXX11_ABI = os.getenv("FLASH_ATTENTION_FORCE_CXX11_ABI", "FALSE") == "TRUE
 USE_TRITON_ROCM = os.getenv("FLASH_ATTENTION_TRITON_AMD_ENABLE", "FALSE") == "TRUE"
 SKIP_CK_BUILD = os.getenv("FLASH_ATTENTION_SKIP_CK_BUILD", "TRUE") == "TRUE" if USE_TRITON_ROCM else False
 
+def install_requires():
+    DEFAULT_REQUIRES = ["torch", "einops"]
+    built_torch_version = os.getenv("MATRIX_TORCH_VERSION", "")
+    if built_torch_version:
+        major_ver, minor_ver, *_ = built_torch_version.split(".")
+        torch_ver = f"torch>={major_ver}.{minor_ver}.0,<{major_ver}.{int(minor_ver) + 1}.0"
+        return [torch_ver, *DEFAULT_REQUIRES[1:]]
+    return DEFAULT_REQUIRES
+
+
 @functools.lru_cache(maxsize=None)
 def cuda_archs() -> str:
     return os.getenv("FLASH_ATTN_CUDA_ARCHS", "80;90;100;120").split(";")
@@ -555,10 +565,7 @@ setup(
         "bdist_wheel": CachedWheelsCommand,
     },
     python_requires=">=3.9",
-    install_requires=[
-        "torch",
-        "einops",
-    ],
+    install_requires=install_requires(),
     setup_requires=[
         "packaging",
         "psutil",


### PR DESCRIPTION
# 🎉Summary

🔥🔥The `GLIBC` problem has been resolved now!!

Using manylinux([https://github.com/pypa/manylinux](https://github.com/pypa/manylinux)) to build the wheels rather than hosted runner.

Building wheels against the manylinux standard eliminates the dependency on newer versions of GLIBC. PyTorch and other major binary distributions are compiled in this way, thereby providing much broader compatibility across Linux platforms.

Streamline the CI pipeline by removing unnecessary steps—such as performing a checkout and fetching tags on the hosted runner—and upload all wheel files directly with softprops/action-gh-release@v2, rather than using the deprecated actions/upload-release-asset@v1 action.

This CI workflow has been successfully tested in my fork(more details at: [https://github.com/zipzou/flash-attention/actions/runs/16568138528](https://github.com/zipzou/flash-attention/actions/runs/16568138528)), and all wheel packages build correctly. Moreover, while the original 2.8.x builds added GPU support for the Blackwell architecture, they depend on `GLIBC_2_32` and therefore crashed on Ubuntu 20.04. Rebuilding the wheels with the manylinux toolchain resolves this problem, allowing them to be installed and run on Ubuntu 20.04 without issues.

The related issues—including #1708 , #1762 , and #1330 —have now been resolved.

# ChangeLog

1. Update CI-workflow yaml to support building on the manylinux paltform;
2. Freeze the specific PyTorch version in the wheel’s metadata(`install_requires` used by the setup) to ensure that the installed wheel is used with the correct PyTorch release;

# Recommendation
Publish all compiled wheel packages to PyPI so that they can be installed directly with commands such as `pip install flash-attention==2.8.2+torch24cu128`. Wheels built using the manylinux toolchain are fully compliant with the relevant PEP standards.
