### PR TITLE
Add `FLASH_ATTENTION_TRITON_AMD_CONFIG_JSON` env var support

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,9 +145,9 @@ FLASH_ATTENTION_TRITON_AMD_ENABLE="TRUE" pytest tests/test_flash_attn_triton_amd
 
 For better performance, enable autotune with `FLASH_ATTENTION_TRITON_AMD_AUTOTUNE="TRUE"`.
 
-Alternativly, if _not_ autotuning, `FLASH_ATTENTION_TRITON_AMD_CONFIG_JSON` may be used to set a single triton config overriding the hardcoded defaults. E.g.
+Alternativly, if _not_ autotuning, `FLASH_ATTENTION_FWD_TRITON_AMD_CONFIG_JSON` may be used to set a single triton config overriding the hardcoded defaults for `attn_fwd`. E.g.
 ```sh
-FLASH_ATTENTION_TRITON_AMD_CONFIG_JSON='{"BLOCK_M":128,"BLOCK_N":64,"waves_per_eu":1,"PRE_LOAD_V":false,"num_stages":1,"num_warps":8}'
+FLASH_ATTENTION_FWD_TRITON_AMD_CONFIG_JSON='{"BLOCK_M":128,"BLOCK_N":64,"waves_per_eu":1,"PRE_LOAD_V":false,"num_stages":1,"num_warps":8}'
 ```
 
 For a quick start with Docker:

--- a/flash_attn/flash_attn_triton_amd/fwd_prefill.py
+++ b/flash_attn/flash_attn_triton_amd/fwd_prefill.py
@@ -7,8 +7,8 @@ from typing import Literal, Optional
 from .common import compute_alibi_block, compute_fp8_scaling_factors, apply_rotary
 from .utils import (
     AUTOTUNE,
-    CONF_OVERRIDE,
     DEBUG,
+    FWD_CONF_OVERRIDE,
     get_arch,
     is_fp8,
 )
@@ -35,8 +35,8 @@ def get_fwd_prefill_configs(autotune: bool):
     #   - RDNA: BLOCK_N=32
     # See _get_block_size_n_triton() in test_flash_attn_triton_amd.py
     if not autotune:
-        if CONF_OVERRIDE:
-            return [CONF_OVERRIDE]
+        if FWD_CONF_OVERRIDE:
+            return [FWD_CONF_OVERRIDE]
 
         arch = get_arch()
         if arch.name == "gfx950":

--- a/flash_attn/flash_attn_triton_amd/utils.py
+++ b/flash_attn/flash_attn_triton_amd/utils.py
@@ -111,19 +111,19 @@ AUTOTUNE = os.environ.get("FLASH_ATTENTION_TRITON_AMD_AUTOTUNE", "0").lower() in
 # User override config json.
 # Note: Ignored if FLASH_ATTENTION_TRITON_AMD_AUTOTUNE is enabled.
 #
-# e.g. FLASH_ATTENTION_TRITON_AMD_CONFIG_JSON='{"BLOCK_M":32,"BLOCK_N":32,"waves_per_eu":1,"PRE_LOAD_V":false,"num_stages":1,"num_warps":4}'
-CONF_OVERRIDE = None
+# e.g. FLASH_ATTENTION_FWD_TRITON_AMD_CONFIG_JSON='{"BLOCK_M":32,"BLOCK_N":32,"waves_per_eu":1,"PRE_LOAD_V":false,"num_stages":1,"num_warps":4}'
+FWD_CONF_OVERRIDE = None
 try:
-    conf_json = os.getenv("FLASH_ATTENTION_TRITON_AMD_CONFIG_JSON")
+    conf_json = os.getenv("FLASH_ATTENTION_FWD_TRITON_AMD_CONFIG_JSON")
     if conf_json:
         conf = json.loads(conf_json)
-        CONF_OVERRIDE = triton.Config(
+        FWD_CONF_OVERRIDE = triton.Config(
             conf,
             num_stages=conf.pop("num_stages", 1),
             num_warps=conf.pop("num_warps", 4),
         )
 except Exception as e:
-    logger.warning(f'FLASH_ATTENTION_TRITON_AMD_CONFIG_JSON parse error: {e}')
+    logger.warning(f'FLASH_ATTENTION_FWD_TRITON_AMD_CONFIG_JSON parse error: {e}')
 
 # Unified debug level:
 #   0 = off (default)


### PR DESCRIPTION
Add an env var for configuring `attn_fwd` triton.Config. This allows setting of more optimal config without having to enable autotuning, which has issues.

## Motivation
With autotuning disabled the current default configs are sub-optimal, at least for my gfx1100 but probably for other cards too.

I get roughly 2x faster wan2.2 workflow performance using config `FLASH_ATTENTION_FWD_TRITON_AMD_CONFIG_JSON='{"BLOCK_M":128,"BLOCK_N":64,"waves_per_eu":1,"PRE_LOAD_V":false,"num_stages":1,"num_warps":8}'`

Autotuning itself is very slow to run (e.g. takes 82 minutes) and needs to re-run on any param change (it also isn't persisting maybe?). So it is helpful to be able to override the !autotune config.

## Alternatives
Provide better default configs, e.g. use the above example for gfx1100. This is less flexible though.