### PR TITLE
score-mod backward SM90

### DIFF
--- a/flash_attn/cute/block_sparsity.py
+++ b/flash_attn/cute/block_sparsity.py
@@ -2,7 +2,7 @@
 Block-sparsity utilities for FlexAttention
 """
 
-from typing import NamedTuple, Optional, Tuple
+from typing import Callable, NamedTuple, Tuple
 
 import cutlass.cute as cute
 import torch
@@ -17,8 +17,8 @@ def ceildiv(a: int, b: int) -> int:
 class BlockSparseTensors(NamedTuple):
     mask_block_cnt: cute.Tensor
     mask_block_idx: cute.Tensor
-    full_block_cnt: Optional[cute.Tensor]
-    full_block_idx: Optional[cute.Tensor]
+    full_block_cnt: cute.Tensor | None
+    full_block_idx: cute.Tensor | None
 
     def __new_from_mlir_values__(self, values):
         if len(values) == 2:
@@ -29,14 +29,16 @@ class BlockSparseTensors(NamedTuple):
 class BlockSparseTensorsTorch(NamedTuple):
     mask_block_cnt: torch.Tensor
     mask_block_idx: torch.Tensor
-    full_block_cnt: Optional[torch.Tensor] = None
-    full_block_idx: Optional[torch.Tensor] = None
+    full_block_cnt: torch.Tensor | None = None
+    full_block_idx: torch.Tensor | None = None
 
 
 def _expand_sparsity_tensor(
     tensor: torch.Tensor,
     expected_shape: Tuple[int, ...],
     tensor_name: str,
+    context: str | None,
+    hint: str | Callable[[], str] | None,
 ) -> torch.Tensor:
     """Check if we need to expand the tensor to expected shape, and do so if possible."""
     needs_expand = tensor.shape != expected_shape
@@ -44,19 +46,25 @@ def _expand_sparsity_tensor(
         return tensor
     can_expand = all(map(lambda cur, tgt: cur == tgt or cur == 1, tensor.shape, expected_shape))
     if not can_expand:
+        context_clause = f" ({context})" if context else ""
+        resolved_hint = hint() if callable(hint) else hint
+        hint_clause = f" Hint: {resolved_hint}" if resolved_hint else ""
         raise ValueError(
-            f"{tensor_name} with shape {tensor.shape} cannot be expanded to expected shape {expected_shape}."
+            f"{tensor_name}{context_clause} with shape {tensor.shape} cannot be expanded to expected shape {expected_shape}."
+            f"{hint_clause}"
         )
     return tensor.expand(*expected_shape).contiguous()
 
 
 def _check_and_expand_block(
     name: str,
-    cnt: Optional[torch.Tensor],
-    idx: Optional[torch.Tensor],
+    cnt: torch.Tensor | None,
+    idx: torch.Tensor | None,
     expected_count_shape: Tuple[int, int, int],
     expected_index_shape: Tuple[int, int, int, int],
-) -> Tuple[Optional[torch.Tensor], Optional[torch.Tensor]]:
+    context: str | None,
+    hint: str | Callable[[], str] | None,
+) -> Tuple[torch.Tensor | None, torch.Tensor | None]:
     if (cnt is None) != (idx is None):
         raise ValueError(
             f"{name}_block_cnt and {name}_block_idx must both be provided or both be None"
@@ -69,8 +77,12 @@ def _check_and_expand_block(
         raise ValueError(f"{name}_block_cnt and {name}_block_idx must be on the same device")
     if not cnt.is_cuda or not idx.is_cuda:
         raise ValueError(f"{name}_block tensors must live on CUDA")
-    expanded_cnt = _expand_sparsity_tensor(cnt, expected_count_shape, f"{name}_block_cnt")
-    expanded_idx = _expand_sparsity_tensor(idx, expected_index_shape, f"{name}_block_idx")
+    expanded_cnt = _expand_sparsity_tensor(
+        cnt, expected_count_shape, f"{name}_block_cnt", context, hint
+    )
+    expanded_idx = _expand_sparsity_tensor(
+        idx, expected_index_shape, f"{name}_block_idx", context, hint
+    )
     return expanded_cnt, expanded_idx
 
 
@@ -120,6 +132,8 @@ def normalize_block_sparse_tensors(
     *,
     expected_count_shape: Tuple[int, int, int],
     expected_index_shape: Tuple[int, int, int, int],
+    context: str | None = None,
+    hint: str | Callable[[], str] | None = None,
 ) -> BlockSparseTensorsTorch:
     if tensors.mask_block_cnt is None or tensors.mask_block_idx is None:
         raise ValueError("mask_block_cnt and mask_block_idx must be provided for block sparsity.")
@@ -130,6 +144,8 @@ def normalize_block_sparse_tensors(
         tensors.mask_block_idx,
         expected_count_shape,
         expected_index_shape,
+        context,
+        hint,
     )
     if mask_cnt is None or mask_idx is None:
         raise ValueError("mask_block_cnt and mask_block_idx must be provided for block sparsity.")
@@ -140,6 +156,8 @@ def normalize_block_sparse_tensors(
         tensors.full_block_idx,
         expected_count_shape,
         expected_index_shape,
+        context,
+        hint,
     )
     if full_cnt is not None and mask_cnt.device != full_cnt.device:
         raise ValueError("All block sparse tensors must be on the same device")
@@ -158,7 +176,7 @@ def is_block_sparsity_enabled(tensors: BlockSparseTensorsTorch) -> bool:
 
 def to_cute_block_sparse_tensors(
     tensors: BlockSparseTensorsTorch, enable_tvm_ffi: bool = True
-) -> Optional[BlockSparseTensors]:
+) -> BlockSparseTensors | None:
     """Convert torch block sparsity tensors to CuTe tensors, optionally for tvm ffi"""
     if not is_block_sparsity_enabled(tensors):
         return None

--- a/tests/cute/test_mask_mod.py
+++ b/tests/cute/test_mask_mod.py
@@ -13,7 +13,6 @@
 #   pytest test_mask_mod.py                            # Run all tests
 
 import math
-from typing import Optional
 
 import pytest
 import torch
@@ -62,7 +61,7 @@ def create_tensors(
     }
 
 
-def compute_reference_flex_attn(tensors, mask_mod_flex, block_size: Optional[tuple[int, int]] = None):
+def compute_reference_flex_attn(tensors, mask_mod_flex, block_size: tuple[int, int] | None = None):
     """Compute reference using flex_attention for custom mask_mods"""
     batch_size, seqlen_q, nheads, headdim = tensors["q"].shape
     _, seqlen_k, nheads_kv, _ = tensors["k"].shape
@@ -240,6 +239,31 @@ def _run_mask_test(
         *_,
     ) = bm.as_tuple()
 
+    # SM90 block-sparse backward expects BlockMask granularity (128, 128) regardless of fwd tiling.
+    if COMPUTE_CAPABILITY == 9 and use_block_sparsity:
+        bm_bwd = create_block_mask(
+            mask_mod_flex,
+            batch_size,
+            nheads,
+            seqlen_q,
+            seqlen_k,
+            device="cuda",
+            BLOCK_SIZE=(128, 128),
+        )
+        (
+            _seq_q,
+            _seq_k,
+            _kv_mask_cnt,
+            _kv_mask_idx,
+            _full_kv_cnt,
+            _full_kv_idx,
+            q_mask_cnt,
+            q_mask_idx,
+            full_q_cnt,
+            full_q_idx,
+            *_,
+        ) = bm_bwd.as_tuple()
+
     softmax_scale = 1.0 / math.sqrt(headdim)
 
     block_sparse_mask_fwd = BlockSparseTensorsTorch(
@@ -343,8 +367,7 @@ def _run_mask_test(
         f"Kernel error {cute_error:.2e} exceeds {rtol}x PyTorch error {pt_error:.2e} + {fwd_atol:.2e}"
     )
 
-    # Backward pass (SM100 only)
-    if needs_backward and COMPUTE_CAPABILITY == 10 and kv_mode == "mha":
+    if needs_backward and kv_mode == "mha":
         q = tensors["q"]
         k = tensors["k"]
         v = tensors["v"]
@@ -453,9 +476,6 @@ def test_q_boundary_masking_block_sparse_bwd(seqlen_q, seqlen_k, mask_name):
     - Block-sparse with mask_mod: exercises is_full_block=True path
     - Backward pass: where the bug manifested
     """
