### PR TITLE
fix broken test_mask_mod and test_score_mod

### DIFF
--- a/flash_attn/cute/mask.py
+++ b/flash_attn/cute/mask.py
@@ -549,6 +549,7 @@ class AttentionMask:
                         head_idx_ssa,
                         q_idx_ssa,
                         kv_idx_ssa,
+                        self.seqlen_info,
                         aux_tensors,
                     )
                     cond = cutlass.Boolean(utils.ssa_to_scalar(mask_value))

--- a/tests/cute/test_score_mod.py
+++ b/tests/cute/test_score_mod.py
@@ -76,6 +76,7 @@ SEQLEN_CONFIGS = [
     (4096, 4096),
     (4224, 4224),
 ]
+COMPUTE_CAPABILITY = torch.cuda.get_device_capability()[0]
 
 
 def create_tensors(


### PR DESCRIPTION
These two tests have been failing with syndrome like:

test_mask_mod.py:
`E           TypeError: cute_block_diagonal_mask() missing 1 required positional argument: 'aux_tensors'`

test_score_mod.py:
`>       if COMPUTE_CAPABILITY == 9:`
`E       NameError: name 'COMPUTE_CAPABILITY' is not defined`