### PR TITLE
Add blocksparse support for bwd on blackwell

### DIFF
--- a/flash_attn/cute/block_sparsity.py
+++ b/flash_attn/cute/block_sparsity.py
@@ -102,6 +102,29 @@ def get_block_sparse_expected_shapes(
     return expected_count_shape, expected_index_shape
 
 
+def get_block_sparse_expected_shapes_bwd(
+    batch_size: int,
+    num_head: int,
+    seqlen_q: int,
+    seqlen_k: int,
+    m_block_size: int,
+    n_block_size: int,
+    subtile_factor: int,
+) -> Tuple[Tuple[int, int, int], Tuple[int, int, int, int]]:
+    """Return (expected_count_shape, expected_index_shape) for backward block sparse normalization.
+
+    Backward uses Q-direction indexing (transposed from forward), where shapes are
+    indexed by N-blocks first, then M-blocks. The sparse_block_size_q is determined
+    by subtile_factor * m_block_size.
+    """
+    sparse_block_size_q = subtile_factor * m_block_size
+    expected_m_blocks = ceildiv(seqlen_q, sparse_block_size_q)
+    expected_n_blocks = ceildiv(seqlen_k, n_block_size)
+    expected_count_shape = (batch_size, num_head, expected_n_blocks)
+    expected_index_shape = (batch_size, num_head, expected_n_blocks, expected_m_blocks)
+    return expected_count_shape, expected_index_shape
+
+
 def normalize_block_sparse_tensors(
     tensors: BlockSparseTensorsTorch,
     *,

--- a/flash_attn/cute/flash_bwd_sm100.py
+++ b/flash_attn/cute/flash_bwd_sm100.py
@@ -31,6 +31,13 @@ from flash_attn.cute.tile_scheduler import (
 from flash_attn.cute import barrier
 from flash_attn.cute.named_barrier import NamedBarrierBwdSm100
 from flash_attn.cute.softmax import apply_score_mod_inner, apply_score_mod_bwd_inner
+from flash_attn.cute.block_sparsity import BlockSparseTensors
+from flash_attn.cute.block_sparse_utils import (
+    get_total_q_block_count_bwd,
+    get_block_sparse_iteration_info_bwd,
+    get_m_block_from_iter_bwd,
+    produce_block_sparse_q_loads_bwd_sm100,
+)
 
 
 class FlashAttentionBackwardSm100:
@@ -50,7 +57,9 @@ class FlashAttentionBackwardSm100:
         cluster_size: int = 1,
         score_mod: cutlass.Constexpr | None = None,
         score_mod_bwd: cutlass.Constexpr | None = None,
+        mask_mod: cutlass.Constexpr | None = None,
         has_aux_tensors: cutlass.Constexpr = False,
+        subtile_factor: cutlass.Constexpr[int] = 1,
     ):
         # padding head_dim to a multiple of 16 as k_block_size
         hdim_multiple_of = 16
@@ -93,10 +102,12 @@ class FlashAttentionBackwardSm100:
         self.use_tma_store = True
         self.deterministic = deterministic
 
-        # Score mod support
+        # Score mod and mask mod support
         self.score_mod = score_mod
         self.score_mod_bwd = score_mod_bwd
+        self.mask_mod = mask_mod
         self.has_aux_tensors = has_aux_tensors
+        self.subtile_factor = subtile_factor
         # For score_mod, use vec_size=1 (like forward) to handle per-element indices
         if cutlass.const_expr(has_aux_tensors):
             self.vec_size: cutlass.Constexpr = 1
@@ -377,6 +388,8 @@ class FlashAttentionBackwardSm100:
         mdK_semaphore: Optional[cute.Tensor] = None,
         mdV_semaphore: Optional[cute.Tensor] = None,
         aux_tensors: Optional[list] = None,
+        # Block-sparse tensors (Q direction - for iterating m_blocks per n_block):
+        blocksparse_tensors: Optional[BlockSparseTensors] = None,
     ):
         assert all(x is None for x in (mCuSeqlensQ, mCuSeqlensK, mSeqUsedQ, mSeqUsedK)), (
             "Variable sequence length is not supported yet in FlashAttentionBackwardSm100"
@@ -703,6 +716,7 @@ class FlashAttentionBackwardSm100:
             seqlen_q_divmod = FastDivmodDivisor(seqlen_q)
             seqlen_k_divmod = FastDivmodDivisor(seqlen_k)
             fastdiv_mods = (seqlen_q_divmod, seqlen_k_divmod)
+        self.use_block_sparsity = cutlass.const_expr(blocksparse_tensors is not None)
 
         self.kernel(
             tma_tensor_Q,
@@ -753,6 +767,7 @@ class FlashAttentionBackwardSm100:
             tile_sched_params,
             aux_tensors,
             fastdiv_mods,
+            blocksparse_tensors,
         ).launch(
             grid=grid_dim,
             block=[self.threads_per_cta, 1, 1],
@@ -813,6 +828,7 @@ class FlashAttentionBackwardSm100:
         tile_sched_params: ParamsBase,
         aux_tensors: Optional[list] = None,
         fastdiv_mods=(None, None),
+        blocksparse_tensors: Optional[BlockSparseTensors] = None,
     ):
         warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
 
@@ -1097,6 +1113,7 @@ class FlashAttentionBackwardSm100:
                 block_info,
                 SeqlenInfoCls,
                 TileSchedulerCls,
+                blocksparse_tensors,
                 should_load_Q=True,
                 should_load_dO=True,
             )
@@ -1143,6 +1160,7 @@ class FlashAttentionBackwardSm100:
                 block_info,
                 SeqlenInfoCls,
                 TileSchedulerCls,
+                blocksparse_tensors,
             )
             cute.arch.relinquish_tmem_alloc_permit()
             tmem_ptr = cute.arch.retrieve_tmem_ptr(
@@ -1194,6 +1212,7 @@ class FlashAttentionBackwardSm100:
                 mdV_semaphore,
                 aux_tensors,
                 fastdiv_mods,
+                blocksparse_tensors,
             )
             cute.arch.mbarrier_arrive(tmem_dealloc_mbar_ptr)
 
