### PR TITLE
[Fix typos] remove redundant double semicolons

### DIFF
--- a/csrc/layer_norm/ln_utils.cuh
+++ b/csrc/layer_norm/ln_utils.cuh
@@ -706,7 +706,7 @@ struct Stats<T, 1, WARPS_M, WARPS_N> {
         }
         __syncthreads();
 
-        int n = 0;;
+        int n = 0;
         T m = Zeros<T>::get();
         T m2 = Zeros<T>::get();
 

--- a/hopper/mainloop_fwd_sm80.hpp
+++ b/hopper/mainloop_fwd_sm80.hpp
@@ -35,7 +35,7 @@ struct CollectiveMainloopFwdSm80 {
     using Element = Element_;
     using ElementAccum = ElementAccum_;
     using ArchTag = ArchTag_;
-    static constexpr bool Is_FP8 = cute::is_same_v<Element, cutlass::float_e4m3_t> || cute::is_same_v<Element, cutlass::float_e5m2_t>;;
+    static constexpr bool Is_FP8 = cute::is_same_v<Element, cutlass::float_e4m3_t> || cute::is_same_v<Element, cutlass::float_e5m2_t>;
     static constexpr bool Is_causal = Is_causal_;
     static constexpr bool Is_local = Is_local_;
     static constexpr bool Has_softcap = Has_softcap_;

--- a/hopper/mainloop_fwd_sm90_tma_gmma_ws.hpp
+++ b/hopper/mainloop_fwd_sm90_tma_gmma_ws.hpp
@@ -41,7 +41,7 @@ struct CollectiveMainloopFwdSm90 {
     using Element = Element_;
     using ElementAccum = ElementAccum_;
     using ArchTag = ArchTag_;
-    static constexpr bool Is_FP8 = cute::is_same_v<Element, cutlass::float_e4m3_t> || cute::is_same_v<Element, cutlass::float_e5m2_t>;;
+    static constexpr bool Is_FP8 = cute::is_same_v<Element, cutlass::float_e4m3_t> || cute::is_same_v<Element, cutlass::float_e5m2_t>;
     static constexpr bool Is_causal = Is_causal_;
     static constexpr bool Is_local = Is_local_;
     static constexpr bool Has_softcap = Has_softcap_;

--- a/hopper/rotary.h
+++ b/hopper/rotary.h
@@ -207,7 +207,7 @@ struct Rotary {
                 }
             }
         }
-        return cute::make_tuple(tRrCos, tRrSin);;
+        return cute::make_tuple(tRrCos, tRrSin);
     }
 
     template <bool kInterleaved=true>


### PR DESCRIPTION
This commit removes redundant double semicolons (;;) found in several files to improve code style. These changes are cosmetic and do not affect functionality.

Affected files:
- hopper/mainloop_fwd_sm90_tma_gmma_ws.hpp
- hopper/mainloop_fwd_sm80.hpp
- hopper/rotary.h
- csrc/layer_norm/ln_utils.cuh