### PR TITLE
Add shift scheduler for deterministic full‑mask FA3 bwd on Hopper (sm90)

### DIFF
--- a/hopper/tile_m_scheduler.hpp
+++ b/hopper/tile_m_scheduler.hpp
@@ -1,0 +1,72 @@
+#pragma once
+
+#include "cutlass/fast_math.h"
+#include <cuda/std/iterator>
+
+/*
+Scheduler and dependency helpers for the execution order of q tiles (m_block)
+*/
+
+namespace flash {
+
+// targeting full mask, so m_min must be 0 and m_max must be the same across all kv tiles
+// should be used with shift_dependency
+// e.g. q_tile: 6 active_kv_tile: 3, schedule:
+// | 0    | 4    | 2    |
+// | 1    | 0    | 3    |
+// | 2    | 1    | 0    |
+// | 3    | 2    | 1    |
+// | 4    | 3    | 2    |
+class ShiftScheduler {
+public:
+    int cur_step;
+    const int start_q_idx;
+    const int total_steps;
+
+    using iterator_category = cuda::std::forward_iterator_tag;
+    using value_type = int;
+    using difference_type = cuda::std::ptrdiff_t;
+    using pointer = const int*;
+    using reference = const int&;
+
+    CUTLASS_DEVICE ShiftScheduler(int m_min, int m_max, int active_kv_idx)
+        : cur_step(0), start_q_idx(active_kv_idx), total_steps(m_max) {
+        (void)m_min;
+    }
+
+    CUTLASS_DEVICE bool valid() const { return cur_step < total_steps; }
+
+    CUTLASS_DEVICE ShiftScheduler& operator++() {
+        ++cur_step;
+        return *this;
+    }
+
+    CUTLASS_DEVICE value_type operator*() const {
+        int tmp = start_q_idx + cur_step;
+        if (tmp >= total_steps) tmp -= total_steps;
+        return tmp; // wrap around
+    }
+};
+
+// dependency order for ShiftScheduler
+// e.g. q_tile: 6 active_kv_tile: 3,
+// schedule:
+// | 0    | 4    | 2    |
+// | 1    | 0    | 3    |
+// | 2    | 1    | 0    |
+// | 3    | 2    | 1    |
+// | 4    | 3    | 2    |
+// dependency:
+// | 0    | 2    | 1    |
+// | 1    | 0    | 2    |
+// | 2    | 1    | 0    |
+// | 2    | 1    | 0    |
+// | 2    | 1    | 0    |
+CUTLASS_DEVICE int shift_dependency(int q_id, int active_kv_id, int active_kv_tiles, int executed_kv_tiles) {
+    int effective_row = q_id < active_kv_tiles ? q_id : int(active_kv_tiles - 1);
+    int tmp = effective_row - active_kv_id;
+    if (tmp < 0) tmp += active_kv_tiles;
+    return executed_kv_tiles + tmp;
+}
+
+} // namespace flash


### PR DESCRIPTION
This PR integrates a minimal shift‑scheduler path for deterministic backward when using full‑mask (non‑causal, non‑local, non‑varlen) on Hopper (sm90). The approach follows the shift‑scheduling algorithm described in the following anonymous OpenReview submission:
https://openreview.net/forum?id=bMi5ssfPoM
The integration is gated at dispatch time to avoid affecting other paths (including sliding window) and only enables when num_q_tiles >= num_kv_tiles.

## Key changes:

Add shift scheduler and dependency logic in tile_m_scheduler.hpp.
Add shift‑scheduler support to the sm90 mainloop (full‑mask only).
Add dispatch‑time gating and an env toggle (FLASHATTN_SHIFT_SCHEDULER) in the bwd launch path.
Pass num_sm into sm90 mainloop params to avoid hardcoding SM counts.

## Performance (FA3 bwd, full mask / causal=False, deterministic):
```
hdim=64  seqlen=512:   base 0.715ms 240.2 TFLOPS | new 0.662ms 259.4 TFLOPS
hdim=64  seqlen=1024:  base 1.153ms 297.9 TFLOPS | new 1.013ms 339.3 TFLOPS
hdim=64  seqlen=2048:  base 1.938ms 354.5 TFLOPS | new 1.640ms 419.0 TFLOPS
hdim=64  seqlen=4096:  base 3.485ms 394.4 TFLOPS | new 2.934ms 468.4 TFLOPS
hdim=64  seqlen=8192:  base 6.107ms 450.1 TFLOPS | new 5.462ms 503.2 TFLOPS
hdim=64  seqlen=16384: base 10.845ms 506.9 TFLOPS | new 10.701ms 513.8 TFLOPS

hdim=96  seqlen=512:   base 0.805ms 210.1 TFLOPS | new 0.800ms 211.5 TFLOPS
hdim=96  seqlen=1024:  base 1.155ms 292.9 TFLOPS | new 1.001ms 337.8 TFLOPS
hdim=96  seqlen=2048:  base 1.956ms 345.9 TFLOPS | new 1.733ms 390.4 TFLOPS
hdim=96  seqlen=4096:  base 3.431ms 394.4 TFLOPS | new 3.130ms 432.3 TFLOPS
hdim=96  seqlen=8192:  base 6.001ms 450.9 TFLOPS | new 5.934ms 456.0 TFLOPS
hdim=96  seqlen=16384: base 11.897ms 454.9 TFLOPS | new 11.705ms 462.3 TFLOPS

hdim=128 seqlen=512:   base 0.815ms 210.7 TFLOPS | new 0.831ms 206.8 TFLOPS
hdim=128 seqlen=1024:  base 0.979ms 351.0 TFLOPS | new 0.896ms 383.4 TFLOPS
hdim=128 seqlen=2048:  base 1.614ms 425.9 TFLOPS | new 1.484ms 463.2 TFLOPS
hdim=128 seqlen=4096:  base 2.790ms 492.6 TFLOPS | new 2.586ms 531.6 TFLOPS
hdim=128 seqlen=8192:  base 4.896ms 561.4 TFLOPS | new 4.837ms 568.3 TFLOPS
hdim=128 seqlen=16384: base 9.471ms 580.5 TFLOPS | new 9.533ms 576.7 TFLOPS

hdim=192 seqlen=512:   base 0.843ms 191.1 TFLOPS | new 0.679ms 237.3 TFLOPS
hdim=192 seqlen=1024:  base 1.092ms 295.1 TFLOPS | new 1.001ms 321.9 TFLOPS
hdim=192 seqlen=2048:  base 1.824ms 353.2 TFLOPS | new 1.651ms 390.3 TFLOPS
hdim=192 seqlen=4096:  base 3.176ms 405.7 TFLOPS | new 2.969ms 434.0 TFLOPS
hdim=192 seqlen=8192:  base 5.568ms 462.8 TFLOPS | new 5.696ms 452.4 TFLOPS
hdim=192 seqlen=16384: base 10.659ms 483.5 TFLOPS | new 10.631ms 484.8 TFLOPS
```