@@ -1211,6 +1230,7 @@ class FlashAttentionBackwardSm100:
                 SeqlenInfoCls,
                 TileSchedulerCls,
                 mdQ_semaphore,
+                blocksparse_tensors,
             )
 
         return
@@ -1245,6 +1265,7 @@ class FlashAttentionBackwardSm100:
         block_info: BlockInfo,
         SeqlenInfoCls: Callable,
         TileSchedulerCls: Callable,
+        blocksparse_tensors: Optional[BlockSparseTensors] = None,
         should_load_Q: bool = True,
         should_load_dO: bool = True,
     ):
@@ -1330,74 +1351,120 @@ class FlashAttentionBackwardSm100:
             # gdPsum = cute.logical_divide(gdPsum, (64,))[(None, block_in_cluster_coord_vmnk[1]), None]
             # copy_stats = partial(cute.copy, copy_atom_stats, mcast_mask=q_do_mcast_mask)
 
-            if const_expr(not self.is_local) or m_block_min < m_block_max:
-                # First iteration: load K together w Q & LSE, then V together w dO & dPsum
-                if const_expr(should_load_Q):
-                    # K & Q
-                    pipeline_Q.producer_acquire(
-                        producer_state_Q_LSE, extra_tx_count=self.tma_copy_bytes["K"]
-                    )
-                    load_K(tma_bar_ptr=pipeline_Q.producer_get_barrier(producer_state_Q_LSE))
-                    load_Q(m_block_min, producer_state=producer_state_Q_LSE)
-                    pipeline_Q.producer_commit(producer_state_Q_LSE)
-                    # LSE
-                    pipeline_LSE.producer_acquire(producer_state_Q_LSE)
-                    with cute.arch.elect_one():
-                        copy_stats(
-                            gLSE[None, m_block_min],
-                            sLSE[None, producer_state_Q_LSE.index],
-                            mbar_ptr=pipeline_LSE.producer_get_barrier(producer_state_Q_LSE),
-                        )
-                    producer_state_Q_LSE.advance()
-                if const_expr(should_load_dO):
-                    # V & dO
-                    pipeline_dO.producer_acquire(
-                        producer_state_dO_dPsum, extra_tx_count=self.tma_copy_bytes["V"]
-                    )
-                    load_V(tma_bar_ptr=pipeline_dO.producer_get_barrier(producer_state_dO_dPsum))
-                    load_dO(m_block_min, producer_state=producer_state_dO_dPsum)
-                    pipeline_dO.producer_commit(producer_state_dO_dPsum)
-                    # dPsum
-                    pipeline_dPsum.producer_acquire(producer_state_dO_dPsum)
-                    with cute.arch.elect_one():
-                        copy_stats(
-                            gdPsum[None, m_block_min],
-                            sdPsum[None, producer_state_dO_dPsum.index],
-                            mbar_ptr=pipeline_dPsum.producer_get_barrier(producer_state_dO_dPsum),
-                        )
-                    producer_state_dO_dPsum.advance()
+            # some tiles might be empty due to block sparsity
+            if const_expr(self.use_block_sparsity):
+                total_m_block_cnt = get_total_q_block_count_bwd(
+                    blocksparse_tensors,
+                    batch_idx,
+                    head_idx,
+                    n_block,
+                    subtile_factor=self.subtile_factor,
+                    m_block_max=m_block_max,
+                )
+                process_tile = total_m_block_cnt > Int32(0)
+            else:
+                process_tile = const_expr(not self.is_local) or m_block_min < m_block_max
 
-                for m_block in cutlass.range(m_block_min + 1, m_block_max, unroll=1):
+            if process_tile:
+                if const_expr(self.use_block_sparsity):
+                    producer_state_Q_LSE, producer_state_dO_dPsum = (
+                        produce_block_sparse_q_loads_bwd_sm100(
+                            blocksparse_tensors,
+                            batch_idx,
+                            head_idx,
+                            n_block,
+                            producer_state_Q_LSE,
+                            producer_state_dO_dPsum,
+                            pipeline_Q,
+                            pipeline_LSE,
+                            pipeline_dO,
+                            pipeline_dPsum,
+                            load_K,
+                            load_V,
+                            load_Q,
+                            load_dO,
+                            copy_stats,
+                            gLSE,
+                            sLSE,
+                            gdPsum,
+                            sdPsum,
+                            self.tma_copy_bytes["K"],
+                            self.tma_copy_bytes["V"],
+                            should_load_Q=should_load_Q,
+                            should_load_dO=should_load_dO,
+                            subtile_factor=self.subtile_factor,
+                            m_block_max=m_block_max,
+                        )
+                    )
+                else:
+                    first_m_block = m_block_min
+
+                    # First iteration: load K together w Q & LSE, then V together w dO & dPsum
                     if const_expr(should_load_Q):
-                        # Q
-                        pipeline_Q.producer_acquire(producer_state_Q_LSE)
-                        load_Q(m_block, producer_state=producer_state_Q_LSE)
+                        pipeline_Q.producer_acquire(
+                            producer_state_Q_LSE, extra_tx_count=self.tma_copy_bytes["K"]
+                        )
+                        load_K(tma_bar_ptr=pipeline_Q.producer_get_barrier(producer_state_Q_LSE))
+                        load_Q(first_m_block, producer_state=producer_state_Q_LSE)
                         pipeline_Q.producer_commit(producer_state_Q_LSE)
-                        # LSE
                         pipeline_LSE.producer_acquire(producer_state_Q_LSE)
                         with cute.arch.elect_one():
                             copy_stats(
-                                gLSE[None, m_block],
+                                gLSE[None, first_m_block],
                                 sLSE[None, producer_state_Q_LSE.index],
                                 mbar_ptr=pipeline_LSE.producer_get_barrier(producer_state_Q_LSE),
                             )
                         producer_state_Q_LSE.advance()
                     if const_expr(should_load_dO):
