### PR TITLE
[ROCm] prepare CK sources for pytorch hipify v2 APIs

### DIFF
--- a/csrc/flash_attn_ck/mha_bwd.cpp
+++ b/csrc/flash_attn_ck/mha_bwd.cpp
@@ -220,7 +220,11 @@ mha_bwd(const at::Tensor &dout,                   // batch_size x seqlen_q x num
     if (is_causal) { window_size_right = 0; }
 
     bool is_dropout = p_dropout > 0.0;
+#ifdef HIPIFY_V2
+    auto stream = at::cuda::getCurrentCUDAStream().stream();
+#else
     auto stream = at::cuda::getCurrentHIPStream().stream();
+#endif
 
     auto q_dtype = q.dtype();
     TORCH_CHECK(q_dtype == torch::kFloat16 || q_dtype == torch::kBFloat16,

--- a/csrc/flash_attn_ck/mha_fwd.cpp
+++ b/csrc/flash_attn_ck/mha_fwd.cpp
@@ -272,7 +272,11 @@ mha_fwd(at::Tensor &q,                            // batch_size x seqlen_q x num
 
     if (seqlen_k > 0) {
         auto drop_seed_offset = std::make_pair(rng_state_ptr, rng_state_ptr + 1);
+#ifdef HIPIFY_V2
+        auto stream = at::cuda::getCurrentCUDAStream().stream();
+#else
         auto stream = at::cuda::getCurrentHIPStream().stream();
+#endif
         ck_tile::stream_config stream_config{stream};
 
         auto traits =

--- a/csrc/flash_attn_ck/mha_varlen_fwd.cpp
+++ b/csrc/flash_attn_ck/mha_varlen_fwd.cpp
@@ -469,7 +469,11 @@ mha_varlen_fwd(at::Tensor &q,                   // total_q x num_heads x head_si
     }
 
     if (max_seqlen_k > 0) {
+#ifdef HIPIFY_V2
+        auto stream = at::cuda::getCurrentCUDAStream().stream();
+#else
         auto stream = at::cuda::getCurrentHIPStream().stream();
+#endif
         ck_tile::stream_config stream_config{stream};
 
         if (paged_KV)

--- a/setup.py
+++ b/setup.py
@@ -173,6 +173,18 @@ def check_if_rocm_home_none(global_option: str) -> None:
     )
 
 
+def detect_hipify_v2():
+    try:
+        from torch.utils.hipify import __version__
+        from packaging.version import Version
+        if Version(__version__) >= Version("2.0.0"):
+            return True
+    except Exception as e:
+        print("failed to detect pytorch hipify version, defaulting to version 1.0.0 behavior")
+        print(e)
+    return False
+
+
 def append_nvcc_threads(nvcc_extra_args):
     nvcc_threads = os.getenv("NVCC_THREADS") or "4"
     return nvcc_extra_args + ["--threads", nvcc_threads]
@@ -408,6 +420,12 @@ elif not SKIP_CUDA_BUILD and IS_ROCM:
             f"build/fmha_*wd*.cpp"
         )
 
+        # Check if torch is using hipify v2. Until CK is updated with HIPIFY_V2 macro,
+        # we must replace the incorrect APIs.
+        maybe_hipify_v2_flag = []
+        if detect_hipify_v2():
+            maybe_hipify_v2_flag = ["-DHIPIFY_V2"]
+
         rename_cpp_to_cu(sources)
 
         renamed_sources = ["csrc/flash_attn_ck/flash_api.cu",
@@ -450,8 +468,8 @@ elif not SKIP_CUDA_BUILD and IS_ROCM:
             cc_flag += ["-mllvm", "-amdgpu-coerce-illegal-types=1"]
 
         extra_compile_args = {
-            "cxx": ["-O3", "-std=c++17"] + generator_flag,
-            "nvcc": cc_flag + generator_flag,
+            "cxx": ["-O3", "-std=c++17"] + generator_flag + maybe_hipify_v2_flag,
+            "nvcc": cc_flag + generator_flag + maybe_hipify_v2_flag,
         }
 
         include_dirs = [


### PR DESCRIPTION
See https://github.com/pytorch/pytorch/pull/151845.
pytorch has removed caffe2, but hipify still contained work-arounds for caffe2 vs torch compatibility.
As a result of hipify v2 changes, some torch APIs are changing.