### PR TITLE
windows error error C2039:

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -263,7 +263,8 @@ if not SKIP_CUDA_BUILD and not IS_ROCM:
 
     compiler_c17_flag=["-O3", "-std=c++17"]
     # Add Windows-specific flags
-    if sys.platform == "win32" and os.getenv('DISTUTILS_USE_SDK') == '1':
+    #if sys.platform == "win32" and os.getenv('DISTUTILS_USE_SDK') == '1':
+    if sys.platform == "win32":    
         nvcc_flags.extend(["-Xcompiler", "/Zc:__cplusplus"])
         compiler_c17_flag=["-O2", "/std:c++17", "/Zc:__cplusplus"]
 


### PR DESCRIPTION
While attempting to compile flash-attn from source on Windows (CUDA 12.6, PyTorch 2.7.1), the build fails with the following compilation error: windows error error C2039: "is_unsigned_v" is not a member of "cutlass::platform"

This error occurs because the Windows-specific MSVC compiler flag `/Zc:__cplusplus` is only applied when the `DISTUTILS_USE_SDK` environment variable is set to `'1'`. This variable is typically only set in professional SDK build environments, meaning regular users building from source encounter this compilation failure.

## Root Cause

MSVC does not properly set the `__cplusplus` macro by default, causing CUTLASS to believe that C++17 features are unavailable. The workaround for this already exists in the code (using the `/Zc:__cplusplus` flag), but it is hidden behind the `DISTUTILS_USE_SDK` check, making it inaccessible to most users.

## Solution

This PR removes the `DISTUTILS_USE_SDK` requirement and applies the Windows MSVC flags unconditionally when building on Windows. Since CUDA requires MSVC on Windows, this change ensures the correct flags are always used without requiring users to set obscure environment variables.

## Testing

Successfully compiled and built flash-attn from source with the following configuration:
- Windows 11
- AMD 5800x
- RTX 4090
- MSVC 2022 (version 14.44)
- CUDA 12.8
- PyTorch 2.7.1

The build now completes without errors, where it previously failed with the `is_unsigned_v` compilation error.