-                        # dO
-                        pipeline_dO.producer_acquire(producer_state_dO_dPsum)
-                        load_dO(m_block, producer_state=producer_state_dO_dPsum)
+                        pipeline_dO.producer_acquire(
+                            producer_state_dO_dPsum, extra_tx_count=self.tma_copy_bytes["V"]
+                        )
+                        load_V(
+                            tma_bar_ptr=pipeline_dO.producer_get_barrier(producer_state_dO_dPsum)
+                        )
+                        load_dO(first_m_block, producer_state=producer_state_dO_dPsum)
                         pipeline_dO.producer_commit(producer_state_dO_dPsum)
-                        # dPsum
                         pipeline_dPsum.producer_acquire(producer_state_dO_dPsum)
                         with cute.arch.elect_one():
                             copy_stats(
-                                gdPsum[None, m_block],
+                                gdPsum[None, first_m_block],
                                 sdPsum[None, producer_state_dO_dPsum.index],
                                 mbar_ptr=pipeline_dPsum.producer_get_barrier(
                                     producer_state_dO_dPsum
                                 ),
                             )
                         producer_state_dO_dPsum.advance()
+
+                    # Dense path: iterate from m_block_min+1 to m_block_max
+                    for m_block in cutlass.range(m_block_min + 1, m_block_max, unroll=1):
+                        if const_expr(should_load_Q):
+                            pipeline_Q.producer_acquire(producer_state_Q_LSE)
+                            load_Q(m_block, producer_state=producer_state_Q_LSE)
+                            pipeline_Q.producer_commit(producer_state_Q_LSE)
+                            pipeline_LSE.producer_acquire(producer_state_Q_LSE)
+                            with cute.arch.elect_one():
+                                copy_stats(
+                                    gLSE[None, m_block],
+                                    sLSE[None, producer_state_Q_LSE.index],
+                                    mbar_ptr=pipeline_LSE.producer_get_barrier(
+                                        producer_state_Q_LSE
+                                    ),
+                                )
+                            producer_state_Q_LSE.advance()
+                        if const_expr(should_load_dO):
+                            pipeline_dO.producer_acquire(producer_state_dO_dPsum)
+                            load_dO(m_block, producer_state=producer_state_dO_dPsum)
+                            pipeline_dO.producer_commit(producer_state_dO_dPsum)
+                            pipeline_dPsum.producer_acquire(producer_state_dO_dPsum)
+                            with cute.arch.elect_one():
+                                copy_stats(
+                                    gdPsum[None, m_block],
+                                    sdPsum[None, producer_state_dO_dPsum.index],
+                                    mbar_ptr=pipeline_dPsum.producer_get_barrier(
+                                        producer_state_dO_dPsum
+                                    ),
+                                )
+                            producer_state_dO_dPsum.advance()
 
                 if const_expr(should_load_Q):
                     pipeline_Q.producer_tail(
@@ -1446,6 +1513,7 @@ class FlashAttentionBackwardSm100:
         block_info: BlockInfo,
         SeqlenInfoCls: Callable,
         TileSchedulerCls: Callable,
+        blocksparse_tensors: Optional[BlockSparseTensors] = None,
     ):
         # [2025-10-21] For reasons I don't understand, putting these partitioning in the main
         # kernel (before warp specialization) is a lot slower tha putting them here.
@@ -1535,7 +1603,22 @@ class FlashAttentionBackwardSm100:
             m_block_min, m_block_max = block_info.get_m_block_min_max(
                 seqlen, n_block // self.cluster_shape_mnk[0]
             )
-            if const_expr(not self.is_local) or m_block_min < m_block_max:
+
+            if const_expr(self.use_block_sparsity):
+                block_iter_count = get_total_q_block_count_bwd(
+                    blocksparse_tensors,
+                    batch_idx,
+                    head_idx,
+                    n_block,
+                    subtile_factor=self.subtile_factor,
+                    m_block_max=m_block_max,
+                )
+                process_tile = block_iter_count > Int32(0)
+            else:
+                block_iter_count = m_block_max - m_block_min
+                process_tile = const_expr(not self.is_local) or m_block_min < m_block_max
+
+            if process_tile:
                 accumulate_dK = False
                 # -----------------------------------------------------------
                 ###### Prologue
@@ -1575,7 +1658,14 @@ class FlashAttentionBackwardSm100:
                 # 4. dP = V    @ dO.T
                 # 5. dV = P.T  @ dO
 
-                for _ in cutlass.range(m_block_min + 1, m_block_max, unroll=1):
+                # For block sparsity, we use block_iter_count; for dense, use m_block range
+                # MMA doesn't need actual m_block indices, just the iteration count
+                main_loop_iters = (
+                    block_iter_count - 1
+                    if const_expr(self.use_block_sparsity)
+                    else m_block_max - m_block_min - 1
+                )
+                for _ in cutlass.range(main_loop_iters, unroll=1):
                     # 1) S = K @ Q_i
                     handle_Q_next = pipeline_Q_consumer.wait_and_advance()
                     # Don't need to wait for S, as P must have been ready ealier, i.e., S is ready
@@ -1820,6 +1910,7 @@ class FlashAttentionBackwardSm100:
         mdV_semaphore: Optional[cute.Tensor],
         aux_tensors: Optional[list] = None,
         fastdiv_mods=(None, None),
+        blocksparse_tensors: Optional[BlockSparseTensors] = None,
     ):
         sLSE_2D = cute.make_tensor(
             sLSE.iterator,
@@ -1936,13 +2027,53 @@ class FlashAttentionBackwardSm100:
                 mask_seqlen=True,
                 mask_causal=self.is_causal,
                 mask_local=self.is_local,
+                mask_mod=self.mask_mod,
+                batch_idx=batch_idx,
+                head_idx=head_idx,
+                aux_tensors=aux_tensors,
+                fastdiv_mods=fastdiv_mods,
             )
 
             # prefetch_LSE = not self.is_causal
             prefetch_LSE = False
 
