### PR TITLE
[Cute,Flex,Sm100] vectorized mask_mod

### DIFF
--- a/flash_attn/cute/flash_fwd.py
+++ b/flash_attn/cute/flash_fwd.py
@@ -108,7 +108,7 @@ class FlashAttentionForwardBase:
                 "due to accumulator thread ownership pattern."
             )
         self.mask_vec_size: cutlass.Constexpr = getattr(mask_mod, "__vec_size__", 1)
-        if self.mask_vec_size > 2:
+        if self.mask_vec_size > 1:
             raise ValueError(
                 f"mask_mod vec_size {self.mask_vec_size} not supported on Sm80/90/120 "
                 "due to accumulator thread ownership pattern."
@@ -1012,7 +1012,6 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
             mask_causal=self.is_causal,
             mask_local=self.is_local,
             aux_tensors=aux_tensors,
-            vec_size=self.mask_vec_size,
             fastdiv_mods=fastdiv_mods if const_expr(self.mask_mod is not None) else None,
         )
 

--- a/flash_attn/cute/flash_fwd.py
+++ b/flash_attn/cute/flash_fwd.py
@@ -99,12 +99,18 @@ class FlashAttentionForwardBase:
         self.score_mod = score_mod
         self.mask_mod = mask_mod
         self.qk_acc_dtype = Float32
-        self.vec_size: cutlass.Constexpr = getattr(
+        self.score_vec_size: cutlass.Constexpr = getattr(
             score_mod, "__vec_size__", 1 if cutlass.const_expr(has_aux_tensors) else 2
         )
-        if self.vec_size > 2:
+        if self.score_vec_size > 2:
             raise ValueError(
-                f"score_mod vec_size {self.vec_size} not supported on Sm80/90/120 "
+                f"score_mod vec_size {self.score_vec_size} not supported on Sm80/90/120 "
+                "due to accumulator thread ownership pattern."
+            )
+        self.mask_vec_size: cutlass.Constexpr = getattr(mask_mod, "__vec_size__", 1)
+        if self.mask_vec_size > 2:
+            raise ValueError(
+                f"mask_mod vec_size {self.mask_vec_size} not supported on Sm80/90/120 "
                 "due to accumulator thread ownership pattern."
             )
         self.arch = BaseDSL._get_dsl().get_arch_enum()

--- a/flash_attn/cute/flash_fwd.py
+++ b/flash_attn/cute/flash_fwd.py
@@ -1012,6 +1012,7 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
             mask_causal=self.is_causal,
             mask_local=self.is_local,
             aux_tensors=aux_tensors,
+            vec_size=self.mask_vec_size,
             fastdiv_mods=fastdiv_mods if const_expr(self.mask_mod is not None) else None,
         )
 
@@ -1217,7 +1218,7 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
             batch_idx,
             head_idx,
             softmax_scale,
-            self.vec_size,
+            self.score_vec_size,
             self.qk_acc_dtype,
             aux_tensors,
             fastdiv_mods,

--- a/flash_attn/cute/flash_fwd_sm100.py
+++ b/flash_attn/cute/flash_fwd_sm100.py
@@ -185,9 +185,10 @@ class FlashAttentionForwardSm100:
         )
         self.score_mod = score_mod
         self.mask_mod = mask_mod
-        self.vec_size: cutlass.Constexpr = getattr(
+        self.score_vec_size: cutlass.Constexpr = getattr(
             score_mod, "__vec_size__", 1 if cutlass.const_expr(has_aux_tensors) else 2
         )
+        self.mask_vec_size: cutlass.Constexpr = getattr(mask_mod, "__vec_size__", 1)
         # Does S1 need to wait for S0 to finish
         # self.s0_s1_barrier = self.head_dim_padded in [64, 96] and (not self.is_causal and not self.is_local)
         is_sm103 = self.arch >= Arch.sm_103 and self.arch <= Arch.sm_103f
@@ -1943,6 +1944,7 @@ class FlashAttentionForwardSm100:
                 batch_idx=batch_idx,
                 head_idx=head_idx,
                 aux_tensors=aux_tensors,
+                vec_size=self.mask_vec_size,
             )
 
             # Recompute fastdiv_mods if necessary
@@ -3107,7 +3109,7 @@ class FlashAttentionForwardSm100:
             batch_idx,
             head_idx,
             softmax.softmax_scale,
-            self.vec_size,
+            self.score_vec_size,
             self.qk_acc_dtype,
             aux_tensors,
             fastdiv_mods,

--- a/flash_attn/cute/flash_fwd_sm90.py
+++ b/flash_attn/cute/flash_fwd_sm90.py
@@ -557,7 +557,9 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                 blocksparse_tensors.cu_total_m_blocks if blocksparse_tensors is not None else None
             ),
             mCuBlockIdxOffsets=(
-                blocksparse_tensors.cu_block_idx_offsets if blocksparse_tensors is not None else None
+                blocksparse_tensors.cu_block_idx_offsets
+                if blocksparse_tensors is not None
+                else None
             ),
             # Don't need to pass in tile_mn because we won't access offset_padded
         )
@@ -1507,7 +1509,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
             batch_idx,
             head_idx,
             softmax_scale,
-            self.vec_size,
+            self.score_vec_size,
             self.qk_acc_dtype,
             aux_tensors,
             fastdiv_mods,

--- a/flash_attn/cute/mask.py
+++ b/flash_attn/cute/mask.py
@@ -102,6 +102,33 @@ def row_to_r2p_idx(x: Int32, num_rep: int, num_wg: int) -> Int32:
     return x // (num_rep * num_wg) * num_rep + min(x % (num_rep * num_wg), num_rep)
 
 
+@cute.jit
+def mask_mod_r2p(
+    X: cute.Tensor,
+    mask: cute.Tensor,
+) -> None:
+    """
+    Applies masks resulting from mask_mod callables to compile 
+    down to the r2p instruction. 
+    Args:
+        X: cute.Tensor, tensor to be masked 
+        mask: cute.Tensor, vector of Uint32 dtypes wide enough to cover 
+            width of X. 
+    
+    The mask is treated as bit-packed where low bits correspond to low 
+    kv indices (i.e. further left in the scores matrix).
+    """
+    ncol = const_expr(cute.size(X.shape))
+    width = 32
+
+    for s in cutlass.range_constexpr(cute.ceil_div(ncol, width)):
+        val = mask[s] 
+        for i in cutlass.range_constexpr(min(width, ncol - s * width)):
+            cond = cutlass.Boolean(val & (1 << i))
+            col = s * width + i 
+            X[col] = X[col] if cond else -Float32.inf
+
+
 @dataclass(frozen=True)
 class AttentionMask:
     tile_m: cutlass.Constexpr[int]
@@ -386,6 +413,7 @@ class AttentionMask:
         aux_tensors: Optional[list] = None,
         fastdiv_mods=(None, None),
         head_divmod=None,
+        vec_size: cutlass.Constexpr[int] = 1,
         check_q_boundary: bool = False,
         r2p: bool = True,
         rBitmask: Optional[cute.Tensor] = None,
@@ -438,7 +466,16 @@ class AttentionMask:
             batch_idx_ssa = utils.scalar_to_ssa(batch_idx, cutlass.Int32)
 
             ncol = const_expr(cute.size(tScS_t2r.shape))
-            for i in cutlass.range_constexpr(ncol):
+            # vectorized mask_mod application happens in two stages:
+            #   1: evaluation, where a Uint32 fragment bitmask is populated 
+            #   2: application, where it is applied to compile down to r2p 
+            #
+            # evaluation
+            num_mask_vals = (ncol + 32 - 1) // 32 
+            mask = cute.make_rmem_tensor(num_mask_vals, dtype=cutlass.Uint32)
+            mask.fill(cutlass.Uint32(0))
+            for s in cutlass.range_constexpr(cute.ceil_div(ncol, vec_size)):
+                i = s * vec_size
                 row_coord = tScS_t2r[i][0] if not self.swap_AB else tScS_t2r[i][1]
                 col_coord = tScS_t2r[i][1] if not self.swap_AB else tScS_t2r[i][0]
                 global_row = row_coord + m_block * self.tile_m
@@ -471,12 +508,23 @@ class AttentionMask:
                     self.seqlen_info,
                     aux_tensors,
                 )
-                cond = cutlass.Boolean(utils.ssa_to_scalar(mask_value))
-                acc_S[i] = acc_S[i] if cond else -Float32.inf
-                if const_expr(mask_seqlen):
-                    acc_S[i] = -Float32.inf if global_col >= self.seqlen_k else acc_S[i]
-                if check_q_boundary:
-                    acc_S[i] = -Float32.inf if mask_row >= self.seqlen_q else acc_S[i]
+                for j in cutlass.range_constexpr(min(vec_size, ncol - i)):
+                    idx = j // 32 
+                    cond = cutlass.Boolean(mask_value[idx] & (cutlass.Uint32(1) << j))
+                    col = i + j
+                    if const_expr(mask_seqlen):
+                        cond = cond & cutlass.Boolean(global_col < self.seqlen_k)
+                    if check_q_boundary:
+                        cond = cond & cutlass.Boolean(mask_row < self.seqlen_q)
+
+                    # set bit i if cond 
+                    val = col // 32 
+                    bit = col % 32 
+                    if cond: 
+                        mask[val] = mask[val] | (cutlass.Uint32(1) << bit)
+
+            # mask application 
+            mask_mod_r2p(acc_S, mask)
 
         else:  # Causal or local
             causal_row_offset = self.seqlen_k - n_block * self.tile_n - self.seqlen_q

--- a/flash_attn/cute/mask.py
+++ b/flash_attn/cute/mask.py
@@ -103,29 +103,50 @@ def row_to_r2p_idx(x: Int32, num_rep: int, num_wg: int) -> Int32:
 
 
 @cute.jit
