### PR TITLE
[Sm90, fwd] refine UseSchedulerBarrier heuristic for kHeadDim=128

### DIFF
--- a/hopper/mainloop_fwd_sm90_tma_gmma_ws.hpp
+++ b/hopper/mainloop_fwd_sm90_tma_gmma_ws.hpp
@@ -350,7 +350,7 @@ struct CollectiveMainloopFwdSm90 {
 
     // These are tuned for speed. They don't affect correctness.
     static constexpr bool UseSchedulerBarrier = (IntraWGOverlap
-        ? (NumMmaWarpGroups >= 2) && (!Is_FP8 ? kHeadDim <= 128 : kHeadDim >= 128)
+        ? (NumMmaWarpGroups >= 2) && (!Is_FP8 ? kHeadDim < 128 : kHeadDim >= 128)
         : NumMmaWarpGroups == 2)
         && !LargeHeadDimV;
     static constexpr bool RescaleOBeforeGemm = kHeadDim > 128 && (!Is_FP8 || V_colmajor) && IntraWGOverlap;


### PR DESCRIPTION
## Background

In the Hopper (SM90) TMA-based mainloop, `UseSchedulerBarrier` is a heuristic used to control instruction scheduling and overlap between Warp Groups. Currently, for non-FP8 data types, this barrier is enabled for `kHeadDim <= 128`.

## Changes

This PR adjusts the threshold from `kHeadDim <= 128` to `kHeadDim < 128`. When `kHeadDim` is exactly 128, disabling the scheduler barrier reduces synchronization overhead between warp groups.


## Performance Results

Benchmark testing on NVIDIA H200 (PCIe) shows that this change consistently improves TFLOPS across most configurations, with a peak gain of **4.19%**.

### Performance Benchmarks (TFLOPS)

| Seq Len | Batch Size | Original (TFLOPS) | Optimized (TFLOPS) | Improvement (%) |
| --- | --- | --- | --- | --- |
| **2048** | 1 | 609 | 612 | +0.58% |
|  | 2 | 626 | 638 | +1.91% |
|  | 4 | 638 | 652 | +2.22% |
|  | 8 | 637 | 661 | **+3.68%** |
|  | 16 | 614 | 629 | +2.50% |
|  | 32 | 583 | 600 | +2.83% |
| **4096** | 1 | 657 | 676 | +2.87% |
|  | 2 | 659 | 682 | **+3.50%** |
|  | 4 | 645 | 643 | -0.32% |
|  | 8 | 609 | 622 | +2.18% |
|  | 16 | 602 | 613 | +1.78% |
|  | 32 | 602 | 610 | +1.23% |
| **8192** | 1 | 643 | 670 | **+4.19%** |
|  | 2 | 630 | 645 | +2.49% |
|  | 4 | 617 | 636 | +3.11% |
|  | 8 | 617 | 632 | +2.35% |
|  | 16 | 617 | 629 | +1.91% |
|  | 32 | 618 | 624 | +0.96% |