+            # some tiles might be empty due to block sparsity
+            if const_expr(self.use_block_sparsity):
+                (
+                    curr_q_cnt,
+                    curr_q_idx,
+                    curr_full_cnt,
+                    curr_full_idx,
+                    loop_count,
+                ) = get_block_sparse_iteration_info_bwd(
+                    blocksparse_tensors,
+                    batch_idx,
+                    head_idx,
+                    n_block,
+                    subtile_factor=self.subtile_factor,
+                    m_block_max=m_block_max,
+                )
+                process_tile = loop_count > Int32(0)
+            else:
+                process_tile = const_expr(not self.is_local) or m_block_min < m_block_max
+                loop_count = m_block_max - m_block_min
+
             # Mainloop
-            for m_block in cutlass.range(m_block_min, m_block_max, unroll=1):
+            # Block sparsity: iterate over sparse m_block count and derive actual m_block
+            # from Q_IDX/FULL_Q_IDX tensors. Dense: iterate m_block_min..m_block_max directly.
+            for iter_idx in cutlass.range(loop_count, unroll=1):
+                if const_expr(self.use_block_sparsity):
+                    m_block, is_full_block = get_m_block_from_iter_bwd(
+                        iter_idx,
+                        curr_q_cnt,
+                        curr_q_idx,
+                        curr_full_cnt,
+                        curr_full_idx,
+                        subtile_factor=self.subtile_factor,
+                    )
+                else:
+                    m_block = m_block_min + iter_idx
+                    is_full_block = False
                 # Prefetch 1 stage of LSE
                 pipeline_LSE.consumer_wait(consumer_state_LSE)
                 tSrLSE_s2r = cute.make_fragment(tScS_t2r[None, 0, 0, 0].shape, Float32)
@@ -1956,14 +2087,11 @@ class FlashAttentionBackwardSm100:
                 cute.copy(thr_copy_t2r, tStS_t2r, tSrS_t2r)
 
                 if const_expr(self.score_mod is not None):
-                    # Preserve unscaled S for backward score_mod BEFORE masking
+                    # Preserve unscaled S for backward score_mod BEFORE any modification
                     tSrS_pre = cute.make_fragment_like(tSrS_t2r)
                     cute.autovec_copy(tSrS_t2r, tSrS_pre)
 
-                #### APPLY MASK
-                mask_fn(tSrS_t2r, m_block=m_block)
-
-                if const_expr(self.score_mod is not None):
+                    # Apply score_mod FIRST -> matches forward
                     self.apply_score_mod(
                         tSrS_t2r,
                         thr_copy_t2r,
@@ -1977,6 +2105,15 @@ class FlashAttentionBackwardSm100:
                         aux_tensors,
                         fastdiv_mods,
                     )
+
+                #### APPLY MASK (after score_mod, matching forward pass order)
+                check_m_boundary = (m_block + 1) * self.tile_m > seqlen.seqlen_q
+                mask_fn(
+                    tSrS_t2r,
+                    m_block=m_block,
+                    is_full_block=is_full_block,
+                    check_m_boundary=check_m_boundary,
+                )
 
                 num_stages = cute.size(tScS_t2r, mode=[1])
 
@@ -2123,7 +2260,8 @@ class FlashAttentionBackwardSm100:
                 producer_state_dS.advance()
 
             # Epilogue
-            if const_expr(not self.is_local) or m_block_min < m_block_max:
+            # Run epilogue if we processed any m_blocks for this n_block
+            if process_tile:
                 if const_expr(not self.use_tma_store):
                     consumer_state_dKV = self.epilogue_dKV(
                         dp_idx,
@@ -2179,10 +2317,18 @@ class FlashAttentionBackwardSm100:
                         int(NamedBarrierBwdSm100.EpilogueWG1),  # barrier_id
                         mdK_semaphore,
                     )
-            if const_expr(self.qhead_per_kvhead == 1 and self.is_local):
-                if m_block_min >= m_block_max:
-                    # if tidx == 0:
-                    #     cute.printf("m_block_min = {}, m_block_max = {}", m_block_min, m_block_max)
+            # Zero dK/dV for empty tiles (local attention or block sparsity)
+            # When total_m_block_cnt == 0 for block sparsity, no Q tiles contribute to this KV tile
+            if const_expr(self.qhead_per_kvhead == 1):
+                should_zero_dKV = False
+                if const_expr(self.is_local):
+                    should_zero_dKV = m_block_min >= m_block_max
+                if const_expr(self.use_block_sparsity):
+                    # For block sparsity, zero when no m_blocks contribute to this n_block
+                    if not process_tile:
+                        should_zero_dKV = True
+
+                if should_zero_dKV:
                     # like other epis, currently assumes hdim == hdimv
                     gmem_tiled_copy_zero_dKV = copy_utils.tiled_copy_2d(
                         self.dk_dtype,
@@ -2228,6 +2374,7 @@ class FlashAttentionBackwardSm100:
         SeqlenInfoCls: Callable,
         TileSchedulerCls: Callable,
         mdQ_semaphore: Optional[cute.Tensor],
+        blocksparse_tensors: Optional[BlockSparseTensors] = None,
     ):
         num_reduce_threads = cute.arch.WARP_SIZE * len(self.reduce_warp_ids)
         tidx = cute.arch.thread_idx()[0] % num_reduce_threads
@@ -2279,7 +2426,42 @@ class FlashAttentionBackwardSm100:
             delay_semaphore_release = self.is_causal
             n_block_global_max = cute.ceil_div(seqlen.seqlen_k, self.tile_n)
 
