### PR TITLE
[FIX] Allow m_block_size == 192 and mma_pv_is_rs == False in Sm90 CuTe DSL

### DIFF
--- a/flash_attn/cute/flash_fwd.py
+++ b/flash_attn/cute/flash_fwd.py
@@ -1801,7 +1801,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         # tOrP.store(tOrP_acc.load().to(self.dtype))
         utils.cvt_f16(tOrP_acc, tOrP)
         if const_expr(not self.mma_pv_is_rs):
-            tPrP = smem_copy_params.smem_thr_copy_P.retile(mma_params.tOrP)
+            tPrP = smem_copy_params.smem_thr_copy_P.retile(tOrP)
             cute.copy(smem_copy_params.smem_thr_copy_P, tPrP, smem_copy_params.tPsP)
         softmax.rescale_O(mma_params.acc_O, row_scale)
         if const_expr(not self.mma_pv_is_rs):


### PR DESCRIPTION
The purpose of this PR is twofold: 
1. to add support for `mma_pv_is_rs == False`, which is currently always set to `True`
2. to allow 3 mma warp groups, thus enabling `m_block_size == 192`, and as a result head dimension 96. 

Currently, the kernel hangs with `m_block_size == 192` due to launching too few threads per block and attempting to allocate too many registers. This fix puts the CuTe DSL kernel in line with the C++ version; see e.g. [the register allocation logic here.](https://github.com/ColfaxResearch/flash-attention/blob/3268c04b81d16f4a94a50dfffdd879c3222e71aa/hopper/flash_fwd_kernel_sm90.h#L82)