### PR TITLE
[Cute] update row_max before safe overwrite for online_softmax

### DIFF
--- a/flash_attn/cute/softmax.py
+++ b/flash_attn/cute/softmax.py
@@ -83,6 +83,7 @@ class Softmax(ParamsBase):
 
             row_max_cur = utils.warp_reduce(row_max_cur, cute.arch.fmax, width=4)
             # Update row_max before changing row_max_cur to safe value for -inf
+            row_max_prev = row_max[r]
             row_max[r] = row_max_cur
 
             if cutlass.const_expr(check_inf):
@@ -95,7 +96,6 @@ class Softmax(ParamsBase):
                 acc_S_row_sum = utils.fadd_reduce(acc_S_row_exp, init_val=None, arch=arch)
                 row_scale[r] = 1.0
             else:
-                row_max_prev = row_max[r]
                 row_max_cur_scaled = row_max_cur * scale_log2
                 acc_S_row_exp = utils.exp2f(acc_S_row * scale_log2 - row_max_cur_scaled)
                 # row_scale[r] = utils.exp2f(row_max_prev * self.scale_log2 - row_max_cur_scaled)


### PR DESCRIPTION
This fixes the issue pointed out in #2082 for online softmax as used for the sm90 kernel. Note that the corresponding logic for sm100 was already working.