### PR TITLE
[Cute][Testing] Accelerate cutedsl fa4 tests with parallel compile and persistent compile cache

### DIFF
--- a/flash_attn/cute/cache_utils.py
+++ b/flash_attn/cute/cache_utils.py
@@ -1,0 +1,233 @@
+# Manage Ahead-of-Time (AOT) compiled kernels
+import fcntl
+import hashlib
+import os
+import pickle
+import tempfile
+import time
+from distutils.ccompiler import CCompiler, new_compiler
+from getpass import getuser
+from pathlib import Path
+from typing import Hashable, Optional, TypeAlias
+
+import cutlass.cute as cute
+import tvm_ffi
+from cutlass.cutlass_dsl import JitCompiledFunction
+
+CompileKeyType: TypeAlias = tuple[Hashable, ...]
+CallableFunction: TypeAlias = JitCompiledFunction | tvm_ffi.Function
+
+
+# Enable cache via `FLASH_ATTENTION_CUTE_DSL_CACHE_ENABLED=1`
+def is_cache_enabled() -> bool:
+    return int(os.getenv("FLASH_ATTENTION_CUTE_DSL_CACHE_ENABLED", 0)) == 1
+
+
+# Customize cache dir via `FLASH_ATTENTION_CUTE_DSL_CACHE_DIR`, default is
+# `/tmp/${USER}/flash_attention_cute_dsl_cache``
+def get_cache_path() -> Path:
+    default_cache_path = os.getenv("FLASH_ATTENTION_CUTE_DSL_CACHE_DIR", None)
+    if default_cache_path is None:
+        tmp_dir = Path(os.environ.get("TMPDIR", tempfile.gettempdir()))
+        cache_path: Path = tmp_dir / getuser() / "flash_attention_cute_dsl_cache"
+    else:
+        cache_path: Path = Path(default_cache_path)
+    cache_path.mkdir(parents=True, exist_ok=True)
+    return cache_path
+
+
+class FileLock:
+    """Context manager for advisory file locks using fcntl.flock.
+
+    Supports exclusive (write) and shared (read) locks.
+    Always blocks with polling until the lock is acquired or timeout is reached.
+
+    Usage:
+        with FileLock(lock_path, exclusive=True, timeout=15, label="abc"):
+            # do work under lock
+    """
+
+    def __init__(
+        self,
+        lock_path: Path,
+        exclusive: bool,
+        timeout: float = 15,
+        label: str = "",
+    ):
+        """
+        Args:
+            lock_path: Path to the lock file on disk.
+            exclusive: True for exclusive (write) lock, False for shared (read) lock.
+            timeout: Max seconds to wait for lock acquisition before raising RuntimeError.
+            label: Optional human-readable label for error messages.
+        """
+        self.lock_path: Path = lock_path
+        self.exclusive: bool = exclusive
+        self.timeout: float = timeout
+        self.label: str = label
+        self._fd: int = -1
+
+    @property
+    def _lock_label(self) -> str:
+        kind = "exclusive" if self.exclusive else "shared"
+        return f"{kind} {self.label}" if self.label else kind
+
+    def __enter__(self) -> "FileLock":
+        open_flags = (
+            os.O_WRONLY | os.O_CREAT if self.exclusive else os.O_RDONLY | os.O_CREAT
+        )
+        lock_type = fcntl.LOCK_EX if self.exclusive else fcntl.LOCK_SH
+
+        self._fd = os.open(str(self.lock_path), open_flags)
+
+        deadline = time.monotonic() + self.timeout
+        acquired = False
+        while time.monotonic() < deadline:
+            try:
+                fcntl.flock(self._fd, lock_type | fcntl.LOCK_NB)
+                acquired = True
+                break
+            except OSError:
+                time.sleep(0.1)
+        if not acquired:
+            os.close(self._fd)
+            self._fd = None
+            raise RuntimeError(
+                f"Timed out after {self.timeout}s waiting for "
+                f"{self._lock_label} lock: {self.lock_path}"
+            )
+
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        if self._fd is not None:
+            fcntl.flock(self._fd, fcntl.LOCK_UN)
+            os.close(self._fd)
+            self._fd = None
+
+
+class JITCache:
+    """
+    In-memory cache for compiled functions.
+    """
+
+    def __init__(self):
+        self.cache: dict[CompileKeyType, CallableFunction] = {}
+
+    def __setitem__(self, key: CompileKeyType, fn: JitCompiledFunction) -> None:
+        self.cache[key] = fn
+
+    def __getitem__(self, key: CompileKeyType) -> CallableFunction:
+        return self.cache[key]
+
+    def __contains__(self, key: CompileKeyType) -> bool:
+        return key in self.cache
+
+
+class JITPersistentCache(JITCache):
+    """
+    In-memory cache for compiled functions, which is also backed by persistent storage.
+    Use cutedsl ahead-of-time (AOT) compilation.
+    """
+
+    EXPORT_FUNCTION_PREFIX = "func"
+    LOCK_TIMEOUT_SECONDS = 15
+
+    _compiler: CCompiler = new_compiler()
+
+    def __init__(self, cache_path: Path, enable_tvm_ffi: bool = True):
+        super().__init__()
+        cache_path.mkdir(parents=True, exist_ok=True)
+        self.enable_tvm_ffi: bool = enable_tvm_ffi
+        self.cache_path: Path = cache_path
+
+    def __setitem__(self, key: CompileKeyType, fn: JitCompiledFunction) -> None:
+        JITCache.__setitem__(self, key, fn)
+        self._try_export_to_storage(key, fn)
+
+    def __getitem__(self, key: CompileKeyType) -> CallableFunction:
+        # Use __contains__ to try populating in-memory cache with persistent storage
+        self.__contains__(key)
+        return JITCache.__getitem__(self, key)
+
+    def __contains__(self, key: CompileKeyType) -> bool:
+        # Checks in-memory cache first, then tries loading from storage.
+        # When returning True, guarantees the in-memory cache is populated.
+        if JITCache.__contains__(self, key):
+            return True
+        return self._try_load_from_storage(key)
+
+    def _try_load_from_storage(self, key: CompileKeyType) -> bool:
+        """
+        Try to load a function from persistent storage into in-memory cache.
+        Returns True if loaded successfully, False if not found on disk.
+        Holds a shared lock during loading to prevent concurrent writes.
+        """
+        sha256_hex = self._key_to_hash(key)
+        if self.enable_tvm_ffi:
+            so_path = self.cache_path / f"{sha256_hex}.so"
+            with FileLock(
+                self._lock_path(sha256_hex),
+                exclusive=False,
+                timeout=self.LOCK_TIMEOUT_SECONDS,
+                label=sha256_hex,
+            ):
+                if so_path.exists():
+                    m = cute.runtime.load_module(
+                        str(so_path), enable_tvm_ffi=self.enable_tvm_ffi
+                    )
+                    fn = getattr(m, self.EXPORT_FUNCTION_PREFIX)
+                    JITCache.__setitem__(self, key, fn)
+                    return True
+        else:
+            raise NotImplementedError("non tvm_ffi path is not supported")
+        return False
+
+    def _try_export_to_storage(
+        self, key: CompileKeyType, fn: JitCompiledFunction
+    ) -> None:
+        """Export a compiled function to persistent storage under exclusive lock."""
+        if not self.enable_tvm_ffi:
+            raise NotImplementedError("non tvm_ffi path is not supported")
+        sha256_hex = self._key_to_hash(key)
+        with FileLock(
+            self._lock_path(sha256_hex),
+            exclusive=True,
+            timeout=self.LOCK_TIMEOUT_SECONDS,
+            label=sha256_hex,
+        ):
+            so_path = self.cache_path / f"{sha256_hex}.so"
+            if so_path.exists():
+                # Another process already exported.
+                return
+            obj_path = self.cache_path / f"{sha256_hex}.o"
+            fn.export_to_c(
+                object_file_path=str(obj_path),
+                function_name=self.EXPORT_FUNCTION_PREFIX,
+            )
+            # TODO: as of cutedsl 4.4.0, `export_to_c` only supports exporting
+            # "relocatable" .o files. But tvm_ffi expects "shared library" .so
+            # files. Link ourselves to workaround.
+            JITPersistentCache._compiler.link_shared_object(
+                [str(obj_path)], str(so_path)
+            )
+
+    def _key_to_hash(self, key: CompileKeyType) -> str:
+        return hashlib.sha256(pickle.dumps(key)).hexdigest()
+
+    def _lock_path(self, sha256_hex: str) -> Path:
+        return self.cache_path / f"{sha256_hex}.lock"
+
+
+def get_jit_cache(name: Optional[str] = None) -> JITCache:
+    """
+    JIT cache factory.
+    `name` is an optional identifier to create subdirectories to manage cache.
+    """
+    if is_cache_enabled():
+        path = get_cache_path()
+        if name:
+            path = (path / name)
+        return JITPersistentCache(path)
+    else:
+        return JITCache()

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -31,6 +31,7 @@ import cuda.bindings.driver as cuda
 
 import cutlass
 import cutlass.cute as cute
