### PR TITLE
[Cute][Flex] add back in contig

### DIFF
--- a/flash_attn/cute/cute_dsl_utils.py
+++ b/flash_attn/cute/cute_dsl_utils.py
@@ -132,3 +132,13 @@ def to_cute_tensor(t, assumed_align=16, leading_dim=-1, fully_dynamic=False, ena
     if leading_dim == -1:
         leading_dim = t.ndim - 1
     return tensor.mark_layout_dynamic(leading_dim=leading_dim)
+
+
+def get_broadcast_dims(tensor: torch.Tensor) -> Tuple[bool, ...]:
+    """Return tuple of bools indicating which dims have stride=0 (broadcast).
+
+    This is useful for compile keys since CuTe's mark_layout_dynamic() keeps
+    stride=0 as static, meaning kernels compiled with different broadcast
+    patterns are not interchangeable.
+    """
+    return tuple(s == 0 for s in tensor.stride())


### PR DESCRIPTION
Stacked PRs:
 * #2180
 * __->__#2177


--- --- ---

[Cute][Flex] add back in contig

See comments. I add the helper to the cutedsl utils. I think in theory this could happen for q,k,v as well but its very unlikely.

MQA -> we dont actually expand the tensors.

we could I guess expand B for k, v in which case we might want to mixin their expanded dims. headdim =1 always and seqlen expansion I guess could also trigger but seems kind of unlikely.. 


<img width="1590" height="151" alt="image" src="https://github.com/user-attachments/assets/9559c3f0-d697-419a-a211-9b74e0ce4e83" />