### PR TITLE
Refactors to enable FlexAttention

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.ncu-rep
 .DS_store
+.vscode
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/flash_attn/cute/flash_fwd_sm100.py
+++ b/flash_attn/cute/flash_fwd_sm100.py
@@ -1254,7 +1254,7 @@ class FlashAttentionForwardSm100:
             n_block_min, n_block_max = block_info.get_n_block_min_max(seqlen, m_block)
             mask = AttentionMaskCls(seqlen.seqlen_q, seqlen.seqlen_k)
             mask_fn = partial(
-                mask.apply_mask_sm100, m_block=m_block * 2 + stage, thr_mma=thr_mma_qk, thr_tmem_load=thr_tmem_load, mask_causal=self.is_causal, mask_local=self.is_local
+                mask.apply_mask_sm100, m_block=self.q_stage * m_block + stage, thr_mma=thr_mma_qk, thr_tmem_load=thr_tmem_load, mask_causal=self.is_causal, mask_local=self.is_local
             )
             softmax = SoftmaxSm100(softmax_scale_log2, rescale_threshold=8.0 if const_expr(self.q_dtype.width == 16) else 0.0, softmax_scale=softmax_scale)
             softmax.reset()
@@ -1275,7 +1275,7 @@ class FlashAttentionForwardSm100:
                 stage=stage,
                 batch_idx=batch_idx,
                 head_idx=head_idx,
