### PR TITLE
[Cute] Fix shuffle sync and enable pack gqa for varlen sm100

### DIFF
--- a/flash_attn/cute/flash_fwd_sm100.py
+++ b/flash_attn/cute/flash_fwd_sm100.py
@@ -2394,8 +2394,6 @@ class FlashAttentionForwardSm100:
             tOcO = gmem_thr_copy_O.partition_S(cO)
             t0OcO = gmem_tiled_copy_O.get_slice(0).partition_S(cO)
             tOpO = utils.predicate_k(tOcO, limit=mO_cur.shape[1])
-            # TODO: the packgqa case isn't correct rn (sometimes IMA), disabling it
-            assert not self.pack_gqa
             pack_gqa = PackGQA(
                 self.m_block_size,
                 self.head_dim_v_padded,
@@ -2488,8 +2486,6 @@ class FlashAttentionForwardSm100:
                     tOcO = gmem_thr_copy_O.partition_S(cO)
                     t0OcO = gmem_tiled_copy_O.get_slice(0).partition_S(cO)
                     tOpO = utils.predicate_k(tOcO, limit=mO.shape[1])
-                    # TODO: the packgqa case isn't correct rn (sometimes IMA), disabling it
-                    assert not self.pack_gqa
                     pack_gqa = PackGQA(
                         self.m_block_size,
                         self.head_dim_v_padded,

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -276,11 +276,9 @@ def _flash_attn_fwd(
             n_block_size = 192
 
     if compute_capability == 10:
-        # TODO: fix the varlen case
         if (
             pack_gqa
             and (128 % qhead_per_kvhead != 0)
-            or (cu_seqlens_q is not None or seqused_q is not None)
         ):
             pack_gqa = False
         # TODO: fix GQA + SplitKV + non-varlen

--- a/flash_attn/cute/utils.py
+++ b/flash_attn/cute/utils.py
@@ -527,7 +527,8 @@ def shuffle_sync(
     mask = cute.arch.WARP_SIZE - width
     clamp = cute.arch.WARP_SIZE - 1
     mask_and_clamp = mask << 8 | clamp
-    val = cute.make_fragment(1, type(value))
+    # important: need stride 1 and not 0 for recast_tensor to work
+    val = cute.make_rmem_tensor(cute.make_layout((1, ), stride=(1, )), type(value))
     val[0] = value
     val_i32 = cute.recast_tensor(val, cutlass.Int32)
     for i in cutlass.range_constexpr(cute.size(val_i32)):

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -233,9 +233,9 @@ def test_flash_attn_output(
         print(f"Pytorch max diff: {(out_pt - out_ref).abs().max().item()}")
         print(f"Pytorch mean diff: {(out_pt - out_ref).abs().mean().item()}")
         # num_splits_vals = [1, 3]
-        # pack_gqa_vals = [False, True, None]
+        pack_gqa_vals = [False, True, None]
         # SplitKV is not supported for hdim >= 192
-        pack_gqa_vals = [False]
+        # pack_gqa_vals = [False]
         num_splits_vals = [1, 3] if d < 192 and not DISABLE_SPLIT and not TEST_BWD_ONLY else [1]
         for pack_gqa, num_splits in itertools.product(pack_gqa_vals, num_splits_vals):
             out, lse = flash_attn_func(
@@ -600,8 +600,8 @@ def test_flash_attn_varlen_output(
         fwd_atol = 2 * (out_ref + 0.3 - 0.3 - out_ref).abs().max().item()
         rtol = 2 if softcap == 0.0 else 3
 
-        # pack_gqa_vals = [False, True, None]
-        pack_gqa_vals = [False]
+        pack_gqa_vals = [False, True, None]
+        # pack_gqa_vals = [False]
         # num_splits_vals = [1, 3]
         # SplitKV is not supported for hdim >= 192
         num_splits_vals = [1, 3] if d < 192 and not DISABLE_SPLIT else [1]


### PR DESCRIPTION
This PR fixes the layout for the value tensor used in `shuffle_sync` to make it compatible with `recast_tensor`. The problem was that `recast_tensor` for i64 -> i32 wasn't expanding stride 0 modes, for example with `val = cute.make_fragment(1, type(value))` we had
```
val_i64 =  tensor<ptr<i64, rmem, align<32>> o 1:0>
val_i32 =  tensor<ptr<i32, rmem, align<32>> o 1:0>
```
This caused IMA when computing pointer addresses using shuffle sync (like we were doing in the pack gqa epilogue with varlen) since we were never shuffling the high 32 bits of the 64 bit addresses. If we change layout to (1):(1) we correctly expand
```
val i64 =  tensor<ptr<i64, rmem, align<32>> o (1):(1)>
val i32 =  tensor<ptr<i32, rmem, align<32>> o (2):(1)>
```
which fixes the problem. We therefore also enable pack gqa with varlen for this PR.