### PR TITLE
Fix compile on FA3 with MSVC

### DIFF
--- a/hopper/setup.py
+++ b/hopper/setup.py
@@ -568,6 +568,7 @@ if not SKIP_CUDA_BUILD:
         "-DCUTLASS_DEBUG_TRACE_LEVEL=0",  # Can toggle for debugging
         "-DNDEBUG",  # Important, otherwise performance is severely impacted
     ]
+    cxx_flags = ["-O3", "-std=c++17", "-DPy_LIMITED_API=0x03090000"]
     if get_platform() == "win_amd64":
         nvcc_flags.extend(
             [
@@ -575,6 +576,7 @@ if not SKIP_CUDA_BUILD:
                 "-Xcompiler=/Zc:__cplusplus",  # sets __cplusplus correctly, CUTLASS_CONSTEXPR_IF_CXX17 needed for cutlass::gcd
             ]
         )
+        cxx_flags.extend(["/O2", "/std:c++17", "/Zc:__cplusplus"])
     include_dirs = [
         Path(this_dir),
         cutlass_dir / "include",
@@ -585,7 +587,7 @@ if not SKIP_CUDA_BUILD:
             name=f"{PACKAGE_NAME}._C",
             sources=sources,
             extra_compile_args={
-                "cxx": ["-O3", "-std=c++17", "-DPy_LIMITED_API=0x03090000"] + stable_args + feature_args,
+                "cxx": cxx_flags + stable_args + feature_args,
                 "nvcc": nvcc_threads_args() + nvcc_flags + cc_flag + feature_args,
             },
             include_dirs=include_dirs,


### PR DESCRIPTION
This PR is similar to #1716 and allows for FlashAttention-3 to be compiled using MSVC on Windows.

There is still an issue at the very end relating to linking of objects; it seems like it could be a command length issue but am investigating.

EDIT - The total length of the absolute path of all the *.cu files, even with the shortest folder name possible already exceeds 31k characters alone. With the addition of \build\temp.win-amd64-cpython-312\Release to the file paths while the package is being compiled by distutils easily exceeds the 32767 character command line limit in Windows.

This is a limitation in the current msvc compiler implementation in setuptools:
https://github.com/pypa/setuptools/blob/d198e86f57231e83de87975c5c82bc40c196da79/setuptools/_distutils/compilers/C/msvc.py#L554

Command line captured from logs:
```
"C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.44.35207\bin\HostX64\x64\link.exe" /nologo /INCREMENTAL:NO /LTCG /DLL /MANIFEST:EMBED,ID=2 /MANIFESTUAC:NO /LIBPATH:J:\Dev\venv\Lib\site-packages\torch\lib "/LIBPATH:C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.8\lib\x64" /LIBPATH:J:\Dev\venv\libs /LIBPATH:C:\Users\zzlol63\anaconda3\envs\onetrainer\libs /LIBPATH:C:\Users\zzlol63\anaconda3\envs\onetrainer /LIBPATH:J:\Dev\venv\PCbuild\amd64 "/LIBPATH:C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.44.35207\lib\x64" "/LIBPATH:C:\Program Files (x86)\Windows Kits\NETFXSDK\4.8\lib\um\x64" "/LIBPATH:C:\Program Files (x86)\Windows Kits\10\lib\10.0.26100.0\ucrt\x64" "/LIBPATH:C:\Program Files (x86)\Windows Kits\10\\lib\10.0.26100.0\\um\x64" c10.lib torch.lib torch_cpu.lib cudart.lib c10_cuda.lib torch_cuda.lib /EXPORT:PyInit__C J:\f\hopper\build\temp.win-amd64-cpython-312\Release\flash_api.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\flash_fwd_combine.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\flash_prepare_scheduler.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_bwd_hdim128_bf16_sm80.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_bwd_hdim128_bf16_softcap_sm80.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_bwd_hdim128_bf16_softcapall_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_bwd_hdim128_fp16_sm80.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_bwd_hdim128_fp16_softcap_sm80.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_bwd_hdim128_fp16_softcapall_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_bwd_hdim192_bf16_sm80.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_bwd_hdim192_bf16_softcap_sm80.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_bwd_hdim192_bf16_softcapall_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_bwd_hdim192_fp16_sm80.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_bwd_hdim192_fp16_softcap_sm80.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_bwd_hdim192_fp16_softcapall_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_bwd_hdim256_bf16_sm80.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_bwd_hdim256_bf16_softcap_sm80.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_bwd_hdim256_bf16_softcapall_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_bwd_hdim256_fp16_sm80.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_bwd_hdim256_fp16_softcap_sm80.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_bwd_hdim256_fp16_softcapall_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_bwd_hdim64_bf16_sm80.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_bwd_hdim64_bf16_softcap_sm80.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_bwd_hdim64_bf16_softcapall_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_bwd_hdim64_fp16_sm80.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_bwd_hdim64_fp16_softcap_sm80.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_bwd_hdim64_fp16_softcapall_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_bwd_hdim96_bf16_sm80.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_bwd_hdim96_bf16_softcap_sm80.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_bwd_hdim96_bf16_softcapall_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_bwd_hdim96_fp16_sm80.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_bwd_hdim96_fp16_softcap_sm80.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_bwd_hdim96_fp16_softcapall_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim128_bf16_packgqa_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim128_bf16_paged_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim128_bf16_paged_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim128_bf16_paged_softcapall_sm80.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim128_bf16_paged_split_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim128_bf16_paged_split_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim128_bf16_paged_split_softcapall_sm80.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim128_bf16_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim128_bf16_softcap_packgqa_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim128_bf16_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim128_bf16_softcapall_sm80.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim128_bf16_split_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim128_bf16_split_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim128_bf16_split_softcapall_sm80.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim128_e4m3_packgqa_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim128_e4m3_paged_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim128_e4m3_paged_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim128_e4m3_paged_split_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim128_e4m3_paged_split_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim128_e4m3_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim128_e4m3_softcap_packgqa_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim128_e4m3_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim128_e4m3_split_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim128_e4m3_split_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim128_fp16_packgqa_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim128_fp16_paged_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim128_fp16_paged_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim128_fp16_paged_softcapall_sm80.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim128_fp16_paged_split_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim128_fp16_paged_split_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim128_fp16_paged_split_softcapall_sm80.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim128_fp16_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim128_fp16_softcap_packgqa_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim128_fp16_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim128_fp16_softcapall_sm80.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim128_fp16_split_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim128_fp16_split_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim128_fp16_split_softcapall_sm80.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_128_bf16_packgqa_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_128_bf16_paged_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_128_bf16_paged_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_128_bf16_paged_split_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_128_bf16_paged_split_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_128_bf16_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_128_bf16_softcap_packgqa_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_128_bf16_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_128_bf16_split_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_128_bf16_split_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_128_e4m3_packgqa_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_128_e4m3_paged_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_128_e4m3_paged_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_128_e4m3_paged_split_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_128_e4m3_paged_split_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_128_e4m3_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_128_e4m3_softcap_packgqa_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_128_e4m3_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_128_e4m3_split_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_128_e4m3_split_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_128_fp16_packgqa_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_128_fp16_paged_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_128_fp16_paged_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_128_fp16_paged_split_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_128_fp16_paged_split_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_128_fp16_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_128_fp16_softcap_packgqa_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_128_fp16_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_128_fp16_split_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_128_fp16_split_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_bf16_packgqa_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_bf16_paged_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_bf16_paged_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_bf16_paged_softcapall_sm80.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_bf16_paged_split_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_bf16_paged_split_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_bf16_paged_split_softcapall_sm80.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_bf16_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_bf16_softcap_packgqa_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_bf16_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_bf16_softcapall_sm80.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_bf16_split_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_bf16_split_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_bf16_split_softcapall_sm80.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_e4m3_packgqa_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_e4m3_paged_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_e4m3_paged_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_e4m3_paged_split_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_e4m3_paged_split_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_e4m3_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_e4m3_softcap_packgqa_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_e4m3_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_e4m3_split_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_e4m3_split_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_fp16_packgqa_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_fp16_paged_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_fp16_paged_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_fp16_paged_softcapall_sm80.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_fp16_paged_split_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_fp16_paged_split_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_fp16_paged_split_softcapall_sm80.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_fp16_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_fp16_softcap_packgqa_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_fp16_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_fp16_softcapall_sm80.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_fp16_split_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_fp16_split_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim192_fp16_split_softcapall_sm80.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim256_bf16_packgqa_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim256_bf16_paged_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim256_bf16_paged_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim256_bf16_paged_softcapall_sm80.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim256_bf16_paged_split_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim256_bf16_paged_split_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim256_bf16_paged_split_softcapall_sm80.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim256_bf16_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim256_bf16_softcap_packgqa_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim256_bf16_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim256_bf16_softcapall_sm80.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim256_bf16_split_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim256_bf16_split_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim256_bf16_split_softcapall_sm80.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim256_e4m3_packgqa_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim256_e4m3_paged_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim256_e4m3_paged_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim256_e4m3_paged_split_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim256_e4m3_paged_split_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim256_e4m3_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim256_e4m3_softcap_packgqa_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim256_e4m3_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim256_e4m3_split_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim256_e4m3_split_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim256_fp16_packgqa_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim256_fp16_paged_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim256_fp16_paged_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim256_fp16_paged_softcapall_sm80.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim256_fp16_paged_split_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim256_fp16_paged_split_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim256_fp16_paged_split_softcapall_sm80.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim256_fp16_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim256_fp16_softcap_packgqa_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim256_fp16_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim256_fp16_softcapall_sm80.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim256_fp16_split_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim256_fp16_split_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim256_fp16_split_softcapall_sm80.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_256_bf16_packgqa_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_256_bf16_paged_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_256_bf16_paged_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_256_bf16_paged_split_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_256_bf16_paged_split_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_256_bf16_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_256_bf16_softcap_packgqa_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_256_bf16_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_256_bf16_split_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_256_bf16_split_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_256_fp16_packgqa_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_256_fp16_paged_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_256_fp16_paged_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_256_fp16_paged_split_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_256_fp16_paged_split_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_256_fp16_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_256_fp16_softcap_packgqa_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_256_fp16_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_256_fp16_split_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_256_fp16_split_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_512_bf16_packgqa_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_512_bf16_paged_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_512_bf16_paged_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_512_bf16_paged_split_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_512_bf16_paged_split_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_512_bf16_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_512_bf16_softcap_packgqa_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_512_bf16_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_512_bf16_split_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_512_bf16_split_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_512_fp16_packgqa_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_512_fp16_paged_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_512_fp16_paged_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_512_fp16_paged_split_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_512_fp16_paged_split_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_512_fp16_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_512_fp16_softcap_packgqa_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_512_fp16_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_512_fp16_split_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_512_fp16_split_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_bf16_packgqa_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_bf16_paged_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_bf16_paged_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_bf16_paged_softcapall_sm80.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_bf16_paged_split_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_bf16_paged_split_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_bf16_paged_split_softcapall_sm80.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_bf16_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_bf16_softcap_packgqa_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_bf16_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_bf16_softcapall_sm80.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_bf16_split_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_bf16_split_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_bf16_split_softcapall_sm80.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_e4m3_packgqa_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_e4m3_paged_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_e4m3_paged_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_e4m3_paged_split_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_e4m3_paged_split_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_e4m3_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_e4m3_softcap_packgqa_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_e4m3_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_e4m3_split_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_e4m3_split_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_fp16_packgqa_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_fp16_paged_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_fp16_paged_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_fp16_paged_softcapall_sm80.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_fp16_paged_split_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_fp16_paged_split_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_fp16_paged_split_softcapall_sm80.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_fp16_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_fp16_softcap_packgqa_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_fp16_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_fp16_softcapall_sm80.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_fp16_split_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_fp16_split_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim64_fp16_split_softcapall_sm80.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim96_bf16_packgqa_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim96_bf16_paged_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim96_bf16_paged_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim96_bf16_paged_softcapall_sm80.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim96_bf16_paged_split_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim96_bf16_paged_split_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim96_bf16_paged_split_softcapall_sm80.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim96_bf16_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim96_bf16_softcap_packgqa_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim96_bf16_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim96_bf16_softcapall_sm80.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim96_bf16_split_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim96_bf16_split_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim96_bf16_split_softcapall_sm80.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim96_e4m3_packgqa_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim96_e4m3_paged_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim96_e4m3_paged_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim96_e4m3_paged_split_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim96_e4m3_paged_split_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim96_e4m3_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim96_e4m3_softcap_packgqa_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim96_e4m3_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim96_e4m3_split_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim96_e4m3_split_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim96_fp16_packgqa_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim96_fp16_paged_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim96_fp16_paged_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim96_fp16_paged_softcapall_sm80.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim96_fp16_paged_split_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim96_fp16_paged_split_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim96_fp16_paged_split_softcapall_sm80.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim96_fp16_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim96_fp16_softcap_packgqa_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim96_fp16_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim96_fp16_softcapall_sm80.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim96_fp16_split_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim96_fp16_split_softcap_sm90.obj J:\f\hopper\build\temp.win-amd64-cpython-312\Release\instantiations\flash_fwd_hdim96_fp16_split_softcapall_sm80.obj /OUT:build\lib.win-amd64-cpython-312\flash_attn_3\_C.pyd /IMPLIB:J:\f\hopper\build\temp.win-amd64-cpython-312\Release\_C.lib
  error: command 'C:\\Program Files (x86)\\Microsoft Visual Studio\\2022\\BuildTools\\VC\\Tools\\MSVC\\14.44.35207\\bin\\HostX64\\x64\\link.exe' failed: None
  error: subprocess-exited-with-error
```