-                m_block=m_block * 2 + stage,
+                m_block=self.q_stage * m_block + stage,
                 seqlen=seqlen,
                 buffers=buffers,
                 fastdiv_mods=fastdiv_mods,

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -212,6 +212,7 @@ def _flash_attn_fwd(
 
     compile_key = (
         dtype, head_dim, head_dim_v, qhead_per_kvhead, causal, utils.hash_callable(score_mod) if score_mod is not None else None,
+        buffers is not None,
         lse is None, cu_seqlens_q is None, cu_seqlens_k is None, seqused_q is None, seqused_k is None,
         page_table is not None,
         window_size_left is not None, window_size_right is not None,
@@ -239,6 +240,7 @@ def _flash_attn_fwd(
                 num_threads=num_threads,
                 Q_in_regs=False,
                 score_mod=score_mod,
+                has_buffers=buffers is not None,
             )
         elif compute_capability == 10:
             assert page_size in [None, 128], "Only page_size=128 is supported for paged KV on SM 10.0"
@@ -251,6 +253,7 @@ def _flash_attn_fwd(
                 pack_gqa=pack_gqa,
                 is_persistent=not causal and not local and cu_seqlens_q is None and seqused_q is None,
                 score_mod=score_mod,
+                has_buffers=buffers is not None,
             )
         else:
             raise ValueError(f"Unsupported compute capability: {compute_capability}. Supported: 9.x, 10.x")

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -20,7 +20,7 @@
 # - bwd pass optimized for Hopper/Blackwell
 
 import math
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Callable
 
 import torch
 
@@ -49,7 +49,6 @@ torch2cute_dtype_map = {
     torch.float32: cutlass.Float32,
 }
 
-
 def _flash_attn_fwd(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -73,7 +72,20 @@ def _flash_attn_fwd(
     num_threads: int = 384,
     pack_gqa: Optional[bool] = None,
     _compute_capability: Optional[int] = None,
+    score_mod: Callable | None = None,
+    return_lse: bool = False,
+    out: Optional[torch.Tensor] = None,
+    lse: Optional[torch.Tensor] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Forward pass for FlashAttention.
+
+    Args:
+        ...
+        score_mod: A callable that takes the attention scores and applies a modification.
+        return_lse: Whether to return the log softmax of the attention scores. If set to True will always calculate
+        out: Optional pre-allocated output tensor. If None, will be allocated internally.
+        lse: Optional pre-allocated log-sum-exp tensor. If None, will be allocated when needed.
+    """
     q, k, v = [maybe_contiguous(t) for t in (q, k, v)]
     num_head, head_dim = q.shape[-2:]
     if cu_seqlens_q is None:
@@ -137,10 +149,25 @@ def _flash_attn_fwd(
     out_torch_dtype = q.dtype
     device = q.device
     q_batch_seqlen_shape = (batch_size, seqlen_q) if cu_seqlens_q is None else (total_q,)
-    out = torch.empty(*q_batch_seqlen_shape, num_head, head_dim_v, dtype=out_torch_dtype, device=device)
     lse_shape = (batch_size, num_head, seqlen_q) if cu_seqlens_q is None else (num_head, total_q)
     requires_grad = q.requires_grad or k.requires_grad or v.requires_grad
-    lse = torch.empty(lse_shape, dtype=torch.float32, device=device) if requires_grad else None
+    
+    if out is None:
+        out = torch.empty(*q_batch_seqlen_shape, num_head, head_dim_v, dtype=out_torch_dtype, device=device)
+    else:
+        expected_out_shape = (*q_batch_seqlen_shape, num_head, head_dim_v)
+        assert out.shape == expected_out_shape, f"out tensor shape {out.shape} does not match expected shape {expected_out_shape}"
+        assert out.dtype == out_torch_dtype, f"out tensor dtype {out.dtype} does not match expected dtype {out_torch_dtype}"
+        assert out.device == device, f"out tensor device {out.device} does not match input device {device}"
+        assert out.is_cuda, "out tensor must be on CUDA device"
+    
+    if lse is None:
+        lse = torch.empty(lse_shape, dtype=torch.float32, device=device) if requires_grad or return_lse else None
+    elif lse is not None:
+        assert lse.shape == lse_shape, f"lse tensor shape {lse.shape} does not match expected shape {lse_shape}"
+        assert lse.dtype == torch.float32, f"lse tensor dtype {lse.dtype} does not match expected dtype torch.float32"
+        assert lse.device == device, f"lse tensor device {lse.device} does not match input device {device}"
+        assert lse.is_cuda, "lse tensor must be on CUDA device"
 
     dtype = torch2cute_dtype_map[q.dtype]
     q_tensor, k_tensor, v_tensor, o_tensor = [
@@ -173,8 +200,12 @@ def _flash_attn_fwd(
         if pack_gqa and (128 % qhead_per_kvhead != 0) or (cu_seqlens_q is not None or seqused_q is not None):
             pack_gqa = False
 
+    if softcap is not None:
+        assert score_mod is None, "softcap and score_mod cannot be used together"
+        score_mod = utils.create_softcap_scoremod(softcap)
+
     compile_key = (
-        dtype, head_dim, head_dim_v, qhead_per_kvhead, causal, softcap is not None,
+        dtype, head_dim, head_dim_v, qhead_per_kvhead, causal, utils.hash_callable(score_mod) if score_mod is not None else None,
         lse is None, cu_seqlens_q is None, cu_seqlens_k is None, seqused_q is None, seqused_k is None,
         page_table is not None,
         window_size_left is not None, window_size_right is not None,
@@ -182,6 +213,7 @@ def _flash_attn_fwd(
         m_block_size, n_block_size, num_threads, pack_gqa,
         compute_capability,
     )
+
     if compile_key not in _flash_attn_fwd.compile_cache:
         if compute_capability == 9:
             assert page_table is None, "paged KV not supported on SM 9.0"
@@ -200,6 +232,7 @@ def _flash_attn_fwd(
                 num_stages=2,
                 num_threads=num_threads,
                 Q_in_regs=False,
+                score_mod=score_mod,
             )
         elif compute_capability == 10:
             assert page_size in [None, 128], "Only page_size=128 is supported for paged KV on SM 10.0"
@@ -211,6 +244,7 @@ def _flash_attn_fwd(
                 is_local=local,
                 pack_gqa=pack_gqa,
                 is_persistent=not causal and not local and cu_seqlens_q is None and seqused_q is None,
+                score_mod=score_mod,
             )
         else:
             raise ValueError(f"Unsupported compute capability: {compute_capability}. Supported: 9.x, 10.x")
@@ -219,19 +253,18 @@ def _flash_attn_fwd(
             fa_fwd, q_tensor, k_tensor, v_tensor, o_tensor, lse_tensor, softmax_scale, current_stream,
             cu_seqlens_q_tensor, cu_seqlens_k_tensor, seqused_q_tensor, seqused_k_tensor,
             page_table_tensor,
-            softcap, window_size_left, window_size_right, learnable_sink_tensor,
+            window_size_left, window_size_right, learnable_sink_tensor,
         )
     _flash_attn_fwd.compile_cache[compile_key](
         q_tensor, k_tensor, v_tensor, o_tensor, lse_tensor, softmax_scale, current_stream,
         cu_seqlens_q_tensor, cu_seqlens_k_tensor, seqused_q_tensor, seqused_k_tensor,
         page_table_tensor,
-        softcap, window_size_left, window_size_right, learnable_sink_tensor,
+        window_size_left, window_size_right, learnable_sink_tensor,
     )
     return out, lse
 
 
 _flash_attn_fwd.compile_cache = {}
-
 
 def _flash_attn_bwd(
     q: torch.Tensor,

--- a/flash_attn/cute/utils.py
+++ b/flash_attn/cute/utils.py
@@ -27,8 +27,7 @@ sub_packed_f32x2 = partial(
 )
 
 def hash_callable(func: Callable) -> str:
-    """Hash a callable based on the source code or bytecode."""
-
+    """Hash a callable based on the source code or bytecode and closure values."""
     try:
         data = inspect.getsource(func).encode()
     except (OSError, TypeError):
@@ -37,7 +36,14 @@ def hash_callable(func: Callable) -> str:
         else:
             data = repr(func).encode()
 
-    return hashlib.sha256(data).hexdigest()
+    hasher = hashlib.sha256(data)
+
+    if hasattr(func, "__closure__") and func.__closure__ is not None:
+        for cell in func.__closure__:
+            cell_value = cell.cell_contents
+            hasher.update(repr(cell_value).encode())
+
+    return hasher.hexdigest()
 
 
 def create_softcap_scoremod(softcap_val):

--- a/tests/cute/test_score_mod.py
+++ b/tests/cute/test_score_mod.py
@@ -1,0 +1,432 @@
+import pytest
+import torch
+import cutlass
+import cutlass.cute as cute
+from cutlass._mlir.dialects import math as mlir_math
+import operator
+from torch.nn.attention.flex_attention import flex_attention
+from flash_attn.cute.interface import _flash_attn_fwd
+
+
+@cute.jit
+def score_mod_1(tSrS_ssa, b_idx, h_idx, q_idx, kv_idx, buffers):
+    tmp0 = tSrS_ssa
+    tSrS_ssa = tmp0
+    return tSrS_ssa
+
+
+@cute.jit
+def score_mod_2(tSrS_ssa, b_idx, h_idx, q_idx, kv_idx, buffers):
+    tmp0 = q_idx
+    tmp1 = kv_idx
+    tmp2 = operator.ge(tmp0, tmp1)
+    tmp3 = tSrS_ssa
+    tmp4 = cute.where(tmp2, tmp3, cute.full_like(tmp3, float("-inf")))
+    tSrS_ssa = tmp4
+    return tSrS_ssa
+
+
+@cute.jit
+def score_mod_3(tSrS_ssa, b_idx, h_idx, q_idx, kv_idx, buffers):
+    tmp0 = tSrS_ssa
+    tmp1 = q_idx
+    tmp2 = kv_idx
+    tmp3 = tmp1 - tmp2
+    tmp4 = cute.TensorSSA(mlir_math.absi(tmp3), tmp3.shape, tmp3.dtype)
+    tmp5 = tmp4.to(cutlass.Float32)
+    tmp6 = tmp0 + tmp5
+    tSrS_ssa = tmp6
+    return tSrS_ssa
+
+
+@cute.jit
+def score_mod_4(tSrS_ssa, b_idx, h_idx, q_idx, kv_idx, buffers):
+    tmp0 = tSrS_ssa
+    tmp1 = q_idx
+    tmp2 = kv_idx
+    tmp3 = tmp1 - tmp2
+    tmp4 = cute.TensorSSA(mlir_math.absi(tmp3), tmp3.shape, tmp3.dtype)
+    tmp5 = tmp4 * cute.full_like(tmp4, 2)
+    tmp6 = tmp5.to(cutlass.Float32)
+    tmp7 = tmp0 + tmp6
+    tSrS_ssa = tmp7
+    return tSrS_ssa
+
+
+@cute.jit
+def score_mod_5(tSrS_ssa, b_idx, h_idx, q_idx, kv_idx, buffers):
+    tmp0 = tSrS_ssa
+    tmp1 = tmp0 * cute.full_like(tmp0, 2)
+    tSrS_ssa = tmp1
+    return tSrS_ssa
+
+
+@cute.jit
+def score_mod_6(tSrS_ssa, b_idx, h_idx, q_idx, kv_idx, buffers):
+    tmp0 = tSrS_ssa
+    tmp1 = tmp0.to(cutlass.Float32)
+    tmp2 = h_idx
+    tmp3 = tmp2 + cute.full_like(tmp2, 1)
+    tmp4 = tmp3 * cute.full_like(tmp3, -8)
+    tmp5 = tmp4.to(cutlass.Float32)
+    tmp6 = tmp5 * cute.full_like(tmp5, 0.125)
+    tmp7 = tmp6 * cute.full_like(tmp6, 0.6931471805599453)
+    tmp8 = cute.math.exp2(tmp7 * 1.4426950408889634)
+    tmp9 = q_idx
+    tmp10 = kv_idx
+    tmp11 = tmp9 - tmp10
+    tmp12 = cute.TensorSSA(mlir_math.absi(tmp11), tmp11.shape, tmp11.dtype)
+    tmp13 = tmp12.to(cutlass.Float32)
+    tmp14 = tmp8 * tmp13
+    tmp15 = tmp1 - tmp14
+    tSrS_ssa = tmp15
+    return tSrS_ssa
+
+
+@cute.jit
+def score_mod_7(tSrS_ssa, b_idx, h_idx, q_idx, kv_idx, buffers):
+    tmp0 = q_idx
+    tmp1 = kv_idx
+    tmp2 = tmp0 - tmp1
+    tmp3 = cute.TensorSSA(mlir_math.absi(tmp2), tmp2.shape, tmp2.dtype)
+    tmp4 = operator.le(tmp3, cute.full_like(tmp3, 256))
+    tmp5 = tSrS_ssa
+    tmp6 = cute.where(tmp4, tmp5, cute.full_like(tmp5, float("-inf")))
+    tSrS_ssa = tmp6
+    return tSrS_ssa
+
+
+@cute.jit
+def score_mod_8(tSrS_ssa, b_idx, h_idx, q_idx, kv_idx, buffers):
+    tmp0 = q_idx
+    tmp1 = kv_idx
+    tmp2 = tSrS_ssa
+    tmp3 = cute.where(
+        operator.eq(tmp0 // 64, tmp1 // 64), tmp2, cute.full_like(tmp2, float("-inf"))
+    )
+    tSrS_ssa = tmp3
+    return tSrS_ssa
+
+
+@cute.jit
+def score_mod_9(tSrS_ssa, b_idx, h_idx, q_idx, kv_idx, buffers):
+    tmp0 = q_idx
+    tmp1 = kv_idx
+    tmp2 = tmp0 - tmp1
+    tmp3 = operator.ge(tmp2, cute.full_like(tmp2, 0))
+    tmp4 = tSrS_ssa
+    tmp5 = cute.where(tmp3, tmp4, cute.full_like(tmp4, float("-inf")))
+    tSrS_ssa = tmp5
+    return tSrS_ssa
+
+
+@cute.jit
+def score_mod_10(tSrS_ssa, b_idx, h_idx, q_idx, kv_idx, buffers):
+    batch_bias = buffers[0]
+
+    # Detect dtype from buffer element type
+    dtype = batch_bias.element_type
+
+    b_frag = cute.make_fragment(1, cutlass.Int32)
+    b_frag.store(b_idx)
+    bias_frag = cute.make_fragment(1, dtype)
+    bias_frag[0] = batch_bias[b_frag[0]]
+    bias_val = (bias_frag.load()).to(cutlass.Float32)
+
+    return tSrS_ssa + bias_val
+
+
+@cute.jit
+def score_mod_11(tSrS_ssa, b_idx, h_idx, q_idx, kv_idx, buffers):
+    head_bias = buffers[0]
+    pos_bias = buffers[1]
+
+    # Detect dtype from buffer element type
+    dtype = head_bias.element_type
+
+    h_frag = cute.make_fragment(1, cutlass.Int32)
+    h_frag.store(h_idx)
+    head_val_frag = cute.make_fragment(1, dtype)
+    head_val_frag[0] = head_bias[h_frag[0]]
+    head_val = (head_val_frag.load()).to(cutlass.Float32)
+
+    q_frag = cute.make_fragment(1, cutlass.Int32)
+    q_frag.store(q_idx)
+    pos_val_frag = cute.make_fragment(1, dtype)
+    pos_val_frag[0] = pos_bias[q_frag[0]]
+    pos_val = (pos_val_frag.load()).to(cutlass.Float32)
+
+    return tSrS_ssa + head_val + pos_val
+
+
+# Eager reference functions for comparison
+def identity_eager(score, b, h, q_idx, kv_idx):
+    return score
+
+
+def causal_mask_eager(score, b, h, q_idx, kv_idx):
+    return torch.where(q_idx >= kv_idx, score, float("-inf"))
+
+
+def relative_bias_eager(score, b, h, q_idx, kv_idx):
+    return score + torch.abs(q_idx - kv_idx)
+
+
+def relative_bias_v2_eager(score, b, h, q_idx, kv_idx):
+    return score + 2 * torch.abs(q_idx - kv_idx)
+
+
+def times_two_eager(score, b, h, q_idx, kv_idx):
+    return score * 2
+
+
+def alibi_bias_eager(score, b, h, q_idx, kv_idx):
+    slope = 2 ** (-8 * (h + 1) / 8)
+    return score - slope * torch.abs(q_idx - kv_idx)
+
+
+def sliding_window_eager(score, b, h, q_idx, kv_idx):
+    return torch.where(torch.abs(q_idx - kv_idx) <= 256, score, float("-inf"))
+
+
+def block_diagonal_eager(score, b, h, q_idx, kv_idx):
+    q_block = q_idx // 64
+    kv_block = kv_idx // 64
+    return torch.where(q_block == kv_block, score, float("-inf"))
+
+
+def causal_mask_v2_eager(score, b, h, q_idx, kv_idx):
+    return torch.where(q_idx - kv_idx >= 0, score, float("-inf"))
+
+
+def batch_bias(bias_tensor):
+    """Per-batch bias (tests batch indexing)."""
+
+    def batch_bias_mod(score, b, h, q_idx, kv_idx):
+        return score + bias_tensor[b]
+
+    return batch_bias_mod
+
+
+def dual_buffer_bias(head_bias, pos_scale):
+    """Dual buffer loading (tests loading from 2 separate tensors)."""
+
+    def dual_buffer_mod(score, b, h, q_idx, kv_idx):
+        head_component = head_bias[h]
+        pos_component = pos_scale[q_idx]
+        return score + pos_component + head_component
+
+    return dual_buffer_mod
+
+
+# Test pairs: (cute_jit_function, eager_reference_function)
+TEST_PAIRS = [
+    (score_mod_1, None),
+    (score_mod_2, causal_mask_eager),
+    (score_mod_3, relative_bias_eager),
+    (score_mod_4, relative_bias_v2_eager),
+    (score_mod_5, times_two_eager),
+    (score_mod_6, alibi_bias_eager),
+    (score_mod_7, sliding_window_eager),
+    (score_mod_8, block_diagonal_eager),
+    (score_mod_9, causal_mask_v2_eager),
+]
+
+# Test pairs with buffers: (cute_jit_function, eager_reference_function_factory)
+TEST_PAIRS_WITH_BUFFERS = [
+    (score_mod_10, batch_bias),
+    (score_mod_11, dual_buffer_bias),
+]
+
+
+def create_tensors(
+    batch_size=2, num_heads=4, seqlen_q=64, seqlen_kv=64, dim=128, dtype=torch.bfloat16
+):
+    q = torch.randn(batch_size, num_heads, seqlen_q, dim, device="cuda", dtype=dtype)
+    k = torch.randn(batch_size, num_heads, seqlen_kv, dim, device="cuda", dtype=dtype)
+    v = torch.randn(batch_size, num_heads, seqlen_kv, dim, device="cuda", dtype=dtype)
+    return q, k, v
+
+
+def run_cute_flash(q, k, v, cute_score_mod, buffers=None) -> torch.Tensor:
+    q_transposed, k_transposed, v_transposed = map(
+        lambda x: x.transpose(1, 2), (q, k, v)
+    )
+    out = torch.empty_like(q_transposed)
+    _flash_attn_fwd(
+        q_transposed,
+        k_transposed,
+        v_transposed,
+        return_lse=True,
+        score_mod=cute_score_mod,
+        out=out,
+        lse=None,
+        buffers=buffers,
+    )
+    return out.transpose(1, 2)
+
+
+def run_flex_reference(q, k, v, eager_score_mod, dtype=None) -> torch.Tensor:
+    if dtype is not None:
+        q, k, v = q.to(dtype), k.to(dtype), v.to(dtype)
+    return flex_attention(q, k, v, score_mod=eager_score_mod)
+
+
+@pytest.mark.parametrize(
+    "seqlen_q,seqlen_kv",
+    [
+        (1, 1),
+        (64, 128),
+        (128, 192),
+        (256, 256),
+        (239, 1),
+        (799, 3),
+        (113, 203),
+        (113, 128),
+        (128, 217),
+        (113, 211),
+        (108, 256),
+        (256, 512),
+        (384, 256),
+        (640, 128),
+        (512, 256),
+        (1024, 1024),
+        (1023, 1024),
+        (1024, 1023),
+        (4096, 4096),
+        (4224, 4224),
+    ],
+)
+@pytest.mark.parametrize("num_heads", [1, 4])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("score_mod_pair", TEST_PAIRS)
+def test_cute_vs_flex_attention(seqlen_q, seqlen_kv, num_heads, dtype, score_mod_pair):
+    torch.random.manual_seed(42)
+    cute_score_mod, eager_score_mod = score_mod_pair
+
+    q, k, v = create_tensors(
+        seqlen_q=seqlen_q, seqlen_kv=seqlen_kv, num_heads=num_heads, dtype=dtype
+    )
+
+    out_ref_fp32 = run_flex_reference(q, k, v, eager_score_mod, dtype=torch.float32)
+
+    out_pt = run_flex_reference(q, k, v, eager_score_mod)
+    out_cute = run_cute_flash(q, k, v, cute_score_mod)
+
+    # Basic shape and NaN checks
+    assert out_cute.shape == out_ref_fp32.shape == out_pt.shape
+    assert not torch.isnan(out_cute).any()
+    assert not torch.isnan(out_ref_fp32).any()
+    assert not torch.isnan(out_pt).any()
+    assert torch.isfinite(out_cute).all()
+    assert torch.isfinite(out_ref_fp32).all()
+    assert torch.isfinite(out_pt).all()
+
+    # Numerical error if we just do any arithmetic on out_ref
+    fwd_atol = 2 * (out_ref_fp32 + 0.3 - 0.3 - out_ref_fp32).abs().max().item()
+    rtol = 2
+
+    # Calculate actual errors
+    pt_error = (out_pt - out_ref_fp32).abs().max().item()
+    cute_error = (out_cute - out_ref_fp32).abs().max().item()
+
+    print(f"\nNumerical comparison for {cute_score_mod.__name__}:")
+    print(f"  PyTorch vs FP32 ref max error: {pt_error:.2e}")
+    print(f"  CuTE vs FP32 ref max error: {cute_error:.2e}")
+    print(f"  Dynamic absolute tolerance: {fwd_atol:.2e}")
+    print(f"  Error ratio (CuTE/PyTorch): {cute_error / max(pt_error, 1e-10):.2f}")
+
+    # Assert that CuTE's error is at most rtol times PyTorch's error + fwd_atol
+    assert cute_error <= rtol * pt_error + fwd_atol, (
+        f"CuTE error {cute_error:.2e} exceeds {rtol}x PyTorch error {pt_error:.2e} + {fwd_atol:.2e}"
+    )
+
+
+@pytest.mark.parametrize(
+    "seqlen_q,seqlen_kv",
+    [
+        (1, 1),
+        (64, 128),
+        (128, 192),
+        (256, 256),
+        (239, 1),
+        (799, 3),
+        (113, 203),
+        (113, 128),
+        (128, 217),
+        (113, 211),
+        (108, 256),
+        (256, 512),
+        (384, 256),
+        (640, 128),
+        (512, 256),
+        (1024, 1024),
+        (1023, 1024),
+        (1024, 1023),
+        (4096, 4096),
+        (4224, 4224),
+    ],
+)
+@pytest.mark.parametrize("num_heads", [1, 4])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("score_mod_pair", TEST_PAIRS_WITH_BUFFERS)
+def test_cute_vs_flex_attention_with_buffers(
+    seqlen_q, seqlen_kv, num_heads, dtype, score_mod_pair
+):
+    torch.random.manual_seed(42)
+    cute_score_mod, eager_score_mod_factory = score_mod_pair
+
+    batch_size = 2
+    q, k, v = create_tensors(
+        batch_size=batch_size,
+        seqlen_q=seqlen_q,
+        seqlen_kv=seqlen_kv,
+        num_heads=num_heads,
+        dtype=dtype,
+    )
+
+    if cute_score_mod == score_mod_10:
+        buffer = torch.randn(batch_size, device="cuda", dtype=dtype) * 0.1
+        buffers = [buffer]
+        eager_score_mod = eager_score_mod_factory(buffer)
+        assert buffer.shape == (batch_size,)
+    elif cute_score_mod == score_mod_11:
+        head_bias = torch.randn(num_heads, device="cuda", dtype=dtype) * 0.2
+        pos_scale = torch.arange(seqlen_q, device="cuda", dtype=dtype) * 0.01
+        buffers = [head_bias, pos_scale]
+        eager_score_mod = eager_score_mod_factory(head_bias, pos_scale)
+        assert head_bias.shape == (num_heads,)
+        assert pos_scale.shape == (seqlen_q,)
+
+    out_ref_fp32 = run_flex_reference(q, k, v, eager_score_mod, dtype=torch.float32)
+
+    out_pt = run_flex_reference(q, k, v, eager_score_mod)
+    out_cute = run_cute_flash(q, k, v, cute_score_mod, buffers=buffers)
+
+    # Basic shape and NaN checks
+    assert out_cute.shape == out_ref_fp32.shape == out_pt.shape
+    assert not torch.isnan(out_cute).any()
+    assert not torch.isnan(out_ref_fp32).any()
+    assert not torch.isnan(out_pt).any()
+    assert torch.isfinite(out_cute).all()
+    assert torch.isfinite(out_ref_fp32).all()
+    assert torch.isfinite(out_pt).all()
+
+    # Numerical error if we just do any arithmetic on out_ref
+    fwd_atol = 2 * (out_ref_fp32 + 0.3 - 0.3 - out_ref_fp32).abs().max().item()
+    rtol = 2
+
+    # Calculate actual errors
+    pt_error = (out_pt - out_ref_fp32).abs().max().item()
+    cute_error = (out_cute - out_ref_fp32).abs().max().item()
+
+    print(f"\nNumerical comparison for {cute_score_mod.__name__}:")
+    print(f"  PyTorch vs FP32 ref max error: {pt_error:.2e}")
+    print(f"  CuTE vs FP32 ref max error: {cute_error:.2e}")
+    print(f"  Dynamic absolute tolerance: {fwd_atol:.2e}")
+    print(f"  Error ratio (CuTE/PyTorch): {cute_error / max(pt_error, 1e-10):.2f}")
+
+    # Assert that CuTE's error is at most rtol times PyTorch's error + fwd_atol
+    assert cute_error <= rtol * pt_error + fwd_atol, (
+        f"CuTE error {cute_error:.2e} exceeds {rtol}x PyTorch error {pt_error:.2e} + {fwd_atol:.2e}"
+    )

--- a/tests/cute/test_score_mod.py
+++ b/tests/cute/test_score_mod.py
@@ -430,3 +430,7 @@ def test_cute_vs_flex_attention_with_buffers(
     assert cute_error <= rtol * pt_error + fwd_atol, (
         f"CuTE error {cute_error:.2e} exceeds {rtol}x PyTorch error {pt_error:.2e} + {fwd_atol:.2e}"
     )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
# Summary

This currently only enables score_mods with inline global loads. For a majority of score_mods I have found that unless you are indexing along the kv_index dim the slow down due to global loads is too high compared to the additional math inlined. KV_indexing however is a major performance hit ~700 Tflops and we will likely need to design something smarter here that goes through smem if there is room.

PT stack: https://github.com/pytorch/pytorch/pull/162031

## Changes for SM100/SM80/90:
* TensorSSA based score_mods
* Optional list of buffers that can used in score_mod functions
* Allow for caller to pass in lse and out instead of creating (needed for inductor manage allocations)
* Abstracted out softcap to score_mod -> No perf hit for h100 and pretty bad perf for blackwell but now supported

### Tests
One thing that I really thought was going to be necessary was to move the loads out of the softmax hotpath. And potentially have them pre-loaded to in SMEM (although I am not sure how much room we have left). However at least from early testing, for something like 

Example usage:
```Py
def dual_buffer_bias(b, n_heads, q, kv, dtype):
    """Dual buffer loading (tests loading from 2 separate tensors)."""
    head_bias = torch.randn(n_heads, device="cuda", dtype=dtype) * 0.2
    pos_scale = torch.randn(q + kv, device="cuda", dtype=dtype) * 0.1
    def dual_buffer_mod(score, b, h, q_idx, kv_idx):
        head_component = head_bias[h]
        pos_component = pos_scale[kv_idx]
        return score + head_component + pos_component
    return dual_buffer_mod
 ```

which currently produces:
```Py
    @cute.jit
    def score_mod(tSrS_ssa, b_idx, h_idx, q_idx, kv_idx, buffers):
        in_ptr4 = buffers[0]
        in_ptr5 = buffers[1]
        tmp0 = tSrS_ssa
        tmp1 = h_idx
        tmp2 = cute.make_fragment(1, cutlass.Int32)
        tmp3 = tmp2.store(tmp1)
        tmp4 = cute.make_fragment(1, cutlass.BFloat16)
        tmp5 = tmp2[0]
        tmp6 = tmp4[0] = (in_ptr4[tmp5])
        tmp7 = (tmp4.load()).to(cutlass.Float32)
        tmp8 = (tmp0 + tmp7)
        tmp9 = kv_idx
        tmp10 = tmp2.store(tmp9)
        tmp11 = tmp4[0] = (in_ptr5[tmp5])
        tmp12 = (tmp8 + tmp7)
        tSrS_ssa = tmp12

        return tSrS_ssa
```

We go from 
`FAv4:    3108.38 μs | 1420.43 TFLOPs`
to:
`FAv4:    3485.34 μs | 1266.80 TFLOPs`


### Perf Details
## Performance Details

### 1. General Perf Hit from Score Modifications

**Causal, HeadDim=128 Performance Comparison**

| SeqLen | No score_mod | | Identity score_mod (`lambda x, *_: return x`) |
|--------|-------------|---|-------------|
| 1024   | 0.168ms, 819.3 TFLOPS | | 0.179ms, 769.0 TFLOPS |
| 2048   | 0.242ms, 1136.1 TFLOPS | | 0.261ms, 1052.8 TFLOPS |
| 4096   | 0.398ms, 1379.7 TFLOPS | | 0.433ms, 1269.1 TFLOPS |
| 8192   | 0.726ms, 1513.7 TFLOPS | | 0.789ms, 1393.8 TFLOPS |
| 16384  | 1.385ms, 1587.9 TFLOPS | | 1.509ms, 1457.1 TFLOPS |
| 32768  | 2.697ms, 1630.6 TFLOPS | | 2.948ms, 1491.6 TFLOPS |

### 2. Dual Buffer Loading Performance

For dual buffer bias loading from 2 separate tensors:
- **Before:** 3108.38 μs | 1420.43 TFLOPs
- **After:** 3485.34 μs | 1266.80 TFLOPs

Which honestly is much less of a drop than I expected.

Motivation for all these changes:
```Shell
[Results]
Flex+FA:    3463.58 μs | 1274.76 TFLOPs
Triton: 11915.89 μs | 370.53 TFLOPs
Speedup: 3.44x
```
This is a little unfair because the PT implementation is block-sparse(TO BE DONE AS A FOLLOW UP HERE), but that being said a very significant performance increase.

### 3. Softcap Performance

**NOTE:** I just realized that on SM100 it doesn't appear like softcapping was even working..

#### SM100 Softcap Results (pretty miserable, need to grab H100 and compare)

| SeqLen | Latency | TFLOPS |
|--------|---------|--------|
| 1024   | 0.555ms | 247.7  |
| 2048   | 1.011ms | 271.9  |
| 4096   | 1.936ms | 284.0  |
| 8192   | 3.778ms | 291.0  |
| 16384  | 7.479ms | 294.0  |
| 32768  | 14.884ms| 295.5  |

#### H100 Softcap Comparison (w/ power limit)

| SeqLen | Before | | After |
|--------|--------|---|-------|
| 1024   | 0.531ms, 258.7 TFLOPS | | 0.540ms, 239.1 TFLOPS |
| 2048   | 0.910ms, 301.9 TFLOPS | | 0.915ms, 282.9 TFLOPS |
| 4096   | 1.669ms, 329.3 TFLOPS | | 1.663ms, 311.3 TFLOPS |
| 8192   | 3.237ms, 339.7 TFLOPS | | 3.184ms, 327.8 TFLOPS |
| 16384  | 6.796ms, 323.6 TFLOPS | | 6.740ms, 297.4 TFLOPS |
| 32768  | 13.823ms, 318.2 TFLOPS | | 13.527ms, 297.6 TFLOPS |

### Tests
I have lots of tests in PT and brought some of them over w/ score_mods that were produced via codegen -> not very readable but they work :)

On Sm100 machine also could attach a picture of all green :)
<img width="893" height="611" alt="Screenshot 2025-10-07 at 6 08 14 PM" src="https://github.com/user-attachments/assets/04426a60-20a5-4e93-adba-c3004cb9b0ed" />


On sm90 Machine
<img width="1684" height="228" alt="Screenshot 2025-09-15 at 3 39 47 PM" src="https://github.com/user-attachments/assets/f9537d0b-35ee-49de-a9ac-4a14ccda9b00" />