-            for m_block in cutlass.range(m_block_min, m_block_max, unroll=1):
+            # some tiles might be empty due to block sparsity
+            if const_expr(self.use_block_sparsity):
+                (
+                    curr_q_cnt,
+                    curr_q_idx,
+                    curr_full_cnt,
+                    curr_full_idx,
+                    loop_count,
+                ) = get_block_sparse_iteration_info_bwd(
+                    blocksparse_tensors,
+                    batch_idx,
+                    head_idx,
+                    n_block,
+                    subtile_factor=self.subtile_factor,
+                    m_block_max=m_block_max,
+                )
+                process_tile = loop_count > Int32(0)
+            else:
+                process_tile = const_expr(not self.is_local) or m_block_min < m_block_max
+                loop_count = m_block_max - m_block_min
+
+            # dQacc_reduce mainloop
+            # Block sparsity: iterate over sparse m_block count and derive actual m_block
+            # from Q_IDX/FULL_Q_IDX tensors. Dense: iterate m_block_min..m_block_max directly.
+            for iter_idx in cutlass.range(loop_count, unroll=1):
+                if const_expr(self.use_block_sparsity):
+                    m_block, _ = get_m_block_from_iter_bwd(
+                        iter_idx,
+                        curr_q_cnt,
+                        curr_q_idx,
+                        curr_full_cnt,
+                        curr_full_idx,
+                        subtile_factor=self.subtile_factor,
+                    )
+                else:
+                    m_block = m_block_min + iter_idx
                 pipeline_dQ.consumer_wait(dQ_consumer_state)
                 # TMEM -> RMEM
                 tdQrdQ_t2r = cute.make_fragment(tdQrdQ_t2r_shape, Float32)

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -52,6 +52,7 @@ from flash_attn.cute.block_sparsity import (
     to_cute_block_sparse_tensors,
     normalize_block_sparse_tensors,
     get_block_sparse_expected_shapes,
+    get_block_sparse_expected_shapes_bwd,
 )
 
 def maybe_contiguous(x):
