### PR TITLE
BlockSparse Tweaks

### DIFF
--- a/flash_attn/cute/benchmark_mask_mod.py
+++ b/flash_attn/cute/benchmark_mask_mod.py
@@ -16,10 +16,8 @@ import torch
 
 from flash_fwd import FlashAttentionForwardSm90
 from mask_definitions import (
-    MASK_FUNCTIONS,
+    get_mask_pair,
     random_doc_id_tensor,
-    create_cute_sliding_window_mask,
-    create_flex_sliding_window_mask,
 )
 from flash_attn.cute.block_sparsity import (
     compute_block_sparsity,
@@ -99,12 +97,12 @@ class FlashAttentionBenchmark:
             config.use_mask_mod = False
 
         if config.use_mask_mod:
-            if config.mask_mod_name == "sliding_window":
-                # Use factory function for custom window size
-                self.mask_mod_cute = create_cute_sliding_window_mask(config.window_size)
-                self.mask_mod_flex = create_flex_sliding_window_mask(config.window_size)
-            else:
-                self.mask_mod_cute, self.mask_mod_flex = MASK_FUNCTIONS[config.mask_mod_name]
+            self.mask_mod_cute, self.mask_mod_flex = get_mask_pair(
+                config.mask_mod_name,
+                seqlen_q=config.seqlen_q,
+                seqlen_k=config.seqlen_k,
+                window_size=config.window_size,
+            )
         else:
             self.mask_mod_cute = None
             self.mask_mod_flex = None

--- a/flash_attn/cute/block_sparsity.py
+++ b/flash_attn/cute/block_sparsity.py
@@ -36,40 +36,82 @@ class BlockSparseTensorsTorch(NamedTuple):
     full_block_idx: Optional[torch.Tensor] = None
 
 
-def validate_block_sparse_tensors(
+def _expand_sparsity_tensor(
+    tensor: torch.Tensor,
+    expected_shape: Tuple[int, ...],
+    tensor_name: str,
+) -> torch.Tensor:
+    """Check if we need to expand the tensor to expected shape, and do so if possible."""
+    needs_expand = tensor.shape != expected_shape
+    if not needs_expand:
+        return tensor
+    can_expand = all(map(lambda cur, tgt: cur == tgt or cur == 1, tensor.shape, expected_shape))
+    if not can_expand:
+        raise ValueError(
+            f"{tensor_name} with shape {tensor.shape} cannot be expanded to expected shape {expected_shape}."
+        )
+    return tensor.expand(*expected_shape).contiguous()
+
+
+def _check_and_expand_block(
+    name: str,
+    cnt: Optional[torch.Tensor],
+    idx: Optional[torch.Tensor],
+    expected_count_shape: Tuple[int, int, int],
+    expected_index_shape: Tuple[int, int, int, int],
+) -> Tuple[Optional[torch.Tensor], Optional[torch.Tensor]]:
+    if (cnt is None) != (idx is None):
+        raise ValueError(
+            f"{name}_block_cnt and {name}_block_idx must both be provided or both be None"
+        )
+    if cnt is None or idx is None:
+        return None, None
+    if cnt.dtype != torch.int32 or idx.dtype != torch.int32:
+        raise ValueError(f"{name}_block tensors must have dtype torch.int32")
+    if cnt.device != idx.device:
+        raise ValueError(f"{name}_block_cnt and {name}_block_idx must be on the same device")
+    if not cnt.is_cuda or not idx.is_cuda:
+        raise ValueError(f"{name}_block tensors must live on CUDA")
+    expanded_cnt = _expand_sparsity_tensor(cnt, expected_count_shape, f"{name}_block_cnt")
+    expanded_idx = _expand_sparsity_tensor(idx, expected_index_shape, f"{name}_block_idx")
+    return expanded_cnt, expanded_idx
+
+
+def normalize_block_sparse_tensors(
     tensors: BlockSparseTensorsTorch,
     *,
     expected_count_shape: Tuple[int, int, int],
     expected_index_shape: Tuple[int, int, int, int],
-) -> None:
-    for name, cnt, idx in (
-        ("mask", tensors.mask_block_cnt, tensors.mask_block_idx),
-        ("full", tensors.full_block_cnt, tensors.full_block_idx),
-    ):
-        if (cnt is None) != (idx is None):
-            raise ValueError(
-                f"{name}_block_cnt and {name}_block_idx must both be provided or both be None"
-            )
-        if cnt is None:
-            continue
-        if cnt.dtype != torch.int32 or idx.dtype != torch.int32:
-            raise ValueError(f"{name}_block tensors must have dtype torch.int32")
-        if cnt.device != idx.device:
-            raise ValueError(f"{name}_block_cnt and {name}_block_idx must be on the same device")
-        if not cnt.is_cuda or not idx.is_cuda:
-            raise ValueError(f"{name}_block tensors must live on CUDA")
-        if cnt.shape != expected_count_shape:
-            raise ValueError(
-                f"{name}_block_cnt has shape {tuple(cnt.shape)}, expected {expected_count_shape}"
-            )
-        if idx.shape != expected_index_shape:
-            raise ValueError(
-                f"{name}_block_idx has shape {tuple(idx.shape)}, expected {expected_index_shape}"
-            )
+) -> BlockSparseTensorsTorch:
+    if tensors.mask_block_cnt is None or tensors.mask_block_idx is None:
+        raise ValueError("mask_block_cnt and mask_block_idx must be provided for block sparsity.")
 
-    if tensors.full_block_cnt is not None and tensors.mask_block_cnt is not None:
-        if tensors.full_block_cnt.device != tensors.mask_block_cnt.device:
-            raise ValueError("All block sparse tensors must be on the same device")
+    mask_cnt, mask_idx = _check_and_expand_block(
+        "mask",
+        tensors.mask_block_cnt,
+        tensors.mask_block_idx,
+        expected_count_shape,
+        expected_index_shape,
+    )
+    if mask_cnt is None or mask_idx is None:
+        raise ValueError("mask_block_cnt and mask_block_idx must be provided for block sparsity.")
+
+    full_cnt, full_idx = _check_and_expand_block(
+        "full",
+        tensors.full_block_cnt,
+        tensors.full_block_idx,
+        expected_count_shape,
+        expected_index_shape,
+    )
+    if full_cnt is not None and mask_cnt.device != full_cnt.device:
+        raise ValueError("All block sparse tensors must be on the same device")
+
+    return BlockSparseTensorsTorch(
+        mask_block_cnt=mask_cnt,
+        mask_block_idx=mask_idx,
+        full_block_cnt=full_cnt,
+        full_block_idx=full_idx,
+    )
 
 
 def is_block_sparsity_enabled(tensors: BlockSparseTensorsTorch) -> bool:

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -45,7 +45,7 @@ from flash_attn.cute.flash_fwd_combine import FlashAttentionForwardCombine
 from flash_attn.cute.block_sparsity import (
     BlockSparseTensorsTorch,
     to_cute_block_sparse_tensors,
-    validate_block_sparse_tensors,
+    normalize_block_sparse_tensors,
 )
 
 
@@ -261,7 +261,7 @@ def _flash_attn_fwd(
             raise ValueError("Block sparsity requires fixed-length sequences (seqlen_q must be known).")
         expected_m_blocks = (seqlen_q + m_block_size - 1) // m_block_size
         expected_n_blocks = (seqlen_k + n_block_size - 1) // n_block_size
-        validate_block_sparse_tensors(
+        block_sparse_tensors = normalize_block_sparse_tensors(
             block_sparse_tensors,
             expected_count_shape=(batch_size, num_head, expected_m_blocks),
             expected_index_shape=(batch_size, num_head, expected_m_blocks, expected_n_blocks),

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -48,7 +48,6 @@ from flash_attn.cute.block_sparsity import (
     normalize_block_sparse_tensors,
 )
 
-
 def maybe_contiguous(x):
     return x.contiguous() if x is not None and x.stride(-1) != 1 else x
 
@@ -136,6 +135,7 @@ def _flash_attn_fwd(
         assert cu_seqlens_k.shape == (batch_size + 1,), (
             "cu_seqlens_k must have shape (batch_size + 1,)"
         )
+
     if cu_seqlens_q is not None:
         assert cu_seqlens_q.shape == (batch_size + 1,), (
             "cu_seqlens_q must have shape (batch_size + 1,)"
@@ -348,7 +348,7 @@ def _flash_attn_fwd(
 
     cute_aux_tensors = None
     if aux_tensors is not None:
-        cute_aux_tensors = [from_dlpack(buf) for buf in aux_tensors]
+        cute_aux_tensors = [from_dlpack(buf).mark_layout_dynamic() for buf in aux_tensors]
 
     compile_key = (
         dtype,
@@ -359,7 +359,7 @@ def _flash_attn_fwd(
         score_mod_hash,
         mask_mod_hash,
         use_block_sparsity,
-        aux_tensors is not None,
+        len(aux_tensors) if aux_tensors is not None else 0,
         lse is None,
         cu_seqlens_q is None,
         cu_seqlens_k is None,

--- a/flash_attn/cute/mask_definitions.py
+++ b/flash_attn/cute/mask_definitions.py
@@ -7,247 +7,150 @@ import cutlass
 import cutlass.cute as cute
 import torch
 
+from flash_attn.cute import utils
+
 
 MaskModCallable = Optional[
     Callable[
         [
-            "cutlass.Int32",
-            "cutlass.Int32",
-            "cutlass.Int32",
-            "cutlass.Int32",
-            "cutlass.Int32",
-            "cutlass.Int32",
+            "cute.TensorSSA",
+            "cute.TensorSSA",
+            "cute.TensorSSA",
+            "cute.TensorSSA",
+            "Optional[list]",
         ],
-        "cutlass.Boolean",
+        "cute.TensorSSA",
     ]
 ]
 
 
 # Flex Attention mask functions (PyTorch signatures for reference implementation)
-
-
-def flex_identity_mask(b, h, q_idx, kv_idx, seqlen_q=None, seqlen_k=None):
-    if torch.is_tensor(q_idx):
-        return torch.ones_like(q_idx, dtype=torch.bool)
-    return True
-
-
-def flex_identity_partial_mask(b, h, q_idx, kv_idx, seqlen_q=None, seqlen_k=None):
-    if torch.is_tensor(q_idx):
-        return torch.ones_like(q_idx, dtype=torch.bool)
-    return True
-
-
-def flex_causal_mask(b, h, q_idx, kv_idx, seqlen_q=None, seqlen_k=None):
-    # Right-aligned causal masking
-    if seqlen_q is not None and seqlen_k is not None:
-        offset = seqlen_k - seqlen_q
+def get_flex_causal_mask(offset: int):
+    def _flex_causal_mask(b, h, q_idx, kv_idx):
         return kv_idx <= q_idx + offset
-    return kv_idx <= q_idx
+
+    return _flex_causal_mask
 
 
-def flex_block_causal_mask(b, h, q_idx, kv_idx, seqlen_q=None, seqlen_k=None):
-    # Right-aligned causal masking
-    if seqlen_q is not None and seqlen_k is not None:
-        offset = seqlen_k - seqlen_q
+def get_flex_block_causal_mask(offset: int):
+    def _flex_block_causal_mask(b, h, q_idx, kv_idx):
         return kv_idx <= q_idx + offset
-    return kv_idx <= q_idx
+
+    return _flex_block_causal_mask
 
 
-def create_flex_sliding_window_mask(window_size=1024):
-    """Factory function to create a sliding window mask with configurable window size"""
+def get_flex_sliding_window_mask(window_left: int, window_right: int, offset: int):
+    def _flex_sliding_window_mask(b, h, q_idx, kv_idx):
+        center = q_idx + offset
+        lower = center - window_left
+        upper = center + window_right
+        return (kv_idx >= lower) & (kv_idx <= upper)
 
-    def flex_sliding_window_mask(b, h, q_idx, kv_idx, seqlen_q=None, seqlen_k=None):
-        # Sliding window: q_idx - window_size <= kv_idx <= q_idx
-        if seqlen_q is not None and seqlen_k is not None:
-            offset = seqlen_k - seqlen_q
-            return (kv_idx <= q_idx + offset) & (kv_idx >= q_idx + offset - window_size)
-        return (kv_idx <= q_idx) & (kv_idx >= q_idx - window_size)
-
-    return flex_sliding_window_mask
+    return _flex_sliding_window_mask
 
 
-# Default sliding window mask with window_size=1024 for backward compatibility
-def flex_sliding_window_mask(b, h, q_idx, kv_idx, seqlen_q=None, seqlen_k=None):
-    window_size = 1024
-    if seqlen_q is not None and seqlen_k is not None:
-        offset = seqlen_k - seqlen_q
-        # Sliding window: q_pos - window_size < kv_pos <= q_pos
-        # Note: using strict inequality on the left to match typical sliding window behavior
-        return (kv_idx <= q_idx + offset) & (kv_idx > q_idx + offset - window_size)
-    return (kv_idx <= q_idx) & (kv_idx > q_idx - window_size)
-
-
-def flex_block_diagonal_mask(b, h, q_idx, kv_idx, seqlen_q=None, seqlen_k=None, block_size=64):
+def flex_block_diagonal_mask(b, h, q_idx, kv_idx):
+    block_size = 64
     return (q_idx // block_size) == (kv_idx // block_size)
 
 
-def flex_mini_causal_mask(b, h, q_idx, kv_idx, seqlen_q=None, seqlen_k=None):
+def flex_mini_causal_mask(b, h, q_idx, kv_idx):
     return (q_idx % 128) >= (kv_idx % 128)
 
 
-def flex_half_identity_mask(b, h, q_idx, kv_idx, seqlen_q=None, seqlen_k=None):
-    """Even k-blocks are full blocks, odd k-blocks are masked blocks (both return True)"""
-    if torch.is_tensor(kv_idx):
-        return torch.ones_like(kv_idx, dtype=torch.bool)
-    return True
-
-
-def flex_document_mask(b, h, q_idx, kv_idx, doc_id: torch.Tensor):
+def flex_document_mask(b, h, q_idx, kv_idx, doc_id):
     return doc_id[b, h, q_idx] == doc_id[b, h, kv_idx]
 
 
 # CuTe versions for kernel compilation
-
-
-@cute.jit
-def cute_identity_mask(
-    batch: cutlass.Int32,
-    head: cutlass.Int32,
-    m_idx: cutlass.Int32,
-    n_idx: cutlass.Int32,
-    seqlen_q: cutlass.Int32,
-    seqlen_k: cutlass.Int32,
-    aux_tensors: None,
-) -> cutlass.Boolean:
-    return cutlass.Boolean(True)
-
-
-@cute.jit
-def cute_identity_partial_mask(
-    batch: cutlass.Int32,
-    head: cutlass.Int32,
-    m_idx: cutlass.Int32,
-    n_idx: cutlass.Int32,
-    seqlen_q: cutlass.Int32,
-    seqlen_k: cutlass.Int32,
-    aux_tensors: None,
-) -> cutlass.Boolean:
-    return cutlass.Boolean(True)
-
-
-@cute.jit
-def cute_causal_mask(
-    batch: cutlass.Int32,
-    head: cutlass.Int32,
-    m_idx: cutlass.Int32,
-    n_idx: cutlass.Int32,
-    seqlen_q: cutlass.Int32,
-    seqlen_k: cutlass.Int32,
-    aux_tensors: None,
-) -> cutlass.Boolean:
-    # Right-aligned causal masking
-    offset = seqlen_k - seqlen_q
-    return cutlass.Boolean(n_idx <= m_idx + offset)
-
-
-@cute.jit
-def cute_block_causal_mask(
-    batch: cutlass.Int32,
-    head: cutlass.Int32,
-    m_idx: cutlass.Int32,
-    n_idx: cutlass.Int32,
-    seqlen_q: cutlass.Int32,
-    seqlen_k: cutlass.Int32,
-    aux_tensors: None,
-) -> cutlass.Boolean:
-    # Right-aligned causal masking
-    offset = seqlen_k - seqlen_q
-    return cutlass.Boolean(n_idx <= m_idx + offset)
-
-
-def create_cute_sliding_window_mask(window_size=1024):
-    """Factory function to create a CuTe sliding window mask with configurable window size"""
-
+def get_cute_causal_mask(offset: int):
     @cute.jit
-    def cute_sliding_window_mask(
-        batch: cutlass.Int32,
-        head: cutlass.Int32,
-        m_idx: cutlass.Int32,
-        n_idx: cutlass.Int32,
-        seqlen_q: cutlass.Int32,
-        seqlen_k: cutlass.Int32,
+    def _cute_causal_mask(
+        batch: cute.TensorSSA,
+        head: cute.TensorSSA,
+        m_idx: cute.TensorSSA,
+        n_idx: cute.TensorSSA,
+        aux_tensors: None,
+    ) -> cute.TensorSSA:
+        offset_ssa = utils.scalar_to_ssa(offset, cutlass.Int32)
+        return n_idx <= (m_idx + offset_ssa)
+
+    return _cute_causal_mask
+
+
+def get_cute_block_causal_mask(offset: int):
+    @cute.jit
+    def _cute_block_causal_mask(
+        batch: cute.TensorSSA,
+        head: cute.TensorSSA,
+        m_idx: cute.TensorSSA,
+        n_idx: cute.TensorSSA,
+        aux_tensors: None,
+    ) -> cute.TensorSSA:
+        offset_ssa = utils.scalar_to_ssa(offset, cutlass.Int32)
+        return n_idx <= (m_idx + offset_ssa)
+
+    return _cute_block_causal_mask
+
+
+def get_cute_sliding_window_mask(window_left: int, window_right: int, offset: int):
+    @cute.jit
+    def _cute_sliding_window_mask(
+        batch: cute.TensorSSA,
+        head: cute.TensorSSA,
+        m_idx: cute.TensorSSA,
+        n_idx: cute.TensorSSA,
         aux_tensors,
-    ) -> cutlass.Boolean:
-        offset = seqlen_k - seqlen_q
+    ) -> cute.TensorSSA:
+        offset_ssa = utils.scalar_to_ssa(offset, cutlass.Int32)
+        window_left_ssa = utils.scalar_to_ssa(window_left, cutlass.Int32)
+        window_right_ssa = utils.scalar_to_ssa(window_right, cutlass.Int32)
+        center = m_idx + offset_ssa
+        lower = center - window_left_ssa
+        upper = center + window_right_ssa
+        return (n_idx >= lower) & (n_idx <= upper)
 
-        return cutlass.Boolean(
-            (n_idx <= m_idx + offset) and (n_idx >= m_idx + offset - window_size)
-        )
-
-    return cute_sliding_window_mask
-
-
-# Default sliding window mask with window_size=1024 for backward compatibility
-@cute.jit
-def cute_sliding_window_mask(
-    batch: cutlass.Int32,
-    head: cutlass.Int32,
-    m_idx: cutlass.Int32,
-    n_idx: cutlass.Int32,
-    seqlen_q: cutlass.Int32,
-    seqlen_k: cutlass.Int32,
-    aux_tensors,
-) -> cutlass.Boolean:
-    window_size = 1024
-    # offset = seqlen_k - seqlen_q
-    offset = 0
-    return cutlass.Boolean((n_idx <= m_idx + offset) and (n_idx >= m_idx + offset - window_size))
+    return _cute_sliding_window_mask
 
 
 @cute.jit
 def cute_document_mask(
-    batch: cutlass.Int32,
-    head: cutlass.Int32,
-    m_idx: cutlass.Int32,
-    n_idx: cutlass.Int32,
-    seqlen_q: cutlass.Int32,
-    seqlen_k: cutlass.Int32,
+    batch: cute.TensorSSA,
+    head: cute.TensorSSA,
+    m_idx: cute.TensorSSA,
+    n_idx: cute.TensorSSA,
     aux_tensors: list,
-):
+) -> cute.TensorSSA:
     doc_id = aux_tensors[0]
-    return cutlass.Boolean(doc_id[batch, head, m_idx] == doc_id[batch, head, n_idx])
+    m_doc = utils.scalar_to_ssa(doc_id[batch[0], head[0], m_idx[0]], cutlass.Int32)
+    n_doc = utils.scalar_to_ssa(doc_id[batch[0], head[0], n_idx[0]], cutlass.Int32)
+    return m_doc == n_doc
 
 
 @cute.jit
 def cute_block_diagonal_mask(
-    batch: cutlass.Int32,
-    head: cutlass.Int32,
-    m_idx: cutlass.Int32,
-    n_idx: cutlass.Int32,
-    seqlen_q: cutlass.Int32,
-    seqlen_k: cutlass.Int32,
+    batch: cute.TensorSSA,
+    head: cute.TensorSSA,
+    m_idx: cute.TensorSSA,
+    n_idx: cute.TensorSSA,
     aux_tensors,
-) -> cutlass.Boolean:
-    return cutlass.Boolean((m_idx // 64) == (n_idx // 64))
+) -> cute.TensorSSA:
+    block_size_ssa = utils.scalar_to_ssa(64, cutlass.Int32)
+    return (m_idx // block_size_ssa) == (n_idx // block_size_ssa)
 
 
 @cute.jit
 def cute_mini_causal_mask(
-    batch: cutlass.Int32,
-    head: cutlass.Int32,
-    m_idx: cutlass.Int32,
-    n_idx: cutlass.Int32,
-    seqlen_q: cutlass.Int32,
-    seqlen_k: cutlass.Int32,
+    batch: cute.TensorSSA,
+    head: cute.TensorSSA,
+    m_idx: cute.TensorSSA,
+    n_idx: cute.TensorSSA,
     aux_tensors,
-) -> cutlass.Boolean:
-    """Each tile is locally causal-masked"""
-    m_mod = m_idx % 128
-    n_mod = n_idx % 128
-    return cutlass.Boolean(m_mod >= n_mod)
-
-
-@cute.jit
-def cute_half_identity_mask(
-    batch: cutlass.Int32,
-    head: cutlass.Int32,
-    m_idx: cutlass.Int32,
-    n_idx: cutlass.Int32,
-    seqlen_q: cutlass.Int32,
-    seqlen_k: cutlass.Int32,
-) -> cutlass.Boolean:
-    return cutlass.Boolean(True)
+) -> cute.TensorSSA:
+    tile_size_ssa = utils.scalar_to_ssa(128, cutlass.Int32)
+    m_mod = m_idx % tile_size_ssa
+    n_mod = n_idx % tile_size_ssa
+    return m_mod >= n_mod
 
 
 def random_doc_id_tensor(nheads, batch, seqlen_q, device="cpu"):
@@ -255,7 +158,9 @@ def random_doc_id_tensor(nheads, batch, seqlen_q, device="cpu"):
     for b in range(batch):
         for h in range(nheads):
             N = seqlen_q
-            n = random.randint(1, math.ceil(math.sqrt(N // 4)))
+            max_segments = max(1, math.ceil(math.sqrt(max(N // 4, 1))))
+            n = random.randint(1, max_segments)
+            n = min(n, N)
             cuts = sorted(random.sample(range(1, N), n - 1))
             lengths = [b - a for a, b in zip((0, *cuts), (*cuts, N))]
 
@@ -264,21 +169,51 @@ def random_doc_id_tensor(nheads, batch, seqlen_q, device="cpu"):
                 doc_ids += [i for _ in range(length)]
 
             doc_ids_tensor[b, h, :] = torch.tensor(doc_ids, dtype=torch.int32, device=device)
-    print(f"{doc_ids_tensor.shape = }")
     return doc_ids_tensor
 
 
-MASK_FUNCTIONS = {
-    "identity": (cute_identity_mask, flex_identity_mask),
-    "identity_partial": (cute_identity_partial_mask, flex_identity_partial_mask),
-    "causal": (cute_causal_mask, flex_causal_mask),
-    "block_causal": (cute_block_causal_mask, flex_block_causal_mask),
-    "sliding_window": (cute_sliding_window_mask, flex_sliding_window_mask),
+STATIC_MASKS = {
     "block_diagonal": (cute_block_diagonal_mask, flex_block_diagonal_mask),
     "mini_causal": (cute_mini_causal_mask, flex_mini_causal_mask),
-    "half_identity": (cute_half_identity_mask, flex_half_identity_mask),
     "document": (cute_document_mask, flex_document_mask),
 }
+
+PARAMETERIZED_MASK_FACTORIES = {
+    "causal": (get_cute_causal_mask, get_flex_causal_mask),
+    "block_causal": (get_cute_block_causal_mask, get_flex_block_causal_mask),
+    "sliding_window": (get_cute_sliding_window_mask, get_flex_sliding_window_mask),
+}
+
+
+def get_mask_pair(mask_name, seqlen_q=None, seqlen_k=None, window_size=None):
+    """Get (cute_mask, flex_mask) pair for the given mask name.
+
+    For static masks, seqlen info is not needed.
+    For parameterized masks, seqlen_q and seqlen_k are required.
+    """
+    if mask_name in STATIC_MASKS:
+        return STATIC_MASKS[mask_name]
+
+    if mask_name not in PARAMETERIZED_MASK_FACTORIES:
+        raise ValueError(f"Unknown mask: {mask_name}")
+
+    if seqlen_q is None or seqlen_k is None:
+        raise ValueError(f"Parameterized mask '{mask_name}' requires seqlen_q and seqlen_k")
+
+    cute_factory, flex_factory = PARAMETERIZED_MASK_FACTORIES[mask_name]
+    offset = seqlen_k - seqlen_q
+
+    if mask_name == "sliding_window":
+        if window_size is None:
+            raise ValueError("sliding_window mask requires window_size parameter")
+        cute_mask = cute_factory(window_size, window_size, offset)
+        flex_mask = flex_factory(window_size, window_size, offset)
+    else:
+        cute_mask = cute_factory(offset)
+        flex_mask = flex_factory(offset)
+
+    return cute_mask, flex_mask
+
 
 if __name__ == "__main__":
     doc_ids = random_doc_id_tensor(1, 2, 128)

--- a/flash_attn/cute/utils.py
+++ b/flash_attn/cute/utils.py
@@ -781,3 +781,8 @@ def scalar_to_ssa(a: cute.Numeric, dtype) -> cute.TensorSSA:
     vec = cute.make_fragment(1, dtype)
     vec[0] = a
     return vec.load()
+
+
+def ssa_to_scalar(val):
+    """ Could inline but nice for reflecting the above api """
+    return val[0]


### PR DESCRIPTION
# Summary

Enables: https://github.com/pytorch/pytorch/pull/166359

What does this do:
* Adds better error messages / expand -> I will not tell you how long it took me to figure out why there was an IMA lol
* In Flex integration for score_mods we standardized on SSA form it makes it reallly nice to codegen made the same change for mask_mods
* I remove the seqlen vars to align w/ flex impl. I went back and fourth on this because at least for the offset based mods this means we have to compile + seqlen instantation. With makes test stupidly slow so idk either we change the mask mods or we revert this and leave as dead params for PT integration.
* For Triton impl -> we basically let dyanmic shapes handles this and we update the kernel siganture with additional symbols.
I think that we will ultmately need something like 
`aux_tensors`
`aux_ints`
`aux_floats`

Which act as containers that get unpacked in the score and mask mods. For now I am just baking in these in

