### PR TITLE
Correct Cutlass Error Handling

### DIFF
--- a/hopper/cuda_check.h
+++ b/hopper/cuda_check.h
@@ -7,6 +7,8 @@
 #include <assert.h>
 #include <stdlib.h>
 
+#include <cutlass/cutlass.h>
+
 #define CHECK_CUDA(call)                        \
     do {                                                                                                  \
         cudaError_t status_ = call;                                                                       \
@@ -17,3 +19,12 @@
     } while(0)
 
 #define CHECK_CUDA_KERNEL_LAUNCH() CHECK_CUDA(cudaGetLastError())
+
+#define CHECK_CUTLASS(call)                                                                               \
+    do {                                                                                                  \
+        cutlass::Status status_ = (call);                                                                 \
+        if (status_ != cutlass::Status::kSuccess) {                                                        \
+            fprintf(stderr, "CUTLASS error (%s:%d): %s\n", __FILE__, __LINE__, cutlass::cutlassGetStatusString(status_)); \
+            exit(1);                                                                                      \
+        }                                                                                                 \
+    } while(0)

--- a/hopper/flash_fwd_combine_launch_template.h
+++ b/hopper/flash_fwd_combine_launch_template.h
@@ -11,6 +11,7 @@
 #include "cutlass/device_kernel.h"  // For device_kernel
 #include "cutlass/kernel_launch.h"  // For kernel_launch
 
+#include "cuda_check.h"
 #include "static_switch.h"
 #include "flash.h"
 #include "flash_fwd_combine_kernel.h"
@@ -48,8 +49,7 @@ void run_flash_fwd_combine(Flash_fwd_params &params, cudaStream_t stream, bool e
         CHECK_CUDA(cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
     }
     // kernel<<<grid_m, CombineKernel::MaxThreadsPerBlock, smem_size, stream>>>(kernel_params);
-    cutlass::kernel_launch<CombineKernel>(grid_m, CombineKernel::MaxThreadsPerBlock, smem_size, stream, kernel_params, Arch >= 90 && enable_pdl /*launch_with_pdl*/);
-    CHECK_CUDA_KERNEL_LAUNCH();
+    CHECK_CUTLASS(cutlass::kernel_launch<CombineKernel>(grid_m, CombineKernel::MaxThreadsPerBlock, smem_size, stream, kernel_params, Arch >= 90 && enable_pdl /*launch_with_pdl*/));
 }
 
 template<typename T, typename Tpartial, int kBlockK>


### PR DESCRIPTION
Hello!
There are some wrong handling of cutlass calls - currently, there are handle by `cudaGetLastError`, but this is not always correct - sometimes such calls can return cutlass errors like `cutlass::Status::kInternal` even without actual calls to cuda kernels.

This MR provides fix for that.


P.S. Thank you for your awesome work!