### PR TITLE
[CuTe,Flex] varlen blocksparsity

### DIFF
--- a/flash_attn/cute/block_sparse_utils.py
+++ b/flash_attn/cute/block_sparse_utils.py
@@ -5,7 +5,7 @@ This module contains runtime execution functions for block-sparse attention kern
 These utilities are used by CUTE DSL kernels to produce and consume block-sparse loads.
 """
 
-from typing import Callable, Optional
+from typing import Callable, Optional, Tuple
 from functools import partial
 import math
 import cutlass
@@ -17,6 +17,48 @@ from quack import copy_utils
 # Import data structures from block_sparsity
 from flash_attn.cute.block_sparsity import BlockSparseTensors
 from flash_attn.cute.named_barrier import NamedBarrierBwd
+from flash_attn.cute.seqlen_info import SeqlenInfoQK
+
+
+@cute.jit
+def get_curr_blocksparse_tensors(
+    batch_idx: cutlass.Int32,
+    head_idx: cutlass.Int32,
+    m_block: cutlass.Int32,
+    blocksparse_tensors: BlockSparseTensors,
+    seqlen_info: SeqlenInfoQK,
+) -> Tuple[cutlass.Int32, cute.Tensor, cutlass.Int32, Optional[cute.Tensor]]:
+    mask_block_cnt, mask_block_idx, full_block_cnt, full_block_idx, *_ = blocksparse_tensors
+    if const_expr(len(mask_block_cnt.shape) == 2):
+        # In the case where we are varlen_q, blocksparse tensors have shape
+        # [nheads, total_m_block] and [nheads, total_n_block]
+        m_block_offset = seqlen_info.m_block_offset
+        n_block_offset = seqlen_info.n_block_offset
+        curr_m_block = m_block_offset + m_block
+        curr_n_block_offset = n_block_offset + m_block * seqlen_info.num_n_blocks
+        curr_mask_block_cnt = mask_block_cnt[head_idx, curr_m_block]
+        curr_mask_block_idx = cute.domain_offset(
+            curr_n_block_offset, mask_block_idx[head_idx, None]
+        )
+        if const_expr(full_block_cnt is not None):
+            curr_full_block_cnt = full_block_cnt[head_idx, curr_m_block]
+            curr_full_block_idx = cute.domain_offset(
+                curr_n_block_offset, full_block_idx[head_idx, None]
+            )
+        else:
+            curr_full_block_cnt = Int32(0)
+            curr_full_block_idx = None
+    else:
+        curr_mask_block_cnt = mask_block_cnt[batch_idx, head_idx, m_block]
+        curr_mask_block_idx = mask_block_idx[batch_idx, head_idx, m_block, None]
+        if const_expr(full_block_cnt is not None):
+            curr_full_block_cnt = full_block_cnt[batch_idx, head_idx, m_block]
+            curr_full_block_idx = full_block_idx[batch_idx, head_idx, m_block, None]
+        else:
+            curr_full_block_cnt = Int32(0)
+            curr_full_block_idx = None
+
+    return (curr_mask_block_cnt, curr_mask_block_idx, curr_full_block_cnt, curr_full_block_idx)
 
 
 # NOTE [SM100 block-sparse empty tiles: mbarrier contract]
@@ -162,6 +204,7 @@ def produce_block_sparse_loads(
     batch_idx,
     head_idx,
     m_block,
+    seqlen_info: SeqlenInfoQK,
     kv_producer_state,
     load_K,
     load_V,
@@ -187,20 +230,20 @@ def produce_block_sparse_loads(
         qhead_per_kvhead: Pack-GQA factor. When > 1, m_block is in packed space and
             must be converted to unpacked for sparse tensor indexing.
     """
-
-    mask_block_cnt, mask_block_idx, full_block_cnt, full_block_idx, *_ = blocksparse_tensors
-
     m_block_sparse = sparse_tensor_m_block(m_block, qhead_per_kvhead, q_subtile_factor)
 
-    curr_mask_block_cnt = mask_block_cnt[batch_idx, head_idx, m_block_sparse]
-    curr_mask_block_idx = mask_block_idx[batch_idx, head_idx, m_block_sparse, None]
-
-    if const_expr(full_block_cnt is not None):
-        curr_full_block_cnt = full_block_cnt[batch_idx, head_idx, m_block_sparse]
-        curr_full_block_idx = full_block_idx[batch_idx, head_idx, m_block_sparse, None]
-    else:
-        curr_full_block_cnt = Int32(0)
-        curr_full_block_idx = None
+    (
+        curr_mask_block_cnt,
+        curr_mask_block_idx,
+        curr_full_block_cnt,
+        curr_full_block_idx,
+    ) = get_curr_blocksparse_tensors(
+        batch_idx,
+        head_idx,
+        m_block_sparse,
+        blocksparse_tensors,
+        seqlen_info,
+    )
 
     mask_empty = curr_mask_block_cnt == 0
     full_empty = curr_full_block_cnt == 0
