### PR TITLE
[Cute] Extract block-sparse utilities from SM80/90

### DIFF
--- a/flash_attn/cute/block_sparse_utils.py
+++ b/flash_attn/cute/block_sparse_utils.py
@@ -1,0 +1,419 @@
+"""
+Block-sparse runtime utilities for CUTE DSL kernels.
+
+This module contains runtime execution functions for block-sparse attention kernels.
+These utilities are used by CUTE DSL kernels to produce and consume block-sparse loads.
+"""
+
+from typing import Callable
+from functools import partial
+import cutlass
+import cutlass.cute as cute
+from cutlass import const_expr
+
+# Import data structures from block_sparsity
+from flash_attn.cute.block_sparsity import BlockSparseTensors
+
+
+@cute.jit
+def load_block_list(
+    block_indices: cute.Tensor,
+    block_count,
+    load_q_with_first: cutlass.Constexpr,
+    first_block_preloaded: cutlass.Constexpr,
+    kv_producer_state,
+    load_Q,
+    load_K,
+    load_V,
+    pipeline_k,
+    pipeline_v,
+    use_tma_q: cutlass.Constexpr,
+    tma_q_bytes: cutlass.Constexpr,
+    intra_wg_overlap: cutlass.Constexpr,
+):
+    """Iterate over the sparse blocks and load K, V (and Q) into the pipeline.
+    for the intra_wg_overlap case, we overlap the loads of K and V. And this
+    means we need to pipeline the last V load from the partial block case,
+    with the loads for the full blocks. Set first_block_preloaded when the
+    caller has already issued the first K load for the list.
+
+    Note:
+        we iterate along the block_n indices in reverse.
+
+    Returns:
+        Updated kv_producer_state after processing the block list.
+
+    """
+    if block_count > 0:
+        if const_expr(not intra_wg_overlap):
+            # Peel first iteration: the first block may need to load Q alongside K,
+            # Parameters are already Constexpr, so no need to wrap in const_expr()
+            n_block_first = block_indices[block_count - 1]
+            extra_tx = tma_q_bytes if const_expr(load_q_with_first) and const_expr(use_tma_q) else 0
+            pipeline_k.producer_acquire(kv_producer_state, extra_tx_count=extra_tx)
+
+            if const_expr(load_q_with_first and use_tma_q):
+                load_Q(tma_bar_ptr=pipeline_k.producer_get_barrier(kv_producer_state))
+
+            load_K(src_idx=n_block_first, producer_state=kv_producer_state)
+            pipeline_v.producer_acquire(kv_producer_state)
+            load_V(src_idx=n_block_first, producer_state=kv_producer_state)
+            kv_producer_state.advance()
+
+            for offset in cutlass.range(1, block_count):
+                n_block = block_indices[block_count - 1 - offset]
+                pipeline_k.producer_acquire(kv_producer_state)
+                load_K(src_idx=n_block, producer_state=kv_producer_state)
+                pipeline_v.producer_acquire(kv_producer_state)
+                load_V(src_idx=n_block, producer_state=kv_producer_state)
+                kv_producer_state.advance()
+        else:
+            n_block_first = block_indices[block_count - 1]
+            if const_expr(not first_block_preloaded):
+                extra_tx = (
+                    tma_q_bytes if const_expr(load_q_with_first) and const_expr(use_tma_q) else 0
+                )
+                pipeline_k.producer_acquire(kv_producer_state, extra_tx_count=extra_tx)
+
+                if const_expr(load_q_with_first and use_tma_q):
+                    load_Q(tma_bar_ptr=pipeline_k.producer_get_barrier(kv_producer_state))
+
+                load_K(src_idx=n_block_first, producer_state=kv_producer_state)
+
+            for idx in cutlass.range(block_count - 1, unroll=1):
+                n_block_prev = block_indices[block_count - 1 - idx]
+                n_block = block_indices[block_count - 2 - idx]
+                kv_producer_state_prev = kv_producer_state.clone()
+                kv_producer_state.advance()
+                pipeline_k.producer_acquire(kv_producer_state)
+                load_K(src_idx=n_block, producer_state=kv_producer_state)
+                pipeline_v.producer_acquire(kv_producer_state_prev)
+                load_V(src_idx=n_block_prev, producer_state=kv_producer_state_prev)
+
+    return kv_producer_state
+
+
+@cute.jit
+def finish_overlap_v_load(
+    block_indices: cute.Tensor,
+    block_count,
+    load_V,
+    pipeline_v,
+    kv_producer_state,
+):
+    """Load the final V block after overlapped K/V loads."""
+    if block_count > 0:
+        n_block_last = block_indices[0]
+        pipeline_v.producer_acquire(kv_producer_state)
+        load_V(src_idx=n_block_last, producer_state=kv_producer_state)
+        kv_producer_state.advance()
+
+    return kv_producer_state
+
+
+@cute.jit
+def produce_block_sparse_loads(
+    blocksparse_tensors: BlockSparseTensors,
+    batch_idx,
+    head_idx,
+    m_block,
+    kv_producer_state,
+    load_Q,
+    load_K,
+    load_V,
+    pipeline_k,
+    pipeline_v,
+    use_tma_q: cutlass.Constexpr,
+    tma_q_bytes: cutlass.Constexpr,
+    intra_wg_overlap: cutlass.Constexpr,
+):
+    """Iterate over the mask and full block lists for a single tile.
+
+    The masked (partial) list may leave the last V load pending when intra-warp-group
+    overlap is enabled. The first full block must consume that pending V while
+    issuing its own K load on the next pipeline stage.
+
+    In the intra-wg-overlap path, the last masked block leaves its V copy in flight
+    while we advance the producer state to start the next full K. Either the full list
+    overlaps that pending V load, or, if no full blocks exist, we explicitly drain it.
+
+    """
+
+    mask_block_cnt, mask_block_idx, full_block_cnt, full_block_idx = blocksparse_tensors
+
+    curr_mask_block_cnt = mask_block_cnt[batch_idx, head_idx, m_block]
+    curr_mask_block_idx = mask_block_idx[batch_idx, head_idx, m_block, None]
+    curr_full_block_cnt = full_block_cnt[batch_idx, head_idx, m_block]
+    curr_full_block_idx = full_block_idx[batch_idx, head_idx, m_block, None]
+
+    mask_empty = curr_mask_block_cnt == 0
+    full_empty = curr_full_block_cnt == 0
+
+    if mask_empty:
+        # No masked blocks: the full list owns the initial Q+K load.
+        kv_producer_state = load_block_list(
+            curr_full_block_idx,
+            curr_full_block_cnt,
+            load_q_with_first=True,
+            first_block_preloaded=False,
+            kv_producer_state=kv_producer_state,
+            load_Q=load_Q,
+            load_K=load_K,
+            load_V=load_V,
+            pipeline_k=pipeline_k,
+            pipeline_v=pipeline_v,
+            use_tma_q=use_tma_q,
+            tma_q_bytes=tma_q_bytes,
+            intra_wg_overlap=intra_wg_overlap,
+        )
+
+        if const_expr(intra_wg_overlap) and curr_full_block_cnt > 0:
+            kv_producer_state = finish_overlap_v_load(
+                curr_full_block_idx,
+                curr_full_block_cnt,
+                load_V,
+                pipeline_v,
+                kv_producer_state,
+            )
+    else:
+        # Masked blocks present: load Q together with the first masked K so consumers can
+        # start immediately. When overlap is disabled this fully drains the list.
+        kv_producer_state = load_block_list(
+            curr_mask_block_idx,
+            curr_mask_block_cnt,
+            load_q_with_first=True,
+            first_block_preloaded=False,
+            kv_producer_state=kv_producer_state,
+            load_Q=load_Q,
+            load_K=load_K,
+            load_V=load_V,
+            pipeline_k=pipeline_k,
+            pipeline_v=pipeline_v,
+            use_tma_q=use_tma_q,
+            tma_q_bytes=tma_q_bytes,
+            intra_wg_overlap=intra_wg_overlap,
+        )
+
+        if full_empty:
+            if const_expr(intra_wg_overlap):
+                kv_producer_state = finish_overlap_v_load(
+                    curr_mask_block_idx,
+                    curr_mask_block_cnt,
+                    load_V,
+                    pipeline_v,
+                    kv_producer_state,
+                )
+        else:
+            if const_expr(intra_wg_overlap):
+                # Bridge the masked list to the full list by overlapping the pending masked V
+                # with the first full K load.
+                n_block_mask_last = curr_mask_block_idx[0]
+                n_block_full_first = curr_full_block_idx[curr_full_block_cnt - 1]
+                kv_producer_state_prev = kv_producer_state.clone()
+                kv_producer_state.advance()
+                pipeline_k.producer_acquire(kv_producer_state)
+                load_K(src_idx=n_block_full_first, producer_state=kv_producer_state)
+                pipeline_v.producer_acquire(kv_producer_state_prev)
+                load_V(src_idx=n_block_mask_last, producer_state=kv_producer_state_prev)
+
+                kv_producer_state = load_block_list(
+                    curr_full_block_idx,
+                    curr_full_block_cnt,
+                    load_q_with_first=False,
+                    first_block_preloaded=True,
+                    kv_producer_state=kv_producer_state,
+                    load_Q=load_Q,
+                    load_K=load_K,
+                    load_V=load_V,
+                    pipeline_k=pipeline_k,
+                    pipeline_v=pipeline_v,
+                    use_tma_q=use_tma_q,
+                    tma_q_bytes=tma_q_bytes,
+                    intra_wg_overlap=intra_wg_overlap,
+                )
+
+                kv_producer_state = finish_overlap_v_load(
+                    curr_full_block_idx,
+                    curr_full_block_cnt,
+                    load_V,
+                    pipeline_v,
+                    kv_producer_state,
+                )
+            else:
+                # Non-overlap path with both lists: run the full list normally (skipping the Q
+                # reload because the masked list already issued it).
+                kv_producer_state = load_block_list(
+                    curr_full_block_idx,
+                    curr_full_block_cnt,
+                    load_q_with_first=False,
+                    first_block_preloaded=False,
+                    kv_producer_state=kv_producer_state,
+                    load_Q=load_Q,
+                    load_K=load_K,
+                    load_V=load_V,
+                    pipeline_k=pipeline_k,
+                    pipeline_v=pipeline_v,
+                    use_tma_q=use_tma_q,
+                    tma_q_bytes=tma_q_bytes,
+                    intra_wg_overlap=intra_wg_overlap,
+                )
+
+    return kv_producer_state
+
+
+@cute.jit
+def consume_block_sparse_loads(
+    blocksparse_tensors: BlockSparseTensors,
+    batch_idx,
+    head_idx,
+    m_block,
+    kv_consumer_state,
+    mma_pv_fn,
+    mma_one_n_block,
+    process_first_half_block,
+    process_last_half_block,
+    mask_fn,
+    score_mod_fn,
+    O_should_accumulate,
+    mask_mod,
+    intra_wg_overlap: cutlass.Constexpr,
+    warp_scheduler_barrier_sync: Callable,
+    warp_scheduler_barrier_arrive: Callable,
+):
+    """Consume the mask and full block lists for a single tile on the consumer side.
+
+    Mirrors `produce_block_sparse_loads` so that the consumer pipeline
+    """
+
+    mask_block_cnt, mask_block_idx, full_block_cnt, full_block_idx = blocksparse_tensors
+
+    curr_mask_block_cnt = mask_block_cnt[batch_idx, head_idx, m_block]
+    curr_mask_block_idx = mask_block_idx[batch_idx, head_idx, m_block, None]
+    curr_full_block_cnt = full_block_cnt[batch_idx, head_idx, m_block]
+    curr_full_block_idx = full_block_idx[batch_idx, head_idx, m_block, None]
+
+    processed_any = curr_mask_block_cnt + curr_full_block_cnt > 0
+
+    if const_expr(not intra_wg_overlap):
+        if curr_mask_block_cnt > 0:
+            mask_n_block = curr_mask_block_idx[curr_mask_block_cnt - 1]
+            warp_scheduler_barrier_sync()
+            kv_consumer_state = mma_one_n_block(
+                kv_consumer_state,
+                n_block=mask_n_block,
+                mma_pv_fn=partial(mma_pv_fn, zero_init=not O_should_accumulate),
+                mask_fn=partial(mask_fn, mask_mod=mask_mod, mask_seqlen=True),
+                is_first_n_block=True,
+            )
+            O_should_accumulate = True
+            for i in cutlass.range(1, curr_mask_block_cnt):
+                mask_n_block = curr_mask_block_idx[curr_mask_block_cnt - 1 - i]
+                kv_consumer_state = mma_one_n_block(
+                    kv_consumer_state,
+                    n_block=mask_n_block,
+                    mma_pv_fn=partial(mma_pv_fn, zero_init=not O_should_accumulate),
+                    mask_fn=partial(mask_fn, mask_mod=mask_mod, mask_seqlen=False),
+                    is_first_n_block=False,
+                )
+                O_should_accumulate = True
+            if curr_full_block_cnt == 0:
+                warp_scheduler_barrier_arrive()
+
+        if curr_full_block_cnt > 0:
+            full_n_block = curr_full_block_idx[curr_full_block_cnt - 1]
+            if curr_mask_block_cnt == 0:
+                warp_scheduler_barrier_sync()
+                kv_consumer_state = mma_one_n_block(
+                    kv_consumer_state,
+                    n_block=full_n_block,
+                    mma_pv_fn=partial(mma_pv_fn, zero_init=not O_should_accumulate),
+                    mask_fn=partial(mask_fn, mask_seqlen=True),
+                    is_first_n_block=True,
+                )
+                O_should_accumulate = True
+                for i in cutlass.range(1, curr_full_block_cnt):
+                    full_n_block = curr_full_block_idx[curr_full_block_cnt - 1 - i]
+                    kv_consumer_state = mma_one_n_block(
+                        kv_consumer_state,
+                        n_block=full_n_block,
+                        mma_pv_fn=partial(mma_pv_fn, zero_init=not O_should_accumulate),
+                        mask_fn=partial(mask_fn, mask_seqlen=False),
+                        is_first_n_block=False,
+                    )
+                    O_should_accumulate = True
+            else:
+                kv_consumer_state = mma_one_n_block(
+                    kv_consumer_state,
+                    n_block=full_n_block,
+                    mma_pv_fn=partial(mma_pv_fn, zero_init=not O_should_accumulate),
+                    mask_fn=partial(mask_fn, mask_mod=None, mask_seqlen=True),
+                    is_first_n_block=False,
+                )
+                O_should_accumulate = True
+                for i in cutlass.range(1, curr_full_block_cnt):
+                    full_n_block = curr_full_block_idx[curr_full_block_cnt - 1 - i]
+                    kv_consumer_state = mma_one_n_block(
+                        kv_consumer_state,
+                        n_block=full_n_block,
+                        mma_pv_fn=partial(mma_pv_fn, zero_init=not O_should_accumulate),
+                        mask_fn=partial(mask_fn, mask_mod=None, mask_seqlen=False),
+                        is_first_n_block=False,
+                    )
+                    O_should_accumulate = True
+            warp_scheduler_barrier_arrive()
+    else:
+        if curr_mask_block_cnt > 0:
+            mask_n_block = curr_mask_block_idx[curr_mask_block_cnt - 1]
+            kv_consumer_state = process_first_half_block(
+                n_block=mask_n_block,
+                kv_consumer_state=kv_consumer_state,
+                mask_fn=partial(mask_fn, mask_mod=mask_mod),
+                score_mod_fn=score_mod_fn,
+                is_first_block=True,
+            )
+            for i in cutlass.range(1, curr_mask_block_cnt):
+                mask_n_block = curr_mask_block_idx[curr_mask_block_cnt - 1 - i]
+                kv_consumer_state = mma_one_n_block(
+                    kv_consumer_state,
+                    n_block=mask_n_block,
+                    mma_pv_fn=partial(mma_pv_fn, zero_init=not O_should_accumulate),
+                    mask_fn=partial(mask_fn, mask_mod=mask_mod, mask_seqlen=False),
+                )
+                O_should_accumulate = True
+
+        if curr_full_block_cnt > 0:
+            full_n_block = curr_full_block_idx[curr_full_block_cnt - 1]
+            if curr_mask_block_cnt == 0:
+                kv_consumer_state = process_first_half_block(
+                    n_block=full_n_block,
+                    kv_consumer_state=kv_consumer_state,
+                    mask_fn=partial(mask_fn, mask_mod=None),
+                    score_mod_fn=score_mod_fn,
+                    is_first_block=True,
+                )
+            else:
+                kv_consumer_state = mma_one_n_block(
+                    kv_consumer_state,
+                    n_block=full_n_block,
+                    mma_pv_fn=partial(mma_pv_fn, zero_init=not O_should_accumulate),
+                    mask_fn=partial(mask_fn, mask_mod=None, mask_seqlen=True),
+                )
+                O_should_accumulate = True
+            for i in cutlass.range(1, curr_full_block_cnt):
+                full_n_block = curr_full_block_idx[curr_full_block_cnt - 1 - i]
+                kv_consumer_state = mma_one_n_block(
+                    kv_consumer_state,
+                    n_block=full_n_block,
+                    mma_pv_fn=partial(mma_pv_fn, zero_init=not O_should_accumulate),
+                    mask_fn=partial(mask_fn, mask_mod=None, mask_seqlen=False),
+                )
+                O_should_accumulate = True
+
+        if curr_mask_block_cnt + curr_full_block_cnt > 0:
+            kv_consumer_state = process_last_half_block(
+                kv_consumer_state=kv_consumer_state,
+                zero_init=not O_should_accumulate,
+            )
+            O_should_accumulate = True
+
+    return kv_consumer_state, O_should_accumulate, processed_any

