### PR TITLE
fix: nan when m_i_new=-inf in online softmax

### DIFF
--- a/flash_attn/ops/triton/cross_entropy.py
+++ b/flash_attn/ops/triton/cross_entropy.py
@@ -57,10 +57,9 @@ def cross_entropy_fwd_kernel(
             if HAS_SMOOTHING:
                 sum_logits += tl.sum(tl.where(cols < n_cols, logits, 0.0))
             m_i_new = tl.maximum(m_i, tl.max(logits))
-            if m_i_new == -float("inf"):
-                continue
-            l_i = tl.exp(m_i - m_i_new) * l_i + tl.sum(tl.exp(logits - m_i_new))
-            m_i = m_i_new
+            if m_i_new > -float("inf"):
+                l_i = tl.exp(m_i - m_i_new) * l_i + tl.sum(tl.exp(logits - m_i_new))
+                m_i = m_i_new
         lse = tl.log(l_i) + m_i
         tl.store(lse_ptr + row_idx, lse)
     else:


### PR DESCRIPTION
Trying to resolve https://github.com/Dao-AILab/flash-attention/issues/1930.

### Test

Environment: H800, CUDA 12.6

> [!WARNING]
> Sorry that I don't have access to newer architectures, on which I have to resort to other contributors to help test on.

```bash
FLASH_ATTN_CUDA_ARCHS="90" python setup.py install
```

#### Test for the issue

```python
import torch
from flash_attn.ops.triton.cross_entropy import cross_entropy_loss

V = 100000
row = torch.full((V,), float('-inf'), device='cuda', dtype=torch.float32)
i = 50000
row[i] = 10
logits = row.unsqueeze(0)  # [1, V]
labels = torch.tensor([i], device='cuda', dtype=torch.long)

loss = cross_entropy_loss(logits, labels)[0]
print(torch.isfinite(loss))
print(loss)
```

Output:

```
tensor([True], device='cuda:0')
tensor([0.], device='cuda:0')
```

#### Existing test

```
$ pytest -q -s tests/losses/test_cross_entropy.py 
...................................................sss...sss...sss...sss...sss...sss...sss...sss...sss...sss...sss...sss...sss...sss...sss...sss...sss...sss...sss...sss...sss...sss...sss...sss...................................................sss...sss...sss...sss...sss...sss...sss...sss...sss...sss...sss...sss...sss...sss...sss...sss...sss...sss...sss...sss...sss...sss...sss...sss
240 passed, 144 skipped in 10.59s
```