### PR TITLE
[Cute,Fwd] enable mask mod without blocksparsity

### DIFF
--- a/flash_attn/cute/flash_fwd.py
+++ b/flash_attn/cute/flash_fwd.py
@@ -2047,7 +2047,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                     kv_consumer_state = process_first_half_block(
                         n_block=n_block_max - 1,
                         kv_consumer_state=kv_consumer_state,
-                        mask_fn=mask_fn,
+                        mask_fn=partial(mask_fn, mask_mod=self.mask_mod),
                         score_mod_fn=score_mod_fn,
                         is_first_block=True,
                     )
@@ -2060,7 +2060,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                         n_block=n_block_max - 1,
                         mma_pv_fn=partial(mma_pv_fn, zero_init=True),
                         is_first_n_block=True,
-                        mask_fn=partial(mask_fn, mask_seqlen=True),
+                        mask_fn=partial(mask_fn, mask_mod=self.mask_mod, mask_seqlen=True),
                     )
                     O_should_accumulate = True
                 # if cute.arch.thread_idx()[0] == 128: cute.printf("m_block = {}, n_block_max = {}, n_block_min = {}", m_block, n_block_max, n_block_min)
@@ -2078,7 +2078,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                             kv_consumer_state,
                             n_block=n_block_max - 1 - n_tile,
                             mma_pv_fn=partial(mma_pv_fn, zero_init=not O_should_accumulate),
-                            mask_fn=partial(mask_fn, mask_seqlen=False),
+                            mask_fn=partial(mask_fn, mask_mod=self.mask_mod, mask_seqlen=False),
                         )
                         O_should_accumulate = True
                     n_block_max = cutlass.min(n_block_max, n_block_min_causal_local_mask)
@@ -2092,6 +2092,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                         kv_consumer_state,
                         n_block=n_block_max - 1 - n_tile,
                         mma_pv_fn=partial(mma_pv_fn, zero_init=not O_should_accumulate),
+                        mask_fn=partial(mask_fn, mask_mod=self.mask_mod, mask_seqlen=False),
                     )
                     O_should_accumulate = True
                 # Separate iterations with local masking on the left
@@ -2102,7 +2103,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                             kv_consumer_state,
                             n_block=n_block_max - 1 - n_tile,
                             mma_pv_fn=partial(mma_pv_fn, zero_init=not O_should_accumulate),
-                            mask_fn=partial(mask_fn, mask_seqlen=False),
+                            mask_fn=partial(mask_fn, mask_mod=self.mask_mod, mask_seqlen=False),
                         )
                         O_should_accumulate = True
                 # Last "half" iteration

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -369,10 +369,6 @@ def _flash_attn_fwd(
             )
 
     if mask_mod is not None:
-        if not use_block_sparsity:
-            raise NotImplementedError(
-                "mask_mod requires the use of block sparsity. This will be fixed in a future PR."
-            )
         if is_varlen:
             raise NotImplementedError(
                 "mask_mod with aux_tensors is not yet supported for varlen sequences. This will be fixed in a future PR."

--- a/tests/cute/test_mask_mod.py
+++ b/tests/cute/test_mask_mod.py
@@ -171,6 +171,7 @@ def _run_mask_test(
     window_right,
     tile_m,
     tile_n,
+    use_block_sparsity,
 ):
     torch.manual_seed(42)
 
@@ -267,7 +268,7 @@ def _run_mask_test(
         mask_block_idx=mask_idx,
         full_block_cnt=full_cnt,
         full_block_idx=full_idx,
-    )
+    ) if use_block_sparsity else None
 
     out_tuple = _flash_attn_fwd(
         q=tensors["q"],
@@ -370,6 +371,7 @@ def test_mask_mod_ima_partial_block():
         window_right=None,
         tile_m=128,
         tile_n=128,
+        use_block_sparsity=True,
     )
 
 
@@ -378,13 +380,14 @@ def test_mask_mod_ima_partial_block():
 @pytest.mark.parametrize("kv_mode", ["mha", "gqa", "mqa"])
 @pytest.mark.parametrize("headdim", [128])
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.parametrize("use_block_sparsity", [True, False])
 @pytest.mark.parametrize(
     "mask_name",
     ["block_diagonal", "mini_causal"],
 )
 @pytest.mark.parametrize("tile_m,tile_n", [(128, 128), (128, 112)])
 def test_static_masks(
-    seqlen_q, seqlen_k, nheads, kv_mode, headdim, dtype, mask_name, tile_m, tile_n
+    seqlen_q, seqlen_k, nheads, kv_mode, headdim, dtype, use_block_sparsity, mask_name, tile_m, tile_n
 ):
     """Test static masks that don't require recompilation per seqlen pair.
 
@@ -408,6 +411,7 @@ def test_static_masks(
         window_right=None,
         tile_m=tile_m,
         tile_n=tile_n,
+        use_block_sparsity=use_block_sparsity,
     )
 
 
@@ -416,6 +420,7 @@ def test_static_masks(
 @pytest.mark.parametrize("kv_mode", ["mha"])
 @pytest.mark.parametrize("headdim", [128])
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.parametrize("use_block_sparsity", [True, False])
 @pytest.mark.parametrize(
     "mask_name,window_size",
     [
@@ -429,7 +434,7 @@ def test_static_masks(
 )
 @pytest.mark.parametrize("tile_m,tile_n", [(128, 128), (128, 112), (64, 128)])
 def test_parameterized_masks(
-    seqlen_q, seqlen_k, nheads, kv_mode, headdim, dtype, mask_name, window_size, tile_m, tile_n
+    seqlen_q, seqlen_k, nheads, kv_mode, headdim, dtype, use_block_sparsity, mask_name, window_size, tile_m, tile_n
 ):
     """Test parameterized masks that require recompilation per seqlen pair.
 
@@ -456,6 +461,7 @@ def test_parameterized_masks(
         window_right=None,
         tile_m=tile_m,
         tile_n=tile_n,
+        use_block_sparsity=use_block_sparsity,
     )
 
 
@@ -506,3 +512,4 @@ def test_sm100_block_sparse_sink_all_masked():
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v", "-s"])
+    


### PR DESCRIPTION
This PR removes the limitation that `mask_mod` may only be used alongside block sparsity. Tested on both Sm90 and Sm100
<img width="1723" height="137" alt="Screenshot 2025-11-24 at 2 58 52 PM" src="https://github.com/user-attachments/assets/beadd762-8f90-4318-a942-50d8623005ec" />
<img width="815" height="189" alt="Screenshot 2025-11-24 at 2 27 49 PM" src="https://github.com/user-attachments/assets/ad2b7464-9a90-4f8b-9adc-5a6028ecc969" />
