### PR TITLE
pytest-dist round robin to gpus

### DIFF
--- a/tests/cute/conftest.py
+++ b/tests/cute/conftest.py
@@ -1,0 +1,31 @@
+import os
+import subprocess
+
+
+def _get_gpu_ids():
+    visible = os.environ.get("CUDA_VISIBLE_DEVICES")
+    if visible:
+        return [g.strip() for g in visible.split(",")]
+
+    try:
+        result = subprocess.run(
+            ["nvidia-smi", "--query-gpu=index", "--format=csv,noheader"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip().splitlines()
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+
+    return ["0"]
+
+
+def pytest_configure(config):
+    worker_id = os.environ.get("PYTEST_XDIST_WORKER")
+    if not worker_id:
+        return
+    worker_num = int(worker_id.replace("gw", ""))
+    gpu_ids = _get_gpu_ids()
+    os.environ["CUDA_VISIBLE_DEVICES"] = gpu_ids[worker_num % len(gpu_ids)]


### PR DESCRIPTION
Stacked PRs:
 * #2218
 * #2227
 * __->__#2241


--- --- ---

pytest-dist round robin to gpus

# Summary


With this conftest the pytest-xdist will launch on all available gpus:
<img width="1083" height="460" alt="image" src="https://github.com/user-attachments/assets/2ab68164-4472-4156-885a-19de1b70e722" />

Sorry neighbors :)

To only launch on 1 w/ pytest-xdist:
Just set the vis device before hand 
`CUDA_VISIBLE_DEVICES=0 pytest -n 12 tests/cute/test_flash_attn.py`