### PR TITLE
Add gfx1150/gfx1151 (RDNA 3.5) to RDNA_ARCHS

### DIFF
--- a/flash_attn/flash_attn_triton_amd/utils.py
+++ b/flash_attn/flash_attn_triton_amd/utils.py
@@ -50,7 +50,7 @@ __all__ = [
 ArchFamily = Literal["cdna", "rdna"]
 
 CDNA_ARCHS = frozenset({"gfx908", "gfx90a", "gfx940", "gfx941", "gfx942", "gfx950"})
-RDNA_ARCHS = frozenset({"gfx1030", "gfx1100", "gfx1101", "gfx1102", "gfx1200", "gfx1201"})
+RDNA_ARCHS = frozenset({"gfx1030", "gfx1100", "gfx1101", "gfx1102", "gfx1150", "gfx1151", "gfx1200", "gfx1201"})
 FP8_ARCHS = frozenset({"gfx942", "gfx950"})
 
 _RECOMMENDED_FP8_REPLACEMENTS: dict[str, dict[torch.dtype, torch.dtype]] = {


### PR DESCRIPTION
Add support for AMD Strix Point (gfx1150) and Strix Halo (gfx1151) APUs to the RDNA architecture detection. These are RDNA 3.5 based GPUs that work with the existing RDNA Triton kernels.

Tested on AMD Radeon 8060S Graphics (gfx1151, Strix Halo) with ROCm 7.12 on Windows.

This allows the Triton AMD backend to properly detect these GPUs as RDNA and use the appropriate kernel configurations.