-    if COMPUTE_CAPABILITY != 10:
-        pytest.skip("SM100-only backward test")
-
     _run_mask_test(
         seqlen_q=seqlen_q,
         seqlen_k=seqlen_k,
@@ -474,6 +494,7 @@ def test_q_boundary_masking_block_sparse_bwd(seqlen_q, seqlen_k, mask_name):
     )
 
 
+@pytest.mark.skipif(COMPUTE_CAPABILITY != 10, reason="Test uses SM100 block mask conventions (2*tile_m)")
 def test_single_doc_bwd_minimal():
     """Minimal test to isolate single-document backward pass bug.
 
@@ -484,9 +505,6 @@ def test_single_doc_bwd_minimal():
 
     Run with: pytest tests/cute/test_mask_mod.py::test_single_doc_bwd_minimal -v -s
     """
-    if COMPUTE_CAPABILITY != 10:
-        pytest.skip("SM100-only test")
-
     import random
     random.seed(42)
     torch.manual_seed(42)
@@ -801,6 +819,77 @@ def run_flex_reference_bwd(q, k, v, block_mask, grad_out, dtype=None):
         dk_ref.transpose(1, 2),
         dv_ref.transpose(1, 2),
     )
+
+
+def test_sm90_block_sparse_bwd_mismatched_q_block_granularity_error_message():
+    if COMPUTE_CAPABILITY != 9:
+        pytest.skip("SM90-only test")
+
+    batch_size = 1
+    seqlen_q = 256
+    seqlen_k = 256
+    nheads = 4
+    nheads_kv = nheads
+    headdim = 128
+    dtype = torch.bfloat16
+    tile_m = 80
+    tile_n = 128
+
+    tensors = create_tensors(batch_size, seqlen_q, seqlen_k, nheads, nheads_kv, headdim, headdim, dtype)
+    mask_mod_cute, mask_mod_flex = get_mask_pair("block_diagonal", seqlen_q=seqlen_q, seqlen_k=seqlen_k)
+    bm = create_block_mask(
+        mask_mod_flex,
+        batch_size,
+        nheads,
+        seqlen_q,
+        seqlen_k,
+        device="cuda",
+        BLOCK_SIZE=(tile_m, tile_n),
+    )
+    (
+        _seq_q,
+        _seq_k,
+        _kv_mask_cnt,
+        _kv_mask_idx,
+        _full_kv_cnt,
+        _full_kv_idx,
+        q_mask_cnt,
+        q_mask_idx,
+        full_q_cnt,
+        full_q_idx,
+        *_,
+    ) = bm.as_tuple()
+
+    block_sparse_mask_bwd = BlockSparseTensorsTorch(
+        mask_block_cnt=q_mask_cnt,
+        mask_block_idx=q_mask_idx,
+        full_block_cnt=full_q_cnt,
+        full_block_idx=full_q_idx,
+    )
+
+    softmax_scale = 1.0 / math.sqrt(headdim)
+    out = torch.empty(batch_size, seqlen_q, nheads, headdim, device="cuda", dtype=dtype)
+    lse = torch.empty(batch_size, nheads, seqlen_q, device="cuda", dtype=torch.float32)
+    grad_out = torch.randn_like(out)
+
+    with pytest.raises(
+        ValueError,
+        match=r"Hint: Backward expects Q-direction block-sparse tensors.*BLOCK_SIZE=\(128, 128\)",
+    ):
+        _flash_attn_bwd(
+            q=tensors["q"],
+            k=tensors["k"],
+            v=tensors["v"],
+            out=out,
+            dout=grad_out,
+            lse=lse,
+            softmax_scale=softmax_scale,
+            causal=False,
+            m_block_size=tile_m,
+            n_block_size=tile_n,
+            mask_mod=mask_mod_cute,
+            block_sparse_tensors=block_sparse_mask_bwd,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/cute/test_score_mod.py
+++ b/tests/cute/test_score_mod.py
@@ -6,6 +6,9 @@ from cutlass._mlir.dialects import math as mlir_math
 import operator
 from torch.nn.attention.flex_attention import flex_attention
 from flash_attn.cute.interface import _flash_attn_fwd, _flash_attn_bwd
+
+COMPUTE_CAPABILITY = torch.cuda.get_device_capability()[0]
+
 from score_mod_definitions import (
     # TensorSSA-based score mods
     score_mod_identity as score_mod_1,
@@ -291,6 +294,7 @@ def _generate_block_kvcache(
     ],
 )
 @pytest.mark.parametrize("score_mod_pair", TEST_PAIRS)
+@pytest.mark.skipif(COMPUTE_CAPABILITY != 10, reason="Paged KV cache only supported on SM100")
 def test_score_mod_with_paged_kvcache(
     seqlen_q,
     seqlen_kv,
@@ -447,6 +451,7 @@ def test_score_mod_with_paged_kvcache(
     ],
 )
 @pytest.mark.parametrize("score_mod_pair", TEST_PAIRS_WITH_AUX_TENSORS)
+@pytest.mark.skipif(COMPUTE_CAPABILITY != 10, reason="Paged KV cache only supported on SM100")
 def test_score_mod_with_paged_kvcache_aux_tensors(
     seqlen_q,
     seqlen_kv,
@@ -740,6 +745,9 @@ def run_flex_reference_bwd(q, k, v, eager_score_mod, grad_out, dtype=None):
 @pytest.mark.parametrize("score_mod_triple", BWD_TEST_PAIRS)
 def test_cute_vs_flex_attention_backward(seqlen_q, seqlen_kv, dim, dtype, score_mod_triple):
     """Test backward pass with score_mod against flex_attention reference."""
+    if COMPUTE_CAPABILITY == 9 and dim == 64:
+        pytest.skip("head_dim=64 not supported on SM90 for backward")
+
     torch.random.manual_seed(42)
     cute_fwd, cute_bwd, eager_ref = score_mod_triple
 
@@ -811,6 +819,9 @@ def make_aux_tensors_for_bwd(cute_score_mod, eager_factory, seqlen_q, num_heads,
 def test_cute_vs_flex_attention_backward_with_aux(
     seqlen_q, seqlen_kv, dim, dtype, score_mod_triple
 ):
+    if COMPUTE_CAPABILITY == 9 and dim == 64:
+        pytest.skip("head_dim=64 not supported on SM90 for backward")
+
     torch.random.manual_seed(42)
     cute_fwd, cute_bwd, eager_factory = score_mod_triple
 
@@ -864,14 +875,16 @@ def test_cute_vs_flex_attention_backward_with_aux(
 
 
 @pytest.mark.parametrize("seqlen_q,seqlen_kv", [(128, 128), (128, 256)])
-@pytest.mark.parametrize("dim", [64])
+@pytest.mark.parametrize("dim", [64, 128])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
 @pytest.mark.parametrize("qhead_per_kvhead,num_kv_heads", [(4, 2)])
 @pytest.mark.parametrize("score_mod_triple", BWD_TEST_PAIRS_PACK_GQA)
 def test_cute_vs_flex_attention_backward_pack_gqa(
     seqlen_q, seqlen_kv, dim, dtype, qhead_per_kvhead, num_kv_heads, score_mod_triple
 ):
-    pytest.skip("pack_gqa backward not yet implemented")
+    if COMPUTE_CAPABILITY == 9:
+        pytest.xfail("pack_gqa backward not yet implemented on SM90")
+
     torch.random.manual_seed(42)
     cute_fwd, cute_bwd, eager_ref = score_mod_triple
 


### PR DESCRIPTION
Stacked PRs:
 * #2158
 * #2145
 * #2146
 * #2143
 * __->__#2137
 * #2136


--- --- ---

### score-mod backward SM90

stack-pr keeps deleting my damn summary, sigh

FWD:
<img width="12505" height="5996" alt="image" src="https://github.com/user-attachments/assets/39f60280-8c39-4a04-840b-f2faf81859a0" />



BWD:
<img width="12505" height="5996" alt="image" src="https://github.com/user-attachments/assets/e4f75325-7c2f-447a-98ea-0704c196aa8a" />

insert pic, of ci being all green :) which I no longer have in my clipboard