### PR TITLE
Fix FA3 segfault with custom CUDA streams in ABI stable build

### DIFF
--- a/hopper/flash_api_stable.cpp
+++ b/hopper/flash_api_stable.cpp
@@ -16,6 +16,10 @@
 #include <torch/csrc/stable/library.h>
 #include <torch/csrc/stable/ops.h>
 #include <torch/csrc/stable/accelerator.h>
+#include <torch/csrc/inductor/aoti_torch/c/shim.h>
+
+// Declare the CUDA stream function that's behind #ifdef USE_CUDA in shim.h
+extern "C" AOTITorchError aoti_torch_get_current_cuda_stream(int32_t device_index, void** ret_stream);
 
 #include <torch/headeronly/core/ScalarType.h>
 #include <torch/headeronly/util/Exception.h>
@@ -717,7 +721,9 @@ mha_fwd_get_scheduler_metadata(
         int const kBlockM = params.arch >= 90 ? std::get<0>(kBlockMN_kernel_args_sm90) : std::get<0>(kBlockMN_kernel_args_sm8x);
         int const kBlockN = params.arch >= 90 ? std::get<1>(kBlockMN_kernel_args_sm90) : std::get<1>(kBlockMN_kernel_args_sm8x);
         auto device_idx = torch::stable::accelerator::getCurrentDeviceIndex();
-        auto stream = (cudaStream_t)torch::stable::accelerator::getCurrentStream(device_idx).id();
+        void* stream_ptr = nullptr;
+        TORCH_ERROR_CODE_CHECK(aoti_torch_get_current_cuda_stream(device_idx, &stream_ptr));
+        cudaStream_t stream = static_cast<cudaStream_t>(stream_ptr);
         prepare_varlen_num_blocks(params, stream, params.pack_gqa, kBlockM, kBlockN, false /*enable_pdl*/);
         CHECK_CUDA_KERNEL_LAUNCH();
     }
