### PR TITLE
[clang build] Fix clang parse error of missing 'typename' prior to dependent typename occurs because `LLVM/Clang` is strictly adhering to C++ standards

### DIFF
--- a/csrc/flash_attn/src/flash_bwd_kernel.h
+++ b/csrc/flash_attn/src/flash_bwd_kernel.h
@@ -550,7 +550,7 @@ inline __device__ void compute_dq_dk_dv_1colblock(const Params &params, const in
             : FLASH_NAMESPACE::convert_type_relu<Element>(acc_s);
         // Reshape rP from (MMA=4, MMA_M, MMA_N) to ((4, 2), MMA_N, MMA_N / 2)
         // if using m16n8k16 or (4, MMA_N, MMA_N) if using m16n8k8.
-        Tensor tPrP = make_tensor(rP.data(), FLASH_NAMESPACE::convert_layout_acc_Aregs<Kernel_traits::TiledMmaSdP>(rP.layout()));
+        Tensor tPrP = make_tensor(rP.data(), FLASH_NAMESPACE::convert_layout_acc_Aregs<typename Kernel_traits::TiledMmaSdP>(rP.layout()));
         Tensor tPaP = smem_thr_copy_PdS.retile_S(tPrP);     // ((Atom,AtomNum), MMA_N, MMA_N)
         cute::copy(smem_tiled_copy_PdS, tPaP, tPsP);
         // if (cute::thread0()) { print(tPaP); }


### PR DESCRIPTION
The error missing 'typename' prior to dependent type name occurs because LLVM/Clang is strictly adhering to C++ standards. It requires the typename keyword when referring to a subtype of a template (like Kernel_traits::TiledMmaSdP), whereas NVIDIA's nvcc is often more "forgiving" and lets it slide.

Signed-off-by: chenwei.sun <chenwei.sun@intel.com>