@@ -575,7 +576,9 @@ def _flash_attn_bwd(
     dv: Optional[torch.Tensor] = None,
     score_mod: Optional[Callable] = None,
     score_mod_bwd: Optional[Callable] = None,
+    mask_mod: Optional[Callable] = None,
     aux_tensors: Optional[list[torch.Tensor]] = None,
+    block_sparse_tensors: Optional[BlockSparseTensorsTorch] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     compute_capability = _get_device_capability()
     assert compute_capability in [9, 10], "Unsupported compute capability. Supported: 9.x, 10.x"
@@ -636,6 +639,8 @@ def _flash_attn_bwd(
             window_size_right = None
         else:
             causal, local = False, True
+
+    use_block_sparsity = block_sparse_tensors is not None
 
     if cu_seqlens_k is None:
         assert k.shape == (batch_size, seqlen_k, num_head_kv, head_dim)
@@ -698,6 +703,9 @@ def _flash_attn_bwd(
 
     device = q.device
     out_torch_dtype = q.dtype
+
+    # nb: this could be derived from the block_sparse_tensors but for now we hardcode it to 2
+    subtile_factor = 2
 
     if dq is None:
         dq = torch.empty_like(q)
@@ -869,6 +877,7 @@ def _flash_attn_bwd(
         # Hash callables for compile key
         score_mod_hash = utils.hash_callable(score_mod) if score_mod else False
         score_mod_bwd_hash = utils.hash_callable(score_mod_bwd) if score_mod_bwd else False
+        mask_mod_hash = utils.hash_callable(mask_mod) if mask_mod else False
         num_aux_tensors = len(aux_tensors) if aux_tensors else 0
         # Convert aux_tensors to cute tensors
         cute_aux_tensors = None
@@ -892,7 +901,9 @@ def _flash_attn_bwd(
             deterministic,
             score_mod_hash,
             score_mod_bwd_hash,
+            mask_mod_hash,
             num_aux_tensors,
+            use_block_sparsity,
         )
     num_threads = 384
     if compile_key not in _flash_attn_bwd.compile_cache:
@@ -970,8 +981,26 @@ def _flash_attn_bwd(
                 deterministic=deterministic,
                 score_mod=score_mod,
                 score_mod_bwd=score_mod_bwd,
+                mask_mod=mask_mod,
                 has_aux_tensors=aux_tensors is not None and len(aux_tensors) > 0,
+                subtile_factor=subtile_factor,
             )
+
+        # Block sparse tensors for backward use Q-direction indexing (transposed from forward).
+        # sparse_block_size_q = 2*tile_m matches forward's q_stage=2 pipelining.
+        sparse_tensors_compile = None
+        if block_sparse_tensors is not None and compute_capability == 10:
+            expected_count_shape, expected_index_shape = get_block_sparse_expected_shapes_bwd(
+                batch_size, num_head, seqlen_q, seqlen_k,
+                m_block_size, n_block_size, subtile_factor,
+            )
+            compile_time_normalized = normalize_block_sparse_tensors(
+                block_sparse_tensors,
+                expected_count_shape=expected_count_shape,
+                expected_index_shape=expected_index_shape,
+            )
+            sparse_tensors_compile = to_cute_block_sparse_tensors(compile_time_normalized)
+
         # TODO: check @can_implement
         _flash_attn_bwd.compile_cache[compile_key] = cute.compile(
             fa_bwd_obj,
@@ -997,8 +1026,21 @@ def _flash_attn_bwd(
             dK_semaphore_tensor,
             dV_semaphore_tensor,
             cute_aux_tensors,
+            sparse_tensors_compile,
             options="--enable-tvm-ffi",
         )
+    normalized_block_sparse_tensors = None
+    if block_sparse_tensors is not None and compute_capability == 10:
+        expected_count_shape, expected_index_shape = get_block_sparse_expected_shapes_bwd(
+            batch_size, num_head, seqlen_q, seqlen_k,
+            m_block_size, n_block_size, subtile_factor,
+        )
+        normalized_block_sparse_tensors = normalize_block_sparse_tensors(
+            block_sparse_tensors,
+            expected_count_shape=expected_count_shape,
+            expected_index_shape=expected_index_shape,
+        )
+
     _flash_attn_bwd.compile_cache[compile_key](
         q,
         k,
@@ -1022,6 +1064,7 @@ def _flash_attn_bwd(
         dK_semaphore,
         dV_semaphore,
         aux_tensors,
+        normalized_block_sparse_tensors,
     )
 
     num_threads = 256 if compute_capability == 9 else 128

--- a/tests/cute/test_mask_mod.py
+++ b/tests/cute/test_mask_mod.py
@@ -20,14 +20,9 @@ import torch
 from torch.nn.attention.flex_attention import create_block_mask, flex_attention
 import torch.nn.functional as F
 
-from flash_attn.cute.interface import _flash_attn_fwd
+from flash_attn.cute.interface import _flash_attn_fwd, _flash_attn_bwd
 from flash_attn.cute.block_sparsity import BlockSparseTensorsTorch
-from flash_attn.cute.mask_definitions import (
-    get_mask_pair,
-    STATIC_MASKS,
-    random_doc_id_tensor,
-)
-from flash_attn.cute.testing import attention_ref
+from flash_attn.cute.mask_definitions import get_mask_pair, random_doc_id_tensor
 COMPUTE_CAPABILITY = torch.cuda.get_device_capability()[0]
 
 
@@ -59,33 +54,12 @@ def create_tensors(
     lse = torch.empty(batch_size, nheads, seqlen_q, device=device, dtype=torch.float32)
 
     return {
-        "q": q.contiguous(),
-        "k": k.contiguous(),
-        "v": v.contiguous(),
-        "out": out.contiguous(),
-        "lse": lse.contiguous(),
+        "q": q,
+        "k": k,
+        "v": v,
+        "out": out,
+        "lse": lse,
     }
-
-
-def compute_reference_flash_attn(tensors, causal, window_size, dtype_ref, upcast=True):
-    """Compute reference using FlashAttention's attention_ref function"""
-    q = tensors["q"].to(dtype_ref)
-    k = tensors["k"].to(dtype_ref)
-    v = tensors["v"].to(dtype_ref)
-
-    out_ref, attn_ref = attention_ref(
-        q,
-        k,
-        v,
-        query_padding_mask=None,
-        key_padding_mask=None,
-        causal=causal,
-        window_size=window_size,
-        upcast=upcast,
-        reorder_ops=False,
-    )
-
-    return out_ref
 
 
 def compute_reference_flex_attn(tensors, mask_mod_flex, block_size: Optional[tuple[int, int]] = None):
@@ -172,6 +146,7 @@ def _run_mask_test(
     tile_m,
     tile_n,
     use_block_sparsity,
+    needs_backward=False,
 ):
     torch.manual_seed(42)
 
@@ -230,7 +205,7 @@ def _run_mask_test(
         batch_size, seqlen_q, seqlen_k, nheads, nheads_kv, headdim, headdim_v, dtype
     )
 
-    # Compute block sparsity for mask_mod
+    # SM100 uses sparse_tile_m = 2*tile_m to match forward q_stage=2 pipelining
     if COMPUTE_CAPABILITY == 10:
         sparse_tile_m = 2 * tile_m
     else:
@@ -245,29 +220,35 @@ def _run_mask_test(
         device="cuda",
         BLOCK_SIZE=(sparse_tile_m, tile_n),
     )
-    _, _, mask_cnt, mask_idx, full_cnt, full_idx, *_ = bm.as_tuple()
+    (
+        _seq_q,
+        _seq_k,
+        kv_mask_cnt,
+        kv_mask_idx,
+        full_kv_cnt,
+        full_kv_idx,
+        q_mask_cnt,
+        q_mask_idx,
+        full_q_cnt,
+        full_q_idx,
+        *_,
+    ) = bm.as_tuple()
 
     softmax_scale = 1.0 / math.sqrt(headdim)
 
-    # if full_cnt is not None:
-    #     print(f"Block sparsity info for {mask_name}:")
-    #     print(f"  full_cnt shape: {full_cnt.shape}")
-    #     print(f"  full_idx shape: {full_idx.shape}")
-    #     print(f"  mask_cnt shape: {mask_cnt.shape}")
-    #     print(f"  mask_idx shape: {mask_idx.shape}")
-    #     print(f"  full_cnt: {full_cnt}")
-    #     print(f"  full_idx: {full_idx}")
-    #     print(f"  mask_cnt: {mask_cnt}")
-    #     print(f"  mask_idx: {mask_idx}")
-    #     if full_cnt[0,0,0] > 0:
-    #         print(f"  First Q block - full indices: {full_idx[0,0,0,:full_cnt[0,0,0].item()]}")
-    #     if mask_cnt[0,0,0] > 0:
-    #         print(f"  First Q block - mask indices: {mask_idx[0,0,0,:mask_cnt[0,0,0].item()]}")
-    block_sparse_mask = BlockSparseTensorsTorch(
-        mask_block_cnt=mask_cnt,
-        mask_block_idx=mask_idx,
-        full_block_cnt=full_cnt,
-        full_block_idx=full_idx,
+    block_sparse_mask_fwd = BlockSparseTensorsTorch(
+        mask_block_cnt=kv_mask_cnt,
+        mask_block_idx=kv_mask_idx,
+        full_block_cnt=full_kv_cnt,
+        full_block_idx=full_kv_idx,
+    ) if use_block_sparsity else None
+
+    # Backward uses Q-direction (transposed) sparse tensors
+    block_sparse_mask_bwd = BlockSparseTensorsTorch(
+        mask_block_cnt=q_mask_cnt,
+        mask_block_idx=q_mask_idx,
+        full_block_cnt=full_q_cnt,
+        full_block_idx=full_q_idx,
     ) if use_block_sparsity else None
 
     out_tuple = _flash_attn_fwd(
@@ -294,12 +275,13 @@ def _run_mask_test(
         _compute_capability=None,
         score_mod=None,
         mask_mod=mask_mod_cute,
-        block_sparse_tensors=block_sparse_mask,
+        block_sparse_tensors=block_sparse_mask_fwd,
         return_lse=True,
         aux_tensors=aux_tensors_arg,
     )
 
     out_cute = out_tuple[0]
+    lse_cute = out_tuple[1]
     tensors_fp32 = {
         k: v.float() if v.dtype in [torch.float16, torch.bfloat16] else v
         for k, v in tensors.items()
@@ -356,6 +338,65 @@ def _run_mask_test(
         f"Kernel error {cute_error:.2e} exceeds {rtol}x PyTorch error {pt_error:.2e} + {fwd_atol:.2e}"
     )
 
+    # Backward pass (SM100 only)
+    if needs_backward and COMPUTE_CAPABILITY == 10 and kv_mode == "mha":
+        q = tensors["q"]
+        k = tensors["k"]
+        v = tensors["v"]
+
+        # Create grad_out once and reuse
+        grad_out = torch.randn_like(out_cute)
+
+        # Create block_mask for flex reference
+        flex_block_mask = create_block_mask(
+            mask_mod_flex, batch_size, nheads, seqlen_q, seqlen_k,
+            device="cuda", BLOCK_SIZE=(tile_m, tile_n),
+        )
+
+        dq_cute, dk_cute, dv_cute = run_cute_mask_bwd(
+            q, k, v, out_cute, lse_cute, grad_out, mask_mod_cute,
+            block_sparse_mask_bwd=block_sparse_mask_bwd, tile_m=tile_m, tile_n=tile_n,
+            aux_tensors=aux_tensors_arg,
+        )
+        _, dq_ref_fp32, dk_ref_fp32, dv_ref_fp32 = run_flex_reference_bwd(
+            q, k, v, flex_block_mask, grad_out, dtype=torch.float32
+        )
+        _, dq_pt, dk_pt, dv_pt = run_flex_reference_bwd(
+            q, k, v, flex_block_mask, grad_out
+        )
+
+        # Check for invalid values
+        assert not torch.isnan(dq_cute).any(), "dQ contains NaN"
+        assert not torch.isnan(dk_cute).any(), "dK contains NaN"
+        assert not torch.isnan(dv_cute).any(), "dV contains NaN"
+
+        bwd_rtol = 2
+        bwd_atol_floor = 1e-5
+        dq_atol = max(bwd_atol_floor, 2 * (dq_ref_fp32 + 0.3 - 0.3 - dq_ref_fp32).abs().max().item())
+        dk_atol = max(bwd_atol_floor, 2 * (dk_ref_fp32 + 0.3 - 0.3 - dk_ref_fp32).abs().max().item())
+        dv_atol = max(bwd_atol_floor, 2 * (dv_ref_fp32 + 0.3 - 0.3 - dv_ref_fp32).abs().max().item())
+
+        dq_ref = dq_ref_fp32.to(dtype)
+        dk_ref = dk_ref_fp32.to(dtype)
+        dv_ref = dv_ref_fp32.to(dtype)
+
+        pt_dq_err = (dq_pt - dq_ref).abs().max().item()
+        pt_dk_err = (dk_pt - dk_ref).abs().max().item()
+        pt_dv_err = (dv_pt - dv_ref).abs().max().item()
+
+        cute_dq_err = (dq_cute - dq_ref).abs().max().item()
+        cute_dk_err = (dk_cute - dk_ref).abs().max().item()
+        cute_dv_err = (dv_cute - dv_ref).abs().max().item()
+
+        print("  Backward comparison:")
+        print(f"    dQ: PT err={pt_dq_err:.2e}, CuTE err={cute_dq_err:.2e}, atol={dq_atol:.2e}")
+        print(f"    dK: PT err={pt_dk_err:.2e}, CuTE err={cute_dk_err:.2e}, atol={dk_atol:.2e}")
+        print(f"    dV: PT err={pt_dv_err:.2e}, CuTE err={cute_dv_err:.2e}, atol={dv_atol:.2e}")
+
+        assert cute_dq_err <= bwd_rtol * pt_dq_err + dq_atol, f"dQ error too large: {cute_dq_err:.2e}"
+        assert cute_dk_err <= bwd_rtol * pt_dk_err + dk_atol, f"dK error too large: {cute_dk_err:.2e}"
+        assert cute_dv_err <= bwd_rtol * pt_dv_err + dv_atol, f"dV error too large: {cute_dv_err:.2e}"
+
 
 def test_mask_mod_ima_partial_block():
     _run_mask_test(
@@ -372,6 +413,59 @@ def test_mask_mod_ima_partial_block():
         tile_m=128,
         tile_n=128,
         use_block_sparsity=True,
+        needs_backward=True,
+    )
+
+
+# Q boundary seqlens: NOT multiples of tile_m (128)
+# These exercise the fix for is_full_block tiles not masking OOB Q rows in backward
+Q_BOUNDARY_SEQLEN_PAIRS = [
+    (200, 200),    # Last m_block: rows 128-199 valid, 200-255 should be masked
+    (300, 300),    # Last m_block: rows 256-299 valid, 300-383 should be masked
+    (129, 129),    # Just 1 element into second tile
+    (255, 255),    # Just 1 element short of 2 full tiles
+    (500, 512),    # Q boundary only (K aligned)
+    (512, 500),    # K boundary only (Q aligned)
+    (333, 444),    # Both non-aligned
+]
+
+
+@pytest.mark.parametrize("seqlen_q,seqlen_k", Q_BOUNDARY_SEQLEN_PAIRS)
+@pytest.mark.parametrize("mask_name", ["block_diagonal", "document"])
+def test_q_boundary_masking_block_sparse_bwd(seqlen_q, seqlen_k, mask_name):
+    """Test Q boundary masking for block-sparse backward pass.
+    
+    This test specifically exercises the fix for the bug where Q rows beyond seqlen_q
+    were not masked in backward pass for is_full_block=True tiles.
+    
+    The bug occurred because:
+    - In forward, apply_mask_sm100 always checks both Q and K bounds
+    - In backward, apply_mask_sm100_transposed with is_full_block=True only checked K bounds
+    - Result: partial last m_blocks had unmasked garbage Q rows contributing to gradients
+    
+    Key conditions:
+    - seqlen_q NOT a multiple of tile_m (128): creates partial last m_block
+    - Block-sparse with mask_mod: exercises is_full_block=True path
+    - Backward pass: where the bug manifested
+    """
+    if COMPUTE_CAPABILITY != 10:
+        pytest.skip("SM100-only backward test")
+    
+    _run_mask_test(
+        seqlen_q=seqlen_q,
+        seqlen_k=seqlen_k,
+        nheads=4,
+        kv_mode="mha",
+        headdim=128,
+        dtype=torch.bfloat16,
+        mask_name=mask_name,
+        window_size=None,
+        window_left=None,
+        window_right=None,
+        tile_m=128,
+        tile_n=128,
+        use_block_sparsity=True,
+        needs_backward=True,
     )
 
 
@@ -412,6 +506,7 @@ def test_static_masks(
         tile_m=tile_m,
         tile_n=tile_n,
         use_block_sparsity=use_block_sparsity,
+        needs_backward=True,
     )
 
 
@@ -462,6 +557,7 @@ def test_parameterized_masks(
         tile_m=tile_m,
         tile_n=tile_n,
         use_block_sparsity=use_block_sparsity,
+        needs_backward=True,
     )
 
 
@@ -510,6 +606,83 @@ def test_sm100_block_sparse_sink_all_masked():
     assert torch.allclose(lse, expected, atol=0.0, rtol=0.0)
 
 
+# =============================================================================
+# Backward Helper Functions
+# =============================================================================
+
+def run_cute_mask_bwd(
+    q, k, v, out, lse, grad_out, mask_mod_cute,
+    block_sparse_mask_bwd=None, tile_m=128, tile_n=128,
+    aux_tensors=None,
+):
+    """Run flash attention backward with mask_mod.
+
+    Args:
+        q, k, v: Input tensors in BSHD format
+        out: Forward output tensor
+        lse: Log-sum-exp from forward pass
+        grad_out: Gradient of output
+        mask_mod_cute: CuTE mask modification function
+        block_sparse_mask_bwd: Block sparse tensors for backward pass
+        tile_m, tile_n: Tile sizes
+        aux_tensors: Auxiliary tensors for mask_mod (e.g., doc_ids for document masking)
+
+    Returns (dq, dk, dv) all in BSHD format.
+    """
+    dq, dk, dv = _flash_attn_bwd(
+        q=q,
+        k=k,
+        v=v,
+        out=out,
+        dout=grad_out,
+        lse=lse,
+        causal=False,
+        m_block_size=tile_m,
+        n_block_size=tile_n,
+        mask_mod=mask_mod_cute,
+        block_sparse_tensors=block_sparse_mask_bwd,
+        aux_tensors=aux_tensors,
+    )
+
+    return dq, dk, dv
+
+
+def run_flex_reference_bwd(q, k, v, block_mask, grad_out, dtype=None):
+    """Run flex_attention forward + backward for reference.
+
+    Args:
+        q, k, v: Input tensors in BSHD format
+        block_mask: Pre-created block mask for flex_attention
+        grad_out: Gradient of output in BSHD format
+        dtype: Optional dtype to cast inputs to (e.g., torch.float32 for reference)
+
+    Returns (out, dq, dk, dv) all in BSHD format.
+    """
+    # Transpose to BHSD for flex_attention
+    if dtype is not None:
+        q_ref = q.transpose(1, 2).to(dtype).requires_grad_(True)
+        k_ref = k.transpose(1, 2).to(dtype).requires_grad_(True)
+        v_ref = v.transpose(1, 2).to(dtype).requires_grad_(True)
+        grad_out_ref = grad_out.transpose(1, 2).to(dtype)
+    else:
+        q_ref = q.transpose(1, 2).requires_grad_(True)
+        k_ref = k.transpose(1, 2).requires_grad_(True)
+        v_ref = v.transpose(1, 2).requires_grad_(True)
+        grad_out_ref = grad_out.transpose(1, 2)
+
+    # Use flex_attention directly without torch.compile for backward tests
+    # torch.compile can hang on certain mask patterns (e.g., mini_causal with float32)
+    out_ref = flex_attention(q_ref, k_ref, v_ref, block_mask=block_mask)
+    dq_ref, dk_ref, dv_ref = torch.autograd.grad(out_ref, (q_ref, k_ref, v_ref), grad_out_ref)
+
+    # Transpose back to BSHD
+    return (
+        out_ref.transpose(1, 2),
+        dq_ref.transpose(1, 2),
+        dk_ref.transpose(1, 2),
+        dv_ref.transpose(1, 2),
+    )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v", "-s"])
-    


### PR DESCRIPTION
# Summary

Some design decisions;
* Due to softmax pipelining in the fwd we are using a block_sparse size of 2 * tile_m and by default (at least in flex in core) we produce the bwds sparse info based off of the forward info. I added subtiling with a default of 2. So that we iterate 2 for all loaded q_indices. This can be loosened / inferred from input data and aligned w/ the triton impl so that we basically just assert sparse_q > tile_m and sparse_q%tile_m == 0 and have arbitrary subtile factor

The rest of it is basically replay of what we did in the fwd. I didnt totally extract out the compute iteration order because its a lil more mixed. And instead inlined into compute and store warps. Could refactor and think harder if needed


### Perf
<img width="12499" height="5995" alt="combined_comparison_bwd" src="https://github.com/user-attachments/assets/88fa2c20-370b-489f-8df1-ebe777adf2c9" />
swa size of 2048

Perf is really good, one note is that this is comparing flash (5 dot) vs triton (7 dot) and using the 2.5 multiplier in the bwd so a little unfair but still. 

My measuring stick has been to compare causal masking implemented w/  `causal = true` vs blocksparse data. The drop from sparse iteration is much smaller than what we see in the fwd (need to take another look at the fwd)



PT changes: https://github.com/pytorch/pytorch/pull/170611