### PR TITLE
Remove c-dlpack

### DIFF
--- a/flash_attn/cute/pyproject.toml
+++ b/flash_attn/cute/pyproject.toml
@@ -27,7 +27,6 @@ dependencies = [
     "einops",
     "typing_extensions",
     "apache-tvm-ffi>=0.1.5,<0.2",
-    "torch-c-dlpack-ext",
     "quack-kernels>=0.2.10",
     "setuptools",
 ]


### PR DESCRIPTION
# Summary

Produces:

| Calling path | With `torch-c-dlpack-ext` | Without | Ratio vs fastest |
|---|---|---|---|
| Direct TVM FFI (`torch.Tensor` passthrough) | 5.1 us | 5.0 us | 1.0x |
| `from_dlpack(enable_tvm_ffi=True)` | 15.6 us | 15.4 us | ~3.1x |
| `from_dlpack(enable_tvm_ffi=False)` | 47.0 us | 46.6 us | ~9.2x |

**Conversion only** (8x `from_dlpack` + `mark_layout_dynamic`, no kernel launch):

| Path | With ext | Without |
|---|---|---|
| `enable_tvm_ffi=True` | 9.0 us | 9.6 us |
| `enable_tvm_ffi=False` | 33.0 us | 32.6 us |


Script:

```Py
"""Benchmark host-side overhead of torch-c-dlpack-ext for CuTe DSL calling paths.

Measures three invocation styles used in flash-attention:
  1. Direct TVM FFI: compiled with fake tensors, called with raw torch.Tensors
  2. Explicit from_dlpack (TVM FFI): from_dlpack(..., enable_tvm_ffi=True)
  3. Explicit from_dlpack (no TVM FFI): from_dlpack(..., enable_tvm_ffi=False)

Also measures conversion-only cost (from_dlpack + mark_layout_dynamic) separately.

Uses 8 tensor args to mirror real flash-attention call patterns (q, k, v, out, lse, ...).

Run in two envs to compare:
  ~/.venvs/tst-c_dlpack/bin/python cutey/c_dlpack.py        # with torch-c-dlpack-ext
  ~/.venvs/tst-c_dlpack_noext/bin/python cutey/c_dlpack.py  # without it
"""

import argparse
import time
import statistics

import torch
from cutlass import cute
from cuda.bindings.driver import CUstream

NUM_TENSORS = 8


@cute.kernel
def _device_noop(t0: cute.Tensor, t1: cute.Tensor, t2: cute.Tensor, t3: cute.Tensor,
                 t4: cute.Tensor, t5: cute.Tensor, t6: cute.Tensor, t7: cute.Tensor):
    pass


@cute.jit
def _jit_noop(t0: cute.Tensor, t1: cute.Tensor, t2: cute.Tensor, t3: cute.Tensor,
              t4: cute.Tensor, t5: cute.Tensor, t6: cute.Tensor, t7: cute.Tensor):
    _device_noop(t0, t1, t2, t3, t4, t5, t6, t7).launch(grid=[1, 1, 1], block=[1, 1, 1])


@cute.jit
def _jit_noop_stream(t0: cute.Tensor, t1: cute.Tensor, t2: cute.Tensor, t3: cute.Tensor,
                     t4: cute.Tensor, t5: cute.Tensor, t6: cute.Tensor, t7: cute.Tensor,
                     stream: CUstream):
    _device_noop(t0, t1, t2, t3, t4, t5, t6, t7).launch(
        grid=[1, 1, 1], block=[1, 1, 1], stream=stream)


def _compile_tvm_ffi():
    n = cute.sym_int()
    fakes = [cute.runtime.make_fake_compact_tensor(cute.Float16, (n,)) for _ in range(NUM_TENSORS)]
    stream = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
    return cute.compile(_jit_noop_stream, *fakes, stream, options="--enable-tvm-ffi")


def _compile_dlpack(enable_tvm_ffi, tensors):
    cuties = [cute.runtime.from_dlpack(t, enable_tvm_ffi=enable_tvm_ffi).mark_layout_dynamic()
              for t in tensors]
    opts = "--enable-tvm-ffi" if enable_tvm_ffi else ""
    return cute.compile(_jit_noop, *cuties, **({"options": opts} if opts else {}))


def _detect_ext():
    try:
        import torch_c_dlpack_ext  # noqa: F401
        return True
    except ImportError:
        return False


def _bench(fn, warmup, iters):
    for _ in range(warmup):
        fn()
    torch.cuda.synchronize()
    times = []
    for _ in range(iters):
        t0 = time.perf_counter()
        fn()
        times.append((time.perf_counter() - t0) * 1e6)
    torch.cuda.synchronize()
    return times


def _report(label, times_us):
    med = statistics.median(times_us)
    p95 = sorted(times_us)[int(len(times_us) * 0.95)]
    print(f"  {label:45s}  median={med:8.1f} us  p95={p95:8.1f} us")
    return med


def main():
    parser = argparse.ArgumentParser(description=__doc__)
    parser.add_argument("--iters", type=int, default=500)
    parser.add_argument("--warmup", type=int, default=50)
    parser.add_argument("--numel", type=int, default=256)
    args = parser.parse_args()

    has_ext = _detect_ext()
    print(f"torch-c-dlpack-ext installed: {has_ext}")
    print(f"torch: {torch.__version__}")
    print(f"iters={args.iters}  warmup={args.warmup}  numel={args.numel}  tensors={NUM_TENSORS}")
    print()

    tensors = [torch.randn(args.numel, device="cuda", dtype=torch.float16)
               for _ in range(NUM_TENSORS)]

    compiled_tvm = _compile_tvm_ffi()
    compiled_dlpack_tvm = _compile_dlpack(True, tensors)
    compiled_dlpack_notvm = _compile_dlpack(False, tensors)

    print(f"=== End-to-end invocation ({NUM_TENSORS} tensors, compile cached) ===")

    def call_direct_tvm():
        compiled_tvm(*tensors)

    def call_dlpack_tvm():
        cuties = [cute.runtime.from_dlpack(t, enable_tvm_ffi=True).mark_layout_dynamic()
                  for t in tensors]
        compiled_dlpack_tvm(*cuties)

    def call_dlpack_notvm():
        cuties = [cute.runtime.from_dlpack(t, enable_tvm_ffi=False).mark_layout_dynamic()
                  for t in tensors]
        compiled_dlpack_notvm(*cuties)

    results = {}
    for label, fn in [
        ("direct TVM FFI (torch.Tensor)", call_direct_tvm),
        ("from_dlpack (enable_tvm_ffi=True)", call_dlpack_tvm),
        ("from_dlpack (enable_tvm_ffi=False)", call_dlpack_notvm),
    ]:
        results[label] = _report(label, _bench(fn, args.warmup, args.iters))

    fastest = min(results.values())
    print()
    for label, med in results.items():
        ratio = med / fastest if fastest > 0 else 0
        print(f"  {label:45s}  {ratio:.2f}x vs fastest")

    print()
    print(f"=== Conversion only ({NUM_TENSORS}x from_dlpack + mark_layout_dynamic) ===")

    def conv_tvm():
        for t in tensors:
            cute.runtime.from_dlpack(t, enable_tvm_ffi=True).mark_layout_dynamic()

    def conv_notvm():
        for t in tensors:
            cute.runtime.from_dlpack(t, enable_tvm_ffi=False).mark_layout_dynamic()

    conv_results = {}
    for label, fn in [
        ("from_dlpack (enable_tvm_ffi=True)", conv_tvm),
        ("from_dlpack (enable_tvm_ffi=False)", conv_notvm),
    ]:
        conv_results[label] = _report(label, _bench(fn, args.warmup, args.iters))

    fastest_conv = min(conv_results.values())
    print()
    for label, med in conv_results.items():
        ratio = med / fastest_conv if fastest_conv > 0 else 0
        print(f"  {label:45s}  {ratio:.2f}x vs fastest")


if __name__ == "__main__":
    main()

```