### PR TITLE
[Cute,Fwd,Sm100] don't pass mask_fn to softmax_step generically

### DIFF
--- a/flash_attn/cute/flash_fwd_sm100.py
+++ b/flash_attn/cute/flash_fwd_sm100.py
@@ -1676,7 +1676,6 @@ class FlashAttentionForwardSm100:
                 seqlen=seqlen,
                 aux_tensors=aux_tensors,
                 fastdiv_mods=fastdiv_mods,
-                mask_fn=partial(mask_fn, mask_seqlen=False),
             )
 
             if has_work:


### PR DESCRIPTION
Fixes perf regression from masking on every iteration:

with fix:
```
### headdim = 128, causal = False, seqlen = 8192, batch_size = 4 ###
FA Python fwd: 1.453ms, 1513.1 TFLOPS
FA Python bwd: 4.553ms, 1207.5 TFLOPS

### headdim = 128, causal = True, seqlen = 8192, batch_size = 4 ###
FA Python fwd: 0.784ms, 1403.2 TFLOPS
FA Python bwd: 2.514ms, 1093.3 TFLOPS
```

without fix:
```
### headdim = 128, causal = False, seqlen = 8192, batch_size = 4 ###
FA Python fwd: 1.470ms, 1495.7 TFLOPS
FA Python bwd: 4.519ms, 1216.5 TFLOPS

### headdim = 128, causal = True, seqlen = 8192, batch_size = 4 ###
FA Python fwd: 0.850ms, 1293.9 TFLOPS
FA Python bwd: 2.517ms, 1092.1 TFLOPS
```