### PR TITLE
Minor changes to get cute-dsl bwd running (divisibility assumptions, returning correct number of args, etc.)

### DIFF
--- a/flash_attn/cute/flash_bwd.py
+++ b/flash_attn/cute/flash_bwd.py
@@ -819,7 +819,7 @@ class FlashAttentionBackwardSm80:
         else:
             tdVrP = mma_params.tdVrP
 
-        # MMA dK
+        # MMA dV
         sm80_utils.gemm(
             mma_params.thr_mma_dkv, mma_params.acc_dV, tdVrP, mma_params.tdVrdO,
             smem_copy_params.tdVsPt,

--- a/flash_attn/cute/flash_bwd_preprocess.py
+++ b/flash_attn/cute/flash_bwd_preprocess.py
@@ -261,7 +261,7 @@ class FlashAttentionBackwardPreprocess:
         gdPsum = cute.local_tile(
             mdPsum[batch_size, num_head, None], (self.m_block_size,), (m_block,)
         )
-        # Only the thread corresponding to column 0 writes out the lse to gmem
+        # Only the thread corresponding to column 0 writes out the dPsum to gmem
         if tOcO[0, 0, 0][1] == 0:
             for m in cutlass.range(cute.size(dP_sum), unroll_full=True):
                 row = tOcO[0, m, 0][0]

--- a/flash_attn/cute/utils.py
+++ b/flash_attn/cute/utils.py
@@ -93,6 +93,7 @@ def warp_reduce(
     op: Callable,
     width: cutlass.Constexpr[int] = cute.arch.WARP_SIZE,
 ) -> cute.TensorSSA | cute.Numeric:
+    assert width <= cute.arch.WARP_SIZE
     if const_expr(isinstance(val, cute.TensorSSA)):
         res = cute.make_fragment(val.shape, val.dtype)
         res.store(val)


### PR DESCRIPTION
# Summary

Some minor changes to clean up + get cute-dsl bwd running. 
- Some of the copy atoms used in the 3 bwd kernels use # copy bits = 128 > dtype bits, so jit compiler complains without marking divisibility (to 8 for the 16 bit dtypes and 4 for the 32 bit dtypes)
- Backward returns the wrong number of arguments
- Added an assert to warp reduce for width (tripped me up when I was modifying copy bits constants since that ended up making width > warp size which wasn't caught by any asserts)
- Minor comment corrections

# Tests

Above changes are enough to get cute-dsl bwd running (no jit compiler errors), but note that I also needed to make the changes described in https://github.com/Dao-AILab/flash-attention/issues/1918 to get fwd running and correct, and https://github.com/Dao-AILab/flash-attention/issues/1915 for bwd correctness since the R2P masking trick was not working. 

After doing that, I get the cute-dsl bwd matching SDPA with `SDPBackend.FLASH_ATTENTION`. See testing script in https://github.com/Dao-AILab/flash-attention/issues/1915.


