### PR TITLE
correct max_seqlen_q for performance.

### DIFF
--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -287,7 +287,7 @@ def _flash_attn_fwd(
             pack_gqa = False
 
     if max_seqlen_q is None:
-        max_seqlen_q = seqlen_q if cu_seqlens_q is None else total_q
+        max_seqlen_q = seqlen_q if cu_seqlens_q is None else cu_seqlens_q.diff().max().item()
     if max_seqlen_k is None:
         max_seqlen_k = seqlen_k
     seqlen_q_packgqa = max_seqlen_q * qhead_per_kvhead


### PR DESCRIPTION
Now, `max_seqlen_q` will be `total_q` if varlen is True for B200. I find this will cause performance degradation when batch size is large but all queries are decoding.

For example,  `qhead_num` is 64 and kv_head_num is 8 for Qwen32B, that is, kv_head_num_per_q_head is 8. Now if we have a batch size 18 of decoding, according to:
```
seqlen_q_packgqa = max_seqlen_q * qhead_per_kvhead # 144
if compute_capability == 10:
        q_stage = 2 if seqlen_q_packgqa > m_block_size else 1
```
we will get `q_stage=2`, which will double tensorcore computation incorrectly, leading to performance degradation around 30% seen from ncu.