### PR TITLE
Fix compute_block_sparsity import in benchmark_mask_mod

### DIFF
--- a/tests/cute/benchmark_mask_mod.py
+++ b/tests/cute/benchmark_mask_mod.py
@@ -20,10 +20,10 @@ from mask_mod_definitions import (
     random_doc_id_tensor,
 )
 from flash_attn.cute.block_sparsity import (
-    compute_block_sparsity,
     BlockSparseTensorsTorch,
     to_cute_block_sparse_tensors,
 )
+from flash_attn.cute.compute_block_sparsity import compute_block_sparsity
 
 
 @dataclass


### PR DESCRIPTION
Fixes #2184.

Changes:
- Import `compute_block_sparsity` from `flash_attn.cute.compute_block_sparsity` in `tests/cute/benchmark_mask_mod.py`.

Notes:
- Matches maintainer guidance in the issue.