+from flash_attn.cute.cache_utils import get_jit_cache
 from flash_attn.cute.testing import is_fake_mode
 
 
@@ -552,7 +553,7 @@ def _flash_attn_fwd(
     return out, lse
 
 
-_flash_attn_fwd.compile_cache = {}
+_flash_attn_fwd.compile_cache = get_jit_cache("fwd")
 
 
 def _flash_attn_bwd(
@@ -1274,9 +1275,9 @@ def _flash_attn_bwd(
     return dq, dk, dv
 
 
-_flash_attn_bwd.compile_cache_pre = {}
-_flash_attn_bwd.compile_cache = {}
-_flash_attn_bwd.compile_cache_post = {}
+_flash_attn_bwd.compile_cache_pre = get_jit_cache("bwd_pre")
+_flash_attn_bwd.compile_cache = get_jit_cache("bwd")
+_flash_attn_bwd.compile_cache_post = get_jit_cache("bwd_post")
 
 
 class FlashAttnFunc(torch.autograd.Function):
@@ -1708,7 +1709,7 @@ def _flash_attn_fwd_combine(
         )
 
 
-_flash_attn_fwd_combine.compile_cache = {}
+_flash_attn_fwd_combine.compile_cache = get_jit_cache("fwd_combine")
 
 
 def flash_attn_combine(

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -31,6 +31,7 @@ import cuda.bindings.driver as cuda
 
 import cutlass
 import cutlass.cute as cute
+from flash_attn.cute.testing import is_fake_mode
 
 
 if os.environ.get("CUTE_DSL_PTXAS_PATH", None) is not None:
@@ -517,6 +518,9 @@ def _flash_attn_fwd(
             options="--enable-tvm-ffi",
         )
 
+    if is_fake_mode():
+        return out, lse
+
     _flash_attn_fwd.compile_cache[compile_key](
         q.detach(),
         k.detach(),
@@ -877,17 +881,18 @@ def _flash_attn_bwd(
             current_stream,
             options="--enable-tvm-ffi",
         )
-    _flash_attn_bwd.compile_cache_pre[compile_key_pre](
-        out,
-        dout,
-        dpsum,
-        lse,
-        lse_log2,
-        dq_accum,
-        cu_seqlens_q,
-        seqused_q,
-        current_stream,
-    )
+    if not is_fake_mode():
+        _flash_attn_bwd.compile_cache_pre[compile_key_pre](
+            out,
+            dout,
+            dpsum,
+            lse,
+            lse_log2,
+            dq_accum,
+            cu_seqlens_q,
+            seqused_q,
+            current_stream,
+        )
 
     # NB num_threads application for 3 kernels
     # There are pre, main, post processing kernels, currenlty num_threads is only actually
@@ -1100,31 +1105,32 @@ def _flash_attn_bwd(
             sparse_tensors_compile,
             options="--enable-tvm-ffi",
         )
-    _flash_attn_bwd.compile_cache[compile_key](
-        q.detach(),
-        k.detach(),
-        v.detach(),
-        dout,
-        lse_log2,
-        dpsum,
-        dq_accum,
-        dk if not dKV_postprocess else dk_accum,
-        dv if not dKV_postprocess else dv_accum,
-        softmax_scale,
-        current_stream,
-        cu_seqlens_q,
-        cu_seqlens_k,
-        seqused_q,
-        seqused_k,
-        None,  # softcap - not yet supported in backward
-        window_size_left,
-        window_size_right,
-        dQ_semaphore,
-        dK_semaphore,
-        dV_semaphore,
-        aux_tensors,
-        normalized_block_sparse_tensors[:4] if normalized_block_sparse_tensors is not None else None,
-    )
+    if not is_fake_mode():
+        _flash_attn_bwd.compile_cache[compile_key](
+            q.detach(),
+            k.detach(),
+            v.detach(),
+            dout,
+            lse_log2,
+            dpsum,
+            dq_accum,
+            dk if not dKV_postprocess else dk_accum,
+            dv if not dKV_postprocess else dv_accum,
+            softmax_scale,
+            current_stream,
+            cu_seqlens_q,
+            cu_seqlens_k,
+            seqused_q,
+            seqused_k,
+            None,  # softcap - not yet supported in backward
+            window_size_left,
+            window_size_right,
+            dQ_semaphore,
+            dK_semaphore,
+            dV_semaphore,
+            aux_tensors,
+            normalized_block_sparse_tensors[:4] if normalized_block_sparse_tensors is not None else None,
+        )
 
     num_threads = 256 if arch // 10 == 9 else 128
     # Postprocess kernel: convert dq_accum from float32 to dq in bf16/fp16
@@ -1163,14 +1169,16 @@ def _flash_attn_bwd(
             current_stream,
             options="--enable-tvm-ffi",
         )
-    _flash_attn_bwd.compile_cache_post[compile_key_post](
-        dq_accum,
-        dq,
-        softmax_scale,
-        cu_seqlens_q,
-        seqused_q,
-        current_stream,
-    )
+
+    if not is_fake_mode():
+        _flash_attn_bwd.compile_cache_post[compile_key_post](
+            dq_accum,
+            dq,
+            softmax_scale,
+            cu_seqlens_q,
+            seqused_q,
+            current_stream,
+        )
 
     if dKV_postprocess:
         # Postprocess kernel: convert dk_accum & dv_accum from float32 to bf16/fp16
@@ -1209,14 +1217,15 @@ def _flash_attn_bwd(
                 current_stream,
                 options="--enable-tvm-ffi",
             )
-        _flash_attn_bwd.compile_cache_post[compile_key_post](
-            dk_accum,
-            dk,
-            softmax_scale,
-            cu_seqlens_k,
-            seqused_k,
-            current_stream,
-        )
+        if not is_fake_mode():
+            _flash_attn_bwd.compile_cache_post[compile_key_post](
+                dk_accum,
+                dk,
+                softmax_scale,
+                cu_seqlens_k,
+                seqused_k,
+                current_stream,
+            )
         compile_key_post = (
             arch,
             dtype,
@@ -1252,14 +1261,15 @@ def _flash_attn_bwd(
                 current_stream,
                 options="--enable-tvm-ffi",
             )
-        _flash_attn_bwd.compile_cache_post[compile_key_post](
-            dv_accum,
-            dv,
-            1.0,
-            cu_seqlens_k,
-            seqused_k,
-            current_stream,
-        )
+        if not is_fake_mode():
+            _flash_attn_bwd.compile_cache_post[compile_key_post](
+                dv_accum,
+                dv,
+                1.0,
+                cu_seqlens_k,
+                seqused_k,
+                current_stream,
+            )
 
     return dq, dk, dv
 
@@ -1684,17 +1694,18 @@ def _flash_attn_fwd_combine(
             current_stream,
             options="--enable-tvm-ffi",
         )
-    _flash_attn_fwd_combine.compile_cache[compile_key](
-        out_partial,
-        lse_partial,
-        out,
-        lse,
-        cu_seqlens,
-        seqused,
-        num_splits_dynamic_ptr,
-        semaphore_to_reset,
-        current_stream,
-    )
+    if not is_fake_mode():
+        _flash_attn_fwd_combine.compile_cache[compile_key](
+            out_partial,
+            lse_partial,
+            out,
+            lse,
+            cu_seqlens,
+            seqused,
+            num_splits_dynamic_ptr,
+            semaphore_to_reset,
+            current_stream,
+        )
 
 
 _flash_attn_fwd_combine.compile_cache = {}

--- a/flash_attn/cute/testing.py
+++ b/flash_attn/cute/testing.py
@@ -1,9 +1,13 @@
 import math
+from contextlib import nullcontext
+from functools import wraps
 from typing import Optional
 
 import torch
 import torch.nn.functional as F
 from einops import rearrange, repeat
+from torch._guards import active_fake_mode
+from torch._subclasses.fake_tensor import FakeTensorMode
 
 
 class IndexFirstAxis(torch.autograd.Function):
@@ -63,8 +67,15 @@ def unpad_input(hidden_states, attention_mask, unused_mask=None):
     all_masks = (attention_mask + unused_mask) if unused_mask is not None else attention_mask
     seqlens_in_batch = all_masks.sum(dim=-1, dtype=torch.int32)
     used_seqlens_in_batch = attention_mask.sum(dim=-1, dtype=torch.int32)
-    indices = torch.nonzero(all_masks.flatten(), as_tuple=False).flatten()
-    max_seqlen_in_batch = seqlens_in_batch.max().item()
+    in_fake_mode = active_fake_mode() is not None
+    if not in_fake_mode:
+        indices = torch.nonzero(all_masks.flatten(), as_tuple=False).flatten()
+        max_seqlen_in_batch = seqlens_in_batch.max().item()
+    else:
+        # torch.nonzero and .item() are not supported in FakeTensorMode
+        batch_size, seqlen = attention_mask.shape
+        indices = torch.arange(batch_size * seqlen, device=hidden_states.device)
+        max_seqlen_in_batch = seqlen
     cu_seqlens = F.pad(torch.cumsum(seqlens_in_batch, dim=0, dtype=torch.int32), (1, 0))
     return (
         index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices),
@@ -421,3 +432,25 @@ def attention_ref(
     if query_padding_mask is not None:
         output.masked_fill_(rearrange(~query_padding_mask, "b s -> b s 1 1"), 0.0)
     return output.to(dtype=dtype_og), attention.to(dtype=dtype_og)
+
+
+def maybe_fake_tensor_mode(fake: bool = True):
+    """
+    One way to populate/pre-compile cache is to use torch fake tensor mode,
+    which does not allocate actual GPU tensors but retains tensor shape/dtype
+    metadata for cute.compile.
+    """
+
+    def decorator(fn):
+        @wraps(fn)
+        def wrapper(*args, **kwargs):
+            with FakeTensorMode() if fake else nullcontext():
+                return fn(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+def is_fake_mode() -> bool:
+    return active_fake_mode() is not None

--- a/tests/cute/conftest.py
+++ b/tests/cute/conftest.py
@@ -1,5 +1,11 @@
 import os
 import subprocess
+import logging
+import tempfile
+import json
+import time
+from pathlib import Path
+from getpass import getuser
 
 
 def _get_gpu_ids():
@@ -16,16 +22,47 @@ def _get_gpu_ids():
         )
         if result.returncode == 0:
             return result.stdout.strip().splitlines()
-    except (FileNotFoundError, subprocess.TimeoutExpired):
+    except (FileNotFoundError,):
         pass
 
+    logging.warning("Failed to get gpu ids, use default '0'")
     return ["0"]
 
 
 def pytest_configure(config):
+    # Always use cutedsl cache unless explicitly disabled
+    os.environ.setdefault("FLASH_ATTENTION_CUTE_DSL_CACHE_ENABLED", "1")
+    tmp = Path(tempfile.gettempdir()) / getuser() / "flash_attention_tests"
+    tmp.mkdir(parents=True, exist_ok=True)
+
     worker_id = os.environ.get("PYTEST_XDIST_WORKER")
+    logging.basicConfig(
+        format=config.getini("log_file_format"),
+        filename=str(tmp / f"tests_{worker_id}.log"),
+        level=config.getini("log_file_level"),
+    )
     if not worker_id:
         return
     worker_num = int(worker_id.replace("gw", ""))
-    gpu_ids = _get_gpu_ids()
+
+    # cache gpu_ids, because nvidia-smi is expensive when we launch many workers doing torch initialization
+    # Always elect worker_0 to get gpu_ids.
+    cached_gpu_ids = tmp / "gpu_ids.json"
+    if worker_num == 0:
+        gpu_ids = _get_gpu_ids()
+        with cached_gpu_ids.open(mode="w") as f:
+            json.dump(gpu_ids, f)
+    else:
+        while not cached_gpu_ids.exists():
+            time.sleep(1)
+        with cached_gpu_ids.open() as f:
+            gpu_ids = json.load(f)
+
     os.environ["CUDA_VISIBLE_DEVICES"] = gpu_ids[worker_num % len(gpu_ids)]
+
+def pytest_collection_finish(session):
+    test_counts = {}
+    for item in session.items:
+        funcname = item.function.__name__
+        test_counts[funcname] = test_counts.setdefault(funcname, 0) + 1
+    print(f"{test_counts=}")

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -20,6 +20,8 @@ from flash_attn.cute.testing import (
     generate_random_padding_mask,
     pad_input,
     unpad_input,
+    maybe_fake_tensor_mode,
+    is_fake_mode,
 )
 from flash_attn.cute.interface import (
     flash_attn_func,
@@ -27,7 +29,8 @@ from flash_attn.cute.interface import (
     flash_attn_combine,
 )
 
-
+# torch FakeTensorMode would enable fast cutedsl kernel compilation without allocating the actual GPU memory or running the kernel
+USE_FAKE_TENSOR = int(os.getenv("FLASH_ATTENTION_FAKE_TENSOR", 0)) == 1
 DISABLE_SPLIT = os.getenv("FLASH_ATTENTION_DISABLE_SPLIT", "FALSE") == "TRUE"
 # SplitKV and paged KV are not supported on SM90
 IS_SM90 = torch.cuda.get_device_capability()[0] == 9
@@ -90,6 +93,7 @@ VERBOSE = True
     ],
 )
 # @pytest.mark.parametrize('seqlen_q,seqlen_k', [(128, 128)])
+@maybe_fake_tensor_mode(USE_FAKE_TENSOR)
 def test_flash_attn_output(
     seqlen_q,
     seqlen_k,
@@ -158,9 +162,14 @@ def test_flash_attn_output(
         else:
             qv_ref = None
         # Put window_size after QKV randn so that window_size changes from test to test
-        window_size = (
-            (None, None) if not local else torch.randint(0, seqlen_k, (2,)).tolist()
-        )
+        if not is_fake_mode():
+            window_size = (
+                (None, None) if not local else torch.randint(0, seqlen_k, (2,)).tolist()
+            )
+        else:
+            window_size = (
+                (None, None) if not local else (seqlen_k, seqlen_k)
+            )
         if local_enum == 2:
             window_size = (None, -window_size[1])
         elif local_enum == 3:
@@ -182,41 +191,42 @@ def test_flash_attn_output(
             q_descale, k_descale, v_descale = None, None, None
         q, k, v = [x.detach().to(dtype).requires_grad_() for x in (q_ref, k_ref, v_ref)]
         qv = qv_ref.detach().to(dtype).requires_grad_() if has_qv else None
-        out_ref, attn_ref = attention_ref(
-            q_ref,
-            k_ref,
-            v_ref,
-            None,
-            None,
-            causal=causal,
-            qv=qv_ref,
-            q_descale=q_descale,
-            k_descale=k_descale,
-            v_descale=v_descale,
-            window_size=window_size,
-            attention_chunk=attention_chunk,
-            learnable_sink=learnable_sink,
-            softcap=softcap,
-        )
-        out_pt, attn_pt = attention_ref(
-            q_ref,
-            k_ref,
-            v_ref,
-            None,
-            None,
-            causal=causal,
-            qv=qv_ref,
-            q_descale=q_descale,
-            k_descale=k_descale,
-            v_descale=v_descale,
-            window_size=window_size,
-            attention_chunk=attention_chunk,
-            learnable_sink=learnable_sink,
-            softcap=softcap,
-            upcast=False,
-            reorder_ops=True,
-            intermediate_dtype=dtype if dtype == torch.float8_e4m3fn else None,
-        )
+        if not is_fake_mode():
+            out_ref, attn_ref = attention_ref(
+                q_ref,
+                k_ref,
+                v_ref,
+                None,
+                None,
+                causal=causal,
+                qv=qv_ref,
+                q_descale=q_descale,
+                k_descale=k_descale,
+                v_descale=v_descale,
+                window_size=window_size,
+                attention_chunk=attention_chunk,
+                learnable_sink=learnable_sink,
+                softcap=softcap,
+            )
+            out_pt, attn_pt = attention_ref(
+                q_ref,
+                k_ref,
+                v_ref,
+                None,
+                None,
+                causal=causal,
+                qv=qv_ref,
+                q_descale=q_descale,
+                k_descale=k_descale,
+                v_descale=v_descale,
+                window_size=window_size,
+                attention_chunk=attention_chunk,
+                learnable_sink=learnable_sink,
+                softcap=softcap,
+                upcast=False,
+                reorder_ops=True,
+                intermediate_dtype=dtype if dtype == torch.float8_e4m3fn else None,
+            )
 
         # k_extended = repeat(k_ref, "b s h d -> b s (h k) d", k=nheads // nheads_kv)
         # qk = torch.einsum('bshd,bthd->bhst', q_ref, k_extended).float()
@@ -229,11 +239,12 @@ def test_flash_attn_output(
         # # lse_ref = torch.logsumexp(qk, dim=-1)
 
         # Numerical error if we just do any arithmetic on out_ref
-        fwd_atol = 2 * (out_ref + 0.3 - 0.3 - out_ref).abs().max().item()
-        rtol = 2 if softcap == 0.0 else 3
+        if not is_fake_mode():
+            fwd_atol = 2 * (out_ref + 0.3 - 0.3 - out_ref).abs().max().item()
+            rtol = 2 if softcap == 0.0 else 3
 
-        print(f"Pytorch max diff: {(out_pt - out_ref).abs().max().item()}")
-        print(f"Pytorch mean diff: {(out_pt - out_ref).abs().mean().item()}")
+            print(f"Pytorch max diff: {(out_pt - out_ref).abs().max().item()}")
+            print(f"Pytorch mean diff: {(out_pt - out_ref).abs().mean().item()}")
         # num_splits_vals = [1, 3]
         pack_gqa_vals = [False, True, None] if not TEST_BWD_ONLY else [False]
         # SplitKV is not supported for hdim >= 192
@@ -258,6 +269,8 @@ def test_flash_attn_output(
                 num_splits=num_splits,
                 deterministic=deterministic,
             )
+            if is_fake_mode():
+                continue
             print(f"Output max diff: {(out - out_ref).abs().max().item()}")
             print(f"Output mean diff: {(out - out_ref).abs().mean().item()}")
             # if not causal:
@@ -281,19 +294,22 @@ def test_flash_attn_output(
             # and False
             and not ((causal or local) and seqlen_k < seqlen_q)
         ):
-            # TODO: SM90 backward pass has invalid MMA tile config for d=64 + non-causal
-            # The m_block_size=80 (non-causal) with head_dim=64 creates an invalid tile.
-            # Fix requires adjusting m_block_size or MMA config in flash_bwd_sm90.py
-            if IS_SM90 and d == 64 and not causal:
-                pytest.xfail("SM90 backward: d=64 + non-causal has invalid MMA tile config (m_block=80)")
-            # TODO: SM90 backward pass does not support local attention yet
-            if IS_SM90 and local:
-                pytest.xfail("SM90 backward: local attention not supported yet")
-            if d == 192 and local:
-                pytest.xfail("hdim 192 backward: local attention not supported yet")
+            if not is_fake_mode():
+                # TODO: SM90 backward pass has invalid MMA tile config for d=64 + non-causal
+                # The m_block_size=80 (non-causal) with head_dim=64 creates an invalid tile.
+                # Fix requires adjusting m_block_size or MMA config in flash_bwd_sm90.py
+                if IS_SM90 and d == 64 and not causal:
+                    pytest.xfail("SM90 backward: d=64 + non-causal has invalid MMA tile config (m_block=80)")
+                # TODO: SM90 backward pass does not support local attention yet
+                if IS_SM90 and local:
+                    pytest.xfail("SM90 backward: local attention not supported yet")
+                if d == 192 and local:
+                    pytest.xfail("hdim 192 backward: local attention not supported yet")
             g = torch.randn_like(out)
             # do_o = ((g.float() * out.float()).sum(-1)).transpose(1, 2)
             dq, dk, dv = torch.autograd.grad(out, (q, k, v), g)
+            if is_fake_mode():
+                continue
             # print(f"dO_O max diff: {(softmax_d - do_o).abs().max().item()}")
             # assert (softmax_d - do_o).abs().max().item() <= 1e-5
             # assert dq_accum.abs().max().item() == 0.0
@@ -435,6 +451,7 @@ def test_flash_attn_output(
         (False, True),
     ],
 )
+@maybe_fake_tensor_mode(USE_FAKE_TENSOR)
 def test_flash_attn_varlen_output(
     seqlen_q,
     seqlen_k,
@@ -510,9 +527,14 @@ def test_flash_attn_varlen_output(
         else:
             qv_ref = None
         # Put window_size after QKV randn so that window_size changes from test to test
-        window_size = (
-            (None, None) if not local else torch.randint(0, seqlen_k, (2,)).tolist()
-        )
+        if not is_fake_mode():
+            window_size = (
+                (None, None) if not local else torch.randint(0, seqlen_k, (2,)).tolist()
+            )
+        else:
+            window_size = (
+                (None, None) if not local else (seqlen_k, seqlen_k)
+            )
         if local_enum == 2:
             window_size = (None, window_size[1])
         elif local_enum == 3:
@@ -611,51 +633,54 @@ def test_flash_attn_varlen_output(
         q_unpad, k_unpad, v_unpad = [
             x.detach().to(dtype).requires_grad_() for x in (q_unpad, k_unpad, v_unpad)
         ]
-        out_ref, attn_ref = attention_ref(
-            q_ref,
-            k_ref,
-            v_ref,
-            query_padding_mask,
-            key_padding_mask,
-            causal=causal,
-            qv=qv_ref,
-            q_descale=q_descale,
-            k_descale=k_descale,
-            v_descale=v_descale,
-            window_size=window_size,
-            attention_chunk=attention_chunk,
-            learnable_sink=learnable_sink,
-            softcap=softcap,
-        )
-        out_pt, attn_pt = attention_ref(
-            q_ref,
-            k_ref,
-            v_ref,
-            query_padding_mask,
-            key_padding_mask,
-            causal=causal,
-            qv=qv_ref,
-            q_descale=q_descale,
-            k_descale=k_descale,
-            v_descale=v_descale,
-            window_size=window_size,
-            attention_chunk=attention_chunk,
-            learnable_sink=learnable_sink,
-            softcap=softcap,
-            upcast=False,
-            reorder_ops=True,
-            intermediate_dtype=dtype if dtype == torch.float8_e4m3fn else None,
-        )
 
-        print(f"Pytorch max diff: {(out_pt - out_ref).abs().max().item()}")
-        print(f"Pytorch mean diff: {(out_pt - out_ref).abs().mean().item()}")
+        if not is_fake_mode():
+            out_ref, attn_ref = attention_ref(
+                q_ref,
+                k_ref,
+                v_ref,
+                query_padding_mask,
+                key_padding_mask,
+                causal=causal,
+                qv=qv_ref,
+                q_descale=q_descale,
+                k_descale=k_descale,
+                v_descale=v_descale,
+                window_size=window_size,
+                attention_chunk=attention_chunk,
+                learnable_sink=learnable_sink,
+                softcap=softcap,
+            )
+            out_pt, attn_pt = attention_ref(
+                q_ref,
+                k_ref,
+                v_ref,
+                query_padding_mask,
+                key_padding_mask,
+                causal=causal,
+                qv=qv_ref,
+                q_descale=q_descale,
+                k_descale=k_descale,
+                v_descale=v_descale,
+                window_size=window_size,
+                attention_chunk=attention_chunk,
+                learnable_sink=learnable_sink,
+                softcap=softcap,
+                upcast=False,
+                reorder_ops=True,
+                intermediate_dtype=dtype if dtype == torch.float8_e4m3fn else None,
+            )
 
-        if query_unused_mask is not None:
-            q_zero_masking = rearrange(query_unused_mask, "b s -> b s 1 1")
+            print(f"Pytorch max diff: {(out_pt - out_ref).abs().max().item()}")
+            print(f"Pytorch mean diff: {(out_pt - out_ref).abs().mean().item()}")
 
-        # Numerical error if we just do any arithmetic on out_ref
-        fwd_atol = 2 * (out_ref + 0.3 - 0.3 - out_ref).abs().max().item()
-        rtol = 2 if softcap == 0.0 else 3
+        if not is_fake_mode():
+            if query_unused_mask is not None:
+                q_zero_masking = rearrange(query_unused_mask, "b s -> b s 1 1")
+
+            # Numerical error if we just do any arithmetic on out_ref
+            fwd_atol = 2 * (out_ref + 0.3 - 0.3 - out_ref).abs().max().item()
+            rtol = 2 if softcap == 0.0 else 3
 
         pack_gqa_vals = [False, True, None] if not TEST_BWD_ONLY else [False]
         # pack_gqa_vals = [False]
@@ -689,6 +714,8 @@ def test_flash_attn_varlen_output(
                 deterministic=deterministic,
             )
             out = output_pad_fn(out_unpad) if unpad_q else out_unpad
+            if is_fake_mode():
+                continue
             if query_unused_mask is not None:
                 out.masked_fill_(q_zero_masking, 0.0)
             print(f"Output max diff: {(out - out_ref).abs().max().item()}")
@@ -749,6 +776,8 @@ def test_flash_attn_varlen_output(
                 ),
                 g_unpad
             )
+            if is_fake_mode():
+                continue
             dq = dq_pad_fn(dq_unpad) if unpad_q else dq_unpad
             dk = dk_pad_fn(dk_unpad) if unpad_kv else dk_unpad
             dv = dk_pad_fn(dv_unpad) if unpad_kv else dv_unpad
@@ -889,6 +918,7 @@ def test_flash_attn_varlen_output(
     ],
 )
 # @pytest.mark.parametrize('seqlen_q,seqlen_k', [(256, 128)])
+@maybe_fake_tensor_mode(USE_FAKE_TENSOR)
 def test_flash_attn_kvcache(
     seqlen_q,
     seqlen_k,
@@ -974,19 +1004,27 @@ def test_flash_attn_kvcache(
             qv_unpad = qv
             cu_seqlens_q, max_seqlen_q = None, None
         # Put window_size after QKV randn so that window_size changes from test to test
-        window_size = (
-            (None, None) if not local else torch.randint(0, seqlen_k, (2,)).tolist()
-        )
+        if not is_fake_mode():
+            window_size = (
+                (None, None) if not local else torch.randint(0, seqlen_k, (2,)).tolist()
+            )
+        else:
+            window_size = (
+                (None, None) if not local else (seqlen_k, seqlen_k)
+            )
         if has_learnable_sink:
             learnable_sink = torch.randn(nheads, dtype=torch.bfloat16, device=device)
         else:
             learnable_sink = None
 
-        seqlen_new = (
-            seqlen_q
-            if seqlen_new_eq_seqlen_q
-            else torch.randint(1, seqlen_q + 1, (1,)).item()
-        )
+        if not is_fake_mode():
+            seqlen_new = (
+                seqlen_q
+                if seqlen_new_eq_seqlen_q
+                else torch.randint(1, seqlen_q + 1, (1,)).item()
+            )
+        else:
+            seqlen_new = seqlen_q
         cu_seqlens_k_new = None
         key_new_padding_mask = None
         if new_kv:
@@ -1061,43 +1099,58 @@ def test_flash_attn_kvcache(
                 dtype,
                 dtype_ref,
             )
-        cache_seqlens = torch.randint(
-            0 if new_kv else 1,
-            # If we don't use seqlen_q in the case of causal and rotary, cos/sin won't be long enough
-            (
+        if not is_fake_mode():
+            cache_seqlens = torch.randint(
+                0 if new_kv else 1,
+                # If we don't use seqlen_q in the case of causal and rotary, cos/sin won't be long enough
                 (
-                    seqlen_k
-                    - (seqlen_q if (causal or local) and rotary_dim > 1 else seqlen_new)
-                    + 1
-                )
-                if new_kv
-                else (seqlen_k + 1)
-            ),
-            (batch_size,),
-            dtype=torch.int32,
-            device=device,
-        )
-        if has_leftpad:
-            cache_leftpad = torch.cat(
-                [
-                    torch.randint(
-                        0,
-                        cache_seqlens[i].item(),
-                        (1,),
-                        dtype=torch.int32,
-                        device=device,
+                    (
+                        seqlen_k
+                        - (seqlen_q if (causal or local) and rotary_dim > 1 else seqlen_new)
+                        + 1
                     )
-                    if cache_seqlens[i].item() > 0
-                    else torch.zeros(1, dtype=torch.int32, device=device)
-                    for i in range(batch_size)
-                ]
+                    if new_kv
+                    else (seqlen_k + 1)
+                ),
+                (batch_size,),
+                dtype=torch.int32,
+                device=device,
             )
+        else:
+            cache_seqlens = torch.ones(
+                batch_size,
+                dtype=torch.int32,
+                device=device,
+            )
+        if has_leftpad:
+            if not is_fake_mode():
+                cache_leftpad = torch.cat(
+                    [
+                        torch.randint(
+                            0,
+                            cache_seqlens[i].item(),
+                            (1,),
+                            dtype=torch.int32,
+                            device=device,
+                        )
+                        if cache_seqlens[i].item() > 0
+                        else torch.zeros(1, dtype=torch.int32, device=device)
+                        for i in range(batch_size)
+                    ]
+                )
+            else:
+                cache_leftpad = torch.zeros(batch_size, dtype=torch.int32, device=device)
         else:
             cache_leftpad = None
         if has_batch_idx:
-            cache_batch_idx = torch.randperm(
-                batch_size_cache, dtype=torch.int32, device=device
-            )[:batch_size]
+            if not is_fake_mode():
+                cache_batch_idx = torch.randperm(
+                    batch_size_cache, dtype=torch.int32, device=device
+                )[:batch_size]
+            else:
+                cache_batch_idx = torch.arange(
+                    batch_size, dtype=torch.int32, device=device
+                )
         else:
             cache_batch_idx = None
         arange = rearrange(torch.arange(seqlen_k, device=device), "s -> 1 s")
@@ -1178,41 +1231,42 @@ def test_flash_attn_kvcache(
                 v_to_update = v_to_update[indices_k]
             k_cache_ref[update_mask] = k_to_update
             v_cache_ref[update_mask] = v_to_update
-        k_cache_rep = repeat(
-            k_cache_ref, "b s h d -> b s (h g) d", g=nheads // nheads_k
-        )
-        v_cache_rep = repeat(
-            v_cache_ref, "b s h d -> b s (h g) d", g=nheads // nheads_k
-        )
-        out_ref, _ = attention_ref(
-            q_ro,
-            k_cache_rep,
-            v_cache_rep,
-            query_padding_mask,
-            key_padding_mask,
-            causal=causal,
-            qv=qv,
-            window_size=window_size,
-            learnable_sink=learnable_sink,
-            attention_chunk=attention_chunk,
-            key_leftpad=cache_leftpad,
-        )
-        out_pt, _ = attention_ref(
-            q_ro,
-            k_cache_rep,
-            v_cache_rep,
-            query_padding_mask,
-            key_padding_mask,
-            causal=causal,
-            qv=qv,
-            window_size=window_size,
-            learnable_sink=learnable_sink,
-            attention_chunk=attention_chunk,
-            upcast=False,
-            reorder_ops=True,
-            key_leftpad=cache_leftpad,
-            intermediate_dtype=dtype if dtype == torch.float8_e4m3fn else None,
-        )
+        if not is_fake_mode():
+            k_cache_rep = repeat(
+                k_cache_ref, "b s h d -> b s (h g) d", g=nheads // nheads_k
+            )
+            v_cache_rep = repeat(
+                v_cache_ref, "b s h d -> b s (h g) d", g=nheads // nheads_k
+            )
+            out_ref, _ = attention_ref(
+                q_ro,
+                k_cache_rep,
+                v_cache_rep,
+                query_padding_mask,
+                key_padding_mask,
+                causal=causal,
+                qv=qv,
+                window_size=window_size,
+                learnable_sink=learnable_sink,
+                attention_chunk=attention_chunk,
+                key_leftpad=cache_leftpad,
+            )
+            out_pt, _ = attention_ref(
+                q_ro,
+                k_cache_rep,
+                v_cache_rep,
+                query_padding_mask,
+                key_padding_mask,
+                causal=causal,
+                qv=qv,
+                window_size=window_size,
+                learnable_sink=learnable_sink,
+                attention_chunk=attention_chunk,
+                upcast=False,
+                reorder_ops=True,
+                key_leftpad=cache_leftpad,
+                intermediate_dtype=dtype if dtype == torch.float8_e4m3fn else None,
+            )
         q = q.to(dtype)
         q_unpad = q_unpad.to(dtype) if varlen_q else None
         k_cache = k_cache.to(dtype)
@@ -1288,6 +1342,8 @@ def test_flash_attn_kvcache(
                 )
                 if varlen_q:
                     out = output_pad_fn(out)
+                if is_fake_mode():
+                    continue
                 # out = flash_attn_with_kvcache(
                 #     q, k_cache, v_cache, cache_seqlens=cache_seqlens, causal=causal, window_size=window_size
                 # )
@@ -1378,6 +1434,7 @@ def test_flash_attn_kvcache(
 @pytest.mark.parametrize("causal", [False, True])
 @pytest.mark.parametrize("d", [64, 128])
 @pytest.mark.parametrize("seqlen_q,seqlen_k", [(128, 128), (256, 256)])
+@maybe_fake_tensor_mode(USE_FAKE_TENSOR)
 def test_flash_attn_bwd_preallocated_outputs(seqlen_q, seqlen_k, d, causal, dtype):
     if IS_SM90 and d == 64 and not causal:
         pytest.xfail("SM90 backward: d=64 + non-causal has invalid MMA tile config (m_block=80)")
@@ -1405,6 +1462,8 @@ def test_flash_attn_bwd_preallocated_outputs(seqlen_q, seqlen_k, d, causal, dtyp
         q, k, v, out, dout, lse, causal=causal, dq=dq, dk=dk, dv=dv
     )
 
+    if is_fake_mode():
+        return
     assert dq_out is dq
     assert dk_out is dk
     assert dv_out is dv
@@ -1470,6 +1529,7 @@ def attention_combine_ref(out_partial, lse_partial):
 @pytest.mark.parametrize("num_splits", [1, 2, 3, 5, 17, 32, 55, 97, 133])
 # @pytest.mark.parametrize("num_splits", [1, 2, 3, 5, 11])
 # @pytest.mark.parametrize("num_splits", [11])
+@maybe_fake_tensor_mode(USE_FAKE_TENSOR)
 def test_flash_attn_combine(num_splits, seqlen, d, dtype):
     device = "cuda"
     # set seed
@@ -1498,6 +1558,8 @@ def test_flash_attn_combine(num_splits, seqlen, d, dtype):
     out, lse = flash_attn_combine(
         out_partial, lse_partial, out_dtype=dtype, return_lse=True
     )
+    if is_fake_mode():
+        return
     out_ref, lse_ref = attention_combine_ref(out_partial, lse_partial)
     out_pt = out_ref.to(dtype)
 

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -3,6 +3,8 @@
 import math
 import itertools
 import os
+import logging
+import json
 
 import pytest
 import torch
@@ -359,7 +361,6 @@ def test_flash_attn_output(
                 print(f"dV max diff: {diff_dv.max().item()}")
                 print(f"  at coordinates {tuple(c.item() for c in coords)}: dV={dv[coords].item()}, dV_ref={dv_ref[coords].item()}")
 
-            # breakpoint()
             dq_atol = 2 * (dq_ref + 0.3 - 0.3 - dq_ref).abs().max().item() + (
                 0 if softcap == 0 else 3e-4
             )
@@ -841,7 +842,6 @@ def test_flash_attn_varlen_output(
                 coords = torch.unravel_index(max_idx, diff_dv.shape)
                 print(f"dV max diff: {diff_dv.max().item()}")
                 print(f"  at coordinates {tuple(c.item() for c in coords)}: dV={dv[coords].item()}, dV_ref={dv_ref[coords].item()}")
-            # breakpoint()
             dq_atol = 2 * (dq_ref + 0.3 - 0.3 - dq_ref).abs().max().item() + (
                 0 if softcap == 0 else 3e-4
             )


### PR DESCRIPTION
### Split this PR to one sub-PR per commit:
- [x] #2283
- [x] #2304
- [x] #2311
- ~~Gave up: Once cutedsl upstream fixed their bugs, enable caching by default~~

### Overview of changes
**The proposed new two-pass test workflow (full sweep in ~25min):**

Step.1: pre-compile tests in parallel with pytest-xdist (e.g., 256 workers)

```
FLASH_ATTENTION_FAKE_TENSOR=1 FLASH_ATTENTION_CUTE_DSL_CACHE_ENABLED=1 pytest -n 256 -x tests/cute/test_flash_attn.py
```

Compiled binaries will be dumped to `/tmp/${USER}/flash_attention_cute_dsl_cache/` by default

On a B200 machine, I got ~43 compiles/sec:
> 30044 passed, 16128 skipped, 413456 warnings in 699.09s (0:11:39)

Step.2: run tests without `cute.compile`
```
FLASH_ATTENTION_FAKE_TENSOR=0 FLASH_ATTENTION_CUTE_DSL_CACHE_ENABLED=1 pytest -x tests/cute/test_flash_attn.py -k 'not test_flash_attn_kvcache'
```
Skipping test_flash_attn_kvcache because it currently has [GPU hangs](https://github.com/Dao-AILab/flash-attention/issues/2278). On the same B200 machine, with single-GPU-single-worker, I got ~36 passed/sec:
> 27548 passed, 15552 skipped, 3072 deselected, 553 warnings in 767.08s (0:12:47)

PS: with `pytest -n 8`, full sweep with all cached compilation would only take 2min
> 27548 passed, 15552 skipped, 1183 warnings in 126.37s (0:02:06)

The new introduced envvar flags are disabled by default. For comparison, the speed of the default/existing single-GPU test is ~0.5 passed/sec:
> 1488 passed, 891 skipped, 3072 deselected, 18113 warnings in 3125.21s (0:52:05) 


**How it works:**

- Use [torch fake tensor mode](https://docs.pytorch.org/docs/stable/user_guide/torch_compiler/torch.compiler_fake_tensor.html#api-the-important-bits) to enable cute.compile but don't allocate GPU memory or run kernels.
- Changes are made throughout `test_flash_attn.py` and `flash_attn/cute/interface.py` to bypass certain "data-dependent" operations when inside fake tensor mode.
- Use cutedsl [ahead-of-time compilation](https://docs.nvidia.com/cutlass/latest/media/docs/pythonDSL/cute_dsl_general/dsl_ahead_of_time_compilation.html#export-interface) support to export and load compiled modules to/from external storage.

> [!IMPORTANT]
> To make the above workflow work, I had to patch the following cutedsl bugs:
> - leaked MLIR threading pool: [cutlass#3062](https://github.com/NVIDIA/cutlass/pull/3062)
> - ahead-of-time compiling not loading shared library correctly: [cutlass#3075](https://github.com/NVIDIA/cutlass/pull/3075)

> [!NOTE]
>  As of cutedsl 4.4.0, cutedsl does not support exporting compiled tvm_ffi kernels as "shared library" (i.e., [only support object files](https://github.com/NVIDIA/cutlass/blob/057635de5c493a34e9913e2c5e836bdd98c58861/python/CuTeDSL/cutlass/cutlass_dsl/tvm_ffi_provider.py#L447)), but tvm_ffi only supports shared library. So my current workaround is an explicit `ld -shared -o foo.so foo.o`.

cutedsl patches attached bellow for your convenience (`cd site-packages && patch -p1 < xxx`):
```
--- a/nvidia_cutlass_dsl/python_packages/cutlass/base_dsl/dsl.py 2026-02-25 17:32:03.674296431 -0800
+++ b/nvidia_cutlass_dsl/python_packages/cutlass/base_dsl/dsl.py 2026-02-23 23:42:18.111766576 -0800
@@ -1345,7 +1345,8 @@
         location=None,
     ):
         """Generate MLIR module and compile iself.T_provider."""
-        with ir.Context(), self.get_ir_location(location):
+        with ir.Context() as ctx, self.get_ir_location(location):
+            ctx.enable_multithreading(False)
             try:
                 # Convert input arguments to MLIR arguments
                 exe_args, func_types, adapted_args = self.generate_mlir_function_types(
--- a/nvidia_cutlass_dsl/python_packages/cutlass/cute/runtime.py 2026-02-25 17:32:03.678703799 -0800
+++ b/nvidia_cutlass_dsl/python_packages/cutlass/cute/runtime.py 2026-02-25 17:28:11.608996616 -0800
@@ -951,7 +951,7 @@
         # no need to load tvm_ffi library here since it will be loaded by tvm_ffi package.
         for path in find_runtime_libraries(enable_tvm_ffi=False):
             if Path(path).exists():
-                _LOAD_MODULE_LIBS_CACHE.append(ctypes.CDLL(path))
+                _LOAD_MODULE_LIBS_CACHE.append(ctypes.CDLL(path, mode=ctypes.RTLD_GLOBAL))

     if enable_tvm_ffi:
         import tvm_ffi
```

**Other minor changes**

Added statistics printing to breakdown number of tests by test name:
```
pytest --co -qq tests/cute/test_flash_attn.py
```
Would print stats like:
```
cute/test_flash_attn.py: 46172
test_counts={'test_flash_attn_output': 2304, 'test_flash_attn_varlen_output': 39168, 'test_flash_attn_kvcache': 3072, 'test_flash_attn_bwd_preallocated_outputs': 8, 'test_flash_attn_combine': 1620}
```

General QoL w.r.t. `pytest -n N`
- Add per-worker logging at `/tmp/${USER}/flash_attention_tests/tests_gw${worker_id}.log`
- Only let one worker to query nvidia-smi and cache that results for other workers. When spawning many workers initializing pytorch, nvidia-smi becomes extremely slow and always timeout.