### PR TITLE
fixing cute bwd func def

### DIFF
--- a/flash_attn/cute/flash_bwd_sm90.py
+++ b/flash_attn/cute/flash_bwd_sm90.py
@@ -295,7 +295,14 @@ class FlashAttentionBackwardSm90:
         softcap: Float32 | float | None = None,
         window_size_left: Int32 | int | None = None,
         window_size_right: Int32 | int | None = None,
+        mdQ_semaphore: Optional[cute.Tensor] = None,
+        mdK_semaphore: Optional[cute.Tensor] = None,
+        mdV_semaphore: Optional[cute.Tensor] = None,
     ):
+        assert mdQ_semaphore is None and mdK_semaphore is None and mdV_semaphore is None, (
+            "determinism not supported yet for Sm90"
+        )
+
         self._check_type(
             *(
                 t.element_type if t is not None else None


### PR DESCRIPTION
**Summary** 

fixes the error below when running `pytest tests/cute/test_flash_attn.py::test_flash_attn_output`

<img width="1238" height="515" alt="Screenshot 2025-12-08 at 5 17 32 PM" src="https://github.com/user-attachments/assets/8e5ff715-7c51-4024-be80-4fb2565a731d" />

