### PR TITLE
Fix IMA in fwd on m boundary

### DIFF
--- a/flash_attn/cute/block_sparse_utils.py
+++ b/flash_attn/cute/block_sparse_utils.py
@@ -717,6 +717,7 @@ def softmax_block_sparse_sm100(
     mbar_P_full_2_offset: Int32,
     q_stage: cutlass.Constexpr,
     stage_idx: Int32,
+    check_m_boundary: bool = False,
 ):
     mask_block_cnt, mask_block_idx, full_block_cnt, full_block_idx = blocksparse_tensors
 
@@ -750,7 +751,7 @@ def softmax_block_sparse_sm100(
                 s0_s1_sequence_phase,
                 mask_n_block,
                 is_first=True,
-                mask_fn=partial(mask_fn, mask_seqlen=True),  # last block could oob
+                mask_fn=partial(mask_fn, mask_seqlen=True, check_q_boundary=check_m_boundary),
             )
             for i in cutlass.range(1, curr_mask_block_cnt):
                 mask_n_block = curr_mask_block_idx[curr_mask_block_cnt - 1 - i]
@@ -763,7 +764,7 @@ def softmax_block_sparse_sm100(
                     si_corr_producer_phase,
                     s0_s1_sequence_phase,
                     mask_n_block,
-                    mask_fn=partial(mask_fn, mask_seqlen=False),
+                    mask_fn=partial(mask_fn, mask_seqlen=False, check_q_boundary=check_m_boundary),
                 )
 
         if curr_full_block_cnt > 0:
