### PR TITLE
Add FA4 publishing strategy

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,31 @@
+# GitHub Workflow Tagging Flow
+
+This repository uses separate tag lanes so FA2 and FA4 publishing do not collide.
+
+## Release lanes
+
+| Tag pattern | Workflow | Package target | Version source |
+| --- | --- | --- | --- |
+| `v*` | `.github/workflows/publish.yml` | Root package (`flash-attn`) | Root package version metadata |
+| `fa4-v*` | `.github/workflows/publish-fa4.yml` | `flash_attn/cute` package (`flash-attn-4`) | `setuptools-scm` with `fa4-v*` tags |
+
+## How to publish
+
+### FA2 / root package lane
+
+1. Create a tag matching `v*` (example: `v2.9.0`).
+2. Push that tag.
+3. `publish.yml` creates a release, builds wheel matrix artifacts, and publishes to PyPI.
+
+### FA4 / CUTE package lane
+
+1. Create a tag matching `fa4-v*` (example: `fa4-v0.1.0`).
+2. Push that tag.
+3. `publish-fa4.yml` builds from `flash_attn/cute`, creates a GitHub release, and uploads `flash-attn-4` to PyPI.
+
+## Guardrails
+
+- Do not use `v*` tags for FA4 releases.
+- Do not use `fa4-v*` tags for FA2 releases.
+- Keep `flash_attn/cute/pyproject.toml` tag parsing in sync with the FA4 tag prefix.
+- The workflow filename (`publish-fa4.yml`) is part of the PyPI trusted publishing OIDC identity — do not rename without updating PyPI.

