### PR TITLE
Fix softcap scoremod kwargs typo.

### DIFF
--- a/flash_attn/cute/utils.py
+++ b/flash_attn/cute/utils.py
@@ -67,7 +67,7 @@ def create_softcap_scoremod(softcap_val):
     inv_softcap = 1.0 / softcap_val
 
     @cute.jit
-    def scoremod_premask_fn(acc_S_SSA, batch_idx, head_idx, q_idx, kv_idx, buffers):
+    def scoremod_premask_fn(acc_S_SSA, batch_idx, head_idx, q_idx, kv_idx, aux_tensors):
         scores = acc_S_SSA * inv_softcap
         return scores * cute.math.tanh(scores, fastmath=True)
 


### PR DESCRIPTION
### Description
One-line fix for a small kwargs typo in the score mod for softcap. 

When passing in a nonzero softcap in the frontend, the interface resolves to a pre-implemented score mod function [here](https://github.com/Dao-AILab/flash-attention/blob/179f793bbc62f095338961fc7aef0d421bdbe8e5/flash_attn/cute/interface.py#L315), but the score mod function named the aux tensors `buffers` instead of `aux_tensors`. This triggers an error when score mod is called because it uses `aux_tensors` as a kwarg, like [here](https://github.com/Dao-AILab/flash-attention/blob/179f793bbc62f095338961fc7aef0d421bdbe8e5/flash_attn/cute/softmax.py#L438).