@@ -305,7 +348,7 @@ def consume_block_sparse_loads(
     batch_idx,
     head_idx,
     m_block,
-    seqlen,
+    seqlen_info,
     kv_consumer_state,
     mma_pv_fn,
     mma_one_n_block,
@@ -331,15 +374,20 @@ def consume_block_sparse_loads(
         qhead_per_kvhead: Pack-GQA factor. When > 1, m_block is in packed space and
             must be converted to unpacked for sparse tensor indexing.
     """
-
-    mask_block_cnt, mask_block_idx, full_block_cnt, full_block_idx, *_ = blocksparse_tensors
-
     m_block_sparse = sparse_tensor_m_block(m_block, qhead_per_kvhead, q_subtile_factor)
 
-    curr_mask_block_cnt = mask_block_cnt[batch_idx, head_idx, m_block_sparse]
-    curr_mask_block_idx = mask_block_idx[batch_idx, head_idx, m_block_sparse, None]
-    curr_full_block_cnt = full_block_cnt[batch_idx, head_idx, m_block_sparse]
-    curr_full_block_idx = full_block_idx[batch_idx, head_idx, m_block_sparse, None]
+    (
+        curr_mask_block_cnt,
+        curr_mask_block_idx,
+        curr_full_block_cnt,
+        curr_full_block_idx,
+    ) = get_curr_blocksparse_tensors(
+        batch_idx,
+        head_idx,
+        m_block_sparse,
+        blocksparse_tensors,
+        seqlen_info,
+    )
 
     processed_any = curr_mask_block_cnt + curr_full_block_cnt > 0
 
@@ -420,7 +468,7 @@ def consume_block_sparse_loads(
             mask_n_block = curr_mask_block_idx[curr_mask_block_cnt - 1]
             kv_consumer_state = process_first_half_block(
                 n_block=mask_n_block,
-                seqlen=seqlen,
+                seqlen=seqlen_info,
                 kv_consumer_state=kv_consumer_state,
                 mask_fn=partial(
                     mask_fn,
@@ -436,7 +484,7 @@ def consume_block_sparse_loads(
                 kv_consumer_state = mma_one_n_block(
                     kv_consumer_state,
                     n_block=mask_n_block,
-                    seqlen=seqlen,
+                    seqlen=seqlen_info,
                     mma_pv_fn=partial(mma_pv_fn, zero_init=not O_should_accumulate),
                     mask_fn=partial(mask_fn, mask_mod=mask_mod, mask_seqlen=False),
                 )
@@ -447,7 +495,7 @@ def consume_block_sparse_loads(
             if curr_mask_block_cnt == 0:
                 kv_consumer_state = process_first_half_block(
                     n_block=full_n_block,
-                    seqlen=seqlen,
+                    seqlen=seqlen_info,
                     kv_consumer_state=kv_consumer_state,
                     mask_fn=partial(mask_fn, mask_mod=None, mask_seqlen=True),
                     score_mod_fn=score_mod_fn,
@@ -457,7 +505,7 @@ def consume_block_sparse_loads(
                 kv_consumer_state = mma_one_n_block(
                     kv_consumer_state,
                     n_block=full_n_block,
-                    seqlen=seqlen,
+                    seqlen=seqlen_info,
                     mma_pv_fn=partial(mma_pv_fn, zero_init=not O_should_accumulate),
                     mask_fn=partial(mask_fn, mask_mod=None, mask_seqlen=True),
                 )
@@ -467,7 +515,7 @@ def consume_block_sparse_loads(
                 kv_consumer_state = mma_one_n_block(
                     kv_consumer_state,
                     n_block=full_n_block,
-                    seqlen=seqlen,
+                    seqlen=seqlen_info,
                     mma_pv_fn=partial(mma_pv_fn, zero_init=not O_should_accumulate),
                     mask_fn=partial(mask_fn, mask_mod=None, mask_seqlen=False),
                 )
@@ -531,6 +579,7 @@ def produce_block_sparse_loads_sm100(
     batch_idx,
     head_idx,
     m_block,
+    seqlen_info,
     kv_producer_state,
     load_Q,
     load_K,
@@ -552,17 +601,18 @@ def produce_block_sparse_loads_sm100(
     """
     m_block_sparse = sparse_tensor_m_block(m_block, qhead_per_kvhead, q_subtile_factor)
 
-    mask_block_cnt, mask_block_idx, full_block_cnt, full_block_idx, *_ = blocksparse_tensors
-
-    curr_mask_block_cnt = mask_block_cnt[batch_idx, head_idx, m_block_sparse]
-    curr_mask_block_idx = mask_block_idx[batch_idx, head_idx, m_block_sparse, None]
-
-    if const_expr(full_block_cnt is not None):
-        curr_full_block_cnt = full_block_cnt[batch_idx, head_idx, m_block_sparse]
-        curr_full_block_idx = full_block_idx[batch_idx, head_idx, m_block_sparse, None]
-    else:
-        curr_full_block_cnt = Int32(0)
-        curr_full_block_idx = None
+    (
+        curr_mask_block_cnt,
+        curr_mask_block_idx,
+        curr_full_block_cnt,
+        curr_full_block_idx,
+    ) = get_curr_blocksparse_tensors(
+        batch_idx,
+        head_idx,
+        m_block_sparse,
+        blocksparse_tensors,
+        seqlen_info,
+    )
 
     mask_empty = curr_mask_block_cnt == 0
     full_empty = curr_full_block_cnt == 0
@@ -626,17 +676,24 @@ def get_total_block_count(
     m_block,
     qhead_per_kvhead: cutlass.Constexpr,
     q_subtile_factor: cutlass.Constexpr,
+    seqlen_info: SeqlenInfoQK,
 ):
     m_block_sparse = sparse_tensor_m_block(m_block, qhead_per_kvhead, q_subtile_factor)
+    mask_block_cnt, _, full_block_cnt, *_ = blocksparse_tensors
 
-    mask_block_cnt, mask_block_idx, full_block_cnt, full_block_idx, *_ = blocksparse_tensors
-    if const_expr(full_block_cnt is not None):
-        return (
-            mask_block_cnt[batch_idx, head_idx, m_block_sparse]
-            + full_block_cnt[batch_idx, head_idx, m_block_sparse]
-        )
+    if const_expr(len(mask_block_cnt.shape) == 2):
+        # varlen path: tensors are [num_heads, total_m_block]
+        curr_m = seqlen_info.m_block_offset + m_block_sparse
+        total = mask_block_cnt[head_idx, curr_m]
+        if const_expr(full_block_cnt is not None):
+            total += full_block_cnt[head_idx, curr_m]
     else:
-        return mask_block_cnt[batch_idx, head_idx, m_block_sparse]
+        # non-varlen: tensors are [batch, num_heads, m_block]
+        total = mask_block_cnt[batch_idx, head_idx, m_block_sparse]
+        if const_expr(full_block_cnt is not None):
+            total += full_block_cnt[batch_idx, head_idx, m_block_sparse]
+
+    return total
 
 
 @cute.jit
@@ -649,7 +706,7 @@ def handle_block_sparse_empty_tile_correction_sm100(
     is_split_kv: cutlass.Constexpr,
     learnable_sink,
     mLSE,
-    seqlen,
+    seqlen_info,
     m_block: Int32,
     head_idx: Int32,
     batch_idx: Int32,
@@ -737,7 +794,7 @@ def handle_block_sparse_empty_tile_correction_sm100(
             tidx,
             stage,
             m_block,
-            seqlen.seqlen_q,
+            seqlen_info.seqlen_q,
             Float32(0.0),  # zero scale ensures empty tile writes zeros into staged outputs
             sO[None, None, stage],
             mO_cur,
@@ -763,6 +820,7 @@ def softmax_block_sparse_sm100(
     batch_idx,
     head_idx,
     m_block,
+    seqlen_info,
     softmax_step: Callable,
     mask_fn: Callable,
     mask_fn_none: Callable,
@@ -780,17 +838,18 @@ def softmax_block_sparse_sm100(
     warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx()) % 4
     m_block_sparse = sparse_tensor_m_block(m_block, qhead_per_kvhead, q_subtile_factor)
 
-    mask_block_cnt, mask_block_idx, full_block_cnt, full_block_idx, *_ = blocksparse_tensors
-
-    curr_mask_block_cnt = mask_block_cnt[batch_idx, head_idx, m_block_sparse]
-    curr_mask_block_idx = mask_block_idx[batch_idx, head_idx, m_block_sparse, None]
-
-    if const_expr(full_block_cnt is not None):
-        curr_full_block_cnt = full_block_cnt[batch_idx, head_idx, m_block_sparse]
-        curr_full_block_idx = full_block_idx[batch_idx, head_idx, m_block_sparse, None]
-    else:
-        curr_full_block_cnt = Int32(0)
-        curr_full_block_idx = None
+    (
+        curr_mask_block_cnt,
+        curr_mask_block_idx,
+        curr_full_block_cnt,
+        curr_full_block_idx,
+    ) = get_curr_blocksparse_tensors(
+        batch_idx,
+        head_idx,
+        m_block_sparse,
+        blocksparse_tensors,
+        seqlen_info,
+    )
 
     total_block_cnt = curr_mask_block_cnt + curr_full_block_cnt
 
@@ -854,7 +913,7 @@ def softmax_block_sparse_sm100(
                     full_n_block,
                     is_first=False,
                     mask_fn=partial(
-                        mask_fn_none, mask_seqlen=False, check_q_boundary=check_m_boundary
+                        mask_fn_none, mask_seqlen=True, check_q_boundary=check_m_boundary
                     ),
                 )
             for i in cutlass.range(1, curr_full_block_cnt):

--- a/flash_attn/cute/block_sparse_utils.py
+++ b/flash_attn/cute/block_sparse_utils.py
@@ -21,6 +21,50 @@ from flash_attn.cute.seqlen_info import SeqlenInfoQK
 
 
 @cute.jit
+def _get_curr_blocksparse_tensors_varlen(
+    head_idx: cutlass.Int32,
+    m_block: cutlass.Int32,
+    blocksparse_tensors: BlockSparseTensors,
+    seqlen_info: SeqlenInfoQK,
+) -> Tuple[cutlass.Int32, cute.Tensor, cutlass.Int32, Optional[cute.Tensor]]:
+    """Varlen path: tensors are 2D [nheads, total_m_blocks] / [nheads, total_n_blocks]."""
+    mask_block_cnt, mask_block_idx, full_block_cnt, full_block_idx, *_ = blocksparse_tensors
+    curr_m_block = seqlen_info.m_block_offset + m_block
+    curr_block_idx_offset = seqlen_info.block_idx_offset + m_block * seqlen_info.num_n_blocks
+    curr_mask_block_cnt = mask_block_cnt[head_idx, curr_m_block]
+    curr_mask_block_idx = cute.domain_offset(curr_block_idx_offset, mask_block_idx[head_idx, None])
+    if const_expr(full_block_cnt is not None):
+        curr_full_block_cnt = full_block_cnt[head_idx, curr_m_block]
+        curr_full_block_idx = cute.domain_offset(
+            curr_block_idx_offset, full_block_idx[head_idx, None]
+        )
+    else:
+        curr_full_block_cnt = Int32(0)
+        curr_full_block_idx = None
+    return (curr_mask_block_cnt, curr_mask_block_idx, curr_full_block_cnt, curr_full_block_idx)
+
+
+@cute.jit
+def _get_curr_blocksparse_tensors(
+    batch_idx: cutlass.Int32,
+    head_idx: cutlass.Int32,
+    m_block: cutlass.Int32,
+    blocksparse_tensors: BlockSparseTensors,
+) -> Tuple[cutlass.Int32, cute.Tensor, cutlass.Int32, Optional[cute.Tensor]]:
+    """Fixed-length path: tensors are 4D [batch, nheads, m_block, n_block]."""
+    mask_block_cnt, mask_block_idx, full_block_cnt, full_block_idx, *_ = blocksparse_tensors
+    curr_mask_block_cnt = mask_block_cnt[batch_idx, head_idx, m_block]
+    curr_mask_block_idx = mask_block_idx[batch_idx, head_idx, m_block, None]
+    if const_expr(full_block_cnt is not None):
+        curr_full_block_cnt = full_block_cnt[batch_idx, head_idx, m_block]
+        curr_full_block_idx = full_block_idx[batch_idx, head_idx, m_block, None]
+    else:
+        curr_full_block_cnt = Int32(0)
+        curr_full_block_idx = None
+    return (curr_mask_block_cnt, curr_mask_block_idx, curr_full_block_cnt, curr_full_block_idx)
+
+
+@cute.jit
 def get_curr_blocksparse_tensors(
     batch_idx: cutlass.Int32,
     head_idx: cutlass.Int32,
@@ -28,37 +72,12 @@ def get_curr_blocksparse_tensors(
     blocksparse_tensors: BlockSparseTensors,
     seqlen_info: SeqlenInfoQK,
 ) -> Tuple[cutlass.Int32, cute.Tensor, cutlass.Int32, Optional[cute.Tensor]]:
-    mask_block_cnt, mask_block_idx, full_block_cnt, full_block_idx, *_ = blocksparse_tensors
-    if const_expr(len(mask_block_cnt.shape) == 2):
-        # In the case where we are varlen_q, blocksparse tensors have shape
-        # [nheads, total_m_block] and [nheads, total_n_block]
-        m_block_offset = seqlen_info.m_block_offset
-        n_block_offset = seqlen_info.n_block_offset
-        curr_m_block = m_block_offset + m_block
-        curr_n_block_offset = n_block_offset + m_block * seqlen_info.num_n_blocks
-        curr_mask_block_cnt = mask_block_cnt[head_idx, curr_m_block]
-        curr_mask_block_idx = cute.domain_offset(
-            curr_n_block_offset, mask_block_idx[head_idx, None]
+    """Extract head, m_block, and batch-local blocksparsity data from blocksparse_tensors"""
+    if const_expr(len(blocksparse_tensors.mask_block_cnt.shape) == 2):
+        return _get_curr_blocksparse_tensors_varlen(
+            head_idx, m_block, blocksparse_tensors, seqlen_info
         )
-        if const_expr(full_block_cnt is not None):
-            curr_full_block_cnt = full_block_cnt[head_idx, curr_m_block]
-            curr_full_block_idx = cute.domain_offset(
-                curr_n_block_offset, full_block_idx[head_idx, None]
-            )
-        else:
-            curr_full_block_cnt = Int32(0)
-            curr_full_block_idx = None
-    else:
-        curr_mask_block_cnt = mask_block_cnt[batch_idx, head_idx, m_block]
-        curr_mask_block_idx = mask_block_idx[batch_idx, head_idx, m_block, None]
-        if const_expr(full_block_cnt is not None):
-            curr_full_block_cnt = full_block_cnt[batch_idx, head_idx, m_block]
-            curr_full_block_idx = full_block_idx[batch_idx, head_idx, m_block, None]
-        else:
-            curr_full_block_cnt = Int32(0)
-            curr_full_block_idx = None
-
-    return (curr_mask_block_cnt, curr_mask_block_idx, curr_full_block_cnt, curr_full_block_idx)
+    return _get_curr_blocksparse_tensors(batch_idx, head_idx, m_block, blocksparse_tensors)
 
 
 # NOTE [SM100 block-sparse empty tiles: mbarrier contract]

--- a/flash_attn/cute/block_sparsity.py
+++ b/flash_attn/cute/block_sparsity.py
@@ -17,17 +17,23 @@ def ceildiv(a: int, b: int) -> int:
 class BlockSparseTensors(NamedTuple):
     mask_block_cnt: cute.Tensor
     mask_block_idx: cute.Tensor
-    full_block_cnt: cute.Tensor | None
-    full_block_idx: cute.Tensor | None
+    full_block_cnt: cute.Tensor | None = None
+    full_block_idx: cute.Tensor | None = None
+    cu_total_m_blocks: cute.Tensor | None = None
+    cu_block_idx_offsets: cute.Tensor | None = None
     dq_write_order: cute.Tensor | None = None
     dq_write_order_full: cute.Tensor | None = None
 
     def __new_from_mlir_values__(self, values):
-        if len(values) == 2:
-            values = (*values, None, None, None, None)
-        elif len(values) == 4:
-            values = (*values, None, None)
-        return BlockSparseTensors(*values)
+        new_fields = []
+        idx = 0
+        for original in self:
+            if original is None:
+                new_fields.append(None)
+            else:
+                new_fields.append(values[idx])
+                idx += 1
+        return BlockSparseTensors(*new_fields)
 
 
 class BlockSparseTensorsTorch(NamedTuple):
@@ -35,6 +41,8 @@ class BlockSparseTensorsTorch(NamedTuple):
     mask_block_idx: torch.Tensor
     full_block_cnt: torch.Tensor | None = None
     full_block_idx: torch.Tensor | None = None
+    cu_total_m_blocks: torch.Tensor | None = None
+    cu_block_idx_offsets: torch.Tensor | None = None
     block_size: tuple[int, int] | None = None
     dq_write_order: torch.Tensor | None = None
     dq_write_order_full: torch.Tensor | None = None
@@ -214,8 +222,8 @@ def _check_and_expand_block(
     name: str,
     cnt: torch.Tensor | None,
     idx: torch.Tensor | None,
-    expected_count_shape: Tuple[int, int, int],
-    expected_index_shape: Tuple[int, int, int, int],
+    expected_count_shape: Tuple[int, ...],
+    expected_index_shape: Tuple[int, ...],
     context: str | None,
     hint: str | Callable[[], str] | None,
 ) -> Tuple[torch.Tensor | None, torch.Tensor | None]:
@@ -402,8 +410,8 @@ def get_block_sparse_expected_shapes_bwd(
 def normalize_block_sparse_tensors(
     tensors: BlockSparseTensorsTorch,
     *,
-    expected_count_shape: Tuple[int, int, int],
-    expected_index_shape: Tuple[int, int, int, int],
+    expected_count_shape: Tuple[int, ...],
+    expected_index_shape: Tuple[int, ...],
     context: str | None = None,
     hint: str | Callable[[], str] | None = None,
 ) -> BlockSparseTensorsTorch:
@@ -461,6 +469,8 @@ def normalize_block_sparse_tensors(
         mask_block_idx=mask_idx,
         full_block_cnt=full_cnt,
         full_block_idx=full_idx,
+        cu_total_m_blocks=tensors.cu_total_m_blocks,
+        cu_block_idx_offsets=tensors.cu_block_idx_offsets,
         block_size=tensors.block_size,
         dq_write_order=dq_write_order,
         dq_write_order_full=dq_write_order_full,
@@ -516,6 +526,13 @@ def normalize_block_sparse_config(
     block_size: tuple[int, int],
     q_stage: int,
 ) -> tuple[BlockSparseTensorsTorch, Tuple[Tuple[bool, ...], ...] | None, int]:
+    """Validate the block-sparse config, infer expected shapes, and normalize.
+
+    Handles both fixed-length (3D `[B, H, M]` / 4D `[B, H, M, N]`) and varlen
+    (2D `[H, total_m_blocks]` / `[H, total_n_blocks]`) layouts. Varlen is
+    detected by `tensors.cu_total_m_blocks is not None` and forces
+    `q_subtile_factor == 1` (TODO: potentially remove this restriction).
+    """
     m_block_size, n_block_size = block_size
     if tensors.block_size is None:
         sparse_block_size_q, sparse_block_size_kv = None, n_block_size
@@ -525,21 +542,34 @@ def normalize_block_sparse_config(
         raise ValueError(
             f"Block sparsity requires sparse_block_size[1]={n_block_size} to match tile_n."
         )
-    expected_count_shape, expected_index_shape, q_subtile_factor = (
-        infer_block_sparse_expected_shapes(
-            tensors,
-            batch_size=batch_size,
-            num_head=num_head,
-            seqlen_q=seqlen_q,
-            seqlen_k=seqlen_k,
-            m_block_size=m_block_size,
-            n_block_size=n_block_size,
-            q_stage=q_stage,
-            context="forward",
-            sparse_block_size_q=sparse_block_size_q,
-            sparse_block_size_kv=sparse_block_size_kv,
+    if tensors.cu_total_m_blocks is not None:
+        base_m_block = q_stage * m_block_size
+        if sparse_block_size_q is not None and sparse_block_size_q != base_m_block:
+            raise ValueError(
+                f"Varlen block sparsity requires sparse_block_size[0]={base_m_block} "
+                f"(= q_stage * tile_m); got {sparse_block_size_q}."
+            )
+        total_m_blocks = tensors.mask_block_cnt.shape[-1]
+        total_n_blocks = tensors.mask_block_idx.shape[-1]
+        expected_count_shape = (num_head, total_m_blocks)
+        expected_index_shape = (num_head, total_n_blocks)
+        q_subtile_factor = 1
+    else:
+        expected_count_shape, expected_index_shape, q_subtile_factor = (
+            infer_block_sparse_expected_shapes(
+                tensors,
+                batch_size=batch_size,
+                num_head=num_head,
+                seqlen_q=seqlen_q,
+                seqlen_k=seqlen_k,
+                m_block_size=m_block_size,
+                n_block_size=n_block_size,
+                q_stage=q_stage,
+                context="forward",
+                sparse_block_size_q=sparse_block_size_q,
+                sparse_block_size_kv=sparse_block_size_kv,
+            )
         )
-    )
     normalized_tensors = normalize_block_sparse_tensors(
         tensors,
         expected_count_shape=expected_count_shape,
@@ -615,6 +645,12 @@ def to_cute_block_sparse_tensors(
         else None
         for t in (tensors.full_block_cnt, tensors.full_block_idx)
     ]
+    cu_total_m_blocks_tensor, cu_block_idx_offsets_tensor = [
+        to_cute_tensor(t, assumed_align=4, leading_dim=0, enable_tvm_ffi=enable_tvm_ffi)
+        if t is not None
+        else None
+        for t in (tensors.cu_total_m_blocks, tensors.cu_block_idx_offsets)
+    ]
     dq_write_order_tensor, dq_write_order_full_tensor = [
         to_cute_tensor(t, assumed_align=4, leading_dim=-1, enable_tvm_ffi=enable_tvm_ffi)
         if t is not None
@@ -627,6 +663,8 @@ def to_cute_block_sparse_tensors(
         mask_block_idx_tensor,
         full_block_cnt_tensor,
         full_block_idx_tensor,
+        cu_total_m_blocks_tensor,
+        cu_block_idx_offsets_tensor,
         dq_write_order_tensor,
         dq_write_order_full_tensor,
     )

--- a/flash_attn/cute/compute_block_sparsity.py
+++ b/flash_attn/cute/compute_block_sparsity.py
@@ -62,11 +62,11 @@ class BlockSparsityKernel:
         mCuSeqlensK: Optional[cute.Tensor] = None,
         mSeqUsedQ: Optional[cute.Tensor] = None,
         mSeqUsedK: Optional[cute.Tensor] = None,
-        mCuTotalMBlocks: Optional[cute.Tensor] = None,
-        mCuTotalNBlocks: Optional[cute.Tensor] = None,
         aux_tensors: Optional[list] = None,
     ):
-        mask_cnt, mask_idx, full_cnt, full_idx, *_ = blocksparse_tensors
+        mask_cnt, mask_idx, full_cnt, full_idx, mCuTotalMBlocks, mCuBlockIdxOffsets, *_ = (
+            blocksparse_tensors
+        )
 
         self.is_varlen_q = const_expr(mCuSeqlensQ is not None)
 
@@ -78,9 +78,6 @@ class BlockSparsityKernel:
             batch_size, num_heads, num_m_blocks, _ = mask_idx.shape
             total_m_blocks = batch_size * num_m_blocks
         else:
-            assert const_expr(mCuSeqlensQ is not None), (
-                "mCuSeqlensQ or mSeqUsedQ must be provided when varlen q"
-            )
             assert const_expr(mCuTotalMBlocks is not None), (
                 "mCuTotalMBlocks must be provided when varlen q"
             )
@@ -109,7 +106,7 @@ class BlockSparsityKernel:
             mSeqUsedQ,
             mSeqUsedK,
             mCuTotalMBlocks,
-            mCuTotalNBlocks,
+            mCuBlockIdxOffsets,
             aux_tensors,
         ).launch(grid=grid, block=[num_threads, 1, 1])
 
@@ -125,7 +122,7 @@ class BlockSparsityKernel:
         mSeqUsedQ: Optional[cute.Tensor] = None,
         mSeqUsedK: Optional[cute.Tensor] = None,
         mCuTotalMBlocks: Optional[cute.Tensor] = None,
-        mCuTotalNBlocks: Optional[cute.Tensor] = None,
+        mCuBlockIdxOffsets: Optional[cute.Tensor] = None,
         aux_tensors: Optional[list] = None,
     ):
         tidx, _, _ = cute.arch.thread_idx()
@@ -155,7 +152,7 @@ class BlockSparsityKernel:
             mSeqUsedQ=mSeqUsedQ,
             mSeqUsedK=mSeqUsedK,
             mCuTotalMBlocks=mCuTotalMBlocks,
-            mCuTotalNBlocks=mCuTotalNBlocks,
+            mCuBlockIdxOffsets=mCuBlockIdxOffsets,
             tile_m=self.tile_mn[0],
             tile_n=self.tile_mn[1],
         )
@@ -348,7 +345,7 @@ def compute_block_sparsity(
     seqused_q: Optional[torch.Tensor] = None,
     seqused_k: Optional[torch.Tensor] = None,
     cu_total_m_blocks: Optional[torch.Tensor] = None,
-    cu_total_n_blocks: Optional[torch.Tensor] = None,
+    cu_block_idx_offsets: Optional[torch.Tensor] = None,
     compute_full_blocks: bool = True,
     use_fast_sampling: bool = False,
 ) -> BlockSparseTensorsTorch:
@@ -370,7 +367,8 @@ def compute_block_sparsity(
         seqused_q: Per-batch effective q sequence lengths
         seqused_k: Per-batch effective k sequence lengths
         cu_total_m_blocks: Cumulative total m blocks tensor for varlen q
-        cu_total_n_blocks: Cumulative total n blocks tensor for varlen k
+        cu_block_idx_offsets: Cumulative offsets into the packed mask_block_idx /
+            full_block_idx tensors per batch (== cumsum of M_b * N_b).
         compute_full_blocks: Whether to compute full blocks. If False, only partially-masked blocks are computed.
         use_fast_sampling: Whether to use 5-point sampling (4 corners + center). This is much faster, but only suitable for masks where this check is sufficient.
 
@@ -386,24 +384,29 @@ def compute_block_sparsity(
     if cu_seqlens_q is not None:
         assert cu_total_m_blocks is not None, "total m blocks must be provided when varlen q"
         total_m_blocks = cu_total_m_blocks[-1].item()
-        if cu_seqlens_k is not None:
-            assert cu_total_n_blocks is not None, "total n blocks must be provided when varlen k"
-            total_n_blocks = cu_total_n_blocks[-1].item()
-        elif seqused_k is not None and cu_total_n_blocks is None:
-            cu_total_n_blocks_list = [0]
+        if cu_block_idx_offsets is None and (cu_seqlens_k is not None or seqused_k is not None):
+            # Derive cu_block_idx_offsets from per-batch K seqlens.
+            cu_block_idx_offsets_list = [0]
             for batch_idx in range(batch_size):
                 batch_seqlen_q = cu_seqlens_q[batch_idx + 1].item() - cu_seqlens_q[batch_idx].item()
-                batch_seqlen_k = seqused_k[batch_idx].item()
+                if cu_seqlens_k is not None:
+                    batch_seqlen_k = (
+                        cu_seqlens_k[batch_idx + 1].item() - cu_seqlens_k[batch_idx].item()
+                    )
+                else:
+                    batch_seqlen_k = seqused_k[batch_idx].item()
                 num_m_blocks_batch = (batch_seqlen_q + tile_m - 1) // tile_m
                 num_n_blocks_batch = (batch_seqlen_k + tile_n - 1) // tile_n
-                cu_total_n_blocks_list.append(
-                    cu_total_n_blocks_list[-1] + num_m_blocks_batch * num_n_blocks_batch
+                cu_block_idx_offsets_list.append(
+                    cu_block_idx_offsets_list[-1] + num_m_blocks_batch * num_n_blocks_batch
                 )
-            cu_total_n_blocks = torch.tensor(
-                cu_total_n_blocks_list, dtype=torch.int32, device=device
+            cu_block_idx_offsets = torch.tensor(
+                cu_block_idx_offsets_list, dtype=torch.int32, device=device
             )
-            total_n_blocks = cu_total_n_blocks[-1].item()
+        if cu_block_idx_offsets is not None:
+            total_n_blocks = cu_block_idx_offsets[-1].item()
         else:
+            # Uniform-K varlen-Q: every batch has the same K seqlen.
             total_n_blocks = total_m_blocks * num_n_blocks
 
         mask_block_cnt = torch.zeros((num_heads, total_m_blocks), device=device, dtype=torch.int32)
@@ -448,6 +451,8 @@ def compute_block_sparsity(
         mask_block_idx=mask_block_idx,
         full_block_cnt=full_block_cnt,
         full_block_idx=full_block_idx,
+        cu_total_m_blocks=cu_total_m_blocks,
+        cu_block_idx_offsets=cu_block_idx_offsets,
         block_size=(tile_m, tile_n),
     )
 
@@ -474,8 +479,6 @@ def compute_block_sparsity(
         (
             cu_seqlens_q_tensor,
             cu_seqlens_k_tensor,
-            cu_total_m_blocks_tensor,
-            cu_total_n_blocks_tensor,
             seqused_q_tensor,
             seqused_k_tensor,
         ) = [
@@ -483,8 +486,6 @@ def compute_block_sparsity(
             for t in (
                 cu_seqlens_q,
                 cu_seqlens_k,
-                cu_total_m_blocks,
-                cu_total_n_blocks,
                 seqused_q,
                 seqused_k,
             )
@@ -513,8 +514,6 @@ def compute_block_sparsity(
             cu_seqlens_k_tensor,
             seqused_q_tensor,
             seqused_k_tensor,
-            cu_total_m_blocks_tensor,
-            cu_total_n_blocks_tensor,
             cute_aux_tensors,
             options="--enable-tvm-ffi",
         )
@@ -526,6 +525,8 @@ def compute_block_sparsity(
                 blocksparse_tensors_torch.mask_block_idx,
                 blocksparse_tensors_torch.full_block_cnt,
                 blocksparse_tensors_torch.full_block_idx,
+                blocksparse_tensors_torch.cu_total_m_blocks,
+                blocksparse_tensors_torch.cu_block_idx_offsets,
                 blocksparse_tensors_torch.dq_write_order,
                 blocksparse_tensors_torch.dq_write_order_full,
             ),
@@ -535,8 +536,6 @@ def compute_block_sparsity(
             cu_seqlens_k,
             seqused_q,
             seqused_k,
-            cu_total_m_blocks,
-            cu_total_n_blocks,
             aux_tensors,
         )
 

--- a/flash_attn/cute/compute_block_sparsity.py
+++ b/flash_attn/cute/compute_block_sparsity.py
@@ -11,6 +11,13 @@ from flash_attn.cute.block_sparsity import (
     BlockSparseTensorsTorch,
     to_cute_block_sparse_tensors,
 )
+from flash_attn.cute.block_sparse_utils import get_curr_blocksparse_tensors
+from flash_attn.cute.testing import is_fake_mode
+from flash_attn.cute.cute_dsl_utils import (
+    to_cute_tensor,
+    get_aux_tensor_metadata,
+    to_cute_aux_tensor,
+)
 from flash_attn.cute.utils import hash_callable, scalar_to_ssa, ssa_to_scalar
 from flash_attn.cute.seqlen_info import SeqlenInfoQK
 
@@ -28,7 +35,6 @@ class BlockSparsityKernel:
 
     TODO:
         - optimize mask_mod evaluation
-        - varlen support
         - transposed tensors for bwd pass
     """
 
@@ -52,18 +58,34 @@ class BlockSparsityKernel:
         blocksparse_tensors: BlockSparseTensors,
         seqlen_q: Int32,
         seqlen_k: Int32,
+        mCuSeqlensQ: Optional[cute.Tensor] = None,
+        mCuSeqlensK: Optional[cute.Tensor] = None,
+        mSeqUsedQ: Optional[cute.Tensor] = None,
+        mSeqUsedK: Optional[cute.Tensor] = None,
+        mCuTotalMBlocks: Optional[cute.Tensor] = None,
+        mCuTotalNBlocks: Optional[cute.Tensor] = None,
         aux_tensors: Optional[list] = None,
     ):
-        self.mask_cnt, self.mask_idx, self.full_cnt, self.full_idx, *_ = blocksparse_tensors
+        mask_cnt, mask_idx, full_cnt, full_idx, *_ = blocksparse_tensors
+
+        self.is_varlen_q = const_expr(mCuSeqlensQ is not None)
 
         if const_expr(self.compute_full_blocks):
-            assert self.full_cnt is not None and self.full_idx is not None, (
+            assert full_cnt is not None and full_idx is not None, (
                 "full block tensors must be provided when computing full blocks"
             )
-
-        batch_size, num_heads, num_m_blocks, num_n_blocks = self.mask_idx.shape
-        # launch 1 CTA per m block
-        grid = [num_m_blocks, num_heads, batch_size]
+        if const_expr(not self.is_varlen_q):
+            batch_size, num_heads, num_m_blocks, _ = mask_idx.shape
+            total_m_blocks = batch_size * num_m_blocks
+        else:
+            assert const_expr(mCuSeqlensQ is not None), (
+                "mCuSeqlensQ or mSeqUsedQ must be provided when varlen q"
+            )
+            assert const_expr(mCuTotalMBlocks is not None), (
+                "mCuTotalMBlocks must be provided when varlen q"
+            )
+            num_heads, total_m_blocks = mask_cnt.shape  # num_m_blocks is total_m_blocks
+            batch_size = mCuSeqlensQ.shape[0] - 1
 
         if const_expr(self.use_fast_sampling):
             num_threads = 5
@@ -72,45 +94,45 @@ class BlockSparsityKernel:
             num_threads = self.tile_mn[0]
             self.num_warps = (num_threads + 32 - 1) // 32
 
+        if const_expr(not self.is_varlen_q):
+            grid = [num_m_blocks, num_heads, batch_size]
+        else:
+            grid = [total_m_blocks, num_heads, 1]
+
         self.kernel(
-            self.mask_cnt,
-            self.mask_idx,
-            self.full_cnt,
-            self.full_idx,
-            num_n_blocks,
+            blocksparse_tensors,
             seqlen_q,
             seqlen_k,
+            batch_size,
+            mCuSeqlensQ,
+            mCuSeqlensK,
+            mSeqUsedQ,
+            mSeqUsedK,
+            mCuTotalMBlocks,
+            mCuTotalNBlocks,
             aux_tensors,
         ).launch(grid=grid, block=[num_threads, 1, 1])
 
     @cute.kernel
     def kernel(
         self,
-        mask_cnt: cute.Tensor,
-        mask_idx: cute.Tensor,
-        full_cnt: cute.Tensor,
-        full_idx: cute.Tensor,
-        num_n_blocks: Int32,
+        blocksparse_tensors: BlockSparseTensors,
         seqlen_q: Int32,
         seqlen_k: Int32,
+        batch_size: Int32,
+        mCuSeqlensQ: Optional[cute.Tensor] = None,
+        mCuSeqlensK: Optional[cute.Tensor] = None,
+        mSeqUsedQ: Optional[cute.Tensor] = None,
+        mSeqUsedK: Optional[cute.Tensor] = None,
+        mCuTotalMBlocks: Optional[cute.Tensor] = None,
+        mCuTotalNBlocks: Optional[cute.Tensor] = None,
         aux_tensors: Optional[list] = None,
     ):
         tidx, _, _ = cute.arch.thread_idx()
         warp_idx = cute.arch.warp_idx()
         lane_id = cute.arch.lane_idx()
-        m_block, head_idx, batch_idx = cute.arch.block_idx()
 
         ssa = partial(scalar_to_ssa, dtype=Int32)
-
-        seqlen = SeqlenInfoQK.create(
-            batch_idx,
-            seqlen_q,
-            seqlen_k,
-            mCuSeqlensQ=None,
-            mCuSeqlensK=None,
-            mSeqUsedQ=None,
-            mSeqUsedK=None,
-        )
 
         @cute.struct
         class SharedStorage:
@@ -124,132 +146,163 @@ class BlockSparsityKernel:
         reduction_buffer = storage.reduction_buffer_smem.get_tensor(
             cute.make_layout((self.num_warps, 2))
         )
+        SeqlenInfoCls = partial(
+            SeqlenInfoQK.create,
+            seqlen_q_static=seqlen_q,
+            seqlen_k_static=seqlen_k,
+            mCuSeqlensQ=mCuSeqlensQ,
+            mCuSeqlensK=mCuSeqlensK,
+            mSeqUsedQ=mSeqUsedQ,
+            mSeqUsedK=mSeqUsedK,
+            mCuTotalMBlocks=mCuTotalMBlocks,
+            mCuTotalNBlocks=mCuTotalNBlocks,
+            tile_m=self.tile_mn[0],
+            tile_n=self.tile_mn[1],
+        )
+
+        if const_expr(not self.is_varlen_q):
+            m_block, head_idx, batch_idx = cute.arch.block_idx()
+        else:
+            global_m_block, head_idx, _ = cute.arch.block_idx()
+            # Binary search over cu_total_m_blocks to find batch_idx
+            lo = Int32(0)
+            hi = batch_size
+            while lo < hi:
+                mid = (lo + hi) // 2
+                if mCuTotalMBlocks[mid + 1] <= global_m_block:
+                    lo = mid + 1
+                else:
+                    hi = mid
+            batch_idx = lo
+            m_block = global_m_block - mCuTotalMBlocks[batch_idx]
+
+        seqlen = SeqlenInfoCls(batch_idx)
+        seqlen_q = seqlen.seqlen_q
+        seqlen_k = seqlen.seqlen_k
+        global_m_block = seqlen.m_block_offset + m_block
+
+        num_n_blocks = (seqlen_k + self.tile_mn[1] - 1) // self.tile_mn[1]
+
+        _, curr_mask_idx, _, curr_full_idx = get_curr_blocksparse_tensors(
+            batch_idx, head_idx, m_block, blocksparse_tensors, seqlen
+        )
 
         num_mask_blocks = Int32(0)
         num_full_blocks = Int32(0)
 
-        for n_block in cutlass.range(num_n_blocks, unroll_full=True):
-            m_base = m_block * self.tile_mn[0]
+        m_base = m_block * self.tile_mn[0]
+        if const_expr(self.use_fast_sampling):
+            # Loop-invariant per-thread q_idx for the 5 sample points
+            # (tidx 0, 1: top corners; 2, 3: bottom corners; 4: center).
+            q_idx_sample = m_base
+            if tidx == 2 or tidx == 3:
+                q_idx_sample = cutlass.min(m_base + self.tile_mn[0] - 1, seqlen_q - 1)
+            elif tidx == 4:
+                q_idx_sample = m_base + cutlass.min(seqlen_q - m_base, self.tile_mn[0]) // 2
+        else:
+            q_idx_thread = m_base + tidx
+            thread_in_bounds = Boolean(tidx < self.tile_mn[0] and q_idx_thread < seqlen_q)
+
+        for n_block in cutlass.range(num_n_blocks):
             n_base = n_block * self.tile_mn[1]
 
             if const_expr(self.use_fast_sampling):
-                # Fast path: 5-point sampling (4 corners + center)
-                # Clamps OOB indices to nearest in bounds.
+                # 5-point sampling (4 corners + center). Interior n_blocks
+                # (n_base + tile_n <= seqlen_k) skip the OOB clamp on the right /
+                # center samples.
+                is_interior = (n_base + self.tile_mn[1]) <= seqlen_k
+                n_right = Int32(0)
+                n_mid = Int32(0)
+                if is_interior:
+                    n_right = n_base + self.tile_mn[1] - 1
+                    n_mid = n_base + self.tile_mn[1] // 2
+                else:
+                    n_right = cutlass.min(n_base + self.tile_mn[1] - 1, seqlen_k - 1)
+                    n_mid = n_base + cutlass.min(seqlen_k - n_base, self.tile_mn[1]) // 2
+
+                kv_idx = n_base
+                if tidx == 1 or tidx == 3:
+                    kv_idx = n_right
+                elif tidx == 4:
+                    kv_idx = n_mid
+
                 thread_result = Boolean(False)
                 thread_is_valid = Boolean(False)
-                q_idx = Int32(0)
-                kv_idx = Int32(0)
-
-                if tidx == 0:
-                    # Top-left corner (0, 0); always in bounds
-                    q_idx = m_base
-                    kv_idx = n_base
-                elif tidx == 1:
-                    # Top-right corner
-                    q_idx = m_base
-                    kv_idx = cutlass.min(n_base + self.tile_mn[1] - 1, seqlen_k - 1)
-                elif tidx == 2:
-                    # Bottom-left corner
-                    q_idx = cutlass.min(m_base + self.tile_mn[0] - 1, seqlen_q - 1)
-                    kv_idx = n_base
-                elif tidx == 3:
-                    # Bottom-right corner
-                    q_idx = cutlass.min(m_base + self.tile_mn[0] - 1, seqlen_q - 1)
-                    kv_idx = cutlass.min(n_base + self.tile_mn[1] - 1, seqlen_k - 1)
-                elif tidx == 4:
-                    # Center point
-                    q_idx = m_base + (cutlass.min(seqlen_q - m_base, self.tile_mn[0])) // 2
-                    kv_idx = n_base + (cutlass.min(seqlen_k - n_base, self.tile_mn[1])) // 2
-                else:
-                    thread_is_valid = Boolean(False)
-
-                # Check bounds and determine if this thread has a valid index pair
-                if tidx < 5 and q_idx < seqlen_q and kv_idx < seqlen_k:
+                if tidx < 5:
                     thread_is_valid = Boolean(True)
-                    q_idx_ssa = ssa(q_idx)
-                    kv_idx_ssa = ssa(kv_idx)
                     thread_result = ssa_to_scalar(
                         self.mask_mod(
                             ssa(batch_idx),
                             ssa(head_idx),
-                            q_idx_ssa,
-                            kv_idx_ssa,
+                            ssa(q_idx_sample),
+                            ssa(kv_idx),
                             seqlen,
                             aux_tensors,
                         )
                     )
-                else:
-                    thread_is_valid = Boolean(False)
 
-                # Use vote_any_sync to see if any valid thread found unmasked or masked
-                # Only count results from threads that checked valid indices
                 has_unmasked = cute.arch.vote_any_sync(thread_result & thread_is_valid)
-                has_masked = cute.arch.vote_any_sync((Boolean(not thread_result)) & thread_is_valid)
+                has_masked = cute.arch.vote_any_sync(Boolean(not thread_result) & thread_is_valid)
 
             else:
-                # Full path: check all elements in the block
-                # Track if this thread's row has any masked or unmasked elements
+                # Full path. Interior blocks (n_base + tile_n <= seqlen_k) drop the
+                # per-element bound check; the boundary block (at most one) keeps it.
                 thread_has_unmasked = Boolean(False)
                 thread_has_masked = Boolean(False)
-                thread_is_valid = Boolean(False)
-
-                # Each thread handles 1 row
-                q_idx = m_base + tidx
                 kv_idx = Int32(0)
-                if tidx < self.tile_mn[0] and q_idx < seqlen_q:
-                    thread_is_valid = Boolean(True)
-                    q_idx_ssa = ssa(q_idx)
+                is_interior = (n_base + self.tile_mn[1]) <= seqlen_k
 
-                    # Loop over all columns in this row
-                    for c in cutlass.range(self.tile_mn[1], unroll_full=True):
-                        kv_idx = n_base + c
-                        kv_idx_ssa = ssa(kv_idx)
-
-                        # Only check elements within valid sequence bounds
-                        if kv_idx < seqlen_k:
-                            # Direct scalar call
+                if is_interior:
+                    if thread_in_bounds:
+                        for c in cutlass.range(self.tile_mn[1], unroll_full=True):
                             mask_val = ssa_to_scalar(
                                 self.mask_mod(
                                     ssa(batch_idx),
                                     ssa(head_idx),
-                                    q_idx_ssa,
-                                    kv_idx_ssa,
+                                    ssa(q_idx_thread),
+                                    ssa(n_base + c),
                                     seqlen,
                                     aux_tensors,
                                 )
                             )
+                            thread_has_unmasked |= Boolean(mask_val)
+                            thread_has_masked |= Boolean(not mask_val)
+                else:
+                    if thread_in_bounds:
+                        for c in cutlass.range(self.tile_mn[1], unroll_full=True):
+                            kv_idx = n_base + c
+                            if kv_idx < seqlen_k:
+                                mask_val = ssa_to_scalar(
+                                    self.mask_mod(
+                                        ssa(batch_idx),
+                                        ssa(head_idx),
+                                        ssa(q_idx_thread),
+                                        ssa(kv_idx),
+                                        seqlen,
+                                        aux_tensors,
+                                    )
+                                )
+                                thread_has_unmasked |= Boolean(mask_val)
+                                thread_has_masked |= Boolean(not mask_val)
 
-                            # Update tracking flags
-                            if mask_val:
-                                thread_has_unmasked = Boolean(True)
-                            else:
-                                thread_has_masked = Boolean(True)
-
-                # Block-level reduction to combine results across all threads
-                # Only count votes from threads that checked valid indices
-                warp_has_unmasked_mask = cute.arch.vote_any_sync(
-                    thread_has_unmasked & thread_is_valid
-                )
-                warp_has_masked_mask = cute.arch.vote_any_sync(thread_has_masked & thread_is_valid)
-
-                # lane 0 writes the ballot mask to shared memory
-                lane_id = tidx % 32
+                warp_unmasked = cute.arch.vote_any_sync(thread_has_unmasked & thread_in_bounds)
+                warp_masked = cute.arch.vote_any_sync(thread_has_masked & thread_in_bounds)
                 if lane_id == 0:
-                    # Store as Int8
-                    reduction_buffer[warp_idx, 0] = Int8(1) if warp_has_unmasked_mask else Int8(0)
-                    reduction_buffer[warp_idx, 1] = Int8(1) if warp_has_masked_mask else Int8(0)
-
+                    reduction_buffer[warp_idx, 0] = Int8(1) if warp_unmasked else Int8(0)
+                    reduction_buffer[warp_idx, 1] = Int8(1) if warp_masked else Int8(0)
                 cute.arch.sync_threads()
 
-                # Thread 0 ORs all warp results together
+                # Cross-warp OR via warp 0; thread 0 (lane 0 of warp 0) holds the result.
                 has_unmasked = Boolean(False)
                 has_masked = Boolean(False)
-                if tidx == 0:
-                    for w in cutlass.range(self.num_warps):
-                        if reduction_buffer[w, 0]:
-                            has_unmasked = Boolean(True)
-                        if reduction_buffer[w, 1]:
-                            has_masked = Boolean(True)
+                if warp_idx == 0:
+                    lane_unmasked = Boolean(False)
+                    lane_masked = Boolean(False)
+                    if lane_id < self.num_warps:
+                        lane_unmasked = reduction_buffer[lane_id, 0] != Int8(0)
+                        lane_masked = reduction_buffer[lane_id, 1] != Int8(0)
+                    has_unmasked = cute.arch.vote_any_sync(lane_unmasked)
+                    has_masked = cute.arch.vote_any_sync(lane_masked)
 
             # Only thread 0 updates the output arrays (common to both paths)
             if tidx == 0:
@@ -261,17 +314,23 @@ class BlockSparsityKernel:
                 is_full = Boolean(has_unmasked and (not has_masked))
 
                 if is_partial:
-                    mask_idx[batch_idx, head_idx, m_block, num_mask_blocks] = n_block
+                    curr_mask_idx[num_mask_blocks] = n_block
                     num_mask_blocks += 1
                 elif is_full and const_expr(self.compute_full_blocks):
-                    full_idx[batch_idx, head_idx, m_block, num_full_blocks] = n_block
+                    curr_full_idx[num_full_blocks] = n_block
                     num_full_blocks += 1
 
         # Only thread 0 writes back the counts
         if tidx == 0:
-            mask_cnt[batch_idx, head_idx, m_block] = num_mask_blocks
-            if const_expr(self.compute_full_blocks):
-                full_cnt[batch_idx, head_idx, m_block] = num_full_blocks
+            mask_cnt, _, full_cnt, *_ = blocksparse_tensors
+            if const_expr(self.is_varlen_q):
+                mask_cnt[head_idx, global_m_block] = num_mask_blocks
+                if const_expr(self.compute_full_blocks):
+                    full_cnt[head_idx, global_m_block] = num_full_blocks
+            else:
+                mask_cnt[batch_idx, head_idx, m_block] = num_mask_blocks
+                if const_expr(self.compute_full_blocks):
+                    full_cnt[batch_idx, head_idx, m_block] = num_full_blocks
 
 
 def compute_block_sparsity(
@@ -282,11 +341,17 @@ def compute_block_sparsity(
     seqlen_q,
     seqlen_k,
     mask_mod: Callable,
-    aux_tensors: Optional[list],  # list[cute.Tensor]
+    aux_tensors: Optional[list],
     device,
+    cu_seqlens_q: Optional[torch.Tensor] = None,
+    cu_seqlens_k: Optional[torch.Tensor] = None,
+    seqused_q: Optional[torch.Tensor] = None,
+    seqused_k: Optional[torch.Tensor] = None,
+    cu_total_m_blocks: Optional[torch.Tensor] = None,
+    cu_total_n_blocks: Optional[torch.Tensor] = None,
     compute_full_blocks: bool = True,
     use_fast_sampling: bool = False,
-) -> Tuple[BlockSparseTensors, BlockSparseTensorsTorch]:
+) -> BlockSparseTensorsTorch:
     """
     Computes block sparsity for a given `mask_mod`.
 
@@ -300,36 +365,83 @@ def compute_block_sparsity(
         mask_mod: The `mask_mod` callable to use.
         aux_tensors: A list of auxiliary tensors.
         device: The device to use.
+        cu_seqlens_q: Cumulative q sequence lengths for varlen
+        cu_seqlens_k: Cumulative k sequence lengths for varlen
+        seqused_q: Per-batch effective q sequence lengths
+        seqused_k: Per-batch effective k sequence lengths
+        cu_total_m_blocks: Cumulative total m blocks tensor for varlen q
+        cu_total_n_blocks: Cumulative total n blocks tensor for varlen k
         compute_full_blocks: Whether to compute full blocks. If False, only partially-masked blocks are computed.
         use_fast_sampling: Whether to use 5-point sampling (4 corners + center). This is much faster, but only suitable for masks where this check is sufficient.
 
     Returns:
-        A tuple of `BlockSparseTensors` and `BlockSparseTensorsTorch`.
+        BlockSparseTensorsTorch
     """
-    # Check if mask_mod is marked as suitable for 5-point fast sampling
+    # Check if mask_mod is marked as suitable for 5-point sampling
     use_fast_sampling = getattr(mask_mod, "use_fast_sampling", use_fast_sampling)
 
     num_m_blocks = (seqlen_q + tile_m - 1) // tile_m
     num_n_blocks = (seqlen_k + tile_n - 1) // tile_n
 
-    mask_block_cnt = torch.zeros(
-        (batch_size, num_heads, num_m_blocks), device=device, dtype=torch.int32
-    )
-    mask_block_idx = torch.zeros(
-        (batch_size, num_heads, num_m_blocks, num_n_blocks), device=device, dtype=torch.int32
-    )
-    full_block_cnt = (
-        torch.zeros((batch_size, num_heads, num_m_blocks), device=device, dtype=torch.int32)
-        if compute_full_blocks
-        else None
-    )
-    full_block_idx = (
-        torch.zeros(
+    if cu_seqlens_q is not None:
+        assert cu_total_m_blocks is not None, "total m blocks must be provided when varlen q"
+        total_m_blocks = cu_total_m_blocks[-1].item()
+        if cu_seqlens_k is not None:
+            assert cu_total_n_blocks is not None, "total n blocks must be provided when varlen k"
+            total_n_blocks = cu_total_n_blocks[-1].item()
+        elif seqused_k is not None and cu_total_n_blocks is None:
+            cu_total_n_blocks_list = [0]
+            for batch_idx in range(batch_size):
+                batch_seqlen_q = cu_seqlens_q[batch_idx + 1].item() - cu_seqlens_q[batch_idx].item()
+                batch_seqlen_k = seqused_k[batch_idx].item()
+                num_m_blocks_batch = (batch_seqlen_q + tile_m - 1) // tile_m
+                num_n_blocks_batch = (batch_seqlen_k + tile_n - 1) // tile_n
+                cu_total_n_blocks_list.append(
+                    cu_total_n_blocks_list[-1] + num_m_blocks_batch * num_n_blocks_batch
+                )
+            cu_total_n_blocks = torch.tensor(
+                cu_total_n_blocks_list, dtype=torch.int32, device=device
+            )
+            total_n_blocks = cu_total_n_blocks[-1].item()
+        else:
+            total_n_blocks = total_m_blocks * num_n_blocks
+
+        mask_block_cnt = torch.zeros((num_heads, total_m_blocks), device=device, dtype=torch.int32)
+        mask_block_idx = torch.zeros((num_heads, total_n_blocks), device=device, dtype=torch.int32)
+        full_block_cnt = (
+            torch.zeros((num_heads, total_m_blocks), device=device, dtype=torch.int32)
+            if compute_full_blocks
+            else None
+        )
+        full_block_idx = (
+            torch.zeros((num_heads, total_n_blocks), device=device, dtype=torch.int32)
+            if compute_full_blocks
+            else None
+        )
+    else:
+        total_m_blocks = batch_size * num_m_blocks
+        total_n_blocks = batch_size * num_m_blocks * num_n_blocks
+
+        mask_block_cnt = torch.zeros(
+            (batch_size, num_heads, num_m_blocks), device=device, dtype=torch.int32
+        )
+        mask_block_idx = torch.zeros(
             (batch_size, num_heads, num_m_blocks, num_n_blocks), device=device, dtype=torch.int32
         )
-        if compute_full_blocks
-        else None
-    )
+        full_block_cnt = (
+            torch.zeros((batch_size, num_heads, num_m_blocks), device=device, dtype=torch.int32)
+            if compute_full_blocks
+            else None
+        )
+        full_block_idx = (
+            torch.zeros(
+                (batch_size, num_heads, num_m_blocks, num_n_blocks),
+                device=device,
+                dtype=torch.int32,
+            )
+            if compute_full_blocks
+            else None
+        )
 
     blocksparse_tensors_torch = BlockSparseTensorsTorch(
         mask_block_cnt=mask_block_cnt,
@@ -340,19 +452,50 @@ def compute_block_sparsity(
     )
 
     mask_mod_hash = hash_callable(mask_mod)
-    blocksparse_tensors = to_cute_block_sparse_tensors(
-        blocksparse_tensors_torch, enable_tvm_ffi=True
-    )
+    if aux_tensors is not None:
+        aux_tensor_metadata = get_aux_tensor_metadata(aux_tensors)
+    else:
+        aux_tensor_metadata = None
 
     compile_key = (
         tile_m,
         tile_n,
         mask_mod_hash,
+        aux_tensor_metadata,
         compute_full_blocks,
+        cu_seqlens_q is None,
+        cu_seqlens_k is None,
+        seqused_q is None,
+        seqused_k is None,
         aux_tensors is not None,
         use_fast_sampling,
     )
     if compile_key not in compute_block_sparsity.compile_cache:
+        (
+            cu_seqlens_q_tensor,
+            cu_seqlens_k_tensor,
+            cu_total_m_blocks_tensor,
+            cu_total_n_blocks_tensor,
+            seqused_q_tensor,
+            seqused_k_tensor,
+        ) = [
+            to_cute_tensor(t, assumed_align=4, leading_dim=0) if t is not None else None
+            for t in (
+                cu_seqlens_q,
+                cu_seqlens_k,
+                cu_total_m_blocks,
+                cu_total_n_blocks,
+                seqused_q,
+                seqused_k,
+            )
+        ]
+        blocksparse_tensors = to_cute_block_sparse_tensors(
+            blocksparse_tensors_torch, enable_tvm_ffi=True
+        )
+        if aux_tensors is not None:
+            cute_aux_tensors = [to_cute_aux_tensor(buf) for buf in aux_tensors]
+        else:
+            cute_aux_tensors = None
         kernel = BlockSparsityKernel(
             mask_mod,
             tile_mn=(tile_m, tile_n),
@@ -362,24 +505,42 @@ def compute_block_sparsity(
         )
 
         compute_block_sparsity.compile_cache[compile_key] = cute.compile(
-            kernel, blocksparse_tensors, seqlen_q, seqlen_k, aux_tensors, options="--enable-tvm-ffi"
+            kernel,
+            blocksparse_tensors,
+            seqlen_q,
+            seqlen_k,
+            cu_seqlens_q_tensor,
+            cu_seqlens_k_tensor,
+            seqused_q_tensor,
+            seqused_k_tensor,
+            cu_total_m_blocks_tensor,
+            cu_total_n_blocks_tensor,
+            cute_aux_tensors,
+            options="--enable-tvm-ffi",
         )
 
-    compute_block_sparsity.compile_cache[compile_key](
-        (
-            blocksparse_tensors_torch.mask_block_cnt,
-            blocksparse_tensors_torch.mask_block_idx,
-            blocksparse_tensors_torch.full_block_cnt,
-            blocksparse_tensors_torch.full_block_idx,
-            blocksparse_tensors_torch.dq_write_order,
-            blocksparse_tensors_torch.dq_write_order_full,
-        ),
-        seqlen_q,
-        seqlen_k,
-        aux_tensors,
-    )
+    if not is_fake_mode():
+        compute_block_sparsity.compile_cache[compile_key](
+            (
+                blocksparse_tensors_torch.mask_block_cnt,
+                blocksparse_tensors_torch.mask_block_idx,
+                blocksparse_tensors_torch.full_block_cnt,
+                blocksparse_tensors_torch.full_block_idx,
+                blocksparse_tensors_torch.dq_write_order,
+                blocksparse_tensors_torch.dq_write_order_full,
+            ),
+            seqlen_q,
+            seqlen_k,
+            cu_seqlens_q,
+            cu_seqlens_k,
+            seqused_q,
+            seqused_k,
+            cu_total_m_blocks,
+            cu_total_n_blocks,
+            aux_tensors,
+        )
 
-    return blocksparse_tensors, blocksparse_tensors_torch
+    return blocksparse_tensors_torch
 
 
 compute_block_sparsity.compile_cache = {}

--- a/flash_attn/cute/flash_fwd.py
+++ b/flash_attn/cute/flash_fwd.py
@@ -630,6 +630,8 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
         window_size_right: Optional[Int32] = None,
         learnable_sink: Optional[cute.Tensor] = None,
         blocksparse_tensors: Optional[BlockSparseTensors] = None,
+        mCuTotalMBlocks: Optional[cute.Tensor] = None,
+        mCuTotalNBlocks: Optional[cute.Tensor] = None,
         aux_tensors=None,
         # Always keep stream as the last parameter (EnvStream: obtained implicitly via TVM FFI).
         stream: cuda.CUstream = None,
@@ -708,6 +710,8 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
             mCuSeqlensK,
             mSeqUsedQ,
             mSeqUsedK,
+            mCuTotalMBlocks,
+            mCuTotalNBlocks,
             softmax_scale_log2,
             softmax_scale,
             window_size_left,
@@ -747,6 +751,8 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
         mCuSeqlensK: Optional[cute.Tensor],
         mSeqUsedQ: Optional[cute.Tensor],
         mSeqUsedK: Optional[cute.Tensor],
+        mCuTotalMBlocks: Optional[cute.Tensor],
+        mCuTotalNBlocks: Optional[cute.Tensor],
         softmax_scale_log2: Float32,
         softmax_scale: Optional[Float32],
         window_size_left: Optional[Int32],
@@ -793,6 +799,8 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
             mCuSeqlensK=mCuSeqlensK,
             mSeqUsedQ=mSeqUsedQ,
             mSeqUsedK=mSeqUsedK,
+            mCuTotalMBlocks=mCuTotalMBlocks,
+            mCuTotalNBlocks=mCuTotalNBlocks,
         )
         n_block_min, n_block_max = block_info.get_n_block_min_max(seqlen, m_block)
         # For varlen, wasted grid tiles (where batch_idx >= num_batch) will have

--- a/flash_attn/cute/flash_fwd.py
+++ b/flash_attn/cute/flash_fwd.py
@@ -630,8 +630,6 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
         window_size_right: Optional[Int32] = None,
         learnable_sink: Optional[cute.Tensor] = None,
         blocksparse_tensors: Optional[BlockSparseTensors] = None,
-        mCuTotalMBlocks: Optional[cute.Tensor] = None,
-        mCuTotalNBlocks: Optional[cute.Tensor] = None,
         aux_tensors=None,
         # Always keep stream as the last parameter (EnvStream: obtained implicitly via TVM FFI).
         stream: cuda.CUstream = None,
@@ -710,8 +708,6 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
             mCuSeqlensK,
             mSeqUsedQ,
             mSeqUsedK,
-            mCuTotalMBlocks,
-            mCuTotalNBlocks,
             softmax_scale_log2,
             softmax_scale,
             window_size_left,
@@ -751,8 +747,6 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
         mCuSeqlensK: Optional[cute.Tensor],
         mSeqUsedQ: Optional[cute.Tensor],
         mSeqUsedK: Optional[cute.Tensor],
-        mCuTotalMBlocks: Optional[cute.Tensor],
-        mCuTotalNBlocks: Optional[cute.Tensor],
         softmax_scale_log2: Float32,
         softmax_scale: Optional[Float32],
         window_size_left: Optional[Int32],
@@ -799,8 +793,6 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
             mCuSeqlensK=mCuSeqlensK,
             mSeqUsedQ=mSeqUsedQ,
             mSeqUsedK=mSeqUsedK,
-            mCuTotalMBlocks=mCuTotalMBlocks,
-            mCuTotalNBlocks=mCuTotalNBlocks,
         )
         n_block_min, n_block_max = block_info.get_n_block_min_max(seqlen, m_block)
         # For varlen, wasted grid tiles (where batch_idx >= num_batch) will have

--- a/flash_attn/cute/flash_fwd_sm100.py
+++ b/flash_attn/cute/flash_fwd_sm100.py
@@ -373,8 +373,6 @@ class FlashAttentionForwardSm100:
         learnable_sink: Optional[cute.Tensor] = None,
         descale_tensors: Optional[DescaleTensors] = None,
         blocksparse_tensors: Optional[BlockSparseTensors] = None,
-        mCuTotalMBlocks: Optional[cute.Tensor] = None,
-        mCuTotalNBlocks: Optional[cute.Tensor] = None,
         aux_tensors: Optional[list] = None,
         # Always keep stream as the last parameter (EnvStream: obtained implicitly via TVM FFI).
         stream: cuda.CUstream = None,
@@ -725,7 +723,9 @@ class FlashAttentionForwardSm100:
         if cutlass.const_expr(self.use_block_sparsity and mPageTable is not None):
             raise NotImplementedError("Block sparsity + paged KV not supported on SM100")
         if cutlass.const_expr(self.use_block_sparsity and self.is_varlen_q):
-            assert const_expr(mCuTotalMBlocks is not None), "cu_total_m_blocks must be provided for use with varlen blocksparsity"
+            assert const_expr(blocksparse_tensors.cu_total_m_blocks is not None), (
+                "blocksparse_tensors.cu_total_m_blocks must be provided for varlen blocksparsity"
+            )
 
         # Launch the kernel synchronously
         self.kernel(
@@ -738,8 +738,6 @@ class FlashAttentionForwardSm100:
             mCuSeqlensK,
             mSeqUsedQ,
             mSeqUsedK,
-            mCuTotalMBlocks,
-            mCuTotalNBlocks,
             mPageTable,
             tma_atom_Q,
             tma_atom_K,
@@ -787,8 +785,6 @@ class FlashAttentionForwardSm100:
         mCuSeqlensK: Optional[cute.Tensor],
         mSeqUsedQ: Optional[cute.Tensor],
         mSeqUsedK: Optional[cute.Tensor],
-        mCuTotalMBlocks: Optional[cute.Tensor],
-        mCuTotalNBlocks: Optional[cute.Tensor],
         mPageTable: Optional[cute.Tensor],
         tma_atom_Q: Optional[cute.CopyAtom],
         tma_atom_K: Optional[cute.CopyAtom],
@@ -1057,8 +1053,12 @@ class FlashAttentionForwardSm100:
             mCuSeqlensK=mCuSeqlensK,
             mSeqUsedQ=mSeqUsedQ,
             mSeqUsedK=mSeqUsedK,
-            mCuTotalMBlocks=mCuTotalMBlocks,
-            mCuTotalNBlocks=mCuTotalNBlocks,
+            mCuTotalMBlocks=(
+                blocksparse_tensors.cu_total_m_blocks if blocksparse_tensors is not None else None
+            ),
+            mCuBlockIdxOffsets=(
+                blocksparse_tensors.cu_block_idx_offsets if blocksparse_tensors is not None else None
+            ),
         )
         AttentionMaskCls = partial(
             AttentionMask,

--- a/flash_attn/cute/flash_fwd_sm100.py
+++ b/flash_attn/cute/flash_fwd_sm100.py
@@ -373,6 +373,8 @@ class FlashAttentionForwardSm100:
         learnable_sink: Optional[cute.Tensor] = None,
         descale_tensors: Optional[DescaleTensors] = None,
         blocksparse_tensors: Optional[BlockSparseTensors] = None,
+        mCuTotalMBlocks: Optional[cute.Tensor] = None,
+        mCuTotalNBlocks: Optional[cute.Tensor] = None,
         aux_tensors: Optional[list] = None,
         # Always keep stream as the last parameter (EnvStream: obtained implicitly via TVM FFI).
         stream: cuda.CUstream = None,
@@ -722,6 +724,8 @@ class FlashAttentionForwardSm100:
         self.use_block_sparsity = cutlass.const_expr(blocksparse_tensors is not None)
         if cutlass.const_expr(self.use_block_sparsity and mPageTable is not None):
             raise NotImplementedError("Block sparsity + paged KV not supported on SM100")
+        if cutlass.const_expr(self.use_block_sparsity and self.is_varlen_q):
+            assert const_expr(mCuTotalMBlocks is not None), "cu_total_m_blocks must be provided for use with varlen blocksparsity"
 
         # Launch the kernel synchronously
         self.kernel(
@@ -734,6 +738,8 @@ class FlashAttentionForwardSm100:
             mCuSeqlensK,
             mSeqUsedQ,
             mSeqUsedK,
+            mCuTotalMBlocks,
+            mCuTotalNBlocks,
             mPageTable,
             tma_atom_Q,
             tma_atom_K,
@@ -781,6 +787,8 @@ class FlashAttentionForwardSm100:
         mCuSeqlensK: Optional[cute.Tensor],
         mSeqUsedQ: Optional[cute.Tensor],
         mSeqUsedK: Optional[cute.Tensor],
+        mCuTotalMBlocks: Optional[cute.Tensor],
+        mCuTotalNBlocks: Optional[cute.Tensor],
         mPageTable: Optional[cute.Tensor],
         tma_atom_Q: Optional[cute.CopyAtom],
         tma_atom_K: Optional[cute.CopyAtom],
@@ -1049,6 +1057,8 @@ class FlashAttentionForwardSm100:
             mCuSeqlensK=mCuSeqlensK,
             mSeqUsedQ=mSeqUsedQ,
             mSeqUsedK=mSeqUsedK,
+            mCuTotalMBlocks=mCuTotalMBlocks,
+            mCuTotalNBlocks=mCuTotalNBlocks,
         )
         AttentionMaskCls = partial(
             AttentionMask,
@@ -1488,6 +1498,7 @@ class FlashAttentionForwardSm100:
                     batch_idx,
                     head_idx,
                     m_block,
+                    seqlen,
                     kv_producer_state,
                     load_Q,
                     load_K,
@@ -1637,6 +1648,7 @@ class FlashAttentionForwardSm100:
                     m_block,
                     self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
                     self.q_subtile_factor if self.q_subtile_factor is not None else 1,
+                    seqlen_info=seqlen,
                 )
                 process_tile = block_iter_count > Int32(0)
             else:
@@ -2003,6 +2015,7 @@ class FlashAttentionForwardSm100:
                     m_block,
                     self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
                     self.q_subtile_factor if self.q_subtile_factor is not None else 1,
+                    seqlen_info=seqlen,
                 )
                 has_work = tile_block_count > Int32(0)
             else:
@@ -2058,6 +2071,7 @@ class FlashAttentionForwardSm100:
                     batch_idx,
                     head_idx,
                     m_block,
+                    seqlen,
                     softmax_step,
                     mask_fn,
                     mask_fn_none,
@@ -2415,6 +2429,7 @@ class FlashAttentionForwardSm100:
                     m_block,
                     self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
                     self.q_subtile_factor if self.q_subtile_factor is not None else 1,
+                    seqlen_info=seqlen,
                 )
                 has_work = total_block_count > Int32(0)
             else:

--- a/flash_attn/cute/flash_fwd_sm90.py
+++ b/flash_attn/cute/flash_fwd_sm90.py
@@ -171,6 +171,8 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         window_size_right: Int32 | int | None = None,
         learnable_sink: Optional[cute.Tensor] = None,
         blocksparse_tensors: Optional[BlockSparseTensors] = None,
+        mCuTotalMBlocks: Optional[cute.Tensor] = None,
+        mCuTotalNBlocks: Optional[cute.Tensor] = None,
         aux_tensors: Optional[list] = None,
         # Always keep stream as the last parameter (EnvStream: obtained implicitly via TVM FFI).
         stream: cuda.CUstream = None,
@@ -363,6 +365,8 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
             mCuSeqlensK,
             mSeqUsedQ,
             mSeqUsedK,
+            mCuTotalMBlocks,
+            mCuTotalNBlocks,
             mPageTable,
             tma_atom_Q,
             tma_atom_K,
@@ -409,6 +413,8 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         mCuSeqlensK: Optional[cute.Tensor],
         mSeqUsedQ: Optional[cute.Tensor],
         mSeqUsedK: Optional[cute.Tensor],
+        mCuTotalMBlocks: Optional[cute.Tensor],
+        mCuTotalNBlocks: Optional[cute.Tensor],
         mPageTable: Optional[cute.Tensor],
         tma_atom_Q: Optional[cute.CopyAtom],
         tma_atom_K: Optional[cute.CopyAtom],
@@ -553,6 +559,8 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
             mCuSeqlensK=mCuSeqlensK,
             mSeqUsedQ=mSeqUsedQ,
             mSeqUsedK=mSeqUsedK,
+            mCuTotalMBlocks=mCuTotalMBlocks,
+            mCuTotalNBlocks=mCuTotalNBlocks,
             # Don't need to pass in tile_mn because we won't access offset_padded
         )
         AttentionMaskCls = partial(

--- a/flash_attn/cute/flash_fwd_sm90.py
+++ b/flash_attn/cute/flash_fwd_sm90.py
@@ -171,8 +171,6 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         window_size_right: Int32 | int | None = None,
         learnable_sink: Optional[cute.Tensor] = None,
         blocksparse_tensors: Optional[BlockSparseTensors] = None,
-        mCuTotalMBlocks: Optional[cute.Tensor] = None,
-        mCuTotalNBlocks: Optional[cute.Tensor] = None,
         aux_tensors: Optional[list] = None,
         # Always keep stream as the last parameter (EnvStream: obtained implicitly via TVM FFI).
         stream: cuda.CUstream = None,
@@ -365,8 +363,6 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
             mCuSeqlensK,
             mSeqUsedQ,
             mSeqUsedK,
-            mCuTotalMBlocks,
-            mCuTotalNBlocks,
             mPageTable,
             tma_atom_Q,
             tma_atom_K,
@@ -413,8 +409,6 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         mCuSeqlensK: Optional[cute.Tensor],
         mSeqUsedQ: Optional[cute.Tensor],
         mSeqUsedK: Optional[cute.Tensor],
-        mCuTotalMBlocks: Optional[cute.Tensor],
-        mCuTotalNBlocks: Optional[cute.Tensor],
         mPageTable: Optional[cute.Tensor],
         tma_atom_Q: Optional[cute.CopyAtom],
         tma_atom_K: Optional[cute.CopyAtom],
@@ -559,8 +553,12 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
             mCuSeqlensK=mCuSeqlensK,
             mSeqUsedQ=mSeqUsedQ,
             mSeqUsedK=mSeqUsedK,
-            mCuTotalMBlocks=mCuTotalMBlocks,
-            mCuTotalNBlocks=mCuTotalNBlocks,
+            mCuTotalMBlocks=(
+                blocksparse_tensors.cu_total_m_blocks if blocksparse_tensors is not None else None
+            ),
+            mCuBlockIdxOffsets=(
+                blocksparse_tensors.cu_block_idx_offsets if blocksparse_tensors is not None else None
+            ),
             # Don't need to pass in tile_mn because we won't access offset_padded
         )
         AttentionMaskCls = partial(

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -313,8 +313,6 @@ def _flash_attn_fwd(
     score_mod: Optional[Callable] = None,
     mask_mod: Optional[Callable] = None,
     block_sparse_tensors: Optional[BlockSparseTensorsTorch] = None,
-    cu_total_m_blocks: Optional[torch.Tensor] = None,
-    cu_total_n_blocks: Optional[torch.Tensor] = None,
     return_lse: bool = False,
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
@@ -611,51 +609,28 @@ def _flash_attn_fwd(
                 "Block sparsity is not yet supported with SplitKV. TODO: partition sparse block lists per split."
             )
         if cu_seqlens_q is not None:
-            assert cu_total_m_blocks is not None, "Varlen block sparsity requires cu_total_m_blocks."
+            assert block_sparse_tensors.cu_total_m_blocks is not None, (
+                "Varlen block sparsity requires block_sparse_tensors.cu_total_m_blocks."
+            )
 
     # See get_broadcast_dims for why this is needed in compile key
     block_sparse_broadcast_pattern = None
     normalized_block_sparse_tensors = None
     q_subtile_factor = None
     if block_sparse_tensors is not None:
-        if cu_seqlens_q is not None:
-            cnt = block_sparse_tensors.mask_block_cnt
-            if cnt.ndim != 2:
-                raise ValueError("Varlen block sparse tensors must be 2D [H, total_m].")
-            if cnt.shape[0] not in (1, num_head):
-                raise ValueError(
-                    f"Varlen block sparse head dim must be 1 or {num_head}, got {cnt.shape[0]}."
-                )
-            if cnt.shape[0] == 1 and num_head > 1:
-                # Expand head-1 tensors to (num_head, ...) with stride-0 head dim so
-                # get_broadcast_dims correctly detects the broadcast.
-                def _expand_head(t):
-                    return t.expand(num_head, -1) if t is not None else None
-                normalized_block_sparse_tensors = BlockSparseTensorsTorch(
-                    mask_block_cnt=_expand_head(block_sparse_tensors.mask_block_cnt),
-                    mask_block_idx=_expand_head(block_sparse_tensors.mask_block_idx),
-                    full_block_cnt=_expand_head(block_sparse_tensors.full_block_cnt),
-                    full_block_idx=_expand_head(block_sparse_tensors.full_block_idx),
-                    block_size=block_sparse_tensors.block_size,
-                )
-            else:
-                normalized_block_sparse_tensors = block_sparse_tensors
-            q_subtile_factor = 1
-            block_sparse_broadcast_pattern = get_block_sparse_broadcast_pattern(normalized_block_sparse_tensors)
-        else:
-            (
-                normalized_block_sparse_tensors,
-                block_sparse_broadcast_pattern,
-                q_subtile_factor,
-            ) = normalize_block_sparse_config(
-                block_sparse_tensors,
-                batch_size=batch_size,
-                num_head=num_head,
-                seqlen_q=seqlen_q,
-                seqlen_k=seqlen_k,
-                block_size=(tile_m, tile_n),
-                q_stage=q_stage,
-            )
+        (
+            normalized_block_sparse_tensors,
+            block_sparse_broadcast_pattern,
+            q_subtile_factor,
+        ) = normalize_block_sparse_config(
+            block_sparse_tensors,
+            batch_size=batch_size,
+            num_head=num_head,
+            seqlen_q=seqlen_q,
+            seqlen_k=seqlen_k,
+            block_size=(tile_m, tile_n),
+            q_stage=q_stage,
+        )
     if aux_tensors is not None:
         aux_tensor_metadata = get_aux_tensor_metadata(aux_tensors)
     else:
@@ -722,8 +697,8 @@ def _flash_attn_fwd(
         q_descale is not None,
         k_descale is not None,
         v_descale is not None,
-        cu_total_m_blocks is None,
-        cu_total_n_blocks is None,
+        block_sparse_tensors is None or block_sparse_tensors.cu_total_m_blocks is None,
+        block_sparse_tensors is None or block_sparse_tensors.cu_block_idx_offsets is None,
         tile_m,
         tile_n,
         q_stage,
@@ -751,13 +726,11 @@ def _flash_attn_fwd(
             seqused_q_tensor,
             seqused_k_tensor,
             learnable_sink_tensor,
-            cu_total_m_blocks_tensor,
-            cu_total_n_blocks_tensor,
         ) = [
             to_cute_tensor(t, assumed_align=4, leading_dim=0)
             if t is not None
             else None
-            for t in (cu_seqlens_q, cu_seqlens_k, seqused_q, seqused_k, learnable_sink, cu_total_m_blocks, cu_total_n_blocks)
+            for t in (cu_seqlens_q, cu_seqlens_k, seqused_q, seqused_k, learnable_sink)
         ]
         page_table_tensor = (
             to_cute_tensor(page_table, assumed_align=4, leading_dim=1)
@@ -1001,8 +974,6 @@ def _flash_attn_fwd(
                 compile_args.append(descale_tensors_tensor)
             compile_args.extend([
                 sparse_tensors,
-                cu_total_m_blocks_tensor,
-                cu_total_n_blocks_tensor,
                 cute_aux_tensors,
             ])
             compile_args.append(current_stream)
@@ -1068,13 +1039,13 @@ def _flash_attn_fwd(
                     normalized_block_sparse_tensors.mask_block_idx,
                     normalized_block_sparse_tensors.full_block_cnt,
                     normalized_block_sparse_tensors.full_block_idx,
+                    normalized_block_sparse_tensors.cu_total_m_blocks,
+                    normalized_block_sparse_tensors.cu_block_idx_offsets,
                     normalized_block_sparse_tensors.dq_write_order,
                     normalized_block_sparse_tensors.dq_write_order_full,
                 )
                 if normalized_block_sparse_tensors is not None
                 else None,
-                cu_total_m_blocks,
-                cu_total_n_blocks,
                 aux_tensors,
             ])
             _flash_attn_fwd.compile_cache[compile_key](*call_args)
@@ -1892,6 +1863,8 @@ def _flash_attn_bwd(
                 normalized_block_sparse_tensors.mask_block_idx,
                 normalized_block_sparse_tensors.full_block_cnt,
                 normalized_block_sparse_tensors.full_block_idx,
+                normalized_block_sparse_tensors.cu_total_m_blocks,
+                normalized_block_sparse_tensors.cu_block_idx_offsets,
                 normalized_block_sparse_tensors.dq_write_order,
                 normalized_block_sparse_tensors.dq_write_order_full,
             )
@@ -2060,8 +2033,6 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
         score_mod_bwd: Optional[Callable] = None,
         mask_mod: Optional[Callable] = None,
         block_sparse_tensors: Optional[list] = None,
-        cu_total_m_blocks: Optional[torch.Tensor] = None,
-        cu_total_n_blocks: Optional[torch.Tensor] = None,
         aux_tensors: Optional[list] = None,
         return_lse: bool = False,
     ):
@@ -2089,8 +2060,6 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
             score_mod=score_mod,
             mask_mod=mask_mod,
             block_sparse_tensors=block_sparse_tensors,
-            cu_total_m_blocks=cu_total_m_blocks,
-            cu_total_n_blocks=cu_total_n_blocks,
             aux_tensors=aux_tensors,
             return_lse=return_lse,
             gather_kv_indices=gather_kv_indices,
@@ -2228,8 +2197,6 @@ def flash_attn_varlen_func(
     score_mod_bwd: Optional[Callable] = None,
     mask_mod: Optional[Callable] = None,
     block_sparse_tensors: Optional[BlockSparseTensorsTorch] = None,
-    cu_total_m_blocks: Optional[torch.Tensor] = None,
-    cu_total_n_blocks: Optional[torch.Tensor] = None,
     aux_tensors: Optional[list] = None,
     return_lse: bool = False,
 ):
@@ -2273,8 +2240,6 @@ def flash_attn_varlen_func(
         score_mod_bwd,
         mask_mod,
         block_sparse_tensors,
-        cu_total_m_blocks,
-        cu_total_n_blocks,
         aux_tensors,
         return_lse,
     )

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -55,6 +55,7 @@ from flash_attn.cute.block_sparsity import (
     to_cute_block_sparse_tensors,
     normalize_block_sparse_config,
     normalize_block_sparse_config_bwd,
+    get_block_sparse_broadcast_pattern,
 )
 
 def _parse_arch_str(arch_str):
@@ -312,6 +313,8 @@ def _flash_attn_fwd(
     score_mod: Optional[Callable] = None,
     mask_mod: Optional[Callable] = None,
     block_sparse_tensors: Optional[BlockSparseTensorsTorch] = None,
+    cu_total_m_blocks: Optional[torch.Tensor] = None,
+    cu_total_n_blocks: Optional[torch.Tensor] = None,
     return_lse: bool = False,
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
@@ -598,45 +601,61 @@ def _flash_attn_fwd(
     is_dense_noncausal = not is_varlen and not causal and not local
     use_clc_scheduler = requested_use_clc_scheduler and not is_varlen_mha and not is_dense_noncausal
 
-    if mask_mod is not None:
-        if is_varlen:
-            raise NotImplementedError(
-                "mask_mod with aux_tensors is not yet supported for varlen sequences. This will be fixed in a future PR."
-            )
-
     if use_block_sparsity:
-        if is_varlen:
-            raise NotImplementedError(
-                "Block sparsity is not yet supported for varlen sequences. This will be fixed in a future PR."
-            )
         # NB: pack_gqa requires block sparse head dim == 1 (broadcasted)
-        if pack_gqa and block_sparse_tensors.mask_block_cnt.shape[1] != 1:
+        head_dim_idx = 0 if block_sparse_tensors.mask_block_cnt.ndim == 2 else 1
+        if pack_gqa and block_sparse_tensors.mask_block_cnt.shape[head_dim_idx] != 1:
             pack_gqa = False
         if is_split_kv:
             raise NotImplementedError(
                 "Block sparsity is not yet supported with SplitKV. TODO: partition sparse block lists per split."
             )
+        if cu_seqlens_q is not None:
+            assert cu_total_m_blocks is not None, "Varlen block sparsity requires cu_total_m_blocks."
 
     # See get_broadcast_dims for why this is needed in compile key
     block_sparse_broadcast_pattern = None
     normalized_block_sparse_tensors = None
     q_subtile_factor = None
     if block_sparse_tensors is not None:
-        if seqlen_q is None:
-            raise ValueError("Block sparsity requires fixed-length sequences (seqlen_q must be known).")
-        (
-            normalized_block_sparse_tensors,
-            block_sparse_broadcast_pattern,
-            q_subtile_factor,
-        ) = normalize_block_sparse_config(
-            block_sparse_tensors,
-            batch_size=batch_size,
-            num_head=num_head,
-            seqlen_q=seqlen_q,
-            seqlen_k=seqlen_k,
-            block_size=(tile_m, tile_n),
-            q_stage=q_stage,
-        )
+        if cu_seqlens_q is not None:
+            cnt = block_sparse_tensors.mask_block_cnt
+            if cnt.ndim != 2:
+                raise ValueError("Varlen block sparse tensors must be 2D [H, total_m].")
+            if cnt.shape[0] not in (1, num_head):
+                raise ValueError(
+                    f"Varlen block sparse head dim must be 1 or {num_head}, got {cnt.shape[0]}."
+                )
+            if cnt.shape[0] == 1 and num_head > 1:
+                # Expand head-1 tensors to (num_head, ...) with stride-0 head dim so
+                # get_broadcast_dims correctly detects the broadcast.
+                def _expand_head(t):
+                    return t.expand(num_head, -1) if t is not None else None
+                normalized_block_sparse_tensors = BlockSparseTensorsTorch(
+                    mask_block_cnt=_expand_head(block_sparse_tensors.mask_block_cnt),
+                    mask_block_idx=_expand_head(block_sparse_tensors.mask_block_idx),
+                    full_block_cnt=_expand_head(block_sparse_tensors.full_block_cnt),
+                    full_block_idx=_expand_head(block_sparse_tensors.full_block_idx),
+                    block_size=block_sparse_tensors.block_size,
+                )
+            else:
+                normalized_block_sparse_tensors = block_sparse_tensors
+            q_subtile_factor = 1
+            block_sparse_broadcast_pattern = get_block_sparse_broadcast_pattern(normalized_block_sparse_tensors)
+        else:
+            (
+                normalized_block_sparse_tensors,
+                block_sparse_broadcast_pattern,
+                q_subtile_factor,
+            ) = normalize_block_sparse_config(
+                block_sparse_tensors,
+                batch_size=batch_size,
+                num_head=num_head,
+                seqlen_q=seqlen_q,
+                seqlen_k=seqlen_k,
+                block_size=(tile_m, tile_n),
+                q_stage=q_stage,
+            )
     if aux_tensors is not None:
         aux_tensor_metadata = get_aux_tensor_metadata(aux_tensors)
     else:
@@ -703,6 +722,8 @@ def _flash_attn_fwd(
         q_descale is not None,
         k_descale is not None,
         v_descale is not None,
+        cu_total_m_blocks is None,
+        cu_total_n_blocks is None,
         tile_m,
         tile_n,
         q_stage,
@@ -730,11 +751,13 @@ def _flash_attn_fwd(
             seqused_q_tensor,
             seqused_k_tensor,
             learnable_sink_tensor,
+            cu_total_m_blocks_tensor,
+            cu_total_n_blocks_tensor,
         ) = [
             to_cute_tensor(t, assumed_align=4, leading_dim=0)
             if t is not None
             else None
-            for t in (cu_seqlens_q, cu_seqlens_k, seqused_q, seqused_k, learnable_sink)
+            for t in (cu_seqlens_q, cu_seqlens_k, seqused_q, seqused_k, learnable_sink, cu_total_m_blocks, cu_total_n_blocks)
         ]
         page_table_tensor = (
             to_cute_tensor(page_table, assumed_align=4, leading_dim=1)
@@ -973,13 +996,19 @@ def _flash_attn_fwd(
                 window_size_left,
                 window_size_right,
                 learnable_sink_tensor,
-                sparse_tensors,
-                cute_aux_tensors,
-                current_stream,
             ]
             if arch // 10 in [10, 11]:
-                compile_args.insert(-3, descale_tensors_tensor)
-            _flash_attn_fwd.compile_cache[compile_key] = cute.compile(*compile_args, options="--enable-tvm-ffi")
+                compile_args.append(descale_tensors_tensor)
+            compile_args.extend([
+                sparse_tensors,
+                cu_total_m_blocks_tensor,
+                cu_total_n_blocks_tensor,
+                cute_aux_tensors,
+            ])
+            compile_args.append(current_stream)
+            _flash_attn_fwd.compile_cache[compile_key] = cute.compile(
+                *compile_args, options="--enable-tvm-ffi"
+            )
 
     if not is_fake_mode():
         q_call, k_call, v_call = q.detach(), k.detach(), v.detach()
@@ -1044,6 +1073,8 @@ def _flash_attn_fwd(
                 )
                 if normalized_block_sparse_tensors is not None
                 else None,
+                cu_total_m_blocks,
+                cu_total_n_blocks,
                 aux_tensors,
             ])
             _flash_attn_fwd.compile_cache[compile_key](*call_args)
@@ -2027,6 +2058,10 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
         deterministic: bool = False,
         score_mod: Optional[Callable] = None,
         score_mod_bwd: Optional[Callable] = None,
+        mask_mod: Optional[Callable] = None,
+        block_sparse_tensors: Optional[list] = None,
+        cu_total_m_blocks: Optional[torch.Tensor] = None,
+        cu_total_n_blocks: Optional[torch.Tensor] = None,
         aux_tensors: Optional[list] = None,
         return_lse: bool = False,
     ):
@@ -2052,6 +2087,10 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
             num_splits=num_splits,
             pack_gqa=pack_gqa,
             score_mod=score_mod,
+            mask_mod=mask_mod,
+            block_sparse_tensors=block_sparse_tensors,
+            cu_total_m_blocks=cu_total_m_blocks,
+            cu_total_n_blocks=cu_total_n_blocks,
             aux_tensors=aux_tensors,
             return_lse=return_lse,
             gather_kv_indices=gather_kv_indices,
@@ -2187,6 +2226,10 @@ def flash_attn_varlen_func(
     deterministic: bool = False,
     score_mod: Optional[Callable] = None,
     score_mod_bwd: Optional[Callable] = None,
+    mask_mod: Optional[Callable] = None,
+    block_sparse_tensors: Optional[BlockSparseTensorsTorch] = None,
+    cu_total_m_blocks: Optional[torch.Tensor] = None,
+    cu_total_n_blocks: Optional[torch.Tensor] = None,
     aux_tensors: Optional[list] = None,
     return_lse: bool = False,
 ):
@@ -2228,6 +2271,10 @@ def flash_attn_varlen_func(
         deterministic,
         score_mod,
         score_mod_bwd,
+        mask_mod,
+        block_sparse_tensors,
+        cu_total_m_blocks,
+        cu_total_n_blocks,
         aux_tensors,
         return_lse,
     )

--- a/flash_attn/cute/seqlen_info.py
+++ b/flash_attn/cute/seqlen_info.py
@@ -71,6 +71,9 @@ class SeqlenInfoQK:
     padded_offset_k: Int32
     seqlen_q: Int32
     seqlen_k: Int32
+    m_block_offset: Int32
+    n_block_offset: Int32
+    num_n_blocks: Int32
     has_cu_seqlens_q: cutlass.Constexpr[bool]
     has_cu_seqlens_k: cutlass.Constexpr[bool]
     has_seqused_q: cutlass.Constexpr[bool]
@@ -85,6 +88,8 @@ class SeqlenInfoQK:
         mCuSeqlensK: Optional[cute.Tensor] = None,
         mSeqUsedQ: Optional[cute.Tensor] = None,
         mSeqUsedK: Optional[cute.Tensor] = None,
+        mCuTotalMBlocks: Optional[cute.Tensor] = None,
+        mCuTotalNBlocks: Optional[cute.Tensor] = None,
         tile_m: cutlass.Constexpr[Int32] = 128,
         tile_n: cutlass.Constexpr[Int32] = 128,
     ):
@@ -116,6 +121,12 @@ class SeqlenInfoQK:
                 if const_expr(mCuSeqlensK is None)
                 else mCuSeqlensK[batch_idx + 1] - offset_k
             )
+        m_block_offset = 0 if const_expr(mCuTotalMBlocks is None) else mCuTotalMBlocks[batch_idx]
+        num_n_blocks = (seqlen_k + tile_n - 1) // tile_n
+        if const_expr(mCuTotalNBlocks is not None):
+            n_block_offset = mCuTotalNBlocks[batch_idx]
+        else:
+            n_block_offset = m_block_offset * num_n_blocks
         return SeqlenInfoQK(
             offset_q,
             offset_k,
@@ -123,6 +134,9 @@ class SeqlenInfoQK:
             padded_offset_k,
             seqlen_q,
             seqlen_k,
+            m_block_offset,
+            n_block_offset,
+            num_n_blocks,
             has_cu_seqlens_q=mCuSeqlensQ is not None,
             has_cu_seqlens_k=mCuSeqlensK is not None,
             has_seqused_q=mSeqUsedQ is not None,

--- a/flash_attn/cute/seqlen_info.py
+++ b/flash_attn/cute/seqlen_info.py
@@ -72,7 +72,7 @@ class SeqlenInfoQK:
     seqlen_q: Int32
     seqlen_k: Int32
     m_block_offset: Int32
-    n_block_offset: Int32
+    block_idx_offset: Int32
     num_n_blocks: Int32
     has_cu_seqlens_q: cutlass.Constexpr[bool]
     has_cu_seqlens_k: cutlass.Constexpr[bool]
@@ -89,7 +89,7 @@ class SeqlenInfoQK:
         mSeqUsedQ: Optional[cute.Tensor] = None,
         mSeqUsedK: Optional[cute.Tensor] = None,
         mCuTotalMBlocks: Optional[cute.Tensor] = None,
-        mCuTotalNBlocks: Optional[cute.Tensor] = None,
+        mCuBlockIdxOffsets: Optional[cute.Tensor] = None,
         tile_m: cutlass.Constexpr[Int32] = 128,
         tile_n: cutlass.Constexpr[Int32] = 128,
     ):
@@ -123,10 +123,11 @@ class SeqlenInfoQK:
             )
         m_block_offset = 0 if const_expr(mCuTotalMBlocks is None) else mCuTotalMBlocks[batch_idx]
         num_n_blocks = (seqlen_k + tile_n - 1) // tile_n
-        if const_expr(mCuTotalNBlocks is not None):
-            n_block_offset = mCuTotalNBlocks[batch_idx]
-        else:
-            n_block_offset = m_block_offset * num_n_blocks
+        block_idx_offset = (
+            mCuBlockIdxOffsets[batch_idx]
+            if const_expr(mCuBlockIdxOffsets is not None)
+            else m_block_offset * num_n_blocks
+        )
         return SeqlenInfoQK(
             offset_q,
             offset_k,
@@ -135,7 +136,7 @@ class SeqlenInfoQK:
             seqlen_q,
             seqlen_k,
             m_block_offset,
-            n_block_offset,
+            block_idx_offset,
             num_n_blocks,
             has_cu_seqlens_q=mCuSeqlensQ is not None,
             has_cu_seqlens_k=mCuSeqlensK is not None,

--- a/tests/cute/benchmark_block_sparsity.py
+++ b/tests/cute/benchmark_block_sparsity.py
@@ -39,7 +39,7 @@ class BenchmarkConfig:
     mask_name: str
     tile_m: int = 128
     tile_n: int = 128
-    use_fast_sampling: bool = False
+    use_fast_sampling: bool = True
     aux_tensors_cute: Optional[list] = None
 
 
@@ -162,7 +162,7 @@ def benchmark_cute_block_sparsity(
             blocksparse_tensors,
             config.seqlen_q,
             config.seqlen_k,
-            config.aux_tensors_cute,
+            aux_tensors=config.aux_tensors_cute,
         )
 
         def generate_tensors():
@@ -336,7 +336,7 @@ def main():
                     mask_name=config.mask_name,
                     tile_m=config.tile_m,
                     tile_n=config.tile_n,
-                    use_fast_sampling=False,
+                    use_fast_sampling=True,
                     aux_tensors_cute=[doc_ids_cute],
                 )
             )

--- a/tests/cute/mask_mod_definitions.py
+++ b/tests/cute/mask_mod_definitions.py
@@ -159,7 +159,6 @@ def cute_document_mask(
     return m_doc == n_doc
 
 
-@fast_sampling
 @cute.jit
 def cute_ima_mask(
     batch: cute.TensorSSA,
@@ -180,7 +179,99 @@ def cute_ima_mask(
 #                            n_idx_global = n_idx + seqlen_info.offset_k
 # =============================================================================
 
-# TODO: Add varlen mask implementations here
+
+@fast_sampling
+@cute.jit
+def cute_global_packed_doc_mask(
+    batch: cute.TensorSSA,
+    head: cute.TensorSSA,
+    m_idx: cute.TensorSSA,
+    n_idx: cute.TensorSSA,
+    seqlen_info,
+    aux_tensors,
+) -> cute.TensorSSA:
+    """Document mask using globally-indexed packed 1D doc ID tensors.
+
+    aux_tensors[0]: doc_ids_q (total_q,) int32 — packed doc IDs for Q tokens
+    aux_tensors[1]: doc_ids_k (total_k,) int32 — packed doc IDs for K tokens
+    Mask: doc_ids_q[m_global] == doc_ids_k[n_global]
+    """
+    doc_ids_q = aux_tensors[0]
+    doc_ids_k = aux_tensors[1]
+
+    offset_q = seqlen_info.offset_q
+    m_global = m_idx + offset_q
+    m_frag = cute.make_fragment(1, cutlass.Int32)
+    m_frag.store(m_global)
+    m_doc_frag = cute.make_fragment(1, cutlass.Int32)
+    m_doc_frag[0] = doc_ids_q[m_frag[0]]
+
+    offset_k = seqlen_info.offset_k
+    n_global = n_idx + offset_k
+    n_frag = cute.make_fragment(1, cutlass.Int32)
+    n_frag.store(n_global)
+    n_doc_frag = cute.make_fragment(1, cutlass.Int32)
+    n_doc_frag[0] = doc_ids_k[n_frag[0]]
+
+    m_doc = m_doc_frag.load()
+    n_doc = n_doc_frag.load()
+    return m_doc == n_doc
+
+
+@fast_sampling
+@cute.jit
+def cute_global_ima_mask(
+    batch: cute.TensorSSA,
+    head: cute.TensorSSA,
+    m_idx: cute.TensorSSA,
+    n_idx: cute.TensorSSA,
+    seqlen_info,
+    aux_tensors,
+) -> cute.TensorSSA:
+    """IMA-style mask using globally-indexed threshold tensor.
+
+    aux_tensors[0]: thresholds (total_k,) int32 — per-global-kv-position threshold
+    Mask: n_idx >= thresholds[n_global]  (local n_idx >= globally-indexed threshold)
+    """
+    thresholds = aux_tensors[0]
+
+    offset_k = seqlen_info.offset_k
+    n_global = n_idx + offset_k
+    n_frag = cute.make_fragment(1, cutlass.Int32)
+    n_frag.store(n_global)
+    val_frag = cute.make_fragment(1, cutlass.Int32)
+    val_frag[0] = thresholds[n_frag[0]]
+    threshold = val_frag.load()
+
+    return n_idx >= threshold
+
+
+@fast_sampling
+@cute.jit
+def cute_global_causal_window_mask(
+    batch: cute.TensorSSA,
+    head: cute.TensorSSA,
+    m_idx: cute.TensorSSA,
+    n_idx: cute.TensorSSA,
+    seqlen_info,
+    aux_tensors,
+) -> cute.TensorSSA:
+    """Causal window mask with per-token window sizes indexed globally.
+
+    aux_tensors[0]: windows (total_q,) int32 — per-global-q-position window size
+    Mask: (n_idx <= m_idx) & (m_idx - n_idx <= windows[m_global])
+    """
+    windows = aux_tensors[0]
+
+    offset_q = seqlen_info.offset_q
+    m_global = m_idx + offset_q
+    m_frag = cute.make_fragment(1, cutlass.Int32)
+    m_frag.store(m_global)
+    win_frag = cute.make_fragment(1, cutlass.Int32)
+    win_frag[0] = windows[m_frag[0]]
+    window = win_frag.load()
+
+    return (n_idx <= m_idx) & ((m_idx - n_idx) <= window)
 
 
 # =============================================================================
@@ -247,13 +338,70 @@ def flex_ima_mask(b, h, q_idx, kv_idx, bias):
 
 
 # =============================================================================
+# Flex reference factories for global-index masks (per-sequence)
+# Each factory(seq_idx, sq, sk) -> mask(b, h, q_idx, kv_idx)
+# where q_idx/kv_idx are local (0-indexed) within the sequence.
+# =============================================================================
+
+
+def global_packed_doc_flex_factory(doc_ids_q, doc_ids_k, cu_seqlens_q, cu_seqlens_k):
+    """Factory for per-sequence flex reference of cute_global_packed_doc_mask."""
+
+    def factory(seq_idx, sq, sk):
+        q_offset = cu_seqlens_q[seq_idx].item()
+        k_offset = cu_seqlens_k[seq_idx].item()
+
+        def mask(b, h, q_idx, kv_idx):
+            q_global = q_offset + q_idx
+            k_global = k_offset + kv_idx
+            return doc_ids_q[q_global] == doc_ids_k[k_global]
+
+        return mask
+
+    return factory
+
+
+def global_ima_flex_factory(thresholds, cu_seqlens_k):
+    """Factory for per-sequence flex reference of cute_global_ima_mask."""
+
+    def factory(seq_idx, sq, sk):
+        k_offset = cu_seqlens_k[seq_idx].item()
+
+        def mask(b, h, q_idx, kv_idx):
+            k_global = k_offset + kv_idx
+            return kv_idx >= thresholds[k_global]
+
+        return mask
+
+    return factory
+
+
+def global_causal_window_flex_factory(windows, cu_seqlens_q):
+    """Factory for per-sequence flex reference of cute_global_causal_window_mask."""
+
+    def factory(seq_idx, sq, sk):
+        q_offset = cu_seqlens_q[seq_idx].item()
+
+        def mask(b, h, q_idx, kv_idx):
+            q_global = q_offset + q_idx
+            window = windows[q_global]
+            return (kv_idx <= q_idx) & ((q_idx - kv_idx) <= window)
+
+        return mask
+
+    return factory
+
+
+# =============================================================================
 # Utility functions
 # =============================================================================
 
 
 def random_doc_id_tensor(nheads, batch, seqlen_q, device="cpu"):
     """Generate synthetic document ids shared across heads."""
-    doc_ids_tensor = torch.zeros(batch, nheads, seqlen_q, dtype=torch.int32, device=device)
+    doc_ids_tensor = torch.zeros(
+        batch, nheads, seqlen_q, dtype=torch.int32, device=device
+    )
     for b in range(batch):
         N = seqlen_q
         max_segments = max(1, math.ceil(math.sqrt(max(N // 4, 1))))
@@ -269,6 +417,83 @@ def random_doc_id_tensor(nheads, batch, seqlen_q, device="cpu"):
         for h in range(nheads):
             doc_ids_tensor[b, h, :] = base_doc_ids
     return doc_ids_tensor
+
+
+def make_packed_doc_ids(seqlens_q, seqlens_k, device="cuda"):
+    """Generate packed 1D doc ID tensors for Q and K for varlen global-index testing.
+
+    For each sequence, divides tokens into sqrt(len)-ish segments.
+    Returns (doc_ids_q, doc_ids_k) of shape (total_q,) and (total_k,).
+    """
+    total_q = sum(seqlens_q)
+    total_k = sum(seqlens_k)
+    doc_ids_q = torch.zeros(total_q, dtype=torch.int32, device=device)
+    doc_ids_k = torch.zeros(total_k, dtype=torch.int32, device=device)
+
+    q_off = 0
+    k_off = 0
+    for sq, sk in zip(seqlens_q, seqlens_k):
+        # Q doc IDs
+        n_docs = max(1, math.ceil(math.sqrt(max(sq // 4, 1))))
+        n_docs = min(n_docs, sq)
+        if n_docs > 1 and sq > 1:
+            cuts = sorted(random.sample(range(1, sq), min(n_docs - 1, sq - 1)))
+        else:
+            cuts = []
+        lengths = [b - a for a, b in zip((0, *cuts), (*cuts, sq))]
+        doc_ids_q[q_off : q_off + sq] = torch.repeat_interleave(
+            torch.arange(len(lengths), dtype=torch.int32, device=device),
+            torch.tensor(lengths, dtype=torch.int32, device=device),
+        )
+
+        # K doc IDs (same n_docs range for potential overlap)
+        if n_docs > 1 and sk > 1:
+            cuts_k = sorted(random.sample(range(1, sk), min(n_docs - 1, sk - 1)))
+        else:
+            cuts_k = []
+        lengths_k = [b - a for a, b in zip((0, *cuts_k), (*cuts_k, sk))]
+        doc_ids_k[k_off : k_off + sk] = torch.repeat_interleave(
+            torch.arange(len(lengths_k), dtype=torch.int32, device=device),
+            torch.tensor(lengths_k, dtype=torch.int32, device=device),
+        )
+
+        q_off += sq
+        k_off += sk
+
+    return doc_ids_q, doc_ids_k
+
+
+def make_global_thresholds(seqlens_k, device="cuda"):
+    """Generate per-global-kv-token thresholds for cute_global_ima_mask.
+
+    For each K token at local index i in a sequence of length sk,
+    threshold = random value in [0, sk//2].
+    Returns thresholds of shape (total_k,).
+    """
+    total_k = sum(seqlens_k)
+    thresholds = torch.zeros(total_k, dtype=torch.int32, device=device)
+    k_off = 0
+    for sk in seqlens_k:
+        for i in range(sk):
+            thresholds[k_off + i] = random.randint(0, max(0, sk // 2))
+        k_off += sk
+    return thresholds
+
+
+def make_global_windows(seqlens_q, device="cuda"):
+    """Generate per-global-q-token window sizes for cute_global_causal_window_mask.
+
+    For Q token at local index i, window = random value in [0, i] (causal).
+    Returns windows of shape (total_q,).
+    """
+    total_q = sum(seqlens_q)
+    windows = torch.zeros(total_q, dtype=torch.int32, device=device)
+    q_off = 0
+    for sq in seqlens_q:
+        for i in range(sq):
+            windows[q_off + i] = random.randint(0, i)
+        q_off += sq
+    return windows
 
 
 # =============================================================================

--- a/tests/cute/test_block_sparsity.py
+++ b/tests/cute/test_block_sparsity.py
@@ -487,7 +487,7 @@ def _compare_block_sparsity_varlen(
     full_block_cnt,
     full_block_idx,
     cu_total_m_blocks,
-    cu_total_n_blocks,
+    cu_block_idx_offsets,
     seqlens_q,
     seqlens_k,
     nheads,
@@ -499,7 +499,7 @@ def _compare_block_sparsity_varlen(
     """Compare varlen block sparsity against per-sequence fixed-length references."""
     batch_size = len(seqlens_q)
     cu_m = cu_total_m_blocks.cpu().tolist()
-    cu_n = cu_total_n_blocks.cpu().tolist()
+    cu_n = cu_block_idx_offsets.cpu().tolist()
 
     for b in range(batch_size):
         sq, sk = seqlens_q[b], seqlens_k[b]
@@ -627,7 +627,7 @@ def _generate_varlen_inputs(
         seqlens_k: list of per-batch key sequence lengths
         tile_m, tile_n: tile sizes
     Returns:
-        cu_seqlens_q, cu_seqlens_k, cu_total_m_blocks, cu_total_n_blocks
+        cu_seqlens_q, cu_seqlens_k, cu_total_m_blocks, cu_block_idx_offsets
     """
     batch_size = len(seqlens_q)
     assert len(seqlens_k) == batch_size
@@ -635,7 +635,7 @@ def _generate_varlen_inputs(
     cu_seqlens_q = [0]
     cu_seqlens_k = [0]
     cu_total_m_blocks = [0]
-    cu_total_n_blocks = [0]
+    cu_block_idx_offsets = [0]
 
     for b in range(batch_size):
         cu_seqlens_q.append(cu_seqlens_q[-1] + seqlens_q[b])
@@ -643,13 +643,13 @@ def _generate_varlen_inputs(
         num_m = (seqlens_q[b] + tile_m - 1) // tile_m
         num_n = (seqlens_k[b] + tile_n - 1) // tile_n
         cu_total_m_blocks.append(cu_total_m_blocks[-1] + num_m)
-        cu_total_n_blocks.append(cu_total_n_blocks[-1] + num_m * num_n)
+        cu_block_idx_offsets.append(cu_block_idx_offsets[-1] + num_m * num_n)
 
     return (
         torch.tensor(cu_seqlens_q, device=device, dtype=torch.int32),
         torch.tensor(cu_seqlens_k, device=device, dtype=torch.int32),
         torch.tensor(cu_total_m_blocks, device=device, dtype=torch.int32),
-        torch.tensor(cu_total_n_blocks, device=device, dtype=torch.int32),
+        torch.tensor(cu_block_idx_offsets, device=device, dtype=torch.int32),
     )
 
 
@@ -674,7 +674,7 @@ def _call_compute_block_sparsity_varlen(
         mask_name, seqlen_q=max_seqlen_q, seqlen_k=max_seqlen_k, window_size=window_size
     )
 
-    cu_seqlens_q, cu_seqlens_k, cu_total_m_blocks, cu_total_n_blocks = (
+    cu_seqlens_q, cu_seqlens_k, cu_total_m_blocks, cu_block_idx_offsets = (
         _generate_varlen_inputs(seqlens_q, seqlens_k, tile_m, tile_n)
     )
 
@@ -691,7 +691,7 @@ def _call_compute_block_sparsity_varlen(
         cu_seqlens_q=cu_seqlens_q,
         cu_seqlens_k=cu_seqlens_k,
         cu_total_m_blocks=cu_total_m_blocks,
-        cu_total_n_blocks=cu_total_n_blocks,
+        cu_block_idx_offsets=cu_block_idx_offsets,
         use_fast_sampling=use_fast_sampling,
     )
     mask_block_cnt, mask_block_idx, full_block_cnt, full_block_idx, *_ = torch_tensors
@@ -701,7 +701,7 @@ def _call_compute_block_sparsity_varlen(
         full_block_cnt,
         full_block_idx,
         cu_total_m_blocks,
-        cu_total_n_blocks,
+        cu_block_idx_offsets,
     )
 
 
@@ -717,7 +717,7 @@ def test_varlen(seqlens_q, seqlens_k, tile_m, tile_n, nheads, mask_name):
         full_block_cnt,
         full_block_idx,
         cu_total_m_blocks,
-        cu_total_n_blocks,
+        cu_block_idx_offsets,
     ) = _call_compute_block_sparsity_varlen(
         seqlens_q, seqlens_k, nheads, tile_m, tile_n, mask_name
     )
@@ -728,7 +728,7 @@ def test_varlen(seqlens_q, seqlens_k, tile_m, tile_n, nheads, mask_name):
         full_block_cnt,
         full_block_idx,
         cu_total_m_blocks,
-        cu_total_n_blocks,
+        cu_block_idx_offsets,
         seqlens_q,
         seqlens_k,
         nheads,
@@ -769,7 +769,7 @@ def test_varlen_parameterized_masks(
         full_block_cnt,
         full_block_idx,
         cu_total_m_blocks,
-        cu_total_n_blocks,
+        cu_block_idx_offsets,
     ) = _call_compute_block_sparsity_varlen(
         seqlens_q, seqlens_k, nheads, tile_m, tile_n, mask_name, window_size=window_size
     )
@@ -780,7 +780,7 @@ def test_varlen_parameterized_masks(
         full_block_cnt,
         full_block_idx,
         cu_total_m_blocks,
-        cu_total_n_blocks,
+        cu_block_idx_offsets,
         seqlens_q,
         seqlens_k,
         nheads,
@@ -817,7 +817,7 @@ def test_varlen_matches_fixed_length(nheads, tile_m, tile_n):
         vl_full_cnt,
         vl_full_idx,
         cu_total_m_blocks,
-        cu_total_n_blocks,
+        cu_block_idx_offsets,
     ) = _call_compute_block_sparsity_varlen(
         seqlens_q, seqlens_k, nheads, tile_m, tile_n, mask_name
     )
@@ -825,7 +825,7 @@ def test_varlen_matches_fixed_length(nheads, tile_m, tile_n):
     num_m = (seqlen_q + tile_m - 1) // tile_m
     num_n = (seqlen_k + tile_n - 1) // tile_n
     cu_m = cu_total_m_blocks.cpu().tolist()
-    cu_n = cu_total_n_blocks.cpu().tolist()
+    cu_n = cu_block_idx_offsets.cpu().tolist()
 
     for b in range(batch_size):
         for h in range(nheads):

--- a/tests/cute/test_mask_mod.py
+++ b/tests/cute/test_mask_mod.py
@@ -295,10 +295,11 @@ def _run_mask_test(
         doc_ids = random_doc_id_tensor(nheads, batch_size, doc_len, device="cuda").to(
             dtype=torch.int32, device="cuda"
         )
-        original_flex_mask = mask_mod_flex
+        doc_ids.__leading_dim__ = 2 
+        doc_row = doc_ids[0, 0]  # (doc_len,); batch_size=1, all heads identical
 
-        def mask_mod_flex(b, h, q_idx, kv_idx, doc_ids=doc_ids):
-            return original_flex_mask(b, h, q_idx, kv_idx, doc_ids)
+        def mask_mod_flex(b, h, q_idx, kv_idx):
+            return doc_row[q_idx] == doc_row[kv_idx]
 
         aux_tensors_arg = [doc_ids]
     elif mask_name == "ima":

--- a/tests/cute/test_mask_mod_varlen.py
+++ b/tests/cute/test_mask_mod_varlen.py
@@ -1,0 +1,902 @@
+# mask_mod varlen test script
+# Forward-only 
+#
+# Since flex_attention doesn't support varlen natively, we compare
+# results sequence-by-sequence: run the kernel with cu_seqlens (packed),
+# then run flex_attention per-sequence and compare.
+#
+# Usage:
+#   pytest test_mask_mod_varlen.py -v -s
+
+import math
+import random
+
+import pytest
+import torch
+import torch.nn.functional as F
+import cutlass
+import cutlass.cute as cute
+from torch.nn.attention.flex_attention import create_block_mask, flex_attention
+
+from flash_attn.cute.interface import _flash_attn_fwd
+from flash_attn.cute import utils
+from flash_attn.cute.compute_block_sparsity import compute_block_sparsity
+from mask_mod_definitions import (
+    get_mask_pair,
+    random_doc_id_tensor,
+    STATIC_MASKS,
+    PARAMETERIZED_MASK_FACTORIES,
+    cute_global_packed_doc_mask,
+    cute_global_ima_mask,
+    cute_global_causal_window_mask,
+    global_packed_doc_flex_factory,
+    global_ima_flex_factory,
+    global_causal_window_flex_factory,
+    make_packed_doc_ids,
+    make_global_thresholds,
+    make_global_windows,
+)
+
+COMPUTE_CAPABILITY = torch.cuda.get_device_capability()[0]
+
+
+@pytest.fixture(autouse=True)
+def reset_torch_state():
+    """Reset torch dynamo/compile state between tests to avoid state pollution."""
+    torch._dynamo.reset()
+    torch.cuda.empty_cache()
+    yield
+    torch._dynamo.reset()
+    torch.cuda.empty_cache()
+
+
+# =============================================================================
+# Seqlen configs for varlen (list of per-sequence lengths)
+# =============================================================================
+
+SEQLEN_CONFIGS = [
+    # Simple cases
+    ([1], [1]),
+    ([64], [64]),
+    ([128], [128]),
+    # Multiple sequences, same length
+    ([128, 128], [128, 128]),
+    ([64, 64, 64], [64, 64, 64]),
+    # Multiple sequences, varying lengths
+    ([64, 128], [64, 128]),
+    ([32, 64, 128], [32, 64, 128]),
+    ([113, 203], [113, 203]),
+    ([256, 512], [256, 512]),
+    # Asymmetric Q/K lengths
+    ([64, 128], [32, 64]),
+    ([100, 100], [50, 50]),
+    # Edge cases
+    ([1, 1], [1, 1]),
+    ([1, 256], [1, 256]),
+    ([256, 1], [256, 1]),
+    ([17, 33, 65], [17, 33, 65]),
+    # Larger sequences
+    ([1024, 1024], [1024, 1024]),
+    ([256, 512, 256], [128, 256, 128]),
+]
+
+SEQLEN_CONFIGS_SMOKE = [
+    ([128, 128], [128, 128]),
+    ([64, 128], [64, 128]),
+    ([113, 203], [113, 203]),
+    ([256, 512], [256, 512]),
+    ([64, 128], [32, 64]),
+]
+
+
+# =============================================================================
+# Helper functions
+# =============================================================================
+
+
+def setup_varlen_tensors(
+    seqlens_q, seqlens_k, num_heads, num_kv_heads, head_dim, dtype
+):
+    """Create packed Q, K, V tensors and cu_seqlens for varlen."""
+    device = "cuda"
+    batch_size = len(seqlens_q)
+    total_q = sum(seqlens_q)
+    total_k = sum(seqlens_k)
+
+    q = torch.randn(total_q, num_heads, head_dim, device=device, dtype=dtype)
+    k = torch.randn(total_k, num_kv_heads, head_dim, device=device, dtype=dtype)
+    v = torch.randn(total_k, num_kv_heads, head_dim, device=device, dtype=dtype)
+
+    cu_seqlens_q = torch.tensor(
+        [0] + list(torch.tensor(seqlens_q).cumsum(0).tolist()),
+        device=device,
+        dtype=torch.int32,
+    )
+    cu_seqlens_k = torch.tensor(
+        [0] + list(torch.tensor(seqlens_k).cumsum(0).tolist()),
+        device=device,
+        dtype=torch.int32,
+    )
+
+    return q, k, v, cu_seqlens_q, cu_seqlens_k
+
+
+def run_flex_per_sequence(
+    q,
+    k,
+    v,
+    cu_seqlens_q,
+    cu_seqlens_k,
+    mask_mod_flex_factory,
+    seqlens_q,
+    seqlens_k,
+    num_heads,
+    num_kv_heads,
+    head_dim,
+    dtype=None,
+):
+    """Run flex_attention per-sequence as reference for varlen.
+
+    mask_mod_flex_factory(seq_idx, seqlen_q_i, seqlen_k_i) -> mask_mod function
+    that takes (b, h, q_idx, kv_idx) for that sequence.
+    """
+    batch_size = len(seqlens_q)
+    results = []
+
+    for i in range(batch_size):
+        sq = seqlens_q[i]
+        sk = seqlens_k[i]
+
+        # Extract packed slices
+        q_slice = q[cu_seqlens_q[i] : cu_seqlens_q[i + 1]].unsqueeze(0)  # (1, sq, H, D)
+        k_slice = k[cu_seqlens_k[i] : cu_seqlens_k[i + 1]].unsqueeze(
+            0
+        )  # (1, sk, Hkv, D)
+        v_slice = v[cu_seqlens_k[i] : cu_seqlens_k[i + 1]].unsqueeze(0)
+
+        if dtype is not None:
+            q_slice = q_slice.to(dtype)
+            k_slice = k_slice.to(dtype)
+            v_slice = v_slice.to(dtype)
+
+        # Transpose to (B, H, S, D) for flex_attention
+        q_t = q_slice.transpose(1, 2)
+        k_t = k_slice.transpose(1, 2)
+        v_t = v_slice.transpose(1, 2)
+
+        # Expand KV heads for GQA
+        if num_heads != num_kv_heads:
+            repeat_factor = num_heads // num_kv_heads
+            k_t = k_t.repeat_interleave(repeat_factor, dim=1)
+            v_t = v_t.repeat_interleave(repeat_factor, dim=1)
+
+        scale = 1.0 / math.sqrt(head_dim)
+
+        mask_mod = mask_mod_flex_factory(i, sq, sk)
+
+        if mask_mod is None:
+            out = F.scaled_dot_product_attention(q_t, k_t, v_t, scale=scale)
+        else:
+            block_mask = create_block_mask(
+                mask_mod,
+                B=1,
+                H=num_heads,
+                Q_LEN=sq,
+                KV_LEN=sk,
+                device=q.device,
+            )
+            out = flex_attention(
+                q_t, k_t, v_t, block_mask=block_mask, scale=scale, enable_gqa=True
+            )
+
+        results.append(out.transpose(1, 2).squeeze(0))  # back to (sq, H, D)
+
+    return torch.cat(results, dim=0)
+
+
+def check_varlen_results(
+    out_cute,
+    out_ref_fp32,
+    out_pt,
+    seqlens_q,
+    cu_seqlens_q,
+    test_name,
+    rtol=2,
+    extra_atol=2e-3,
+):
+    """Compare CuTE output against per-sequence flex references."""
+    assert not torch.isnan(out_cute).any(), f"{test_name}: NaN in output"
+    assert torch.isfinite(out_cute).all(), f"{test_name}: Inf in output"
+    assert out_cute.shape == out_ref_fp32.shape, (
+        f"{test_name}: Shape mismatch: {out_cute.shape} vs {out_ref_fp32.shape}"
+    )
+
+    num_seqs = len(seqlens_q)
+    max_cute_error = 0.0
+    max_pt_error = 0.0
+
+    for i in range(num_seqs):
+        start = cu_seqlens_q[i]
+        end = cu_seqlens_q[i + 1]
+        cute_seq = out_cute[start:end]
+        ref_seq = out_ref_fp32[start:end]
+        pt_seq = out_pt[start:end]
+
+        max_cute_error = max(max_cute_error, (cute_seq - ref_seq).abs().max().item())
+        max_pt_error = max(max_pt_error, (pt_seq - ref_seq).abs().max().item())
+
+    fwd_atol = 2 * (out_ref_fp32 + 0.3 - 0.3 - out_ref_fp32).abs().max().item()
+
+    print(f"\n{test_name}:")
+    print(f"  PyTorch vs FP32 ref: {max_pt_error:.2e}")
+    print(f"  CuTE vs FP32 ref: {max_cute_error:.2e}")
+
+    tol = rtol * max_pt_error + fwd_atol + extra_atol
+    assert max_cute_error <= tol, (
+        f"{test_name}: CuTE error {max_cute_error:.2e} exceeds tolerance {tol:.2e} "
+        f"(rtol={rtol} * pt_err={max_pt_error:.2e} + fwd_atol={fwd_atol:.2e} + extra={extra_atol:.2e})"
+    )
+
+
+# =============================================================================
+# Core test runner
+# =============================================================================
+
+
+def _run_varlen_mask_test(
+    seqlens_q,
+    seqlens_k,
+    num_heads,
+    num_kv_heads,
+    head_dim,
+    dtype,
+    mask_name,
+    window_size=None,
+):
+    """Run a varlen mask_mod test: kernel with cu_seqlens vs per-sequence flex_attention."""
+    torch.manual_seed(42)
+    random.seed(42)
+
+    batch_size = len(seqlens_q)
+    pack_gqa = num_heads != num_kv_heads
+
+    if mask_name == "sliding_window":
+        # Skip configs where any seqlen_q > seqlen_k
+        for sq, sk in zip(seqlens_q, seqlens_k):
+            if sq > sk:
+                pytest.skip(
+                    "sliding_window requires seqlen_q <= seqlen_k for each sequence"
+                )
+
+    q, k, v, cu_seqlens_q, cu_seqlens_k = setup_varlen_tensors(
+        seqlens_q, seqlens_k, num_heads, num_kv_heads, head_dim, dtype
+    )
+
+    if mask_name == "block_causal":
+        offsets = [sk - sq for sq, sk in zip(seqlens_q, seqlens_k)]
+        if len(set(offsets)) > 1:
+            pytest.skip(
+                "block_causal captures offset as compile-time constant; "
+                "varlen with different per-sequence offsets not supported"
+            )
+
+    aux_tensors_arg = None
+
+    if mask_name == "document":
+        max_seqlen = max(max(seqlens_q), max(seqlens_k))
+        max_doc_len = max(max(seqlens_q), max(seqlens_k))
+        doc_ids = random_doc_id_tensor(
+            num_heads, batch_size, max_doc_len, device="cuda"
+        ).to(dtype=torch.int32, device="cuda")
+        doc_ids.__leading_dim__ = 2
+        aux_tensors_arg = [doc_ids]
+
+        from mask_mod_definitions import flex_document_mask
+
+        cute_mask_mod = get_mask_pair("document")[0]
+
+        def flex_factory(seq_idx, sq, sk, doc_ids=doc_ids):
+            # Pre-slice to 1D using Python ints *outside* the vmapped closure.
+            # create_block_mask vmaps over all four args (b, h, q_idx, kv_idx);
+            # multi-dim indexing like doc_id[b, h, q_idx] with 0-dim vmap tensors
+            # triggers .item() internally. 1D tensor[0d_tensor] is a safe gather.
+            doc_row = doc_ids[seq_idx, 0]  # (max_doc_len,)
+
+            def _mask(b, h, q_idx, kv_idx):
+                return doc_row[q_idx] == doc_row[kv_idx]
+
+            return _mask
+
+    elif mask_name == "ima":
+        total_k = sum(seqlens_k)
+        pytest.skip(
+            "IMA mask requires global index handling for varlen - not yet implemented"
+        )
+
+    else:
+        if mask_name in STATIC_MASKS:
+            cute_mask_mod = get_mask_pair(mask_name)[0]
+
+            def flex_factory(seq_idx, sq, sk):
+                return get_mask_pair(mask_name)[1]
+
+        elif mask_name in PARAMETERIZED_MASK_FACTORIES:
+            cute_mask_mod = get_mask_pair(
+                mask_name,
+                seqlen_q=seqlens_q[0],
+                seqlen_k=seqlens_k[0],
+                window_size=window_size,
+            )[0]
+
+            def flex_factory(seq_idx, sq, sk):
+                _, flex_mask = get_mask_pair(
+                    mask_name,
+                    seqlen_q=sq,
+                    seqlen_k=sk,
+                    window_size=window_size,
+                )
+                return flex_mask
+
+        else:
+            raise ValueError(f"Unknown mask: {mask_name}")
+
+    # Run the kernel with varlen (packed format)
+    out = torch.empty_like(q)
+    softmax_scale = 1.0 / math.sqrt(head_dim)
+
+    out_tuple = _flash_attn_fwd(
+        q=q,
+        k=k,
+        v=v,
+        out=out,
+        lse=None,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        seqused_q=None,
+        seqused_k=None,
+        page_table=None,
+        softmax_scale=softmax_scale,
+        causal=False,
+        softcap=None,
+        window_size_left=-1,
+        window_size_right=-1,
+        learnable_sink=None,
+        tile_mn=(128, 128),
+        pack_gqa=pack_gqa,
+        _arch=None,
+        score_mod=None,
+        mask_mod=cute_mask_mod,
+        block_sparse_tensors=None,
+        return_lse=True,
+        aux_tensors=aux_tensors_arg,
+    )
+    out_cute = out_tuple[0]
+
+    # Run per-sequence flex_attention references
+    out_ref_fp32 = run_flex_per_sequence(
+        q,
+        k,
+        v,
+        cu_seqlens_q,
+        cu_seqlens_k,
+        flex_factory,
+        seqlens_q,
+        seqlens_k,
+        num_heads,
+        num_kv_heads,
+        head_dim,
+        dtype=torch.float32,
+    )
+    out_pt = run_flex_per_sequence(
+        q,
+        k,
+        v,
+        cu_seqlens_q,
+        cu_seqlens_k,
+        flex_factory,
+        seqlens_q,
+        seqlens_k,
+        num_heads,
+        num_kv_heads,
+        head_dim,
+        dtype=dtype,
+    )
+
+    # Check results
+    mask_desc = f"mask_mod={mask_name}"
+    if window_size is not None:
+        mask_desc += f"(w={window_size})"
+    test_name = (
+        f"{mask_desc} varlen seqs_q={seqlens_q}, seqs_k={seqlens_k}, "
+        f"H={num_heads}/{num_kv_heads}, D={head_dim}"
+    )
+    check_varlen_results(
+        out_cute, out_ref_fp32, out_pt, seqlens_q, cu_seqlens_q, test_name
+    )
+
+
+# =============================================================================
+# Test cases
+# =============================================================================
+
+# Masks that don't need recompilation per seqlen (fast)
+STATIC_MASK_NAMES = ["block_diagonal", "mini_causal"]
+
+# Masks that need per-seqlen compilation (slower)
+PARAMETERIZED_MASK_CONFIGS = [
+    ("causal", None),
+    ("block_causal", None),
+    ("sliding_window", 128),
+    ("sliding_window", 256),
+    ("document", None),
+]
+
+
+@pytest.mark.parametrize("seqlens_q,seqlens_k", SEQLEN_CONFIGS)
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.parametrize("kv_mode", ["mha", "gqa"])
+@pytest.mark.parametrize("mask_name", STATIC_MASK_NAMES)
+def test_varlen_static_masks(seqlens_q, seqlens_k, dtype, kv_mode, mask_name):
+    """Test static mask_mods with varlen (packed) attention."""
+    num_heads = 8
+    if kv_mode == "gqa":
+        if COMPUTE_CAPABILITY < 9:
+            pytest.xfail("pack_gqa requires SM90+")
+        num_kv_heads = 2
+    else:
+        num_kv_heads = num_heads
+
+    _run_varlen_mask_test(
+        seqlens_q=seqlens_q,
+        seqlens_k=seqlens_k,
+        num_heads=num_heads,
+        num_kv_heads=num_kv_heads,
+        head_dim=128,
+        dtype=dtype,
+        mask_name=mask_name,
+    )
+
+
+@pytest.mark.parametrize("seqlens_q,seqlens_k", SEQLEN_CONFIGS)
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.parametrize("kv_mode", ["mha", "gqa"])
+@pytest.mark.parametrize("mask_name,window_size", PARAMETERIZED_MASK_CONFIGS)
+def test_varlen_parameterized_masks(
+    seqlens_q, seqlens_k, dtype, kv_mode, mask_name, window_size
+):
+    """Test parameterized mask_mods with varlen (packed) attention.
+
+    Uses fewer seqlen configs since these require recompilation per seqlen.
+    """
+    num_heads = 8
+    if kv_mode == "gqa":
+        if COMPUTE_CAPABILITY < 9:
+            pytest.xfail("pack_gqa requires SM90+")
+        num_kv_heads = 2
+    else:
+        num_kv_heads = num_heads
+
+    _run_varlen_mask_test(
+        seqlens_q=seqlens_q,
+        seqlens_k=seqlens_k,
+        num_heads=num_heads,
+        num_kv_heads=num_kv_heads,
+        head_dim=128,
+        dtype=dtype,
+        mask_name=mask_name,
+        window_size=window_size,
+    )
+
+
+# =============================================================================
+# Global-index mask test runner
+# =============================================================================
+
+
+def _run_varlen_global_mask_test(
+    seqlens_q,
+    seqlens_k,
+    num_heads,
+    num_kv_heads,
+    head_dim,
+    dtype,
+    mask_name,
+):
+    """Run a varlen global-index mask_mod test: kernel vs per-sequence flex_attention."""
+    torch.manual_seed(42)
+    random.seed(42)
+
+    pack_gqa = num_heads != num_kv_heads
+
+    q, k, v, cu_seqlens_q, cu_seqlens_k = setup_varlen_tensors(
+        seqlens_q, seqlens_k, num_heads, num_kv_heads, head_dim, dtype
+    )
+
+    if mask_name == "global_packed_doc":
+        doc_ids_q, doc_ids_k = make_packed_doc_ids(seqlens_q, seqlens_k, device="cuda")
+        cute_mask = cute_global_packed_doc_mask
+        flex_fac = global_packed_doc_flex_factory(
+            doc_ids_q, doc_ids_k, cu_seqlens_q, cu_seqlens_k
+        )
+        aux_tensors = [doc_ids_q, doc_ids_k]
+    elif mask_name == "global_ima":
+        thresholds = make_global_thresholds(seqlens_k, device="cuda")
+        cute_mask = cute_global_ima_mask
+        flex_fac = global_ima_flex_factory(thresholds, cu_seqlens_k)
+        aux_tensors = [thresholds]
+    elif mask_name == "global_causal_window":
+        windows = make_global_windows(seqlens_q, device="cuda")
+        cute_mask = cute_global_causal_window_mask
+        flex_fac = global_causal_window_flex_factory(windows, cu_seqlens_q)
+        aux_tensors = [windows]
+    else:
+        raise ValueError(f"Unknown global mask: {mask_name}")
+
+    out = torch.empty_like(q)
+    softmax_scale = 1.0 / math.sqrt(head_dim)
+
+    out_tuple = _flash_attn_fwd(
+        q=q,
+        k=k,
+        v=v,
+        out=out,
+        lse=None,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        seqused_q=None,
+        seqused_k=None,
+        page_table=None,
+        softmax_scale=softmax_scale,
+        causal=False,
+        softcap=None,
+        window_size_left=-1,
+        window_size_right=-1,
+        learnable_sink=None,
+        tile_mn=(128, 128),
+        pack_gqa=pack_gqa,
+        _arch=None,
+        score_mod=None,
+        mask_mod=cute_mask,
+        block_sparse_tensors=None,
+        return_lse=True,
+        aux_tensors=aux_tensors,
+    )
+    out_cute = out_tuple[0]
+
+    out_ref_fp32 = run_flex_per_sequence(
+        q,
+        k,
+        v,
+        cu_seqlens_q,
+        cu_seqlens_k,
+        flex_fac,
+        seqlens_q,
+        seqlens_k,
+        num_heads,
+        num_kv_heads,
+        head_dim,
+        dtype=torch.float32,
+    )
+    out_pt = run_flex_per_sequence(
+        q,
+        k,
+        v,
+        cu_seqlens_q,
+        cu_seqlens_k,
+        flex_fac,
+        seqlens_q,
+        seqlens_k,
+        num_heads,
+        num_kv_heads,
+        head_dim,
+        dtype=dtype,
+    )
+
+    test_name = (
+        f"global_mask={mask_name} varlen seqs_q={seqlens_q}, seqs_k={seqlens_k}, "
+        f"H={num_heads}/{num_kv_heads}, D={head_dim}"
+    )
+    check_varlen_results(
+        out_cute, out_ref_fp32, out_pt, seqlens_q, cu_seqlens_q, test_name
+    )
+
+
+GLOBAL_MASK_NAMES = ["global_packed_doc", "global_ima", "global_causal_window"]
+
+
+@pytest.mark.parametrize("seqlens_q,seqlens_k", SEQLEN_CONFIGS)
+@pytest.mark.parametrize("mask_name", GLOBAL_MASK_NAMES)
+def test_varlen_global_masks(seqlens_q, seqlens_k, mask_name):
+    """Test global-index mask_mods (aux-tensor-driven) with varlen packed attention."""
+    _run_varlen_global_mask_test(
+        seqlens_q, seqlens_k, 8, 8, 128, torch.bfloat16, mask_name
+    )
+
+
+# =============================================================================
+# Block sparsity end-to-end tests
+# =============================================================================
+
+
+def _make_block_sparse_tensors(
+    mask_mod,
+    seqlens_q,
+    seqlens_k,
+    num_heads,
+    tile_m,
+    tile_n,
+    device,
+    cu_seqlens_q=None,
+    cu_seqlens_k=None,
+    seqused_k=None,
+    aux_tensors=None,
+):
+    """Compute block sparse tensors, returning (tensors, cu_total_m_blocks, cu_total_n_blocks)."""
+    batch_size = len(seqlens_q)
+    max_seqlen_q = max(seqlens_q)
+    max_seqlen_k = max(seqlens_k)
+
+    if cu_seqlens_q is not None:
+        cu_total_m_blocks_list = [0]
+        for batch_idx in range(batch_size):
+            num_m_blocks = (seqlens_q[batch_idx] + tile_m - 1) // tile_m
+            cu_total_m_blocks_list.append(cu_total_m_blocks_list[-1] + num_m_blocks)
+        cu_total_m_blocks = torch.tensor(
+            cu_total_m_blocks_list, dtype=torch.int32, device=device
+        )
+
+        cu_total_n_blocks = None
+        if cu_seqlens_k is not None or seqused_k is not None:
+            cu_total_n_blocks_list = [0]
+            for batch_idx in range(batch_size):
+                num_m_blocks = (seqlens_q[batch_idx] + tile_m - 1) // tile_m
+                num_n_blocks = (seqlens_k[batch_idx] + tile_n - 1) // tile_n
+                cu_total_n_blocks_list.append(
+                    cu_total_n_blocks_list[-1] + num_m_blocks * num_n_blocks
+                )
+            cu_total_n_blocks = torch.tensor(
+                cu_total_n_blocks_list, dtype=torch.int32, device=device
+            )
+    else:
+        cu_total_m_blocks = None
+        cu_total_n_blocks = None
+
+    block_sparse_tensors = compute_block_sparsity(
+        tile_m=tile_m,
+        tile_n=tile_n,
+        batch_size=batch_size,
+        num_heads=num_heads,
+        seqlen_q=max_seqlen_q,
+        seqlen_k=max_seqlen_k,
+        mask_mod=mask_mod,
+        aux_tensors=aux_tensors,
+        device=device,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        cu_total_m_blocks=cu_total_m_blocks,
+        cu_total_n_blocks=cu_total_n_blocks,
+        seqused_k=seqused_k,
+    )
+    return block_sparse_tensors, cu_total_m_blocks, cu_total_n_blocks
+
+
+def _run_fwd(
+    q,
+    k,
+    v,
+    mask_mod,
+    cu_seqlens_q=None,
+    cu_seqlens_k=None,
+    seqused_k=None,
+    block_sparse_tensors=None,
+    cu_total_m_blocks=None,
+    cu_total_n_blocks=None,
+    aux_tensors=None,
+):
+    out = torch.empty_like(q)
+    return _flash_attn_fwd(
+        q=q,
+        k=k,
+        v=v,
+        out=out,
+        lse=None,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        seqused_q=None,
+        seqused_k=seqused_k,
+        page_table=None,
+        softmax_scale=1.0 / math.sqrt(q.shape[-1]),
+        causal=False,
+        softcap=None,
+        window_size_left=-1,
+        window_size_right=-1,
+        learnable_sink=None,
+        tile_mn=(128, 128),
+        pack_gqa=False,
+        _arch=None,
+        score_mod=None,
+        mask_mod=mask_mod,
+        block_sparse_tensors=block_sparse_tensors,
+        cu_total_m_blocks=cu_total_m_blocks,
+        cu_total_n_blocks=cu_total_n_blocks,
+        return_lse=False,
+        aux_tensors=aux_tensors,
+    )[0]
+
+
+BLOCK_SPARSE_MASK_NAMES = [
+    "causal",
+    "block_diagonal",
+    "mini_causal",
+    "prefix_lm",
+    "sliding_window",
+    "dilated_sliding_window",
+    "document",
+    "ima",
+]
+
+BLOCK_SPARSE_SEQLEN_CONFIGS = [
+    ([128, 192, 256], [128, 192, 256]),
+    ([64, 128], [64, 128]),
+    ([256, 512, 256], [256, 512, 256]),
+    ([128, 192, 256], [64, 128, 192]),
+]
+
+
+# @pytest.mark.parametrize("varlen_q", [False, True])
+@pytest.mark.parametrize("seqlens", BLOCK_SPARSE_SEQLEN_CONFIGS)
+@pytest.mark.parametrize("mask_name", BLOCK_SPARSE_MASK_NAMES)
+@pytest.mark.parametrize("varlen_q", [False, True])
+@pytest.mark.parametrize("varlen_k", [False, True])
+@pytest.mark.parametrize("use_seqused_k", [False, True])
+@pytest.mark.parametrize("head_broadcast", [False, True])
+def test_varlen_block_sparse(
+    varlen_q, varlen_k, use_seqused_k, head_broadcast, mask_name, seqlens
+):
+    """Block sparsity + mask_mod should produce identical output to mask_mod alone."""
+    if varlen_k and use_seqused_k:
+        pytest.skip("packed K (cu_seqlens_k) and seqused_k are mutually exclusive")
+    if not varlen_q and varlen_k:
+        pytest.skip(
+            "block sparsity with padded Q + packed K requires per-batch n-block offsets; not yet supported"
+        )
+
+    torch.manual_seed(42)
+    random.seed(42)
+    device = "cuda"
+    num_heads = 4
+    head_dim = 128
+    dtype = torch.bfloat16
+    # On Blackwell (SM100) q_stage=2 → effective tile is 256; elsewhere 128.
+    tile_m = 256 if COMPUTE_CAPABILITY >= 10 else 128
+    tile_n = 128
+
+    base_seqlens_q, base_seqlens_k = seqlens
+    batch_size = len(base_seqlens_q)
+    max_seqlen_q = max(base_seqlens_q)
+    max_seqlen_k = max(base_seqlens_k)
+
+    seqlens_q = base_seqlens_q if varlen_q else [max_seqlen_q] * batch_size
+    seqlens_k = (
+        base_seqlens_k if (varlen_k or use_seqused_k) else [max_seqlen_k] * batch_size
+    )
+
+    def make_cu_seqlens(seqlens):
+        return torch.tensor(
+            [0] + list(torch.tensor(seqlens).cumsum(0).tolist()),
+            device=device,
+            dtype=torch.int32,
+        )
+
+    if varlen_q:
+        q = torch.randn(sum(seqlens_q), num_heads, head_dim, device=device, dtype=dtype)
+        cu_seqlens_q = make_cu_seqlens(seqlens_q)
+    else:
+        q = torch.randn(
+            batch_size, max_seqlen_q, num_heads, head_dim, device=device, dtype=dtype
+        )
+        cu_seqlens_q = None
+
+    if varlen_k:
+        k = torch.randn(sum(seqlens_k), num_heads, head_dim, device=device, dtype=dtype)
+        v = torch.randn(sum(seqlens_k), num_heads, head_dim, device=device, dtype=dtype)
+        cu_seqlens_k = make_cu_seqlens(seqlens_k)
+        seqused_k = None
+    else:
+        k = torch.randn(
+            batch_size, max_seqlen_k, num_heads, head_dim, device=device, dtype=dtype
+        )
+        v = torch.randn(
+            batch_size, max_seqlen_k, num_heads, head_dim, device=device, dtype=dtype
+        )
+        cu_seqlens_k = None
+        seqused_k = (
+            torch.tensor(seqlens_k, dtype=torch.int32, device=device)
+            if use_seqused_k
+            else None
+        )
+
+    # Build mask_mod and aux_tensors for the requested mask
+    aux_tensors = None
+    if mask_name == "causal":
+        mask_mod, _ = get_mask_pair(
+            "causal", seqlen_q=max_seqlen_q, seqlen_k=max_seqlen_k
+        )
+    elif mask_name == "sliding_window":
+        mask_mod, _ = get_mask_pair(
+            "sliding_window",
+            seqlen_q=max_seqlen_q,
+            seqlen_k=max_seqlen_k,
+            window_size=128,
+        )
+    elif mask_name == "document":
+        max_doc_len = max(max_seqlen_q, max_seqlen_k)
+        doc_ids = random_doc_id_tensor(
+            num_heads, batch_size, max_doc_len, device=device
+        )
+        doc_ids.__leading_dim__ = 2
+        aux_tensors = [doc_ids]
+        mask_mod = get_mask_pair("document")[0]
+    elif mask_name == "ima":
+        bias = torch.randint(
+            0,
+            max(1, max_seqlen_k // 2),
+            (max_seqlen_k,),
+            dtype=torch.int32,
+            device=device,
+        )
+        aux_tensors = [bias]
+        mask_mod = get_mask_pair("ima")[0]
+    else:
+        mask_mod = get_mask_pair(mask_name)[0]
+
+    num_heads_sparse = 1 if head_broadcast else num_heads
+    block_sparse_tensors, cu_total_m_blocks, cu_total_n_blocks = (
+        _make_block_sparse_tensors(
+            mask_mod=mask_mod,
+            seqlens_q=seqlens_q,
+            seqlens_k=seqlens_k,
+            num_heads=num_heads_sparse,
+            tile_m=tile_m,
+            tile_n=tile_n,
+            device=device,
+            cu_seqlens_q=cu_seqlens_q,
+            cu_seqlens_k=cu_seqlens_k,
+            seqused_k=seqused_k,
+            aux_tensors=aux_tensors,
+        )
+    )
+
+    out_with_block_sparsity = _run_fwd(
+        q,
+        k,
+        v,
+        mask_mod,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        seqused_k=seqused_k,
+        block_sparse_tensors=block_sparse_tensors,
+        cu_total_m_blocks=cu_total_m_blocks,
+        cu_total_n_blocks=cu_total_n_blocks,
+        aux_tensors=aux_tensors,
+    )
+    out_no_block_sparsity = _run_fwd(
+        q,
+        k,
+        v,
+        mask_mod,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        seqused_k=seqused_k,
+        aux_tensors=aux_tensors,
+    )
+
+    assert not torch.isnan(out_with_block_sparsity).any(), "NaN in block-sparse output"
+    max_err = (out_with_block_sparsity - out_no_block_sparsity).abs().max().item()
+    assert max_err <= 0.01, (
+        f"block-sparse output differs from mask-mod-only by {max_err}"
+    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])

--- a/tests/cute/test_mask_mod_varlen.py
+++ b/tests/cute/test_mask_mod_varlen.py
@@ -631,7 +631,8 @@ def _make_block_sparse_tensors(
     seqused_k=None,
     aux_tensors=None,
 ):
-    """Compute block sparse tensors, returning (tensors, cu_total_m_blocks, cu_total_n_blocks)."""
+    """Compute block sparse tensors. cu_total_m_blocks / cu_block_idx_offsets are
+    populated on the returned BlockSparseTensorsTorch."""
     batch_size = len(seqlens_q)
     max_seqlen_q = max(seqlens_q)
     max_seqlen_k = max(seqlens_k)
@@ -645,21 +646,21 @@ def _make_block_sparse_tensors(
             cu_total_m_blocks_list, dtype=torch.int32, device=device
         )
 
-        cu_total_n_blocks = None
+        cu_block_idx_offsets = None
         if cu_seqlens_k is not None or seqused_k is not None:
-            cu_total_n_blocks_list = [0]
+            cu_block_idx_offsets_list = [0]
             for batch_idx in range(batch_size):
                 num_m_blocks = (seqlens_q[batch_idx] + tile_m - 1) // tile_m
                 num_n_blocks = (seqlens_k[batch_idx] + tile_n - 1) // tile_n
-                cu_total_n_blocks_list.append(
-                    cu_total_n_blocks_list[-1] + num_m_blocks * num_n_blocks
+                cu_block_idx_offsets_list.append(
+                    cu_block_idx_offsets_list[-1] + num_m_blocks * num_n_blocks
                 )
-            cu_total_n_blocks = torch.tensor(
-                cu_total_n_blocks_list, dtype=torch.int32, device=device
+            cu_block_idx_offsets = torch.tensor(
+                cu_block_idx_offsets_list, dtype=torch.int32, device=device
             )
     else:
         cu_total_m_blocks = None
-        cu_total_n_blocks = None
+        cu_block_idx_offsets = None
 
     block_sparse_tensors = compute_block_sparsity(
         tile_m=tile_m,
@@ -674,10 +675,10 @@ def _make_block_sparse_tensors(
         cu_seqlens_q=cu_seqlens_q,
         cu_seqlens_k=cu_seqlens_k,
         cu_total_m_blocks=cu_total_m_blocks,
-        cu_total_n_blocks=cu_total_n_blocks,
+        cu_block_idx_offsets=cu_block_idx_offsets,
         seqused_k=seqused_k,
     )
-    return block_sparse_tensors, cu_total_m_blocks, cu_total_n_blocks
+    return block_sparse_tensors
 
 
 def _run_fwd(
@@ -689,8 +690,6 @@ def _run_fwd(
     cu_seqlens_k=None,
     seqused_k=None,
     block_sparse_tensors=None,
-    cu_total_m_blocks=None,
-    cu_total_n_blocks=None,
     aux_tensors=None,
 ):
     out = torch.empty_like(q)
@@ -717,8 +716,6 @@ def _run_fwd(
         score_mod=None,
         mask_mod=mask_mod,
         block_sparse_tensors=block_sparse_tensors,
-        cu_total_m_blocks=cu_total_m_blocks,
-        cu_total_n_blocks=cu_total_n_blocks,
         return_lse=False,
         aux_tensors=aux_tensors,
     )[0]
@@ -851,20 +848,18 @@ def test_varlen_block_sparse(
         mask_mod = get_mask_pair(mask_name)[0]
 
     num_heads_sparse = 1 if head_broadcast else num_heads
-    block_sparse_tensors, cu_total_m_blocks, cu_total_n_blocks = (
-        _make_block_sparse_tensors(
-            mask_mod=mask_mod,
-            seqlens_q=seqlens_q,
-            seqlens_k=seqlens_k,
-            num_heads=num_heads_sparse,
-            tile_m=tile_m,
-            tile_n=tile_n,
-            device=device,
-            cu_seqlens_q=cu_seqlens_q,
-            cu_seqlens_k=cu_seqlens_k,
-            seqused_k=seqused_k,
-            aux_tensors=aux_tensors,
-        )
+    block_sparse_tensors = _make_block_sparse_tensors(
+        mask_mod=mask_mod,
+        seqlens_q=seqlens_q,
+        seqlens_k=seqlens_k,
+        num_heads=num_heads_sparse,
+        tile_m=tile_m,
+        tile_n=tile_n,
+        device=device,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        seqused_k=seqused_k,
+        aux_tensors=aux_tensors,
     )
 
     out_with_block_sparsity = _run_fwd(
@@ -876,8 +871,6 @@ def test_varlen_block_sparse(
         cu_seqlens_k=cu_seqlens_k,
         seqused_k=seqused_k,
         block_sparse_tensors=block_sparse_tensors,
-        cu_total_m_blocks=cu_total_m_blocks,
-        cu_total_n_blocks=cu_total_n_blocks,
         aux_tensors=aux_tensors,
     )
     out_no_block_sparsity = _run_fwd(


### PR DESCRIPTION
This PR extends blocksparsity to the variable sequence length case. Whereas in batched blocksparsity the metadata tensors take the shapes
```python
*_block_cnt: [batch_size, num_heads, num_m_blocks]
*_block_idx: [batch_size, num_heads, num_m_blocks, num_n_blocks],
```
in varlen blocksparsity, we pack our metadata tensors to take the shapes
```python
*_block_cnt: [num_heads, total_m_blocks]
*_block_idx: [num_heads, total_n_blocks]
```
where `total_m_blocks` is the sum of all `m` blocks per head (equiv. number of work tiles per head) and `total_n_blocks` is the total of all `n` blocks potentially processed per head across all sequences in the batch. For example, consider a varlen batch with sequences contained in `seqlens_q` and `seqlens_k`. At batch index `b`, we let 
```tex
num_m(b) = ceildiv(seqlens_q[b], tile_m)
num_n(b) = ceildiv(seqlens_k[b], tile_n)
```
and define
```tex
total_m_blocks = sum_{b \in B} num_m(b)
total_n_blocks = sum_{b \in B} num_m(b) * num_n(b)
```

To properly index into the blocksparsity tensors, we use auxiliary `mCuTotalMBlocks` and `mBlockIdxOffsets` tensors, which can be prepared on host. 

cc @drisspg @v0i0 

NOT INTENDED FOR THIS PR:
- bwd support