### PR TITLE
[cute] Add return_lse

### DIFF
--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -133,8 +133,8 @@ def _flash_attn_fwd(
         score_mod: A callable that takes the attention scores and applies a modification.
         mask_mod: A callable that takes token position information and selectively masks
         block_sparse_tensors: A tuple of tensors used for block sparsity.
-        return_lse: Whether to return the log softmax of the attention scores.
-            Note: the returned LSE currently does not support taking gradient. If set to True will always calculate
+        return_lse: Whether to return the log softmax of the attention scores. If set to True will always calculate
+            Note: the returned LSE currently does not support taking gradient.
         out: Optional pre-allocated output tensor. If None, will be allocated internally.
         lse: Optional pre-allocated log-sum-exp tensor. If None, will be allocated when needed.
         aux_tensors: Some score_mods will want to read from global aux_tensors. This is how we thread them through to the inner kernel.


### PR DESCRIPTION
Adds `return_lse` as an explicit parameter to the cute interface. Currently the lse tensor is only not `None` if one of q/k/v requires grad.

Question: Should this be called `return_attn_probs` to fit with the FA2/FA3 naming of this parameter or `return_lse` to fit with existing name in `_flash_attn_fwd` for cute?