### PR TITLE
Use TORCH_TARGET_VERSION over TORCH_STABLE_ONLY

### DIFF
--- a/hopper/setup.py
+++ b/hopper/setup.py
@@ -578,7 +578,7 @@ if not SKIP_CUDA_BUILD:
       
     if torch_version >= target_version:
         flash_api_source = "flash_api_stable.cpp"
-        stable_args = ["-DTORCH_STABLE_ONLY"]  # Checks against including unstable Tensor APIs
+        stable_args = ["-DTORCH_TARGET_VERSION=0x0209000000000000"]  # Targets minimum runtime version torch 2.9.0
     else:
         flash_api_source = "flash_api.cpp"
 


### PR DESCRIPTION
TORCH_TARGET_VERSION is now the recommended, better maintained way to use the stable ABI. It has two advantages:
1. You can specify the minimum libtorch version your extension should be run with (even if it is different from your build time version).
2. It gates unstable APIs to help error out at build time if you're using an unstable API, as well as APIs that are too "new" for the target version.

Disclaimer that we are still hammering out the fine details of stable ABI UX, but TORCH_TARGET_VERSION is better than TORCH_STABLE_ONLY for sure.

Test plan:
I locally built on the 2.10 RC for 2.9 and was able to successfully run a few test_flash_attn.py smoke tests on both the 2.10 RC and the latest 2.9.1 torch. 

cc @mikaylagawarecki 