@@ -1227,7 +1233,9 @@ mha_fwd(Tensor q,   // (b, s_q, h, d) or (total_q, h, d) if there is cu_seqlens_
 
     if (total_q > 0 && (total_k + params.total_knew) > 0 && num_heads_k > 0) {
         auto device_idx = torch::stable::accelerator::getCurrentDeviceIndex();
-        auto stream = (cudaStream_t)torch::stable::accelerator::getCurrentStream(device_idx).id();
+        void* stream_ptr = nullptr;
+        TORCH_ERROR_CODE_CHECK(aoti_torch_get_current_cuda_stream(device_idx, &stream_ptr));
+        cudaStream_t stream = static_cast<cudaStream_t>(stream_ptr);
         run_mha_fwd(params, stream);
         if (params.num_splits > 1) {
             if (out_type == torch::headeronly::ScalarType::BFloat16) {
@@ -1619,7 +1627,9 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Tensor> mha_b
 
     if (total_q > 0 && total_k > 0 && num_heads_k > 0) {
         auto device_idx = torch::stable::accelerator::getCurrentDeviceIndex();
-        auto stream = (cudaStream_t)torch::stable::accelerator::getCurrentStream(device_idx).id();
+        void* stream_ptr = nullptr;
+        TORCH_ERROR_CODE_CHECK(aoti_torch_get_current_cuda_stream(device_idx, &stream_ptr));
+        cudaStream_t stream = static_cast<cudaStream_t>(stream_ptr);
         run_mha_bwd(params, stream);
     } else if (total_k > 0 && num_heads_k > 0) {
         // If seqlen_q == 0, then we have an empty tensor. We need to set the output to 0.
@@ -1726,7 +1736,9 @@ mha_combine(Tensor out_partial,         // num_splits x batch_size x seqlen x nu
 
     if (seqlen > 0 && batch_size > 0) {
         auto device_idx = torch::stable::accelerator::getCurrentDeviceIndex();
-        auto stream = (cudaStream_t)torch::stable::accelerator::getCurrentStream(device_idx).id();
+        void* stream_ptr = nullptr;
+        TORCH_ERROR_CODE_CHECK(aoti_torch_get_current_cuda_stream(device_idx, &stream_ptr));
+        cudaStream_t stream = static_cast<cudaStream_t>(stream_ptr);
         run_mha_fwd_combine(params, stream, false /*enable_pdl*/);
     }
 


### PR DESCRIPTION
Commit https://github.com/Dao-AILab/flash-attention/commit/b3846b05 introduced ABI-stable FA3 by switching to `flash_api_stable.cpp`, but it broke custom CUDA stream support, causing segmentation faults.

The stable API implementation incorrectly retrieved the CUDA stream:

https://github.com/Dao-AILab/flash-attention/commit/b3846b05#diff-5943ae8632df7f82168be9d43f3b09f8536f5f70f9e58f8bc0463a673bea5072R28-R716

```cpp
auto stream = (cudaStream_t)torch::stable::accelerator::getCurrentStream(device_idx).id();
```

The `.id()` method returns a StreamId which is an `int64_t` identifier, not a `cudaStream_t` pointer. Casting an integer ID to a pointer and dereferencing it causes undefined behavior and segfaults.

To fix this, we use the proper AOTI C API function `aoti_torch_get_current_cuda_stream()` which returns the actual CUDA stream pointer:

```cpp
void* stream_ptr = nullptr;
TORCH_ERROR_CODE_CHECK(aoti_torch_get_current_cuda_stream(device_idx, &stream_ptr));
cudaStream_t stream = static_cast<cudaStream_t>(stream_ptr);
```

This fix applies to all 4 locations in `flash_api_stable.cpp` where CUDA streams are retrieved. For context on why this solution works, see the torch source:

https://github.com/pytorch/pytorch/blob/baf91bbbfc70842f8f99011b88e2626116a459f7/torch/csrc/stable/accelerator.h#L65-L69

We wish to access `stream_` instead of the id, but it is private.

# Testing

This bug was discovered by git bisecting with the following script which segfaults at https://github.com/Dao-AILab/flash-attention/commit/b3846b05 and not the prior commit. I confirmed it does not segfault with the PR applied against `main`. I can add the test file to the PR too if desired, but it seems like a point fix.

```py
import faulthandler
import sys
import torch

faulthandler.enable()

import flash_attn_3._C
flash_attn_3_cuda = torch.ops.flash_attn_3

# Test parameters
seqlen_q, seqlen_k, num_heads, head_dim = 128, 256, 1, 64
device = "cuda"

q = torch.randn(seqlen_q, num_heads, head_dim, device=device, dtype=torch.bfloat16)
k = torch.randn(seqlen_k, num_heads, head_dim, device=device, dtype=torch.bfloat16)
v = torch.randn(seqlen_k, num_heads, head_dim, device=device, dtype=torch.bfloat16)

cu_seqlens_q = torch.tensor([0, seqlen_q], device=device, dtype=torch.int32)
cu_seqlens_k = torch.tensor([0, seqlen_k], device=device, dtype=torch.int32)

softmax_scale = head_dim ** -0.5

def call_fa3():
    return flash_attn_3_cuda.fwd(
        q, k, v, None, None, None, None,
        cu_seqlens_q, cu_seqlens_k, None, None, None,
        seqlen_q, seqlen_k, None, None, None,
        None, None, None, None, None, None,
        softmax_scale, False, -1, -1, 0, 0.0, True, None, 1, None, 0,
    )

print("Test 1: FA3 on default stream")
sys.stdout.flush()
try:
    with torch.no_grad():
        out, _, _, _ = call_fa3()
    print(f"✓ Success on default stream! Shape: {out.shape}")
except:
    print("✗ Failed on default stream")
    import traceback
    traceback.print_exc()
    sys.exit(1)

print("\nTest 2: FA3 on custom stream")
sys.stdout.flush()
stream = torch.cuda.Stream(device=device)
try:
    with torch.no_grad(), torch.cuda.stream(stream):
        out, _, _, _ = call_fa3()  # Segfaults here without this change!
    stream.synchronize()
    print(f"✓ Success on custom stream! Shape: {out.shape}")
except:
    print("✗ Failed on custom stream")
    import traceback
    traceback.print_exc()
    sys.exit(1)
```