+def apply_packed_mask_chunk(
+    X: cute.Tensor,
+    chunk_idx: cutlass.Constexpr[int],
+    mask: Uint32,
+) -> None:
+    """Apply one 32-bit keep mask to one 32-column chunk.
+
+    The one-iteration chunk loop keeps the same lowering pattern as mask_r2p_lambda.
+    """
+    ncol = const_expr(cute.size(X.shape))
+    col_base = chunk_idx * MASK_R2P_CHUNK_SIZE
+    for s in cutlass.range_constexpr(1):
+        for i in cutlass.range_constexpr(
+            min(MASK_R2P_CHUNK_SIZE, ncol - col_base - s * MASK_R2P_CHUNK_SIZE)
+        ):
+            in_bound = cutlass.Boolean(mask & (Uint32(1) << i))
+            c = col_base + s * MASK_R2P_CHUNK_SIZE + i
+            X[c] = X[c] if in_bound else -Float32.inf
+
+
+@cute.jit
 def mask_mod_r2p(
     X: cute.Tensor,
     mask: cute.Tensor,
 ) -> None:
     """
-    Applies masks resulting from mask_mod callables to compile 
-    down to the r2p instruction. 
+    Applies masks resulting from mask_mod callables to compile
+    down to the r2p instruction.
     Args:
-        X: cute.Tensor, tensor to be masked 
-        mask: cute.Tensor, vector of Uint32 dtypes wide enough to cover 
-            width of X. 
-    
-    The mask is treated as bit-packed where low bits correspond to low 
+        X: cute.Tensor, tensor to be masked
+        mask: cute.Tensor, vector of Uint32 dtypes wide enough to cover
+            width of X.
+
+    The mask is treated as bit-packed where low bits correspond to low
     kv indices (i.e. further left in the scores matrix).
     """
     ncol = const_expr(cute.size(X.shape))
     width = 32
 
     for s in cutlass.range_constexpr(cute.ceil_div(ncol, width)):
-        val = mask[s] 
+        val = mask[s]
         for i in cutlass.range_constexpr(min(width, ncol - s * width)):
             cond = cutlass.Boolean(val & (1 << i))
-            col = s * width + i 
+            col = s * width + i
             X[col] = X[col] if cond else -Float32.inf
 
 
@@ -457,7 +478,7 @@ class AttentionMask:
                     )
 
         elif const_expr(not mask_causal and not mask_local and mask_mod is not None):
-            # FlexAttention case w/ mask_mod, gated on `mask_mod.__vec_size__`:
+            # FlexAttention mask_mod vectorization is gated on `mask_mod.__vec_size__`.
             #   vec_size == 1:  scalar eval, returns Boolean.
             #   vec_size <= 32: returns shape-(1,) Uint32 fragment, bit i = lane i.
             #   vec_size  > 32: returns shape-(vec_size//32,) Uint32 fragment, bit i of
@@ -577,17 +598,19 @@ class AttentionMask:
                     # ---- handle bounds checking ----
                     bit_offset = const_expr((s % calls_per_apply) * vec_size)
                     seqlen_thresh_call = (
-                        self.seqlen_k - global_col
-                        if const_expr(mask_seqlen)
-                        else cutlass.Int32(0)
+                        self.seqlen_k - global_col if const_expr(mask_seqlen) else cutlass.Int32(0)
                     )
                     q_in_bounds = (
-                        mask_row < self.seqlen_q
-                        if check_q_boundary
-                        else cutlass.Boolean(True)
+                        mask_row < self.seqlen_q if check_q_boundary else cutlass.Boolean(True)
                     )
                     for c in cutlass.range_constexpr(mask_vals_per_apply):
                         mask_val = mask_value[c]
+                        if const_expr(vec_size < 32):
+                            lane_keep = utils.shr_u32(
+                                cutlass.Uint32(0xFFFFFFFF),
+                                cutlass.Uint32(32 - vec_size),
+                            )
+                            mask_val = mask_val & lane_keep
                         if const_expr(mask_seqlen):
                             local_thresh = seqlen_thresh_call - c * 32
                             m_shift = max(cutlass.Int32(32) - local_thresh, cutlass.Int32(0))
@@ -598,22 +621,17 @@ class AttentionMask:
                         if check_q_boundary:
                             mask_val = mask_val if q_in_bounds else cutlass.Uint32(0)
                         mask_vals[c] = mask_vals[c] | (mask_val << bit_offset)
-                    
+
                     # ---- vectorized application (compiles down to r2p) ----
                     is_last_in_apply = const_expr(s % calls_per_apply == calls_per_apply - 1)
                     is_last_overall = const_expr(s == n_calls - 1)
                     if const_expr(is_last_in_apply or is_last_overall):
                         apply_idx = s // calls_per_apply
                         for c in cutlass.range_constexpr(mask_vals_per_apply):
-                            col_base = (apply_idx * mask_vals_per_apply + c) * 32
-                            if const_expr(col_base >= ncol):
-                                break
-                            n_cols = const_expr(min(32, ncol - col_base))
-                            mask_val = mask_vals[c]
-                            for k in cutlass.range_constexpr(n_cols):
-                                col = col_base + k
-                                cond = cutlass.Boolean(mask_val & (cutlass.Uint32(1) << k))
-                                acc_S[col] = acc_S[col] if cond else -Float32.inf
+                            chunk_idx = apply_idx * mask_vals_per_apply + c
+                            # Skip packed chunks that start past the accumulator fragment.
+                            if const_expr(chunk_idx * 32 < ncol):
+                                apply_packed_mask_chunk(acc_S, chunk_idx, mask_vals[c])
 
         else:  # Causal or local
             causal_row_offset = self.seqlen_k - n_block * self.tile_n - self.seqlen_q

--- a/flash_attn/cute/mask.py
+++ b/flash_attn/cute/mask.py
@@ -123,33 +123,6 @@ def apply_packed_mask_chunk(
             X[c] = X[c] if in_bound else -Float32.inf
 
 
-@cute.jit
-def mask_mod_r2p(
-    X: cute.Tensor,
-    mask: cute.Tensor,
-) -> None:
-    """
-    Applies masks resulting from mask_mod callables to compile
-    down to the r2p instruction.
-    Args:
-        X: cute.Tensor, tensor to be masked
-        mask: cute.Tensor, vector of Uint32 dtypes wide enough to cover
-            width of X.
-
-    The mask is treated as bit-packed where low bits correspond to low
-    kv indices (i.e. further left in the scores matrix).
-    """
-    ncol = const_expr(cute.size(X.shape))
-    width = 32
-
-    for s in cutlass.range_constexpr(cute.ceil_div(ncol, width)):
-        val = mask[s]
-        for i in cutlass.range_constexpr(min(width, ncol - s * width)):
-            cond = cutlass.Boolean(val & (1 << i))
-            col = s * width + i
-            X[col] = X[col] if cond else -Float32.inf
-
-
 @dataclass(frozen=True)
 class AttentionMask:
     tile_m: cutlass.Constexpr[int]
@@ -418,6 +391,192 @@ class AttentionMask:
                             )
 
     @cute.jit
