### PR TITLE
[ROCM] Fix AMD Triton backend crash when dropout != 0 and return_attn_probs = False

### DIFF
--- a/flash_attn/flash_attn_triton_amd/fwd_prefill.py
+++ b/flash_attn/flash_attn_triton_amd/fwd_prefill.py
@@ -119,9 +119,10 @@ def _attn_fwd_inner(acc, l_i, m_i, q, k_ptrs, v_ptrs, bias_ptrs, stride_kn, stri
                 if tl_DROPOUT_DUMP:
                     tl.store(dropout_mask_ptrs, dropout_mask, mask=p_mask)
 
-            # return scores with negative values for dropped vals
-            sd_mask = tl.where(dropout_mask, p, -p)
-            tl.store(sd_mask_ptrs, sd_mask, mask=p_mask)
+            if RETURN_SCORES:
+                # return scores with negative values for dropped vals
+                sd_mask = tl.where(dropout_mask, p, -p)
+                tl.store(sd_mask_ptrs, sd_mask, mask=p_mask)
 
             # apply dropout mask in place
             p = tl.where(dropout_mask, p, 0.0)


### PR DESCRIPTION

Fix https://github.com/ROCm/flash-attention/issues/167