### PR TITLE
Fix backward preprocess kernel in FlashAttention3

### DIFF
--- a/hopper/flash_bwd_preprocess_kernel.h
+++ b/hopper/flash_bwd_preprocess_kernel.h
@@ -164,7 +164,7 @@ public:
         Tensor mLSE = make_tensor(make_gmem_ptr(params.ptr_LSE), shape_LSE, params.stride_LSE)(_, bidh, !is_varlen ? bidb : 0);
         Tensor gLSE = local_tile(cute::domain_offset(make_coord(seqlen_info.offset), mLSE), Shape<Int<kBlockM>>{}, make_coord(m_block));
         static_assert(kBlockM <= MaxThreadsPerBlock);
-        float lse = thread_idx < seqlen_o - m_block * kBlockM && thread_idx < kBlockM ? gLSE(thread_idx) : INFINITY;
+        float lse = thread_idx < seqlen_o - m_block * kBlockM && thread_idx < kBlockM ? gLSE(thread_idx) : -INFINITY;
 
         GmemTiledCopy gmem_tiled_copy_O;
         auto gmem_thr_copy_O = gmem_tiled_copy_O.get_thread_slice(thread_idx);


### PR DESCRIPTION
Fix backward preprocess kernel sentinel value for padded LSE positions.

The backward preprocess kernel used +INFINITY as the sentinel value for padded thread positions, which caused NaN/inf gradients in ring attention backward passes when these values were written to the lse log2 buffer. This commit changes the sentinel value from +INFINITY to -INFINITY for padded positions which ensures padded positions write 0.f to the buffer, preventing NaN/inf propagation in ring attention gradient computations.