--- a/flash_attn/cute/block_sparsity.py
+++ b/flash_attn/cute/block_sparsity.py
@@ -13,6 +13,7 @@ import torch
 import cutlass.cute as cute
 from cutlass.cute.runtime import from_dlpack
 
+
 # placeholder
 Config = type("Config", (), {})
 

--- a/flash_attn/cute/flash_fwd.py
+++ b/flash_attn/cute/flash_fwd.py
@@ -30,6 +30,10 @@ from flash_attn.cute.softmax import Softmax, apply_score_mod_inner
 from flash_attn.cute.seqlen_info import SeqlenInfoQK
 from flash_attn.cute.block_info import BlockInfo
 from flash_attn.cute.block_sparsity import BlockSparseTensors
+from flash_attn.cute.block_sparse_utils import (
+    produce_block_sparse_loads,
+    consume_block_sparse_loads,
+)
 from flash_attn.cute import pipeline
 from flash_attn.cute.pack_gqa import PackGQA
 from flash_attn.cute.named_barrier import NamedBarrierFwd
@@ -1832,155 +1836,21 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                         load_V(src_idx=n_block, producer_state=kv_producer_state)
                         kv_producer_state.advance()
                 else:
-                    # ==========================================
-                    # Flex Attention blocksparsity
-                    # ==========================================
-                    mask_block_cnt, mask_block_idx, full_block_cnt, full_block_idx = blocksparse_tensors
-                    curr_mask_block_cnt = mask_block_cnt[batch_idx, head_idx, m_block]
-                    curr_full_block_idx = full_block_idx[batch_idx, head_idx, m_block, None]
-                    curr_full_block_cnt = full_block_cnt[batch_idx, head_idx, m_block]
-                    curr_mask_block_idx = mask_block_idx[batch_idx, head_idx, m_block, None]
-
-                    if const_expr(not self.intra_wg_overlap):
-                        if curr_mask_block_cnt > 0:
-                            # First mask block - load with Q
-                            n_block_mask = curr_mask_block_idx[curr_mask_block_cnt - 1]
-                            pipeline_k.producer_acquire(
-                                kv_producer_state,
-                                extra_tx_count=self.tma_copy_bytes["Q"]
-                                if const_expr(self.use_tma_Q)
-                                else 0,
-                            )
-                            if const_expr(self.use_tma_Q):
-                                load_Q(
-                                    tma_bar_ptr=pipeline_k.producer_get_barrier(kv_producer_state)
-                                )
-                            load_K(src_idx=n_block_mask, producer_state=kv_producer_state)
-                            pipeline_v.producer_acquire(kv_producer_state)
-                            load_V(src_idx=n_block_mask, producer_state=kv_producer_state)
-                            kv_producer_state.advance()
-
-                            # Remaining mask blocks
-                            for i in cutlass.range(1, curr_mask_block_cnt):
-                                n_block_mask = curr_mask_block_idx[curr_mask_block_cnt - 1 - i]
-                                pipeline_k.producer_acquire(kv_producer_state)
-                                load_K(src_idx=n_block_mask, producer_state=kv_producer_state)
-                                pipeline_v.producer_acquire(kv_producer_state)
-                                load_V(src_idx=n_block_mask, producer_state=kv_producer_state)
-                                kv_producer_state.advance()
-
-                        if curr_full_block_cnt > 0:
-                            n_block_full = curr_full_block_idx[curr_full_block_cnt - 1]
-                            if curr_mask_block_cnt == 0:
-                                # must load Q if not loaded in mask loop
-                                pipeline_k.producer_acquire(
-                                    kv_producer_state,
-                                    extra_tx_count=self.tma_copy_bytes["Q"]
-                                    if const_expr(self.use_tma_Q)
-                                    else 0,
-                                )
-                                if const_expr(self.use_tma_Q):
-                                    load_Q(
-                                        tma_bar_ptr=pipeline_k.producer_get_barrier(
-                                            kv_producer_state
-                                        )
-                                    )
-                                load_K(src_idx=n_block_full, producer_state=kv_producer_state)
-                                pipeline_v.producer_acquire(kv_producer_state)
-                                load_V(src_idx=n_block_full, producer_state=kv_producer_state)
-                                kv_producer_state.advance()
-                            else:
-                                pipeline_k.producer_acquire(kv_producer_state)
-                                load_K(src_idx=n_block_full, producer_state=kv_producer_state)
-                                pipeline_v.producer_acquire(kv_producer_state)
-                                load_V(src_idx=n_block_full, producer_state=kv_producer_state)
-                                kv_producer_state.advance()
-                            for j in cutlass.range(1, curr_full_block_cnt):
-                                n_block_full = curr_full_block_idx[curr_full_block_cnt - 1 - j]
-                                pipeline_k.producer_acquire(kv_producer_state)
-                                load_K(src_idx=n_block_full, producer_state=kv_producer_state)
-                                pipeline_v.producer_acquire(kv_producer_state)
-                                load_V(src_idx=n_block_full, producer_state=kv_producer_state)
-                                kv_producer_state.advance()
-
-                    else:
-                        # ==========================================
-                        # Overlap path
-                        # ==========================================
-
-                        # Load Q with the first K block (whether mask or full)
-                        n_block_first = -1
-                        if curr_mask_block_cnt > 0:
-                            n_block_first = curr_mask_block_idx[curr_mask_block_cnt - 1]
-                        elif curr_full_block_cnt > 0:
-                            n_block_first = curr_full_block_idx[curr_full_block_cnt - 1]
-
-                        if n_block_first >= 0:
-                            pipeline_k.producer_acquire(
-                                kv_producer_state,
-                                extra_tx_count=self.tma_copy_bytes["Q"]
-                                if const_expr(self.use_tma_Q)
-                                else 0,
-                            )
-                            if const_expr(self.use_tma_Q):
-                                load_Q(
-                                    tma_bar_ptr=pipeline_k.producer_get_barrier(kv_producer_state)
-                                )
-                            load_K(src_idx=n_block_first, producer_state=kv_producer_state)
-
-                        if curr_mask_block_cnt > 0:
-                            # Staggered loading for remaining mask blocks
-                            for i in cutlass.range(1, curr_mask_block_cnt):
-                                n_block_mask_prev = curr_mask_block_idx[curr_mask_block_cnt - i]
-                                n_block_mask = curr_mask_block_idx[curr_mask_block_cnt - 1 - i]
-                                kv_producer_state_prev = kv_producer_state.clone()
-                                kv_producer_state.advance()
-                                pipeline_k.producer_acquire(kv_producer_state)
-                                load_K(src_idx=n_block_mask, producer_state=kv_producer_state)
-                                pipeline_v.producer_acquire(kv_producer_state_prev)
-                                load_V(
-                                    src_idx=n_block_mask_prev, producer_state=kv_producer_state_prev
-                                )
-
-                            # Handle transition from mask to full blocks
-                            if curr_full_block_cnt > 0:
-                                # Load first full block K, last mask block V
-                                n_block_mask_last = curr_mask_block_idx[0]
-                                n_block_full = curr_full_block_idx[curr_full_block_cnt - 1]
-                                kv_producer_state_prev = kv_producer_state.clone()
-                                kv_producer_state.advance()
-                                pipeline_k.producer_acquire(kv_producer_state)
-                                load_K(src_idx=n_block_full, producer_state=kv_producer_state)
-                                pipeline_v.producer_acquire(kv_producer_state_prev)
-                                load_V(
-                                    src_idx=n_block_mask_last, producer_state=kv_producer_state_prev
-                                )
-                            else:
-                                # No full blocks, just load last mask block V
-                                n_block_mask_last = curr_mask_block_idx[0]
-                                pipeline_v.producer_acquire(kv_producer_state)
-                                load_V(src_idx=n_block_mask_last, producer_state=kv_producer_state)
-                                kv_producer_state.advance()
-
-                        if curr_full_block_cnt > 0:
-                            # Staggered loading for remaining full blocks (
-                            for j in cutlass.range(1, curr_full_block_cnt):
-                                n_block_full_prev = curr_full_block_idx[curr_full_block_cnt - j]
-                                n_block_full = curr_full_block_idx[curr_full_block_cnt - 1 - j]
-                                kv_producer_state_prev = kv_producer_state.clone()
-                                kv_producer_state.advance()
-                                pipeline_k.producer_acquire(kv_producer_state)
-                                load_K(src_idx=n_block_full, producer_state=kv_producer_state)
-                                pipeline_v.producer_acquire(kv_producer_state_prev)
-                                load_V(
-                                    src_idx=n_block_full_prev, producer_state=kv_producer_state_prev
-                                )
-
-                            # Load last full block V
-                            n_block_full_last = curr_full_block_idx[0]
-                            pipeline_v.producer_acquire(kv_producer_state)
-                            load_V(src_idx=n_block_full_last, producer_state=kv_producer_state)
-                            kv_producer_state.advance()
+                    kv_producer_state = produce_block_sparse_loads(
+                        blocksparse_tensors,
+                        batch_idx,
+                        head_idx,
+                        m_block,
+                        kv_producer_state,
+                        load_Q,
+                        load_K,
+                        load_V,
+                        pipeline_k,
+                        pipeline_v,
+                        self.use_tma_Q,
+                        self.tma_copy_bytes["Q"],
+                        self.intra_wg_overlap,
+                    )
 
                 tile_scheduler.prefetch_next_work()
                 tile_scheduler.advance_to_next_work()
