### PR TITLE
Fix comment in tma_get_copy_fn

### DIFF
--- a/flash_attn/cute/copy_utils.py
+++ b/flash_attn/cute/copy_utils.py
@@ -268,7 +268,7 @@ def cpasync_bulk_get_copy_fn(
     # )
     group_rank_src = const_expr(cute.rank(src_tensor) - (1 if not single_stage else 0))
     group_rank_dst = const_expr(cute.rank(dst_tensor) - (1 if not single_stage else 0))
-    # ((atom_v, rest_v), STAGE), ((atom_v, rest_v), RestK)
+    # ((atom_v, rest_v), STAGE), ((atom_v, rest_v), RestL)
     src = cute.group_modes(src_tensor, 0, group_rank_src)
     dst = cute.group_modes(dst_tensor, 0, group_rank_dst)
 
@@ -306,7 +306,7 @@ def tma_get_copy_fn(
     smem_tensor, gmem_tensor = (src_tensor, dst_tensor) if src_is_smem else (dst_tensor, src_tensor)
     group_rank_smem = const_expr(cute.rank(smem_tensor) - (1 if not single_stage else 0))
     group_rank_gmem = const_expr(cute.rank(gmem_tensor) - (1 if not single_stage else 0))
-    # ((atom_v, rest_v), STAGE), ((atom_v, rest_v), RestK)
+    # ((atom_v, rest_v), STAGE), ((atom_v, rest_v), RestL)
     s, g = cpasync.tma_partition(
         atom,
         cta_coord,


### PR DESCRIPTION
The last dim here is L, because the mainloop iterates over L (m_block). K is done in one `gemm_ptx_partial`.