@@ -779,7 +780,9 @@ def softmax_block_sparse_sm100(
                     s0_s1_sequence_phase,
                     full_n_block,
                     is_first=True,
-                    mask_fn=partial(mask_fn_none, mask_seqlen=True),
+                    mask_fn=partial(
+                        mask_fn_none, mask_seqlen=True, check_q_boundary=check_m_boundary
+                    ),
                 )
             else:
                 (
@@ -792,7 +795,9 @@ def softmax_block_sparse_sm100(
                     s0_s1_sequence_phase,
                     full_n_block,
                     is_first=False,
-                    mask_fn=partial(mask_fn_none, mask_seqlen=False),
+                    mask_fn=partial(
+                        mask_fn_none, mask_seqlen=False, check_q_boundary=check_m_boundary
+                    ),
                 )
             for i in cutlass.range(1, curr_full_block_cnt):
                 full_n_block = curr_full_block_idx[curr_full_block_cnt - 1 - i]
@@ -805,7 +810,9 @@ def softmax_block_sparse_sm100(
                     si_corr_producer_phase,
                     s0_s1_sequence_phase,
                     full_n_block,
-                    mask_fn=partial(mask_fn_none, mask_seqlen=False),
+                    mask_fn=partial(
+                        mask_fn_none, mask_seqlen=False, check_q_boundary=check_m_boundary
+                    ),
                 )
 
     return (

--- a/flash_attn/cute/block_sparse_utils.py
+++ b/flash_attn/cute/block_sparse_utils.py
@@ -846,24 +846,12 @@ def get_total_q_block_count_bwd(
     subtile_factor: cutlass.Constexpr = 1,
     m_block_max: int = 0,
 ):
-    """Count total tile iterations for given n_block (KV tile) in backward.
-
-    Args:
-        m_block_max: Maximum m_block index from causal/local masking constraints.
-            Computed by block_info.get_m_block_min_max() based on sequence lengths
-            and attention mask type. When > 0, caps the result to ensure we don't
-            count sparse blocks that fall outside the valid causal/local window.
-
-    Returns min(sparse_block_count * subtile_factor, m_block_max) when m_block_max > 0.
-    """
-    q_block_cnt, _, full_q_block_cnt, _ = blocksparse_tensors
+    """Count total tile iterations for given n_block (KV tile) in backward."""
+    q_block_cnt, _, full_block_cnt, _ = blocksparse_tensors
     total = q_block_cnt[batch_idx, head_idx, n_block]
-    if const_expr(full_q_block_cnt is not None):
-        total = total + full_q_block_cnt[batch_idx, head_idx, n_block]
-    result = total * subtile_factor
-    if m_block_max > 0:
-        result = cutlass.min(result, m_block_max)
-    return result
+    if const_expr(full_block_cnt is not None):
+        total = total + full_block_cnt[batch_idx, head_idx, n_block]
+    return total * subtile_factor
 
 
 @cute.jit
@@ -924,19 +912,23 @@ def produce_block_sparse_q_loads_bwd_sm100(
             curr_full_cnt,
             curr_full_idx,
             subtile_factor,
+            m_block_max,
         )
+        m_block_safe = m_block
+        if m_block_max > 0:
+            m_block_safe = cutlass.min(m_block, m_block_max - 1)
 
         if iter_idx == 0:
             # First block: load K/V alongside Q/dO
             if const_expr(should_load_Q):
                 pipeline_Q.producer_acquire(producer_state_Q_LSE, extra_tx_count=tma_copy_bytes_K)
                 load_K(tma_bar_ptr=pipeline_Q.producer_get_barrier(producer_state_Q_LSE))
-                load_Q(m_block, producer_state=producer_state_Q_LSE)
+                load_Q(m_block_safe, producer_state=producer_state_Q_LSE)
                 pipeline_Q.producer_commit(producer_state_Q_LSE)
                 pipeline_LSE.producer_acquire(producer_state_Q_LSE)
                 with cute.arch.elect_one():
                     copy_stats(
-                        gLSE[None, m_block],
+                        gLSE[None, m_block_safe],
                         sLSE[None, producer_state_Q_LSE.index],
                         mbar_ptr=pipeline_LSE.producer_get_barrier(producer_state_Q_LSE),
                     )
@@ -946,12 +938,12 @@ def produce_block_sparse_q_loads_bwd_sm100(
                     producer_state_dO_dPsum, extra_tx_count=tma_copy_bytes_V
                 )
                 load_V(tma_bar_ptr=pipeline_dO.producer_get_barrier(producer_state_dO_dPsum))
-                load_dO(m_block, producer_state=producer_state_dO_dPsum)
+                load_dO(m_block_safe, producer_state=producer_state_dO_dPsum)
                 pipeline_dO.producer_commit(producer_state_dO_dPsum)
                 pipeline_dPsum.producer_acquire(producer_state_dO_dPsum)
                 with cute.arch.elect_one():
                     copy_stats(
-                        gdPsum[None, m_block],
+                        gdPsum[None, m_block_safe],
                         sdPsum[None, producer_state_dO_dPsum.index],
                         mbar_ptr=pipeline_dPsum.producer_get_barrier(producer_state_dO_dPsum),
                     )
@@ -960,24 +952,24 @@ def produce_block_sparse_q_loads_bwd_sm100(
             # Subsequent blocks: just load Q/dO (K/V already loaded)
             if const_expr(should_load_Q):
                 pipeline_Q.producer_acquire(producer_state_Q_LSE)
-                load_Q(m_block, producer_state=producer_state_Q_LSE)
+                load_Q(m_block_safe, producer_state=producer_state_Q_LSE)
                 pipeline_Q.producer_commit(producer_state_Q_LSE)
                 pipeline_LSE.producer_acquire(producer_state_Q_LSE)
                 with cute.arch.elect_one():
                     copy_stats(
-                        gLSE[None, m_block],
+                        gLSE[None, m_block_safe],
                         sLSE[None, producer_state_Q_LSE.index],
                         mbar_ptr=pipeline_LSE.producer_get_barrier(producer_state_Q_LSE),
                     )
                 producer_state_Q_LSE.advance()
             if const_expr(should_load_dO):
                 pipeline_dO.producer_acquire(producer_state_dO_dPsum)
-                load_dO(m_block, producer_state=producer_state_dO_dPsum)
+                load_dO(m_block_safe, producer_state=producer_state_dO_dPsum)
                 pipeline_dO.producer_commit(producer_state_dO_dPsum)
                 pipeline_dPsum.producer_acquire(producer_state_dO_dPsum)
                 with cute.arch.elect_one():
                     copy_stats(
-                        gdPsum[None, m_block],
+                        gdPsum[None, m_block_safe],
                         sdPsum[None, producer_state_dO_dPsum.index],
                         mbar_ptr=pipeline_dPsum.producer_get_barrier(producer_state_dO_dPsum),
                     )
@@ -997,13 +989,6 @@ def get_block_sparse_iteration_info_bwd(
 ):
     """Extract block-sparse iteration info for backward pass.
 
-    Args:
-        m_block_max: Maximum m_block index from causal/local masking constraints.
-            Computed by block_info.get_m_block_min_max() based on sequence lengths
-            and attention mask type. When > 0, caps total_count to ensure we don't
-            process sparse blocks that fall outside the valid causal/local window.
-            This combines block sparsity with causal/local masking.
-
     Returns (curr_q_cnt, curr_q_idx, curr_full_cnt, curr_full_idx, total_count).
     """
     q_cnt, q_idx, full_cnt, full_idx = blocksparse_tensors
@@ -1020,10 +1005,7 @@ def get_block_sparse_iteration_info_bwd(
     sparse_block_count = curr_q_cnt
     if const_expr(full_cnt is not None):
         sparse_block_count = sparse_block_count + curr_full_cnt
-
     total_count = sparse_block_count * subtile_factor
-    if m_block_max > 0:
-        total_count = cutlass.min(total_count, m_block_max)
 
     return curr_q_cnt, curr_q_idx, curr_full_cnt, curr_full_idx, total_count
 
@@ -1036,39 +1018,26 @@ def get_m_block_from_iter_bwd(
     curr_full_cnt,
     curr_full_idx: Optional[cute.Tensor],
     subtile_factor: cutlass.Constexpr = 1,
+    m_block_max: int = 0,
 ):
     """Derive m_block index and is_full_block flag from iteration index.
 
-    In backward, we iterate in FORWARD order: masked blocks first (low to high),
-    then full blocks (low to high). This ensures that when loop_count is capped
-    to m_block_max, we skip the high (potentially out-of-bounds) m_blocks at the
-    end of iteration rather than in the middle.
-
-    With subtiling (subtile_factor > 1):
-    - sparse_iter_idx = iter_idx // subtile_factor (which sparse block)
-    - subtile_offset = iter_idx % subtile_factor (which subtile within sparse block)
-    - m_block = sparse_m_block * subtile_factor + subtile_offset
-
     Returns (m_block, is_full_block):
-        - m_block: The actual Q-tile block index (after subtiling)
+        - m_block: The actual Q-tile block index
         - is_full_block: True if this is a full block (no mask_mod needed)
-          Note: All subtiles within a sparse block share the same is_full_block status
     """
     sparse_iter_idx = iter_idx // subtile_factor
     subtile_offset = iter_idx % subtile_factor
 
     sparse_m_block = Int32(0)
     is_full_block = False
-
-    # Forward order: process low sparse block indices first
-    if sparse_iter_idx < curr_q_cnt:
-        sparse_m_block = curr_q_idx[sparse_iter_idx]
-        is_full_block = False
+    if const_expr(curr_full_idx is not None):
+        if sparse_iter_idx < curr_q_cnt:
+            sparse_m_block = curr_q_idx[sparse_iter_idx]
+        else:
+            sparse_m_block = curr_full_idx[sparse_iter_idx - curr_q_cnt]
+            is_full_block = True
     else:
-        full_iter = sparse_iter_idx - curr_q_cnt
-        sparse_m_block = curr_full_idx[full_iter]
-        is_full_block = True
+        sparse_m_block = curr_q_idx[sparse_iter_idx]
 
-    m_block = sparse_m_block * subtile_factor + subtile_offset
-
-    return m_block, is_full_block
+    return sparse_m_block * subtile_factor + subtile_offset, is_full_block

--- a/flash_attn/cute/mask.py
+++ b/flash_attn/cute/mask.py
@@ -313,6 +313,7 @@ class AttentionMask:
         head_idx: Int32 = None,
         aux_tensors: Optional[list] = None,
         fastdiv_mods=(None, None),
+        check_q_boundary: bool = False,
     ) -> None:
         assert not (mask_causal and mask_local), "mask_causal and mask_local cannot be both True"
         acc_shape = (self.tile_m, self.tile_n)
@@ -338,14 +339,11 @@ class AttentionMask:
                     mask_r2p(acc_S, seqlenk_col_limit, arch=100, rank1=True)
 
         elif const_expr(not mask_causal and not mask_local and mask_mod is not None):
-            # Block sparse case w/ mask_mod
+            # Block sparse w/ mask_mod
             has_fastdiv = const_expr(
                 fastdiv_mods is not None
                 and fastdiv_mods[0] is not None
                 and fastdiv_mods[1] is not None
-            )
-            wrap_aux_indices = const_expr(
-                has_fastdiv and mask_seqlen and const_expr(aux_tensors is not None)
             )
             batch_idx_ssa = utils.scalar_to_ssa(batch_idx, cutlass.Int32)
             head_idx_ssa = utils.scalar_to_ssa(head_idx, cutlass.Int32)
@@ -356,8 +354,9 @@ class AttentionMask:
             else:
                 mask_row = global_row
             mask_row_for_mod = mask_row
-            if const_expr(wrap_aux_indices):
-                _, mask_row_for_mod = divmod(mask_row, fastdiv_mods[0])
+            if const_expr(has_fastdiv and aux_tensors is not None):
+                if check_q_boundary:
+                    _, mask_row_for_mod = divmod(mask_row, fastdiv_mods[0])
             mask_row_ssa = utils.scalar_to_ssa(mask_row_for_mod, cutlass.Int32)
 
             ncol = const_expr(cute.size(tScS_t2r.shape))
@@ -365,7 +364,7 @@ class AttentionMask:
                 col_coord = tScS_t2r[i][1] if not self.swap_AB else tScS_t2r[i][0]
                 global_col = col_coord + n_block * self.tile_n
                 global_col_for_mod = global_col
-                if const_expr(wrap_aux_indices):
+                if const_expr(has_fastdiv and mask_seqlen and aux_tensors is not None):
                     _, global_col_for_mod = divmod(global_col, fastdiv_mods[1])
                 kv_idx_ssa = utils.scalar_to_ssa(global_col_for_mod, cutlass.Int32)
                 mask_value = mask_mod(
@@ -378,8 +377,9 @@ class AttentionMask:
                 cond = cutlass.Boolean(utils.ssa_to_scalar(mask_value))
                 acc_S[i] = acc_S[i] if cond else -Float32.inf
                 if const_expr(mask_seqlen):
-                    out_of_bounds = (global_row >= self.seqlen_q) or (global_col >= self.seqlen_k)
-                    acc_S[i] = -Float32.inf if out_of_bounds else acc_S[i]
+                    acc_S[i] = -Float32.inf if global_col >= self.seqlen_k else acc_S[i]
+                if check_q_boundary:
+                    acc_S[i] = -Float32.inf if global_row >= self.seqlen_q else acc_S[i]
 
         else:  # Causal or local
             causal_row_offset = 1 + self.seqlen_k - n_block * self.tile_n - self.seqlen_q


### PR DESCRIPTION
# Summary

We would use mask_seqlen to Gate whether or not we would do the aux wrapping. This good for first iteration for wrapping on K but doesnt account for m boundary

no real hit to perf on big shapes
<img width="12499" height="5995" alt="image" src="https://github.com/user-attachments/assets/28137cb4-09f3-4f6a-b5e9-b4a28006ffc4" />


## Testing
`sanitize pytest tests/cute/test_mask_mod.py -k " test_q_boundary_masking_block_sparse_bwd[document-333-444] " `


The top commit in this PR also fixes an error mode we had where the way we were clamping to max-seqlen would cause us to to not iterate over valid full blocks. And fixes that. 

## Updated we good:
delay masking S so that DCE can kick :)
<img width="12499" height="5995" alt="image" src="https://github.com/user-attachments/assets/b6550e6d-b024-4e92-86e3-2d460c7b79a8" />


<img width="593" height="130" alt="image" src="https://github.com/user-attachments/assets/90288fb5-f116-4a6f-bce5-a1b53369b0a4" />



### Stale

I did a perf compare:
<img width="12499" height="5995" alt="image" src="https://github.com/user-attachments/assets/e80f0018-88cc-4314-9113-bc1567782443" />


it basically within noise of the previous iter, 
however for Alibi we are taking a big hit and thats the only one that has a score_mod + casusal

<img width="622" height="159" alt="image" src="https://github.com/user-attachments/assets/94dea341-904f-414f-aa8d-2ce4b1d13a69" />


we are basically spilling 10x more and Im not really sure what about this code caused the change just yet..