### PR TITLE
Add FLASH_ATTENTION_FORCE_NON_STABLE_API option to allow building on NVidia Pytorch 25.09 image

### DIFF
--- a/hopper/setup.py
+++ b/hopper/setup.py
@@ -43,6 +43,7 @@ FORCE_BUILD = os.getenv("FLASH_ATTENTION_FORCE_BUILD", "FALSE") == "TRUE"
 SKIP_CUDA_BUILD = os.getenv("FLASH_ATTENTION_SKIP_CUDA_BUILD", "FALSE") == "TRUE"
 # For CI, we want the option to build with C++11 ABI since the nvcr images use C++11 ABI
 FORCE_CXX11_ABI = os.getenv("FLASH_ATTENTION_FORCE_CXX11_ABI", "FALSE") == "TRUE"
+FORCE_NON_STABLE_API = os.getenv("FLASH_ATTENTION_FORCE_NON_STABLE_API", "FALSE") == "TRUE"
 
 DISABLE_BACKWARD = os.getenv("FLASH_ATTENTION_DISABLE_BACKWARD", "FALSE") == "TRUE"
 DISABLE_SPLIT = os.getenv("FLASH_ATTENTION_DISABLE_SPLIT", "FALSE") == "TRUE"
@@ -576,7 +577,7 @@ if not SKIP_CUDA_BUILD:
     target_version = parse("2.9.0.dev20250830")
     stable_args = []
       
-    if torch_version >= target_version:
+    if torch_version >= target_version and not FORCE_NON_STABLE_API:
         flash_api_source = "flash_api_stable.cpp"
         stable_args = ["-DTORCH_STABLE_ONLY"]  # Checks against including unstable Tensor APIs
     else:


### PR DESCRIPTION
# Summary

This issue here comes from the handling of dev vs alpha versions of libraries in Python. 

The existing code is comparing the version of `torch` already in the 25.09 NGC image (i.e. `2.9.0a0+50eac811a6` to `2.9.0.dev20250830`). From PEP440, dev is ordered before alpha, so we fall into the `flash_api_stable.cpp` case. However the `50eac811a6` tag included in the NGC image is from 2025-08-04 (see https://github.com/pytorch/pytorch/commit/50eac811a68e63e96ad56c11c983bfe298a0bb8a ), before the `20250830` referenced in the `target_version` variable, and crucially before the `accelerator.h` file was added on 14th August: https://github.com/pytorch/pytorch/commits/release/2.9/torch/csrc/stable/accelerator.h

See https://github.com/Dao-AILab/flash-attention/issues/2024 for more discussion.

This solution does pollute the external API with yet another option but also means we make a minimally invasive change which avoids layering on more heuristics to try to figure out the desires of the user, and gives the user a bit more power as the stable API is fleshed out.