+    def apply_mask_mod_sm100_scalar(
+        self,
+        acc_S: cute.Tensor,
+        tScS_t2r: cute.Tensor,
+        m_block: Int32,
+        n_block: Int32,
+        mask_seqlen: cutlass.Constexpr[bool],
+        mask_mod: cutlass.Constexpr[Callable],
+        batch_idx: Int32,
+        head_idx: Int32,
+        aux_tensors: Optional[list] = None,
+        fastdiv_mods=(None, None),
+        head_divmod=None,
+        check_q_boundary: bool = False,
+    ) -> None:
+        """Apply a scalar FlexAttention mask_mod to an SM100 accumulator fragment.
+
+        Each accumulator lane calls mask_mod once with logical (batch, head, q, kv)
+        indices. Pack-GQA rows are converted back to logical q/head indices before
+        the call. When aux tensors are present, indices are wrapped with fastdiv so
+        mask_mod never reads outside the per-example auxiliary storage.
+        """
+        has_fastdiv = const_expr(
+            fastdiv_mods is not None and fastdiv_mods[0] is not None and fastdiv_mods[1] is not None
+        )
+        batch_idx_ssa = utils.scalar_to_ssa(batch_idx, cutlass.Int32)
+        ncol = const_expr(cute.size(tScS_t2r.shape))
+
+        for i in cutlass.range_constexpr(ncol):
+            row_coord = tScS_t2r[i][0] if not self.swap_AB else tScS_t2r[i][1]
+            col_coord = tScS_t2r[i][1] if not self.swap_AB else tScS_t2r[i][0]
+            global_row = row_coord + m_block * self.tile_m
+            global_col = col_coord + n_block * self.tile_n
+
+            if const_expr(self.qhead_per_kvhead_packgqa != 1):
+                assert head_divmod is not None
+                mask_row, head_offset = divmod(global_row, head_divmod)
+                head_idx_for_mod = head_idx * self.qhead_per_kvhead_packgqa + head_offset
+            else:
+                head_idx_for_mod = head_idx
+                mask_row = global_row
+
+            mask_row_for_mod = mask_row
+            if const_expr(has_fastdiv and aux_tensors is not None):
+                if check_q_boundary:
+                    _, mask_row_for_mod = divmod(mask_row, fastdiv_mods[0])
+            global_col_for_mod = global_col
+            if const_expr(has_fastdiv and mask_seqlen and aux_tensors is not None):
+                _, global_col_for_mod = divmod(global_col, fastdiv_mods[1])
+
+            head_idx_ssa = utils.scalar_to_ssa(head_idx_for_mod, cutlass.Int32)
+            mask_row_ssa = utils.scalar_to_ssa(mask_row_for_mod, cutlass.Int32)
+            kv_idx_ssa = utils.scalar_to_ssa(global_col_for_mod, cutlass.Int32)
+            mask_value = mask_mod(
+                batch_idx_ssa,
+                head_idx_ssa,
+                mask_row_ssa,
+                kv_idx_ssa,
+                self.seqlen_info,
+                aux_tensors,
+            )
+            cond = cutlass.Boolean(utils.ssa_to_scalar(mask_value))
+            acc_S[i] = acc_S[i] if cond else -Float32.inf
+            if const_expr(mask_seqlen):
+                acc_S[i] = -Float32.inf if global_col >= self.seqlen_k else acc_S[i]
+            if check_q_boundary:
+                acc_S[i] = -Float32.inf if mask_row >= self.seqlen_q else acc_S[i]
+
+    @cute.jit
+    def apply_mask_mod_sm100_vector(
+        self,
+        acc_S: cute.Tensor,
+        tScS_t2r: cute.Tensor,
+        m_block: Int32,
+        n_block: Int32,
+        mask_seqlen: cutlass.Constexpr[bool],
+        mask_mod: cutlass.Constexpr[Callable],
+        batch_idx: Int32,
+        head_idx: Int32,
+        vec_size: cutlass.Constexpr[int],
+        aux_tensors: Optional[list] = None,
+        fastdiv_mods=(None, None),
+        head_divmod=None,
+        check_q_boundary: bool = False,
+    ) -> None:
+        """Apply a vectorized FlexAttention mask_mod to an SM100 fragment.
+
+        mask_mod receives vec_size adjacent KV indices for one logical q row and
+        returns bit-packed Uint32 keep masks. Low bits correspond to lower KV
+        indices. The packed masks are combined with sequence-boundary checks, then
+        applied in 32-column chunks so the final masking lowers to R2P.
+        """
+        has_fastdiv = const_expr(
+            fastdiv_mods is not None and fastdiv_mods[0] is not None and fastdiv_mods[1] is not None
+        )
+        batch_idx_ssa = utils.scalar_to_ssa(batch_idx, cutlass.Int32)
+        ncol = const_expr(cute.size(tScS_t2r.shape))
+        mask_vals_per_apply = const_expr(max(1, vec_size // 32))
+        calls_per_apply = const_expr(max(1, 32 // vec_size))
+        n_calls = const_expr(cute.ceil_div(ncol, vec_size))
+        mask_vals = cute.make_rmem_tensor(mask_vals_per_apply, dtype=cutlass.Uint32)
+
+        # Accumulate enough vector mask_mod calls to produce 32-bit chunks that
+        # apply_packed_mask_chunk can lower to R2P.
+        for s in cutlass.range_constexpr(n_calls):
+            if const_expr(s % calls_per_apply == 0):
+                for c in cutlass.range_constexpr(mask_vals_per_apply):
+                    mask_vals[c] = cutlass.Uint32(0)
+            i = s * vec_size
+            row_coord = tScS_t2r[i][0] if not self.swap_AB else tScS_t2r[i][1]
+            col_coord = tScS_t2r[i][1] if not self.swap_AB else tScS_t2r[i][0]
+            global_row = row_coord + m_block * self.tile_m
+            global_col = col_coord + n_block * self.tile_n
+            if const_expr(self.qhead_per_kvhead_packgqa != 1):
+                assert head_divmod is not None
+                mask_row, head_offset = divmod(global_row, head_divmod)
+                head_idx_for_mod = head_idx * self.qhead_per_kvhead_packgqa + head_offset
+            else:
+                head_idx_for_mod = head_idx
+                mask_row = global_row
+            mask_row_for_mod = mask_row
+            if const_expr(has_fastdiv and aux_tensors is not None):
+                if check_q_boundary:
+                    _, mask_row_for_mod = divmod(mask_row, fastdiv_mods[0])
+
+            head_idx_ssa = utils.scalar_to_ssa(head_idx_for_mod, cutlass.Int32).broadcast_to(
+                (vec_size,)
+            )
+            mask_row_ssa = utils.scalar_to_ssa(mask_row_for_mod, cutlass.Int32).broadcast_to(
+                (vec_size,)
+            )
+            batch_idx_ssa_call = batch_idx_ssa.broadcast_to((vec_size,))
+            kv_idx_vec = cute.make_rmem_tensor(vec_size, cutlass.Int32)
+
+            # Build the per-lane KV indices for this vectorized mask_mod call.
+            for j in cutlass.range_constexpr(min(vec_size, ncol - i)):
+                col_j_coord = tScS_t2r[i + j][1] if not self.swap_AB else tScS_t2r[i + j][0]
+                col_j_global = col_j_coord + n_block * self.tile_n
+                col_j_for_mod = col_j_global
+                if const_expr(has_fastdiv and mask_seqlen and aux_tensors is not None):
+                    _, col_j_for_mod = divmod(col_j_global, fastdiv_mods[1])
+                kv_idx_vec[j] = col_j_for_mod
+            kv_idx_ssa = kv_idx_vec.load()
+
+            # mask_value is already bit-packed by the vectorized mask_mod.
+            mask_value = mask_mod(
+                batch_idx_ssa_call,
+                head_idx_ssa,
+                mask_row_ssa,
+                kv_idx_ssa,
+                self.seqlen_info,
+                aux_tensors,
+            )
+
+            # For vec_size < 32, multiple mask_mod calls fill one R2P chunk.
+            bit_offset = const_expr((s % calls_per_apply) * vec_size)
+            seqlen_thresh_call = (
+                self.seqlen_k - global_col if const_expr(mask_seqlen) else cutlass.Int32(0)
+            )
+            q_in_bounds = mask_row < self.seqlen_q if check_q_boundary else cutlass.Boolean(True)
+            for c in cutlass.range_constexpr(mask_vals_per_apply):
+                mask_val = mask_value[c]
+                if const_expr(vec_size < 32):
+                    lane_keep = utils.shr_u32(
+                        cutlass.Uint32(0xFFFFFFFF),
+                        cutlass.Uint32(32 - vec_size),
+                    )
+                    mask_val = mask_val & lane_keep
+                if const_expr(mask_seqlen):
+                    mask_val = mask_val & r2p_bitmask_below(seqlen_thresh_call, c)
+                if check_q_boundary:
+                    mask_val = mask_val if q_in_bounds else cutlass.Uint32(0)
+                mask_vals[c] = mask_vals[c] | (mask_val << bit_offset)
+
+            # Apply only when the 32-bit chunk is complete, or at the tile tail.
+            is_last_in_apply = const_expr(s % calls_per_apply == calls_per_apply - 1)
+            is_last_overall = const_expr(s == n_calls - 1)
+            if const_expr(is_last_in_apply or is_last_overall):
+                apply_idx = s // calls_per_apply
+                for c in cutlass.range_constexpr(mask_vals_per_apply):
+                    chunk_idx = apply_idx * mask_vals_per_apply + c
+                    # Skip packed chunks that start past the accumulator fragment.
+                    if const_expr(chunk_idx * 32 < ncol):
+                        apply_packed_mask_chunk(acc_S, chunk_idx, mask_vals[c])
+
+    @cute.jit
     def apply_mask_sm100(
         self,
         acc_S: cute.Tensor,
@@ -479,159 +638,42 @@ class AttentionMask:
 
         elif const_expr(not mask_causal and not mask_local and mask_mod is not None):
             # FlexAttention mask_mod vectorization is gated on `mask_mod.__vec_size__`.
-            #   vec_size == 1:  scalar eval, returns Boolean.
-            #   vec_size <= 32: returns shape-(1,) Uint32 fragment, bit i = lane i.
-            #   vec_size  > 32: returns shape-(vec_size//32,) Uint32 fragment, bit i of
-            #                   element k = lane (k*32 + i).
-            has_fastdiv = const_expr(
-                fastdiv_mods is not None
-                and fastdiv_mods[0] is not None
-                and fastdiv_mods[1] is not None
-            )
-            batch_idx_ssa = utils.scalar_to_ssa(batch_idx, cutlass.Int32)
-
-            ncol = const_expr(cute.size(tScS_t2r.shape))
+            # vec_size == 1 returns a scalar Boolean. vec_size > 1 returns packed
+            # Uint32 mask fragments: one word per 32 evaluated columns.
             assert vec_size % 32 == 0 or 32 % vec_size == 0, (
                 "vec_size must divide 32 or be a multiple of 32"
             )
-
             if const_expr(vec_size == 1):
-                for i in cutlass.range_constexpr(ncol):
-                    row_coord = tScS_t2r[i][0] if not self.swap_AB else tScS_t2r[i][1]
-                    col_coord = tScS_t2r[i][1] if not self.swap_AB else tScS_t2r[i][0]
-                    global_row = row_coord + m_block * self.tile_m
-                    global_col = col_coord + n_block * self.tile_n
-
-                    if const_expr(self.qhead_per_kvhead_packgqa != 1):
-                        assert head_divmod is not None
-                        mask_row, head_offset = divmod(global_row, head_divmod)
-                        head_idx_for_mod = head_idx * self.qhead_per_kvhead_packgqa + head_offset
-                    else:
-                        head_idx_for_mod = head_idx
-                        mask_row = global_row
-
-                    mask_row_for_mod = mask_row
-                    if const_expr(has_fastdiv and aux_tensors is not None):
-                        if check_q_boundary:
-                            _, mask_row_for_mod = divmod(mask_row, fastdiv_mods[0])
-                    global_col_for_mod = global_col
-                    if const_expr(has_fastdiv and mask_seqlen and aux_tensors is not None):
-                        _, global_col_for_mod = divmod(global_col, fastdiv_mods[1])
-
-                    head_idx_ssa = utils.scalar_to_ssa(head_idx_for_mod, cutlass.Int32)
-                    mask_row_ssa = utils.scalar_to_ssa(mask_row_for_mod, cutlass.Int32)
-                    kv_idx_ssa = utils.scalar_to_ssa(global_col_for_mod, cutlass.Int32)
-                    mask_value = mask_mod(
-                        batch_idx_ssa,
-                        head_idx_ssa,
-                        mask_row_ssa,
-                        kv_idx_ssa,
-                        self.seqlen_info,
-                        aux_tensors,
-                    )
-                    cond = cutlass.Boolean(utils.ssa_to_scalar(mask_value))
-                    acc_S[i] = acc_S[i] if cond else -Float32.inf
-                    if const_expr(mask_seqlen):
-                        acc_S[i] = -Float32.inf if global_col >= self.seqlen_k else acc_S[i]
-                    if check_q_boundary:
-                        acc_S[i] = -Float32.inf if mask_row >= self.seqlen_q else acc_S[i]
+                self.apply_mask_mod_sm100_scalar(
+                    acc_S,
+                    tScS_t2r,
+                    m_block,
+                    n_block,
+                    mask_seqlen,
+                    mask_mod,
+                    batch_idx,
+                    head_idx,
+                    aux_tensors,
+                    fastdiv_mods,
+                    head_divmod,
+                    check_q_boundary,
+                )
             else:
-                # Each mask_mod call evaluates `vec_size` elements; each mask_val is a
-                # Uint32 packing the result for 32 elems. Process ncol in apply-steps
-                # of max(vec_size, 32) elems: each step issues `calls_per_apply`
-                # mask_mod calls, assembles `mask_vals_per_apply` packed Uint32
-                # mask_vals, and applies each to acc_S, compiling down to R2P.
-                mask_vals_per_apply = const_expr(max(1, vec_size // 32))
-                calls_per_apply = const_expr(max(1, 32 // vec_size))
-                n_calls = const_expr(cute.ceil_div(ncol, vec_size))
-                mask_vals = cute.make_rmem_tensor(mask_vals_per_apply, dtype=cutlass.Uint32)
-                for s in cutlass.range_constexpr(n_calls):
-                    if const_expr(s % calls_per_apply == 0):
-                        for c in cutlass.range_constexpr(mask_vals_per_apply):
-                            mask_vals[c] = cutlass.Uint32(0)
-                    i = s * vec_size
-                    row_coord = tScS_t2r[i][0] if not self.swap_AB else tScS_t2r[i][1]
-                    col_coord = tScS_t2r[i][1] if not self.swap_AB else tScS_t2r[i][0]
-                    global_row = row_coord + m_block * self.tile_m
-                    global_col = col_coord + n_block * self.tile_n
-                    if const_expr(self.qhead_per_kvhead_packgqa != 1):
-                        assert head_divmod is not None
-                        mask_row, head_offset = divmod(global_row, head_divmod)
-                        head_idx_for_mod = head_idx * self.qhead_per_kvhead_packgqa + head_offset
-                    else:
-                        head_idx_for_mod = head_idx
-                        mask_row = global_row
-                    mask_row_for_mod = mask_row
-                    if const_expr(has_fastdiv and aux_tensors is not None):
-                        if check_q_boundary:
-                            _, mask_row_for_mod = divmod(mask_row, fastdiv_mods[0])
-
-                    head_idx_ssa = utils.scalar_to_ssa(
-                        head_idx_for_mod, cutlass.Int32
-                    ).broadcast_to((vec_size,))
-                    mask_row_ssa = utils.scalar_to_ssa(
-                        mask_row_for_mod, cutlass.Int32
-                    ).broadcast_to((vec_size,))
-                    batch_idx_ssa_call = batch_idx_ssa.broadcast_to((vec_size,))
-                    kv_idx_vec = cute.make_rmem_tensor(vec_size, cutlass.Int32)
-
-                    # ---- populate kv_idx_ssa ----
-                    for j in cutlass.range_constexpr(min(vec_size, ncol - i)):
-                        col_j_coord = tScS_t2r[i + j][1] if not self.swap_AB else tScS_t2r[i + j][0]
-                        col_j_global = col_j_coord + n_block * self.tile_n
-                        col_j_for_mod = col_j_global
-                        if const_expr(has_fastdiv and mask_seqlen and aux_tensors is not None):
-                            _, col_j_for_mod = divmod(col_j_global, fastdiv_mods[1])
-                        kv_idx_vec[j] = col_j_for_mod
-                    kv_idx_ssa = kv_idx_vec.load()
-
-                    # ---- evaluate ----
-                    mask_value = mask_mod(
-                        batch_idx_ssa_call,
-                        head_idx_ssa,
-                        mask_row_ssa,
-                        kv_idx_ssa,
-                        self.seqlen_info,
-                        aux_tensors,
-                    )
-
-                    # ---- handle bounds checking ----
-                    bit_offset = const_expr((s % calls_per_apply) * vec_size)
-                    seqlen_thresh_call = (
-                        self.seqlen_k - global_col if const_expr(mask_seqlen) else cutlass.Int32(0)
-                    )
-                    q_in_bounds = (
-                        mask_row < self.seqlen_q if check_q_boundary else cutlass.Boolean(True)
-                    )
-                    for c in cutlass.range_constexpr(mask_vals_per_apply):
-                        mask_val = mask_value[c]
-                        if const_expr(vec_size < 32):
-                            lane_keep = utils.shr_u32(
-                                cutlass.Uint32(0xFFFFFFFF),
-                                cutlass.Uint32(32 - vec_size),
-                            )
-                            mask_val = mask_val & lane_keep
-                        if const_expr(mask_seqlen):
-                            local_thresh = seqlen_thresh_call - c * 32
-                            m_shift = max(cutlass.Int32(32) - local_thresh, cutlass.Int32(0))
-                            seqlen_keep = utils.shr_u32(
-                                cutlass.Uint32(0xFFFFFFFF), cutlass.Uint32(m_shift)
-                            )
-                            mask_val = mask_val & seqlen_keep
-                        if check_q_boundary:
-                            mask_val = mask_val if q_in_bounds else cutlass.Uint32(0)
-                        mask_vals[c] = mask_vals[c] | (mask_val << bit_offset)
-
-                    # ---- vectorized application (compiles down to r2p) ----
-                    is_last_in_apply = const_expr(s % calls_per_apply == calls_per_apply - 1)
-                    is_last_overall = const_expr(s == n_calls - 1)
-                    if const_expr(is_last_in_apply or is_last_overall):
-                        apply_idx = s // calls_per_apply
-                        for c in cutlass.range_constexpr(mask_vals_per_apply):
-                            chunk_idx = apply_idx * mask_vals_per_apply + c
-                            # Skip packed chunks that start past the accumulator fragment.
-                            if const_expr(chunk_idx * 32 < ncol):
-                                apply_packed_mask_chunk(acc_S, chunk_idx, mask_vals[c])
+                self.apply_mask_mod_sm100_vector(
+                    acc_S,
+                    tScS_t2r,
+                    m_block,
+                    n_block,
+                    mask_seqlen,
+                    mask_mod,
+                    batch_idx,
+                    head_idx,
+                    vec_size,
+                    aux_tensors,
+                    fastdiv_mods,
+                    head_divmod,
+                    check_q_boundary,
+                )
 
         else:  # Causal or local
             causal_row_offset = self.seqlen_k - n_block * self.tile_n - self.seqlen_q

--- a/flash_attn/cute/mask.py
+++ b/flash_attn/cute/mask.py
@@ -457,7 +457,11 @@ class AttentionMask:
                     )
 
         elif const_expr(not mask_causal and not mask_local and mask_mod is not None):
-            # Block sparse case w/ mask_mod
+            # FlexAttention case w/ mask_mod, gated on `mask_mod.__vec_size__`:
+            #   vec_size == 1:  scalar eval, returns Boolean.
+            #   vec_size <= 32: returns shape-(1,) Uint32 fragment, bit i = lane i.
+            #   vec_size  > 32: returns shape-(vec_size//32,) Uint32 fragment, bit i of
+            #                   element k = lane (k*32 + i).
             has_fastdiv = const_expr(
                 fastdiv_mods is not None
                 and fastdiv_mods[0] is not None
@@ -466,65 +470,150 @@ class AttentionMask:
             batch_idx_ssa = utils.scalar_to_ssa(batch_idx, cutlass.Int32)
 
             ncol = const_expr(cute.size(tScS_t2r.shape))
-            # vectorized mask_mod application happens in two stages:
-            #   1: evaluation, where a Uint32 fragment bitmask is populated 
-            #   2: application, where it is applied to compile down to r2p 
-            #
-            # evaluation
-            num_mask_vals = (ncol + 32 - 1) // 32 
-            mask = cute.make_rmem_tensor(num_mask_vals, dtype=cutlass.Uint32)
-            mask.fill(cutlass.Uint32(0))
-            for s in cutlass.range_constexpr(cute.ceil_div(ncol, vec_size)):
-                i = s * vec_size
-                row_coord = tScS_t2r[i][0] if not self.swap_AB else tScS_t2r[i][1]
-                col_coord = tScS_t2r[i][1] if not self.swap_AB else tScS_t2r[i][0]
-                global_row = row_coord + m_block * self.tile_m
-                global_col = col_coord + n_block * self.tile_n
+            assert vec_size % 32 == 0 or 32 % vec_size == 0, (
+                "vec_size must divide 32 or be a multiple of 32"
+            )
 
-                if const_expr(self.qhead_per_kvhead_packgqa != 1):
-                    assert head_divmod is not None
-                    mask_row, head_offset = divmod(global_row, head_divmod)
-                    head_idx_for_mod = head_idx * self.qhead_per_kvhead_packgqa + head_offset
-                else:
-                    head_idx_for_mod = head_idx
-                    mask_row = global_row
+            if const_expr(vec_size == 1):
+                for i in cutlass.range_constexpr(ncol):
+                    row_coord = tScS_t2r[i][0] if not self.swap_AB else tScS_t2r[i][1]
+                    col_coord = tScS_t2r[i][1] if not self.swap_AB else tScS_t2r[i][0]
+                    global_row = row_coord + m_block * self.tile_m
+                    global_col = col_coord + n_block * self.tile_n
 
-                mask_row_for_mod = mask_row
-                if const_expr(has_fastdiv and aux_tensors is not None):
-                    if check_q_boundary:
-                        _, mask_row_for_mod = divmod(mask_row, fastdiv_mods[0])
-                global_col_for_mod = global_col
-                if const_expr(has_fastdiv and mask_seqlen and aux_tensors is not None):
-                    _, global_col_for_mod = divmod(global_col, fastdiv_mods[1])
+                    if const_expr(self.qhead_per_kvhead_packgqa != 1):
+                        assert head_divmod is not None
+                        mask_row, head_offset = divmod(global_row, head_divmod)
+                        head_idx_for_mod = head_idx * self.qhead_per_kvhead_packgqa + head_offset
+                    else:
+                        head_idx_for_mod = head_idx
+                        mask_row = global_row
 
-                head_idx_ssa = utils.scalar_to_ssa(head_idx_for_mod, cutlass.Int32)
-                mask_row_ssa = utils.scalar_to_ssa(mask_row_for_mod, cutlass.Int32)
-                kv_idx_ssa = utils.scalar_to_ssa(global_col_for_mod, cutlass.Int32)
-                mask_value = mask_mod(
-                    batch_idx_ssa,
-                    head_idx_ssa,
-                    mask_row_ssa,
-                    kv_idx_ssa,
-                    self.seqlen_info,
-                    aux_tensors,
-                )
-                for j in cutlass.range_constexpr(min(vec_size, ncol - i)):
-                    idx = j // 32 
-                    cond = cutlass.Boolean(mask_value[idx] & (cutlass.Uint32(1) << j))
-                    col = i + j
+                    mask_row_for_mod = mask_row
+                    if const_expr(has_fastdiv and aux_tensors is not None):
+                        if check_q_boundary:
+                            _, mask_row_for_mod = divmod(mask_row, fastdiv_mods[0])
+                    global_col_for_mod = global_col
+                    if const_expr(has_fastdiv and mask_seqlen and aux_tensors is not None):
+                        _, global_col_for_mod = divmod(global_col, fastdiv_mods[1])
+
+                    head_idx_ssa = utils.scalar_to_ssa(head_idx_for_mod, cutlass.Int32)
+                    mask_row_ssa = utils.scalar_to_ssa(mask_row_for_mod, cutlass.Int32)
+                    kv_idx_ssa = utils.scalar_to_ssa(global_col_for_mod, cutlass.Int32)
+                    mask_value = mask_mod(
+                        batch_idx_ssa,
+                        head_idx_ssa,
+                        mask_row_ssa,
+                        kv_idx_ssa,
+                        self.seqlen_info,
+                        aux_tensors,
+                    )
+                    cond = cutlass.Boolean(utils.ssa_to_scalar(mask_value))
+                    acc_S[i] = acc_S[i] if cond else -Float32.inf
                     if const_expr(mask_seqlen):
-                        cond = cond & cutlass.Boolean(global_col < self.seqlen_k)
+                        acc_S[i] = -Float32.inf if global_col >= self.seqlen_k else acc_S[i]
                     if check_q_boundary:
-                        cond = cond & cutlass.Boolean(mask_row < self.seqlen_q)
+                        acc_S[i] = -Float32.inf if mask_row >= self.seqlen_q else acc_S[i]
+            else:
+                # Each mask_mod call evaluates `vec_size` elements; each mask_val is a
+                # Uint32 packing the result for 32 elems. Process ncol in apply-steps
+                # of max(vec_size, 32) elems: each step issues `calls_per_apply`
+                # mask_mod calls, assembles `mask_vals_per_apply` packed Uint32
+                # mask_vals, and applies each to acc_S, compiling down to R2P.
+                mask_vals_per_apply = const_expr(max(1, vec_size // 32))
+                calls_per_apply = const_expr(max(1, 32 // vec_size))
+                n_calls = const_expr(cute.ceil_div(ncol, vec_size))
+                mask_vals = cute.make_rmem_tensor(mask_vals_per_apply, dtype=cutlass.Uint32)
+                for s in cutlass.range_constexpr(n_calls):
+                    if const_expr(s % calls_per_apply == 0):
+                        for c in cutlass.range_constexpr(mask_vals_per_apply):
+                            mask_vals[c] = cutlass.Uint32(0)
+                    i = s * vec_size
+                    row_coord = tScS_t2r[i][0] if not self.swap_AB else tScS_t2r[i][1]
+                    col_coord = tScS_t2r[i][1] if not self.swap_AB else tScS_t2r[i][0]
+                    global_row = row_coord + m_block * self.tile_m
+                    global_col = col_coord + n_block * self.tile_n
+                    if const_expr(self.qhead_per_kvhead_packgqa != 1):
+                        assert head_divmod is not None
+                        mask_row, head_offset = divmod(global_row, head_divmod)
+                        head_idx_for_mod = head_idx * self.qhead_per_kvhead_packgqa + head_offset
+                    else:
+                        head_idx_for_mod = head_idx
+                        mask_row = global_row
+                    mask_row_for_mod = mask_row
+                    if const_expr(has_fastdiv and aux_tensors is not None):
+                        if check_q_boundary:
+                            _, mask_row_for_mod = divmod(mask_row, fastdiv_mods[0])
 
-                    # set bit i if cond 
-                    val = col // 32 
-                    bit = col % 32 
-                    if cond: 
-                        mask[val] = mask[val] | (cutlass.Uint32(1) << bit)
+                    head_idx_ssa = utils.scalar_to_ssa(
+                        head_idx_for_mod, cutlass.Int32
+                    ).broadcast_to((vec_size,))
+                    mask_row_ssa = utils.scalar_to_ssa(
+                        mask_row_for_mod, cutlass.Int32
+                    ).broadcast_to((vec_size,))
+                    batch_idx_ssa_call = batch_idx_ssa.broadcast_to((vec_size,))
+                    kv_idx_vec = cute.make_rmem_tensor(vec_size, cutlass.Int32)
 
-            # mask application 
-            mask_mod_r2p(acc_S, mask)
+                    # ---- populate kv_idx_ssa ----
+                    for j in cutlass.range_constexpr(min(vec_size, ncol - i)):
+                        col_j_coord = tScS_t2r[i + j][1] if not self.swap_AB else tScS_t2r[i + j][0]
+                        col_j_global = col_j_coord + n_block * self.tile_n
+                        col_j_for_mod = col_j_global
+                        if const_expr(has_fastdiv and mask_seqlen and aux_tensors is not None):
+                            _, col_j_for_mod = divmod(col_j_global, fastdiv_mods[1])
+                        kv_idx_vec[j] = col_j_for_mod
+                    kv_idx_ssa = kv_idx_vec.load()
+
+                    # ---- evaluate ----
+                    mask_value = mask_mod(
+                        batch_idx_ssa_call,
+                        head_idx_ssa,
+                        mask_row_ssa,
+                        kv_idx_ssa,
+                        self.seqlen_info,
+                        aux_tensors,
+                    )
+
+                    # ---- handle bounds checking ----
+                    bit_offset = const_expr((s % calls_per_apply) * vec_size)
+                    seqlen_thresh_call = (
+                        self.seqlen_k - global_col
+                        if const_expr(mask_seqlen)
+                        else cutlass.Int32(0)
+                    )
+                    q_in_bounds = (
+                        mask_row < self.seqlen_q
+                        if check_q_boundary
+                        else cutlass.Boolean(True)
+                    )
+                    for c in cutlass.range_constexpr(mask_vals_per_apply):
+                        mask_val = mask_value[c]
+                        if const_expr(mask_seqlen):
+                            local_thresh = seqlen_thresh_call - c * 32
+                            m_shift = max(cutlass.Int32(32) - local_thresh, cutlass.Int32(0))
+                            seqlen_keep = utils.shr_u32(
+                                cutlass.Uint32(0xFFFFFFFF), cutlass.Uint32(m_shift)
+                            )
+                            mask_val = mask_val & seqlen_keep
+                        if check_q_boundary:
+                            mask_val = mask_val if q_in_bounds else cutlass.Uint32(0)
+                        mask_vals[c] = mask_vals[c] | (mask_val << bit_offset)
+                    
+                    # ---- vectorized application (compiles down to r2p) ----
+                    is_last_in_apply = const_expr(s % calls_per_apply == calls_per_apply - 1)
+                    is_last_overall = const_expr(s == n_calls - 1)
+                    if const_expr(is_last_in_apply or is_last_overall):
+                        apply_idx = s // calls_per_apply
+                        for c in cutlass.range_constexpr(mask_vals_per_apply):
+                            col_base = (apply_idx * mask_vals_per_apply + c) * 32
+                            if const_expr(col_base >= ncol):
+                                break
+                            n_cols = const_expr(min(32, ncol - col_base))
+                            mask_val = mask_vals[c]
+                            for k in cutlass.range_constexpr(n_cols):
+                                col = col_base + k
+                                cond = cutlass.Boolean(mask_val & (cutlass.Uint32(1) << k))
+                                acc_S[col] = acc_S[col] if cond else -Float32.inf
 
         else:  # Causal or local
             causal_row_offset = self.seqlen_k - n_block * self.tile_n - self.seqlen_q

--- a/flash_attn/cute/utils.py
+++ b/flash_attn/cute/utils.py
@@ -144,7 +144,7 @@ def hash_callable(
 
     hasher = hashlib.sha256(base_hash.encode())
 
-    for attr, val in zip(_MIXER_ATTRS, mixer_values):
+    for attr, val in zip(mixer_attrs, mixer_values):
         hasher.update(f"{attr}={val!r}".encode())
 
     return hasher.hexdigest()

--- a/tests/cute/mask_mod_definitions.py
+++ b/tests/cute/mask_mod_definitions.py
@@ -497,6 +497,262 @@ def make_global_windows(seqlens_q, device="cuda"):
 
 
 # =============================================================================
+# Vectorized mask_mod variants (return bit-packed Uint32)
+# =============================================================================
+#
+# Each variant receives shape-(vec_size,) Int32 SSAs and returns a shape-
+# (max(1, vec_size // 32),) Uint32 TensorSSA, where bit i of element k is the
+# mask for lane (k * 32 + i). Bodies assume lane i has idx[i] = idx[0] + i, so
+# they compute the packed Uint32(s) in O(1) via integer/bit arithmetic on the
+# chunk-base indices instead of evaluating per lane.
+
+
+@cute.jit
+def cute_causal_mask_vec(
+    batch: cute.TensorSSA,
+    head: cute.TensorSSA,
+    m_idx: cute.TensorSSA,
+    n_idx: cute.TensorSSA,
+    seqlen_info,
+    aux_tensors: None,
+) -> cute.TensorSSA:
+    offset = seqlen_info.seqlen_k - seqlen_info.seqlen_q
+    threshold = m_idx[0] + offset - n_idx[0] + cutlass.Int32(1)
+    m = max(cutlass.Int32(32) - threshold, cutlass.Int32(0))
+    result = cute.make_rmem_tensor(1, dtype=cutlass.Uint32)
+    result[0] = utils.shr_u32(cutlass.Uint32(0xFFFFFFFF), cutlass.Uint32(m))
+    return result.load()
+
+
+def get_cute_causal_mask_vec(offset: int):
+    return cute_causal_mask_vec
+
+
+def get_cute_sliding_window_mask_vec(window_left: int, window_right: int, offset: int):
+    @cute.jit
+    def _cute_sliding_window_mask_vec(
+        batch: cute.TensorSSA,
+        head: cute.TensorSSA,
+        m_idx: cute.TensorSSA,
+        n_idx: cute.TensorSSA,
+        seqlen_info,
+        aux_tensors,
+    ) -> cute.TensorSSA:
+        runtime_offset = seqlen_info.seqlen_k - seqlen_info.seqlen_q
+        center = m_idx[0] + runtime_offset
+        lo = center - cutlass.Int32(window_left) - n_idx[0]
+        hi_excl = center + cutlass.Int32(window_right) - n_idx[0] + cutlass.Int32(1)
+        m_below = max(cutlass.Int32(32) - hi_excl, cutlass.Int32(0))
+        below = utils.shr_u32(cutlass.Uint32(0xFFFFFFFF), cutlass.Uint32(m_below))
+        n_above = max(lo, cutlass.Int32(0))
+        above = utils.shl_u32(cutlass.Uint32(0xFFFFFFFF), cutlass.Uint32(n_above))
+        result = cute.make_rmem_tensor(1, dtype=cutlass.Uint32)
+        result[0] = below & above
+        return result.load()
+
+    return _cute_sliding_window_mask_vec
+
+
+@cute.jit
+def cute_block_diagonal_mask_vec(
+    batch: cute.TensorSSA,
+    head: cute.TensorSSA,
+    m_idx: cute.TensorSSA,
+    n_idx: cute.TensorSSA,
+    seqlen_info,
+    aux_tensors,
+) -> cute.TensorSSA:
+    block_size = cutlass.Int32(128)
+    block_m = m_idx[0] // block_size
+    lo = block_m * block_size - n_idx[0]
+    hi = (block_m + cutlass.Int32(1)) * block_size - n_idx[0]
+    m_below = max(cutlass.Int32(32) - hi, cutlass.Int32(0))
+    below = utils.shr_u32(cutlass.Uint32(0xFFFFFFFF), cutlass.Uint32(m_below))
+    n_above = max(lo, cutlass.Int32(0))
+    above = utils.shl_u32(cutlass.Uint32(0xFFFFFFFF), cutlass.Uint32(n_above))
+    result = cute.make_rmem_tensor(1, dtype=cutlass.Uint32)
+    result[0] = below & above
+    return result.load()
+
+
+@cute.jit
+def cute_prefix_lm_mask_vec(
+    batch: cute.TensorSSA,
+    head: cute.TensorSSA,
+    m_idx: cute.TensorSSA,
+    n_idx: cute.TensorSSA,
+    seqlen_info,
+    aux_tensors,
+) -> cute.TensorSSA:
+    prefix = cutlass.Int32(512)
+    hi_pref = prefix - n_idx[0]
+    m_below_pref = max(cutlass.Int32(32) - hi_pref, cutlass.Int32(0))
+    term1_below = utils.shr_u32(cutlass.Uint32(0xFFFFFFFF), cutlass.Uint32(m_below_pref))
+    row_in_prefix_mask = (
+        cutlass.Uint32(0xFFFFFFFF) if m_idx[0] < prefix else cutlass.Uint32(0)
+    )
+    term1 = term1_below & row_in_prefix_mask
+    hi_causal = m_idx[0] - n_idx[0] + cutlass.Int32(1)
+    m_below_causal = max(cutlass.Int32(32) - hi_causal, cutlass.Int32(0))
+    term2 = utils.shr_u32(cutlass.Uint32(0xFFFFFFFF), cutlass.Uint32(m_below_causal))
+    result = cute.make_rmem_tensor(1, dtype=cutlass.Uint32)
+    result[0] = term1 | term2
+    return result.load()
+
+
+# =============================================================================
+# Packed-bitmask aux tensor mod
+# =============================================================================
+# aux[0] is a (batch, max_seqlen_q, ceil(max_seqlen_k / 32)) Uint32 tensor where
+# bit k of packed[b, q, c] is the mask for (b, q, c*32 + k).
+
+
+@cute.jit
+def cute_packed_mask_aux(
+    batch: cute.TensorSSA,
+    head: cute.TensorSSA,
+    m_idx: cute.TensorSSA,
+    n_idx: cute.TensorSSA,
+    seqlen_info,
+    aux_tensors,
+) -> cute.TensorSSA:
+    packed = aux_tensors[0]
+    val = packed[batch[0], m_idx[0], n_idx[0] // cutlass.Int32(32)]
+    shift = cutlass.Uint32(n_idx[0] % cutlass.Int32(32))
+    bit_set = cutlass.Boolean(utils.shr_u32(val, shift) & cutlass.Uint32(1))
+    result = cute.make_rmem_tensor(n_idx.shape, dtype=cutlass.Boolean)
+    for j in cutlass.range_constexpr(cute.size(n_idx.shape)):
+        result[j] = bit_set
+    return result.load()
+
+
+def get_cute_packed_mask_aux_vec(vec_size: int):
+    """Vec packed-mask, specialized for `vec_size`. For vec_size > 32, requires
+    `aux_tensors[0].__assumed_align__ = 16` and num_words divisible by 4."""
+    if vec_size <= 32:
+
+        @cute.jit
+        def _mod(
+            batch: cute.TensorSSA,
+            head: cute.TensorSSA,
+            m_idx: cute.TensorSSA,
+            n_idx: cute.TensorSSA,
+            seqlen_info,
+            aux_tensors,
+        ) -> cute.TensorSSA:
+            packed = aux_tensors[0]
+            base = n_idx[0] // cutlass.Int32(32)
+            val = packed[batch[0], m_idx[0], base]
+            shift = cutlass.Uint32(n_idx[0] % cutlass.Int32(32))
+            result = cute.make_rmem_tensor(1, dtype=cutlass.Uint32)
+            result[0] = utils.shr_u32(val, shift)
+            return result.load()
+    else:
+        num_words = vec_size // 32
+
+        @cute.jit
+        def _mod(
+            batch: cute.TensorSSA,
+            head: cute.TensorSSA,
+            m_idx: cute.TensorSSA,
+            n_idx: cute.TensorSSA,
+            seqlen_info,
+            aux_tensors,
+        ) -> cute.TensorSSA:
+            packed = aux_tensors[0]
+            b_str, m_str, _ = packed.stride
+            packed_aligned = cute.make_tensor(
+                packed.iterator,
+                cute.make_layout(
+                    packed.shape,
+                    stride=(
+                        cute.assume(b_str, divby=4),
+                        cute.assume(m_str, divby=4),
+                        1,
+                    ),
+                ),
+            )
+            packed_row = packed_aligned[batch[0], m_idx[0], None]
+            packed_tiled = cute.flat_divide(packed_row, (num_words,))
+            base = n_idx[0] // cutlass.Int32(32)
+            packed_chunk = packed_tiled[None, base // cutlass.Int32(num_words)]
+            loaded = cute.make_rmem_tensor_like(packed_chunk)
+            cute.autovec_copy(packed_chunk, loaded)
+            result = cute.make_rmem_tensor(num_words, dtype=cutlass.Uint32)
+            for k in cutlass.range_constexpr(num_words):
+                result[k] = cutlass.Uint32(loaded[k])
+            return result.load()
+
+    return _mod
+
+
+def make_packed_mask_aux_tensor(
+    batch: int,
+    seqlen_q: int,
+    seqlen_k: int,
+    density: float = 0.5,
+    device="cuda",
+    seed: int = 0,
+):
+    """Random Uint32 bit-packed mask. num_words is rounded up to a multiple of 4
+    so each row is 16-byte aligned (LDG.E.128 requirement at vec_size=128)."""
+    g = torch.Generator(device=device).manual_seed(seed)
+    num_words = ((seqlen_k + 31) // 32 + 3) // 4 * 4
+    bools = (
+        torch.rand(batch, seqlen_q, num_words * 32, device=device, generator=g)
+        < density
+    )
+    bools = bools.reshape(batch, seqlen_q, num_words, 32)
+    powers = 1 << torch.arange(32, device=device, dtype=torch.int64)
+    packed = (bools.to(torch.int64) * powers).sum(-1).to(torch.uint32)
+    packed.__assumed_align__ = 16
+    return packed
+
+
+VEC_MASK_FACTORIES = {
+    "causal": ("factory", get_cute_causal_mask_vec),
+    "block_causal": ("factory", get_cute_causal_mask_vec),
+    "sliding_window": ("factory_window", get_cute_sliding_window_mask_vec),
+    "block_diagonal": ("static", cute_block_diagonal_mask_vec),
+    "prefix_lm": ("static", cute_prefix_lm_mask_vec),
+    "packed_aux": ("factory_vec_size", get_cute_packed_mask_aux_vec),
+}
+
+
+# Scalar mods for vec masks not in STATIC_MASKS / PARAMETERIZED_MASK_FACTORIES.
+EXTRA_SCALAR_MASKS = {
+    "packed_aux": cute_packed_mask_aux,
+}
+
+
+def get_vec_mask(
+    mask_name, seqlen_q=None, seqlen_k=None, window_size=None, vec_size=None
+):
+    """Return a vectorized cute mask callable for `mask_name`, or None if there
+    is no vec form. Caller sets `__vec_size__` on the returned callable.
+    `vec_size` is required for masks whose body specializes on it (packed_aux)."""
+    if mask_name not in VEC_MASK_FACTORIES:
+        return None
+    kind, obj = VEC_MASK_FACTORIES[mask_name]
+    if kind == "static":
+        return obj
+    if kind == "factory_vec_size":
+        if vec_size is None:
+            raise ValueError(f"{mask_name} vec mask requires vec_size")
+        return obj(vec_size)
+    offset = (
+        (seqlen_k - seqlen_q) if (seqlen_q is not None and seqlen_k is not None) else 0
+    )
+    if kind == "factory":
+        return obj(offset)
+    if kind == "factory_window":
+        if window_size is None:
+            raise ValueError("sliding_window vec mask requires window_size")
+        return obj(window_size, window_size, offset)
+    raise ValueError(f"unknown vec mask kind: {kind}")
+
+
+# =============================================================================
 # Mask registry and factory functions
 # =============================================================================
 

--- a/tests/cute/test_mask_mod.py
+++ b/tests/cute/test_mask_mod.py
@@ -53,6 +53,7 @@ def reset_torch_state():
     torch._dynamo.reset()
     torch.cuda.empty_cache()
 
+
 def create_tensors(
     batch_size, seqlen_q, seqlen_k, nheads, nheads_kv, headdim, headdim_v, dtype
 ):
@@ -850,10 +851,9 @@ VEC_MASK_TEST_CASES = [
     ("packed_aux", None, True),
 ]
 
-# vec_size > 32 only supported by packed_aux (other vec mods return shape-(1,) Uint32).
-VEC_MASK_SIZES_TO_CHECK_EQUALITY = (
-    [2, 8, 32, 128] if COMPUTE_CAPABILITY == 10 else [2, 8, 32]
-)
+# Vectorized mask_mod application is currently implemented for SM100/SM110 forward.
+# vec_size > 32 is only supported by packed_aux (other vec mods return shape-(1,) Uint32).
+VEC_MASK_SIZES_TO_CHECK_EQUALITY = [2, 8, 32, 128]
 
 
 def _run_mask_mod_only(q, k, v, mask_mod, aux_tensors, pack_gqa):
@@ -898,6 +898,8 @@ def test_cute_mask_mod_vectorized(
     seqlen_q, seqlen_k, qhead_per_kvhead, num_kv_heads, dtype, mask_case
 ):
     """Tests equality between scalar and vectorized versions of mask mods."""
+    if COMPUTE_CAPABILITY not in (10, 11):
+        pytest.skip("vectorized mask_mod application is SM100/SM110-only")
     mask_name, window_size, needs_aux = mask_case
     torch.manual_seed(42)
 

--- a/tests/cute/test_mask_mod.py
+++ b/tests/cute/test_mask_mod.py
@@ -32,7 +32,13 @@ from flash_attn.cute.block_sparsity import (
 )
 from flash_attn.cute.cache_utils import get_jit_cache
 from flash_attn.cute import utils
-from mask_mod_definitions import get_mask_pair, random_doc_id_tensor
+from mask_mod_definitions import (
+    get_mask_pair,
+    get_vec_mask,
+    random_doc_id_tensor,
+    EXTRA_SCALAR_MASKS,
+    make_packed_mask_aux_tensor,
+)
 COMPUTE_CAPABILITY = torch.cuda.get_device_capability()[0]
 
 
@@ -826,6 +832,121 @@ def test_parameterized_masks(
         needs_backward=True,
         use_autograd=use_autograd,
     )
+
+
+# =============================================================================
+# Vectorized mask_mod equality tests
+# Pattern: scalar mask is reference; vec mask at multiple __vec_size__ values
+# must produce bit-identical output.
+# =============================================================================
+
+# (mask_name, window_size, needs_aux)
+VEC_MASK_TEST_CASES = [
+    ("causal", None, False),
+    ("block_causal", None, False),
+    ("sliding_window", 128, False),
+    ("block_diagonal", None, False),
+    ("prefix_lm", None, False),
+    ("packed_aux", None, True),
+]
+
+# vec_size > 32 only supported by packed_aux (other vec mods return shape-(1,) Uint32).
+VEC_MASK_SIZES_TO_CHECK_EQUALITY = (
+    [2, 8, 32, 128] if COMPUTE_CAPABILITY == 10 else [2, 8, 32]
+)
+
+
+def _run_mask_mod_only(q, k, v, mask_mod, aux_tensors, pack_gqa):
+    out = torch.empty_like(q)
+    _flash_attn_fwd(
+        q=q,
+        k=k,
+        v=v,
+        out=out,
+        lse=None,
+        cu_seqlens_q=None,
+        cu_seqlens_k=None,
+        seqused_q=None,
+        seqused_k=None,
+        page_table=None,
+        softmax_scale=1.0 / math.sqrt(q.shape[-1]),
+        causal=False,
+        softcap=None,
+        window_size_left=-1,
+        window_size_right=-1,
+        learnable_sink=None,
+        tile_mn=(128, 128),
+        pack_gqa=pack_gqa,
+        _arch=None,
+        score_mod=None,
+        mask_mod=mask_mod,
+        block_sparse_tensors=None,
+        return_lse=False,
+        aux_tensors=aux_tensors,
+    )
+    return out
+
+
+@pytest.mark.parametrize(
+    "seqlen_q,seqlen_k",
+    [(128, 128), (256, 256), (113, 203), (256, 512), (1024, 1024)],
+)
+@pytest.mark.parametrize("qhead_per_kvhead,num_kv_heads", [(1, 4), (4, 2)])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("mask_case", VEC_MASK_TEST_CASES)
+def test_cute_mask_mod_vectorized(
+    seqlen_q, seqlen_k, qhead_per_kvhead, num_kv_heads, dtype, mask_case
+):
+    """Tests equality between scalar and vectorized versions of mask mods."""
+    mask_name, window_size, needs_aux = mask_case
+    torch.manual_seed(42)
+
+    num_heads = num_kv_heads * qhead_per_kvhead
+    pack_gqa = qhead_per_kvhead > 1
+    head_dim = 128
+    batch_size = 2
+
+    q = torch.randn(
+        batch_size, seqlen_q, num_heads, head_dim, device="cuda", dtype=dtype
+    )
+    k = torch.randn(
+        batch_size, seqlen_k, num_kv_heads, head_dim, device="cuda", dtype=dtype
+    )
+    v = torch.randn(
+        batch_size, seqlen_k, num_kv_heads, head_dim, device="cuda", dtype=dtype
+    )
+
+    if needs_aux:
+        aux_tensors = [make_packed_mask_aux_tensor(batch_size, seqlen_q, seqlen_k)]
+        scalar_mod = EXTRA_SCALAR_MASKS[mask_name]
+    else:
+        aux_tensors = None
+        scalar_mod, _ = get_mask_pair(
+            mask_name,
+            seqlen_q=seqlen_q,
+            seqlen_k=seqlen_k,
+            window_size=window_size,
+        )
+
+    out_ref = _run_mask_mod_only(q, k, v, scalar_mod, aux_tensors, pack_gqa)
+
+    for vec_size in VEC_MASK_SIZES_TO_CHECK_EQUALITY:
+        if vec_size > 32 and mask_name != "packed_aux":
+            continue
+        vec_mod = get_vec_mask(
+            mask_name,
+            seqlen_q=seqlen_q,
+            seqlen_k=seqlen_k,
+            window_size=window_size,
+            vec_size=vec_size,
+        )
+        if vec_mod is None:
+            pytest.skip(f"no vec mask for {mask_name}")
+        vec_mod.__vec_size__ = vec_size
+        out = _run_mask_mod_only(q, k, v, vec_mod, aux_tensors, pack_gqa)
+        assert torch.equal(out, out_ref), (
+            f"{mask_name} vec_size={vec_size}: output mismatch vs scalar reference"
+        )
 
 
 def test_sm100_block_sparse_sink_all_masked():

--- a/tests/cute/test_mask_mod_varlen.py
+++ b/tests/cute/test_mask_mod_varlen.py
@@ -632,10 +632,9 @@ VEC_MASK_TEST_CASES = [
     ("packed_aux", None, True),
 ]
 
-# vec_size > 32 only supported by packed_aux (other vec mods return shape-(1,) Uint32).
-VEC_MASK_SIZES_TO_CHECK_EQUALITY = (
-    [2, 8, 32, 128] if COMPUTE_CAPABILITY == 10 else [2, 8, 32]
-)
+# Vectorized mask_mod application is currently implemented for SM100/SM110 forward.
+# vec_size > 32 is only supported by packed_aux (other vec mods return shape-(1,) Uint32).
+VEC_MASK_SIZES_TO_CHECK_EQUALITY = [2, 8, 32, 128]
 
 
 def _run_varlen_mask_only(
@@ -677,6 +676,8 @@ def _run_varlen_mask_only(
 @pytest.mark.parametrize("mask_case", VEC_MASK_TEST_CASES)
 def test_varlen_mask_mod_vectorized(seqlens_q, seqlens_k, dtype, kv_mode, mask_case):
     """Tests equality between scalar and vectorized mask mods on varlen inputs."""
+    if COMPUTE_CAPABILITY not in (10, 11):
+        pytest.skip("vectorized mask_mod application is SM100/SM110-only")
     mask_name, window_size, needs_aux = mask_case
 
     if mask_name == "block_causal":

--- a/tests/cute/test_mask_mod_varlen.py
+++ b/tests/cute/test_mask_mod_varlen.py
@@ -23,9 +23,12 @@ from flash_attn.cute import utils
 from flash_attn.cute.compute_block_sparsity import compute_block_sparsity
 from mask_mod_definitions import (
     get_mask_pair,
+    get_vec_mask,
     random_doc_id_tensor,
     STATIC_MASKS,
     PARAMETERIZED_MASK_FACTORIES,
+    EXTRA_SCALAR_MASKS,
+    make_packed_mask_aux_tensor,
     cute_global_packed_doc_mask,
     cute_global_ima_mask,
     cute_global_causal_window_mask,
@@ -611,6 +614,141 @@ def test_varlen_global_masks(seqlens_q, seqlens_k, mask_name):
     _run_varlen_global_mask_test(
         seqlens_q, seqlens_k, 8, 8, 128, torch.bfloat16, mask_name
     )
+
+
+# =============================================================================
+# Vectorized mask_mod equality tests (varlen)
+# Pattern: scalar mask is reference; vec mask at multiple __vec_size__ values
+# must produce bit-identical output.
+# =============================================================================
+
+# (mask_name, window_size, needs_aux)
+VEC_MASK_TEST_CASES = [
+    ("causal", None, False),
+    ("block_causal", None, False),
+    ("sliding_window", 128, False),
+    ("block_diagonal", None, False),
+    ("prefix_lm", None, False),
+    ("packed_aux", None, True),
+]
+
+# vec_size > 32 only supported by packed_aux (other vec mods return shape-(1,) Uint32).
+VEC_MASK_SIZES_TO_CHECK_EQUALITY = (
+    [2, 8, 32, 128] if COMPUTE_CAPABILITY == 10 else [2, 8, 32]
+)
+
+
+def _run_varlen_mask_only(
+    q, k, v, cu_seqlens_q, cu_seqlens_k, mask_mod, aux_tensors, pack_gqa
+):
+    out = torch.empty_like(q)
+    _flash_attn_fwd(
+        q=q,
+        k=k,
+        v=v,
+        out=out,
+        lse=None,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        seqused_q=None,
+        seqused_k=None,
+        page_table=None,
+        softmax_scale=1.0 / math.sqrt(q.shape[-1]),
+        causal=False,
+        softcap=None,
+        window_size_left=-1,
+        window_size_right=-1,
+        learnable_sink=None,
+        tile_mn=(128, 128),
+        pack_gqa=pack_gqa,
+        _arch=None,
+        score_mod=None,
+        mask_mod=mask_mod,
+        block_sparse_tensors=None,
+        return_lse=False,
+        aux_tensors=aux_tensors,
+    )
+    return out
+
+
+@pytest.mark.parametrize("seqlens_q,seqlens_k", SEQLEN_CONFIGS_SMOKE)
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.parametrize("kv_mode", ["mha", "gqa"])
+@pytest.mark.parametrize("mask_case", VEC_MASK_TEST_CASES)
+def test_varlen_mask_mod_vectorized(seqlens_q, seqlens_k, dtype, kv_mode, mask_case):
+    """Tests equality between scalar and vectorized mask mods on varlen inputs."""
+    mask_name, window_size, needs_aux = mask_case
+
+    if mask_name == "block_causal":
+        offsets = [sk - sq for sq, sk in zip(seqlens_q, seqlens_k)]
+        if len(set(offsets)) > 1:
+            pytest.skip(
+                "block_causal captures offset as compile-time constant; "
+                "varlen with different per-sequence offsets not supported"
+            )
+    if mask_name == "sliding_window":
+        for sq, sk in zip(seqlens_q, seqlens_k):
+            if sq > sk:
+                pytest.skip(
+                    "sliding_window requires seqlen_q <= seqlen_k for each sequence"
+                )
+
+    torch.manual_seed(42)
+    num_heads = 8
+    if kv_mode == "gqa":
+        if COMPUTE_CAPABILITY < 9:
+            pytest.xfail("pack_gqa requires SM90+")
+        num_kv_heads = 2
+    else:
+        num_kv_heads = num_heads
+    pack_gqa = num_heads != num_kv_heads
+    head_dim = 128
+
+    q, k, v, cu_seqlens_q, cu_seqlens_k = setup_varlen_tensors(
+        seqlens_q, seqlens_k, num_heads, num_kv_heads, head_dim, dtype
+    )
+
+    batch_size = len(seqlens_q)
+    max_seqlen_q = max(seqlens_q)
+    max_seqlen_k = max(seqlens_k)
+
+    if needs_aux:
+        aux_tensors = [
+            make_packed_mask_aux_tensor(batch_size, max_seqlen_q, max_seqlen_k)
+        ]
+        scalar_mod = EXTRA_SCALAR_MASKS[mask_name]
+    else:
+        aux_tensors = None
+        scalar_mod, _ = get_mask_pair(
+            mask_name,
+            seqlen_q=max_seqlen_q,
+            seqlen_k=max_seqlen_k,
+            window_size=window_size,
+        )
+
+    out_ref = _run_varlen_mask_only(
+        q, k, v, cu_seqlens_q, cu_seqlens_k, scalar_mod, aux_tensors, pack_gqa
+    )
+
+    for vec_size in VEC_MASK_SIZES_TO_CHECK_EQUALITY:
+        if vec_size > 32 and mask_name != "packed_aux":
+            continue
+        vec_mod = get_vec_mask(
+            mask_name,
+            seqlen_q=max_seqlen_q,
+            seqlen_k=max_seqlen_k,
+            window_size=window_size,
+            vec_size=vec_size,
+        )
+        if vec_mod is None:
+            pytest.skip(f"no vec mask for {mask_name}")
+        vec_mod.__vec_size__ = vec_size
+        out = _run_varlen_mask_only(
+            q, k, v, cu_seqlens_q, cu_seqlens_k, vec_mod, aux_tensors, pack_gqa
+        )
+        assert torch.equal(out, out_ref), (
+            f"{mask_name} vec_size={vec_size}: output mismatch vs scalar reference"
+        )
 
 
 # =============================================================================

--- a/tests/cute/test_utils.py
+++ b/tests/cute/test_utils.py
@@ -160,6 +160,19 @@ class TestHashCallable:
         assert call_tracker["sha256"] == 0, "sha256 should not be called"
         assert result == "wrapped-fast-hash"
 
+    def test_vec_size_affects_hash(self):
+        def mask_mod(_b, _h, q_idx, kv_idx):
+            return q_idx >= kv_idx
+
+        base_hash = hash_callable(mask_mod, set_cute_hash=False)
+        mask_mod.__vec_size__ = 16
+        vec16_hash = hash_callable(mask_mod, set_cute_hash=False)
+        mask_mod.__vec_size__ = 32
+        vec32_hash = hash_callable(mask_mod, set_cute_hash=False)
+
+        assert base_hash != vec16_hash
+        assert vec16_hash != vec32_hash
+
     def test_closure_values_affect_hash(self):
         """Functions with different closure values should have different hashes."""
         value1 = 10


### PR DESCRIPTION
Follow-up to #2236. The approach to vectorizing is bipartite:
- Vectorize mask *application*, to compile down to `r2p`
- Vectorize mask *evaluation*

The latter is important for example in situations where `mask_mod` depends on `aux_tensors` that are contiguous in the kv idx, or when `aux_tensors` don't depend on kv index at all. 

`mask_mod`s still emit `TensorSSA`s, but they need not be single values. These are treated as bit-packed masks. 

Note: this current work is Sm100 only. 

See `mask_mod_definitions.py` for many examples. Vectorization leads to a speedup in all relevant mask mods:
```
  ┌───────────────────────────────────┬────────────┬────────────────────┬────────────────────┬─────────────────────┬──────────────┐
  │               mask                │   (b, s)   │ scalar ms / TFLOPS │ vec_32 ms / TFLOPS │ vec_128 ms / TFLOPS │ best speedup │
  ├───────────────────────────────────┼────────────┼────────────────────┼────────────────────┼─────────────────────┼──────────────┤
  │ causal                            │ (8, 2048)  │ 0.107 / 644        │ 0.100 / 690        │ —                   │ +7%          │
  ├───────────────────────────────────┼────────────┼────────────────────┼────────────────────┼─────────────────────┼──────────────┤
  │ causal                            │ (4, 4096)  │ 0.159 / 862        │ 0.153 / 898        │ —                   │ +4%          │
  ├───────────────────────────────────┼────────────┼────────────────────┼────────────────────┼─────────────────────┼──────────────┤
  │ causal                            │ (2, 8192)  │ 0.266 / 1035       │ 0.262 / 1049       │ —                   │ +1%          │
  ├───────────────────────────────────┼────────────┼────────────────────┼────────────────────┼─────────────────────┼──────────────┤
  │ causal                            │ (1, 16384) │ 0.485 / 1135       │ 0.481 / 1143       │ —                   │ +1%          │
  ├───────────────────────────────────┼────────────┼────────────────────┼────────────────────┼─────────────────────┼──────────────┤
  │ block_causal                      │ (8, 2048)  │ 0.106 / 648        │ 0.100 / 691        │ —                   │ +6%          │
  ├───────────────────────────────────┼────────────┼────────────────────┼────────────────────┼─────────────────────┼──────────────┤
  │ block_causal                      │ (1, 16384) │ 0.484 / 1136       │ 0.481 / 1144       │ —                   │ +1%          │
  ├───────────────────────────────────┼────────────┼────────────────────┼────────────────────┼─────────────────────┼──────────────┤
  │ sliding_window 256                │ (8, 2048)  │ 0.121 / 267        │ 0.077 / 419        │ —                   │ +57%         │
  ├───────────────────────────────────┼────────────┼────────────────────┼────────────────────┼─────────────────────┼──────────────┤
  │ sliding_window 256                │ (4, 4096)  │ 0.125 / 267        │ 0.079 / 421        │ —                   │ +58%         │
  ├───────────────────────────────────┼────────────┼────────────────────┼────────────────────┼─────────────────────┼──────────────┤
  │ sliding_window 256                │ (2, 8192)  │ 0.127 / 268        │ 0.080 / 425        │ —                   │ +59%         │
  ├───────────────────────────────────┼────────────┼────────────────────┼────────────────────┼─────────────────────┼──────────────┤
  │ sliding_window 256                │ (1, 16384) │ 0.128 / 268        │ 0.080 / 425        │ —                   │ +60%         │
  ├───────────────────────────────────┼────────────┼────────────────────┼────────────────────┼─────────────────────┼──────────────┤
  │ sliding_with_sink sink=64 win=256 │ (8, 2048)  │ 0.108 / 333        │ 0.082 / 438        │ —                   │ +32%         │
  ├───────────────────────────────────┼────────────┼────────────────────┼────────────────────┼─────────────────────┼──────────────┤
  │ sliding_with_sink sink=64 win=256 │ (4, 4096)  │ 0.108 / 344        │ 0.085 / 438        │ —                   │ +27%         │
  ├───────────────────────────────────┼────────────┼────────────────────┼────────────────────┼─────────────────────┼──────────────┤
  │ sliding_with_sink sink=64 win=256 │ (2, 8192)  │ 0.109 / 348        │ 0.087 / 439        │ —                   │ +26%         │
  ├───────────────────────────────────┼────────────┼────────────────────┼────────────────────┼─────────────────────┼──────────────┤
  │ sliding_with_sink sink=64 win=256 │ (1, 16384) │ 0.111 / 345        │ 0.088 / 438        │ —                   │ +26%         │
  ├───────────────────────────────────┼────────────┼────────────────────┼────────────────────┼─────────────────────┼──────────────┤
  │ block_diagonal 128                │ (8, 2048)  │ 0.072 / 120        │ 0.052 / 164        │ —                   │ +38%         │
  ├───────────────────────────────────┼────────────┼────────────────────┼────────────────────┼─────────────────────┼──────────────┤
  │ block_diagonal 128                │ (4, 4096)  │ 0.073 / 118        │ 0.053 / 161        │ —                   │ +38%         │
  ├───────────────────────────────────┼────────────┼────────────────────┼────────────────────┼─────────────────────┼──────────────┤
  │ block_diagonal 128                │ (2, 8192)  │ 0.072 / 119        │ 0.053 / 163        │ —                   │ +36%         │
  ├───────────────────────────────────┼────────────┼────────────────────┼────────────────────┼─────────────────────┼──────────────┤
  │ block_diagonal 128                │ (1, 16384) │ 0.073 / 118        │ 0.053 / 162        │ —                   │ +38%         │
  ├───────────────────────────────────┼────────────┼────────────────────┼────────────────────┼─────────────────────┼──────────────┤
  │ prefix_lm 512                     │ (8, 2048)  │ 0.113 / 646        │ 0.100 / 729        │ —                   │ +13%         │
  ├───────────────────────────────────┼────────────┼────────────────────┼────────────────────┼─────────────────────┼──────────────┤
  │ prefix_lm 512                     │ (4, 4096)  │ 0.167 / 836        │ 0.155 / 904        │ —                   │ +8%          │
  ├───────────────────────────────────┼────────────┼────────────────────┼────────────────────┼─────────────────────┼──────────────┤
  │ prefix_lm 512                     │ (1, 16384) │ 0.492 / 1120       │ 0.482 / 1142       │ —                   │ +2%          │
  ├───────────────────────────────────┼────────────┼────────────────────┼────────────────────┼─────────────────────┼──────────────┤
  │ document                          │ (8, 2048)  │ 0.229 / 74         │ 0.118 / 143        │ 0.109 / 155         │ 2.1×         │
  ├───────────────────────────────────┼────────────┼────────────────────┼────────────────────┼─────────────────────┼──────────────┤
  │ document                          │ (4, 4096)  │ 0.266 / 166        │ 0.152 / 291        │ 0.137 / 323         │ 1.9×         │
  ├───────────────────────────────────┼────────────┼────────────────────┼────────────────────┼─────────────────────┼──────────────┤
  │ document                          │ (2, 8192)  │ 0.368 / 206        │ 0.247 / 307        │ 0.216 / 350         │ 1.7×         │
  ├───────────────────────────────────┼────────────┼────────────────────┼────────────────────┼─────────────────────┼──────────────┤
  │ document                          │ (1, 16384) │ 0.264 / 139        │ 0.150 / 245        │ 0.135 / 273         │ 2.0×         │
  ├───────────────────────────────────┼────────────┼────────────────────┼────────────────────┼─────────────────────┼──────────────┤
  │ packed_aux                        │ (8, 2048)  │ 1.425 / 48         │ 0.212 / 324        │ 0.160 / 430         │ 8.9×         │
  ├───────────────────────────────────┼────────────┼────────────────────┼────────────────────┼─────────────────────┼──────────────┤
  │ packed_aux                        │ (4, 4096)  │ 2.780 / 49         │ 0.393 / 350        │ 0.284 / 483         │ 9.8×         │
  ├───────────────────────────────────┼────────────┼────────────────────┼────────────────────┼─────────────────────┼──────────────┤
  │ packed_aux                        │ (2, 8192)  │ 5.490 / 50         │ 0.755 / 364        │ 0.535 / 513         │ 10.3×        │
  ├───────────────────────────────────┼────────────┼────────────────────┼────────────────────┼─────────────────────┼──────────────┤
  │ packed_aux                        │ (1, 16384) │ 10.937 / 50        │ 1.479 / 372        │ 1.056 / 521         │ 10.4×        │
  └───────────────────────────────────┴────────────┴────────────────────┴────────────────────┴─────────────────────┴──────────────┘
```
I added tests checking bitwise equality between ordinary and vectorized paths; those and existing mask mod tests all pass (`test_mask_mod` and `test_mask_mod_varlen`, respectively):
<img width="1218" height="194" alt="Screenshot 2026-05-11 at 9 58 58 PM" src="https://github.com/user-attachments/assets/5cca27bd-7600-4578-aee1-fa7bc8cf83e6" />
<img width="1209" height="119" alt="Screenshot 2026-05-11 at 10 13 33 PM" src="https://github.com/user-attachments/assets/df211e06-f750-43a7-816c-b26b10299518" />


cc @drisspg @v0i0 