@@ -2244,143 +2114,27 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                 # ==========================================
                 # Block sparsity
                 # ==========================================
-                mask_block_cnt, mask_block_idx, full_block_cnt, full_block_idx = blocksparse_tensors
-                curr_mask_block_cnt = mask_block_cnt[batch_idx, head_idx, m_block]
-                curr_mask_block_idx = mask_block_idx[batch_idx, head_idx, m_block, None]
-                curr_full_block_cnt = full_block_cnt[batch_idx, head_idx, m_block]
-                curr_full_block_idx = full_block_idx[batch_idx, head_idx, m_block, None]
-
-                # first masked and full blocks
-                mask_n_block = 0
-                full_n_block = 0
-                if curr_mask_block_cnt > 0:
-                    mask_n_block = curr_mask_block_idx[curr_mask_block_cnt - 1]
-                if curr_full_block_cnt > 0:
-                    full_n_block = curr_full_block_idx[curr_full_block_cnt - 1]
-
-                if const_expr(not self.intra_wg_overlap):
-                    # ==========================================
-                    # Non-overlap path
-                    # ==========================================
-                    if curr_mask_block_cnt > 0:
-                        self.warp_scheduler_barrier_sync()
-                        kv_consumer_state = mma_one_n_block(
-                            kv_consumer_state,
-                            n_block=mask_n_block,
-                            mma_pv_fn=partial(mma_pv_fn, zero_init=not O_should_accumulate),
-                            mask_fn=partial(mask_fn, mask_mod=self.mask_mod, mask_seqlen=True),
-                            is_first_n_block=True,
-                        )
-                        O_should_accumulate = True
-                        for i in cutlass.range(1, curr_mask_block_cnt):
-                            mask_n_block = curr_mask_block_idx[curr_mask_block_cnt - 1 - i]
-                            kv_consumer_state = mma_one_n_block(
-                                kv_consumer_state,
-                                n_block=mask_n_block,
-                                mma_pv_fn=partial(mma_pv_fn, zero_init=not O_should_accumulate),
-                                mask_fn=partial(mask_fn, mask_mod=self.mask_mod, mask_seqlen=False),
-                                is_first_n_block=False,
-                            )
-                        if curr_full_block_cnt == 0:
-                            self.warp_scheduler_barrier_arrive()
-
-                    if curr_full_block_cnt > 0:
-                        if curr_mask_block_cnt == 0:
-                            self.warp_scheduler_barrier_sync()
-                            kv_consumer_state = mma_one_n_block(
-                                kv_consumer_state,
-                                n_block=full_n_block,
-                                mma_pv_fn=partial(mma_pv_fn, zero_init=not O_should_accumulate),
-                                mask_fn=partial(mask_fn, mask_seqlen=True),
-                                is_first_n_block=True,
-                            )
-                            O_should_accumulate = True
-                        else:
-                            kv_consumer_state = mma_one_n_block(
-                                kv_consumer_state,
-                                n_block=full_n_block,
-                                mma_pv_fn=partial(mma_pv_fn, zero_init=not O_should_accumulate),
-                                mask_fn=partial(mask_fn, mask_seqlen=True),
-                                is_first_n_block=False,
-                            )
-                            O_should_accumulate = True
-                        for i in cutlass.range(1, curr_full_block_cnt):
-                            full_n_block = curr_full_block_idx[curr_full_block_cnt - 1 - i]
-                            kv_consumer_state = mma_one_n_block(
-                                kv_consumer_state,
-                                n_block=full_n_block,
-                                mma_pv_fn=partial(mma_pv_fn, zero_init=not O_should_accumulate),
-                                mask_fn=partial(mask_fn, mask_seqlen=False),
-                                is_first_n_block=False,
-                            )
-                        self.warp_scheduler_barrier_arrive()
-                else:
-                    # ==========================================
-                    # Overlap path
-                    # ==========================================
-
-                    # Process first block
-                    if curr_mask_block_cnt > 0:
-                        kv_consumer_state = process_first_half_block(
-                            n_block=mask_n_block,
-                            kv_consumer_state=kv_consumer_state,
-                            mask_fn=partial(mask_fn, mask_mod=self.mask_mod),
-                            score_mod_fn=score_mod_fn,
-                            is_first_block=True,
-                        )
-
-                        # Process remaining mask blocks
-                        for i in cutlass.range(1, curr_mask_block_cnt):
-                            mask_n_block = curr_mask_block_idx[curr_mask_block_cnt - 1 - i]
-                            kv_consumer_state = mma_one_n_block(
-                                kv_consumer_state,
-                                n_block=mask_n_block,
-                                mma_pv_fn=partial(mma_pv_fn, zero_init=not O_should_accumulate),
-                                mask_fn=partial(mask_fn, mask_mod=self.mask_mod, mask_seqlen=False),
-                            )
-                            O_should_accumulate = True
-
-                    # Process full blocks
-                    if curr_full_block_cnt > 0:
-                        # If no mask blocks, first full block is the overall first
-                        if curr_mask_block_cnt == 0:
-                            kv_consumer_state = process_first_half_block(
-                                n_block=full_n_block,
-                                kv_consumer_state=kv_consumer_state,
-                                mask_fn=partial(mask_fn, mask_mod=None),
-                                score_mod_fn=score_mod_fn,
-                                is_first_block=True,
-                            )
-
-                        else:
-                            kv_consumer_state = mma_one_n_block(
-                                kv_consumer_state,
-                                n_block=full_n_block,
-                                mma_pv_fn=partial(mma_pv_fn, zero_init=not O_should_accumulate),
-                                mask_fn=partial(mask_fn, mask_mod=None, mask_seqlen=True),
-                            )
-                            O_should_accumulate = True
-
-                        # Process remaining full blocks
-                        for i in cutlass.range(1, curr_full_block_cnt):
-                            full_n_block = curr_full_block_idx[curr_full_block_cnt - 1 - i]
-                            kv_consumer_state = mma_one_n_block(
-                                kv_consumer_state,
-                                n_block=full_n_block,
-                                mma_pv_fn=partial(mma_pv_fn, zero_init=not O_should_accumulate),
-                                mask_fn=partial(mask_fn, mask_mod=None, mask_seqlen=False),
-                            )
-                            O_should_accumulate = True
-
-                    # Final PV gemm for last block
-                    if curr_mask_block_cnt > 0 or curr_full_block_cnt > 0:
-                        kv_consumer_state = process_last_half_block(
-                            kv_consumer_state=kv_consumer_state,
-                            zero_init=not O_should_accumulate,
-                        )
-                        O_should_accumulate = True
-
-                if curr_mask_block_cnt + curr_full_block_cnt == 0:
+                kv_consumer_state, O_should_accumulate, processed_any = consume_block_sparse_loads(
+                    blocksparse_tensors,
+                    batch_idx,
+                    head_idx,
+                    m_block,
+                    kv_consumer_state,
+                    mma_pv_fn,
+                    mma_one_n_block,
+                    process_first_half_block,
+                    process_last_half_block,
+                    mask_fn,
+                    score_mod_fn,
+                    O_should_accumulate,
+                    self.mask_mod,
+                    self.intra_wg_overlap,
+                    self.warp_scheduler_barrier_sync,
+                    self.warp_scheduler_barrier_arrive,
+                )
+                
+                # Handle empty case (when no blocks to process)
+                if not processed_any:
                     softmax.reset()
                     acc_O.fill(0.0)
 
@@ -2422,6 +2176,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
 
             tile_scheduler.advance_to_next_work()
             work_tile = tile_scheduler.get_current_work()
+
 
     @cute.jit
     def first_half_block_overlap(


### PR DESCRIPTION
# summary
- Create block_sparse_utils.py with SM80/90 block-sparse logic
- Refactor flash_fwd.py to use extracted utilities

This extracts the block-sparse consumer loop and related utilities from flash_fwd.py into a reusable module for SM80/90 architectures