### PR TITLE
[Rotary] Add FixedPosition support for K RoPE in store_kv_new (Sm80, Sm90)

### DIFF
--- a/hopper/mainloop_fwd_sm80.hpp
+++ b/hopper/mainloop_fwd_sm80.hpp
@@ -696,7 +696,7 @@ struct CollectiveMainloopFwdSm80 {
         static constexpr int kBlockN = get<1>(TileShape_MNK{});
         static constexpr int kHeadDim = get<2>(TileShape_MNK{});
         int const seqlen_k_new = seqlen_info.seqlen_k_new;
-        using Rotary_t = Rotary<kBlockN, kHeadDim, NumMmaThreads, Element>;
+        using Rotary_t = Rotary<kBlockN, kHeadDim, NumMmaThreads, Element, !(Is_causal || Is_local) /*FixedPosition*/>;
         Rotary_t rotary(params.ptr_rotary_cos, params.shape_rotary, params.stride_rotary_cos,
                         params.ptr_rotary_sin, params.stride_rotary_sin,
                         params.is_rotary_interleaved, thread_idx, seqlen_k_new,

--- a/hopper/mainloop_fwd_sm90_tma_gmma_ws.hpp
+++ b/hopper/mainloop_fwd_sm90_tma_gmma_ws.hpp
@@ -1590,7 +1590,7 @@ struct CollectiveMainloopFwdSm90 {
         static constexpr int kBlockN = get<1>(TileShape_MNK{});
         static constexpr int kHeadDim = get<2>(TileShape_MNK{});
         int const seqlen_k_new = seqlen_info.seqlen_k_new;
-        using Rotary_t = Rotary<kBlockN, kHeadDim, NumMmaThreads, Element>;
+        using Rotary_t = Rotary<kBlockN, kHeadDim, NumMmaThreads, Element, !(Is_causal || Is_local) /*FixedPosition*/>;
         Rotary_t rotary(params.ptr_rotary_cos, params.shape_rotary, params.stride_rotary_cos,
                         params.ptr_rotary_sin, params.stride_rotary_sin,
                         params.is_rotary_interleaved, thread_idx, seqlen_k_new,


### PR DESCRIPTION
### Changes made

* `hopper/mainloop_fwd_sm80.hpp` (line 699) — K rotary in `store_kv_new`
* `hopper/mainloop_fwd_sm90_tma_gmma_ws.hpp` (line 1593) — K rotary in `store_kv_new`

Both were changed from:

```cpp
using Rotary_t = Rotary<kBlockN, kHeadDim, NumMmaThreads, Element>;
```

to:

```cpp
using Rotary_t = Rotary<kBlockN, kHeadDim, NumMmaThreads, Element, !(Is_causal || Is_local) /* FixedPosition */>;
```

### Explanation

**What `FixedPosition=true` does**
This sets the M-dimension stride and block-stride to zero in the rotary tensor layout. As a result, all rows map to the same memory location, allowing the compiler to reuse a single row of registers for `tRrCos` and `tRrSin`. This significantly reduces register pressure and eliminates spilling.

**Why `!(Is_causal || Is_local)` is appropriate for K**
This mirrors the existing condition used for Q rotary. In the non-causal, non-local decode case, `seqlen_k_new = 1`, meaning there is only one new K token per step. Therefore, all rows in the block share the same rotary position.

Out-of-bounds rows are already handled by the existing guard:

```
row < std::min(max_seqlen - n_block * kBlockMN, kBlockMN)
```

in `apply_K_interleaved` and `apply_K_contiguous`.

From testing, this produces identical results while reducing register usage. 

Closes #2254  