### PR TITLE
Fix GQA crash in cute FLASH backend: init load_Q before conditional

### DIFF
--- a/flash_attn/cute/flash_fwd.py
+++ b/flash_attn/cute/flash_fwd.py
@@ -1755,6 +1755,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                 mV_cur = seqlen.offset_batch_K(mV, batch_idx, dim=3)[None, None, head_idx_kv]
                 gK = cute.local_tile(mK_cur, (self.tile_n, self.tile_hdim), (None, 0))
                 gV = cute.local_tile(mV_cur, (self.tile_n, self.tile_hdimv), (None, 0))
+                load_Q = None
                 if const_expr(self.use_tma_Q):
                     gQ = cute.local_tile(mQ_cur, (self.tile_m, self.tile_hdim), (m_block, 0))
                     load_Q, _, _ = copy_utils.tma_get_copy_fn(


### PR DESCRIPTION
Fix for #2300.

When GQA is used with `pack_gqa=True` and `tile_m % qhead_per_kvhead != 0`, `use_tma_Q` is `False` so `load_Q` is never assigned inside the `if const_expr(self.use_tma_Q)` block. But `load_Q` is referenced unconditionally at line 1822 in the block sparsity path, causing:

```
UnboundLocalError: cannot access local variable load_Q
DSLRuntimeError: Error during runtime code generation
```

Fix: initialize `load_Q = None` before the conditional.

**Repro:**

```python
import torch
from torch.nn.attention.flex_attention import flex_attention, create_block_mask

compiled_flex = torch.compile(flex_attention)

def causal(b, h, q_idx, kv_idx):
    return q_idx >= kv_idx

mask = create_block_mask(causal, B=None, H=None, Q_LEN=512, KV_LEN=512, device="cuda")

# GQA: 40 Q heads, 4 KV heads — crashes without fix
q = torch.randn(1, 40, 512, 128, device="cuda", dtype=torch.bfloat16)
k = torch.randn(1, 4, 512, 128, device="cuda", dtype=torch.bfloat16)
v = torch.randn(1, 4, 512, 128, device="cuda", dtype=torch.bfloat16)

y = compiled_flex(q, k, v, block_mask=mask, enable_gqa=True,
                  kernel_options={"BACKEND": "FLASH"})
```

Tested on H100 with torch 2.12.0.dev20260221+cu128, cutlass-dsl 4.4.1.

Made with [Cursor](https://cursor.com)