### PR TITLE
[CuTe] Include broadcast dims in backward compile cache keys

### DIFF
--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -41,7 +41,9 @@ if os.environ.get("CUTE_DSL_PTXAS_PATH", None) is not None:
 
 
 from flash_attn.cute import utils
-from flash_attn.cute.cute_dsl_utils import to_cute_tensor, to_cute_aux_tensor, get_aux_tensor_metadata
+from flash_attn.cute.cute_dsl_utils import (
+    to_cute_tensor, to_cute_aux_tensor, get_aux_tensor_metadata, get_broadcast_dims,
+)
 from flash_attn.cute.flash_fwd import FlashAttentionForwardSm90
 from flash_attn.cute.flash_fwd_sm100 import FlashAttentionForwardSm100
 from flash_attn.cute.flash_bwd_preprocess import FlashAttentionBackwardPreprocess
@@ -853,6 +855,8 @@ def _flash_attn_bwd(
         num_threads,
         cu_seqlens_q is None,
         seqused_q is None,
+        get_broadcast_dims(out),
+        get_broadcast_dims(dout),
     )
     if compile_key_pre not in _flash_attn_bwd.compile_cache_pre:
         o_tensor, do_tensor = [to_cute_tensor(t) for t in (out, dout)]
@@ -961,6 +965,10 @@ def _flash_attn_bwd(
             num_aux_tensors,
             use_block_sparsity,
             block_sparse_broadcast_pattern,
+            get_broadcast_dims(q),
+            get_broadcast_dims(k),
+            get_broadcast_dims(v),
+            get_broadcast_dims(dout),
         )
     else:
         compile_key = (
@@ -990,6 +998,10 @@ def _flash_attn_bwd(
             cu_seqlens_k is None,
             seqused_q is None,
             seqused_k is None,
+            get_broadcast_dims(q),
+            get_broadcast_dims(k),
+            get_broadcast_dims(v),
+            get_broadcast_dims(dout),
         )
     if compile_key not in _flash_attn_bwd.compile_cache:
         q_tensor, k_tensor, v_tensor, do_tensor, dq_tensor, dk_tensor, dv_tensor = [
@@ -1148,7 +1160,9 @@ def _flash_attn_bwd(
         cu_seqlens_q is None,
         seqused_q is None,
         use_2cta_instrs,
-        1, # no cluster for tile_m 
+        1, # no cluster for tile_m
+        get_broadcast_dims(dq_accum),
+        get_broadcast_dims(dq),
     )
     if compile_key_post not in _flash_attn_bwd.compile_cache_post:
         dq_accum_tensor = to_cute_tensor(dq_accum)
@@ -1194,7 +1208,9 @@ def _flash_attn_bwd(
             cu_seqlens_k is None,
             seqused_k is None,
             False, # even for 2cta, is split along hdim, so always False
-            cluster_size, # cluster is for tile_n 
+            cluster_size, # cluster is for tile_n
+            get_broadcast_dims(dk_accum),
+            get_broadcast_dims(dk),
         )
         if compile_key_post not in _flash_attn_bwd.compile_cache_post:
             dk_accum_tensor = to_cute_tensor(dk_accum)
@@ -1238,6 +1254,8 @@ def _flash_attn_bwd(
             seqused_k is None,
             False,
             cluster_size,
+            get_broadcast_dims(dv_accum),
+            get_broadcast_dims(dv),
         )
         if compile_key_post not in _flash_attn_bwd.compile_cache_post:
             dv_accum_tensor = to_cute_tensor(dv_accum)


### PR DESCRIPTION
## Summary

`to_cute_tensor()` calls `mark_layout_dynamic()` (from cutlass-dsl) to make tensor strides dynamic at compile time. However, `stride=0` is kept as a **static** constraint in the compiled kernel — a broadcast dimension gets baked in as `(0, ?, ?, 1)` rather than `(?, ?, ?, 1)`.

The backward compile cache keys (`compile_key_pre`, `compile_key`, `compile_key_post`) don't include stride/broadcast information, so two calls with different broadcast patterns share the same cached kernel. This causes a collision when:

1. A backward call with `B=1` and `stride[0]=0` (produced by `torch.compile`'s inductor via `reinterpret_tensor` for size-1 batch dims) compiles kernels with `stride=0` baked in.
2. A subsequent call with `B>1` and normal strides hits the same cache key, but the TVM FFI rejects the stride mismatch.

**Fix:** Include `get_broadcast_dims()` in `compile_key_pre`, `compile_key`, and `compile_key_post` so that different broadcast patterns produce separate cache entries.

## Reproducer

```python
"""_flash_attn_bwd compile cache collision when stride[0]=0."""

import torch
from flash_attn.cute.interface import _flash_attn_fwd, _flash_attn_bwd


def fa4_backward(B, S, H, D, *, stride0=None):
    q = torch.randn(B, S, H, D, device="cuda", dtype=torch.bfloat16)
    k = torch.randn(B, S, H, D, device="cuda", dtype=torch.bfloat16)
    v = torch.randn(B, S, H, D, device="cuda", dtype=torch.bfloat16)
    out, lse, *_ = _flash_attn_fwd(q, k, v, return_lse=True)
    dout = torch.randn_like(out)
    if stride0 is not None:
        out = out.as_strided(out.shape, (stride0,) + out.stride()[1:])
        dout = dout.as_strided(dout.shape, (stride0,) + dout.stride()[1:])
    _flash_attn_bwd(q, k, v, out, dout, lse)


# Call 1: B=1, stride[0]=0 — compiles preprocess kernel with stride=0 static.
fa4_backward(B=1, S=64, H=4, D=64, stride0=0)

# Call 2: B>1, stride[0]!=0 — same compile_key_pre, TVM FFI rejects mismatch.
fa4_backward(B=2, S=64, H=4, D=64)