--- a/.github/workflows/publish-fa4.yml
+++ b/.github/workflows/publish-fa4.yml
@@ -1,0 +1,65 @@
+name: Publish flash-attn-4 to PyPI
+
+on:
+  push:
+    tags:
+      - 'fa4-v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+    - name: Install build dependencies
+      run: pip install build twine
+    - name: Build package
+      run: python -m build
+      working-directory: flash_attn/cute
+    - name: Check package metadata
+      run: twine check dist/*
+      working-directory: flash_attn/cute
+    - name: Store distribution packages
+      uses: actions/upload-artifact@v4
+      with:
+        name: python-package-distributions
+        path: flash_attn/cute/dist/
+
+  github-release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download distribution packages
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Create GitHub Release
+      uses: softprops/action-gh-release@v2
+      with:
+        files: dist/*
+        generate_release_notes: true
+
+  publish-to-pypi:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/flash-attn-4
+    permissions:
+      id-token: write
+    steps:
+    - name: Download distribution packages
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -62,6 +62,22 @@ import flash_attn_interface
 flash_attn_interface.flash_attn_func()
 ```
 
+## FlashAttention-4 (CuTeDSL)
+
+FlashAttention-4 is written in CuTeDSL and optimized for Hopper and Blackwell GPUs (e.g. H100, B200).
+
+To install:
+```sh
+pip install flash-attn-4
+```
+
+Once installed, you can use it as follows:
+```python
+from flash_attn.cute import flash_attn_func
+
+out = flash_attn_func(q, k, v, causal=True)
+```
+
 ## Installation and features
 **Requirements:**
 - CUDA toolkit or ROCm toolkit

--- a/flash_attn/cute/MANIFEST.in
+++ b/flash_attn/cute/MANIFEST.in
@@ -1,0 +1,5 @@
+global-exclude *.egg-info/*
+prune flash_attn_4.egg-info
+prune flash_attn.egg-info
+prune build
+prune dist

--- a/flash_attn/cute/README.md
+++ b/flash_attn/cute/README.md
@@ -1,26 +1,26 @@
-# Flash Attention CUTE
+# FlashAttention-4 (CuTeDSL)
 
-## Development Installation
+FlashAttention-4 is a CuTeDSL-based implementation of FlashAttention for Hopper and Blackwell GPUs.
 
-1. Clone the repository (if you haven't already):
-   ```bash
-   git clone https://github.com/Dao-AILab/flash-attention.git
-   cd flash-attention/cute
-   ```
+## Installation
 
-2. Install in editable mode with dev dependencies:
-   ```bash
-   pip install -e "./cute[dev]"
-   ```
-
-## Running Tests
-
-```bash
-pytest tests/cute/
+```sh
+pip install flash-attn-4
 ```
 
-## Linting
+## Usage
 
-```bash
-ruff check flash_attn/cute/
+```python
+from flash_attn.cute import flash_attn_func, flash_attn_varlen_func
+
+out = flash_attn_func(q, k, v, causal=True)
+```
+
+## Development
+
+```sh
+git clone https://github.com/Dao-AILab/flash-attention.git
+cd flash-attention
+pip install -e "flash_attn/cute[dev]"
+pytest tests/cute/
 ```

--- a/flash_attn/cute/__init__.py
+++ b/flash_attn/cute/__init__.py
@@ -1,6 +1,11 @@
 """Flash Attention CUTE (CUDA Template Engine) implementation."""
 
-__version__ = "0.1.0"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("flash-attn-4")
+except PackageNotFoundError:
+    __version__ = "0.0.0"
 
 import cutlass.cute as cute
 

--- a/flash_attn/cute/pyproject.toml
+++ b/flash_attn/cute/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools", "setuptools-scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "flash-attn-cute"
-version = "0.1.0"
+name = "flash-attn-4"
+dynamic = ["version"]
 description = "Flash Attention CUTE (CUDA Template Engine) implementation"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -44,6 +44,12 @@ Repository = "https://github.com/Dao-AILab/flash-attention"
 [tool.setuptools]
 packages = ["flash_attn.cute"]
 package-dir = {"flash_attn.cute" = "."}
+
+[tool.setuptools_scm]
+root = "../.."
+tag_regex = "^fa4-v(?P<version>.+)$"
+git_describe_command = "git describe --dirty --tags --long --match 'fa4-v*'"
+fallback_version = "0.0.0"
 
 [tool.ruff]
 line-length = 100

--- a/setup.py
+++ b/setup.py
@@ -606,6 +606,8 @@ setup(
             "docs",
             "benchmarks",
             "flash_attn.egg-info",
+            "flash_attn.cute",
+            "flash_attn.cute.*",
         )
     ),
     author="Tri Dao",


### PR DESCRIPTION
Add FA4 publishing strategy

# Summary

Let me describe my tentative plan; we have allocated two pypi namespaces: 
`flash-attn-cute`, `flash-attn-4`. The current plan I went with is install via `flash-attn-4`.

Reason why I chose this: With the recent release of fa3: https://download.pytorch.org/whl/flash-attn-3/ installable via: `pip install flash-attn-3 –-index-url=https://download.pytorch.org/whl/cu126/flash-attn-3/`
I think it is coherent to have this version of FA installable as FA4. Although it shares the main namespace with flash-attn and is usable via from flash_attn.cute I still think its the most coherent story. While the hope is that FA4 will completely superseded FA2 and FA3 in the interim I think it make sense;

## How do make a new wheel
I need to setup the secrets but basically create a new tag with `fa4-v0.1.0` and the wheel builds should be automagic and published. 

This still allows for tagging with `v3.0.0` and keep the publish flow separate from the current core fa2 implementation.

## Things I tried and verified
- `python -m build` and `twine check` pass for `flash_attn/cute` artifacts.
- Artifact metadata  -> `flash-attn-4`.
- `pip install --no-deps -e flash_attn/cute` resolves an SCM-derived FA4 version as expected.
- Found a hard pinning bug in PT nightly and will fix: https://github.com/pytorch/pytorch/issues/175948
This ones I was worried about:
- Creating fresh envs and installing both FA3 and FA4 works, they can coexist and imports work correclty
- Mixed FA2 + FA4 install modes can resolve initially in tested Python 3.11 envs.
- There is some weirdness with uninstalling : Uninstalling either `flash-attn` or `flash-attn-4` can remove shared files under `flash_attn/*` (including `flash_attn/cute/__init__.py`). Root package discovery currently includes `flash_attn.cute`, which explains overlapping file ownership.
For ^ I think I can just exclude the cute subfolder from main fa2 install, although this is only would work with new installs so I dont know if it will be helpful


## What happens in the future

My main worry is lets say the cute impl supports everything that FA2/3 does and with full coverage. Ideally It would be great if we could remove the existing FA2 and Hopper dirs and have move all the cute sources into the FA2 and remove the csrc files. Does this path make it not possible?  Yea since we have independent that happen to live in the same git repo things should work. In the future we could use either  flash_attn + shims to the exsitng paths or use flash_attn.cute for everything again with shims and rename global to fa4 and stop publishing fa2 wheels. Regartdless I dont think there is any lock in with doing this for now. 


### Experiment files
I could check this in but they feel kind of one off, did similar things for the fa3 wheels, and fa4 in different uv envs and coexisting is fine 

```Py
import sys
import traceback
from importlib.metadata import PackageNotFoundError, version

import torch


def dist_version(dist_name: str) -> str:
    try:
        return version(dist_name)
    except PackageNotFoundError:
        return "MISSING"


def classify_skip(exc: BaseException) -> bool:
    msg = f"{type(exc).__name__}: {exc}".lower()
    skip_markers = [
        "no module named 'flash_attn_2_cuda'",
        "no module named 'flash_attn.flash_attn_interface'",
        "no module named 'cutlass'",
        "no module named 'apache_tvm_ffi'",
        "no module named 'quack_kernels'",
        "no kernel image is available",
        "not compiled with cuda",
        "cuda toolkit",
        "requires cuda",
        "cuda error",
        "nvidia driver",
    ]
    return any(marker in msg for marker in skip_markers)


def run_interface(name: str, call, expected_shape):
    try:
        out = call()
        out_tensor = out[0] if isinstance(out, tuple) and out and isinstance(out[0], torch.Tensor) else out
        if not isinstance(out_tensor, torch.Tensor):
            raise RuntimeError(f"{name} returned non-tensor output: {type(out)}")
        if out_tensor.shape != expected_shape:
            raise RuntimeError(f"{name} returned shape {tuple(out_tensor.shape)} expected {tuple(expected_shape)}")
        print(f"PASS {name}: output shape {tuple(out_tensor.shape)}")
        return "pass"
    except Exception as exc:
        if classify_skip(exc):
            print(f"SKIP {name}: {type(exc).__name__}: {exc}")
            return "skip"
        print(f"FAIL {name}: {type(exc).__name__}: {exc}")
        traceback.print_exc()
        return "fail"


def main() -> int:
    print(f"torch={torch.__version__}")
    print(f"flash-attn={dist_version('flash-attn')}")
    print(f"flash-attn-4={dist_version('flash-attn-4')}")

    if not torch.cuda.is_available():
        print("SKIP: torch.cuda.is_available() is False")
        return 0

    device = torch.device("cuda")
    dtype = torch.float16
    q = torch.randn((1, 64, 4, 64), device=device, dtype=dtype)
    k = torch.randn((1, 64, 4, 64), device=device, dtype=dtype)
    v = torch.randn((1, 64, 4, 64), device=device, dtype=dtype)
    print(f"device={torch.cuda.get_device_name(device)} capability={torch.cuda.get_device_capability(device)}")

    statuses: list[str] = []

    try:
        from flash_attn.flash_attn_interface import flash_attn_func as flash_attn_func_fa2

        statuses.append(
            run_interface(
                "FA2 interface",
                lambda: flash_attn_func_fa2(q, k, v, dropout_p=0.0, causal=False),
                q.shape,
            )
        )
    except Exception as exc:
        if classify_skip(exc):
            print(f"SKIP FA2 import: {type(exc).__name__}: {exc}")
            statuses.append("skip")
        else:
            print(f"FAIL FA2 import: {type(exc).__name__}: {exc}")
            traceback.print_exc()
            statuses.append("fail")

    try:
        from flash_attn.cute import flash_attn_func as flash_attn_func_fa4

        statuses.append(
            run_interface(
                "FA4 interface",
                lambda: flash_attn_func_fa4(q, k, v, causal=False),
                q.shape,
            )
        )
    except Exception as exc:
        if classify_skip(exc):
            print(f"SKIP FA4 import: {type(exc).__name__}: {exc}")
            statuses.append("skip")
        else:
            print(f"FAIL FA4 import: {type(exc).__name__}: {exc}")
            traceback.print_exc()
            statuses.append("fail")

    if any(status == "fail" for status in statuses):
        return 1
    if all(status == "skip" for status in statuses):
        print("SKIP: neither interface runnable in this environment/device configuration")
    else:
        print("Smoke test completed.")
    return 0


if __name__ == "__main__":
    raise SystemExit(main())
```
Produces:

```Shell
❯ python ~/meta/package-fa4/scripts/testing/interface_smoke_core.py
torch=2.12.0.dev20260226+cu130
flash-attn=2.8.3
flash-attn-4=0.0.1.dev1302+g5e2bab073
device=NVIDIA B200 capability=(10, 0)
PASS FA2 interface: output shape (1, 64, 4, 64)
PASS FA4 interface: output shape (1, 64, 4, 64)
Smoke test completed.
❯ pip uninstall flash_attn
Found existing installation: flash_attn 2.8.3
Uninstalling flash_attn-2.8.3:
  Would remove:
    /tmp/fa2-fa4-both-cuda-manual/lib/python3.11/site-packages/__editable__.flash_attn-2.8.3.pth
    /tmp/fa2-fa4-both-cuda-manual/lib/python3.11/site-packages/__editable___flash_attn_2_8_3_finder.py
    /tmp/fa2-fa4-both-cuda-manual/lib/python3.11/site-packages/flash_attn-2.8.3.dist-info/*
Proceed (Y/n)? y
  Successfully uninstalled flash_attn-2.8.3
❯ python ~/meta/package-fa4/scripts/testing/interface_smoke_core.py
torch=2.12.0.dev20260226+cu130
flash-attn=MISSING
flash-attn-4=0.0.1.dev1302+g5e2bab073
device=NVIDIA B200 capability=(10, 0)
SKIP FA2 import: ModuleNotFoundError: No module named 'flash_attn.flash_attn_interface'
PASS FA4 interface: output shape (1, 64, 4, 64)
Smoke test completed.
~/me/package-fa4 package-fa4 *21 ?1 ❯     
```

With the update to setup.py uninstall fa will not uninstall fa4