### PR TITLE
[Cute,Bwd,Sm100] Fix tmem use-after-free: add within-CTA dealloc barrier

### DIFF
--- a/flash_attn/cute/flash_bwd_sm100.py
+++ b/flash_attn/cute/flash_bwd_sm100.py
@@ -782,7 +782,8 @@ class FlashAttentionBackwardSm100:
                     cutlass.Int64, self.dQaccum_reduce_stage // 2
                 ]
                 tmem_holding_buf: Int32
-                tmem_dealloc_mbar_ptr: cutlass.Int64
+                two_cta_tmem_dealloc_mbar_ptr: cutlass.Int64
+                within_cta_tmem_dealloc_mbar_ptr: cutlass.Int64
 
                 # 2-CTA
                 Qt_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2 * self.Q_stage]
@@ -861,7 +862,8 @@ class FlashAttentionBackwardSm100:
                     cutlass.Int64, self.dQaccum_reduce_stage // 2
                 ]
                 tmem_holding_buf: Int32
-                tmem_dealloc_mbar_ptr: Int64
+                two_cta_tmem_dealloc_mbar_ptr: Int64
+                within_cta_tmem_dealloc_mbar_ptr: Int64
 
                 sQ: cute.struct.Align[
                     cute.struct.MemRange[cute.Uint8, sQ_alloc_bytes],
@@ -1122,6 +1124,10 @@ class FlashAttentionBackwardSm100:
             dQaccum_empty_mbar_ptr = None
 
         # Barrier initialization
+        if warp_idx == 1:
+            cute.arch.mbarrier_init(
+                storage.within_cta_tmem_dealloc_mbar_ptr, cute.arch.WARP_SIZE * (len(self.compute_warp_ids))
+            )
         if const_expr(self.use_2cta_instrs):
             if const_expr(self.tile_hdim == 192):
                 if warp_idx == 2:
@@ -1150,7 +1156,7 @@ class FlashAttentionBackwardSm100:
             barrier_for_retrieve=tmem_alloc_barrier,
             allocator_warp_id=self.mma_warp_id,
             is_two_cta=self.use_2cta_instrs,
-            two_cta_tmem_dealloc_mbar_ptr=storage.tmem_dealloc_mbar_ptr,
+            two_cta_tmem_dealloc_mbar_ptr=storage.two_cta_tmem_dealloc_mbar_ptr,
         )
 
         # UMMA producers and AsyncThread consumers
@@ -1544,6 +1550,7 @@ class FlashAttentionBackwardSm100:
             )
             # Dealloc the tensor memory buffer
             tmem.relinquish_alloc_permit()
+            cute.arch.mbarrier_wait(storage.within_cta_tmem_dealloc_mbar_ptr, 0)
             tmem.free(tmem_ptr)
 
         # Compute
@@ -1595,6 +1602,7 @@ class FlashAttentionBackwardSm100:
                 fastdiv_mods,
                 blocksparse_tensors,
             )
+            cute.arch.mbarrier_arrive(storage.within_cta_tmem_dealloc_mbar_ptr)
 
         # Reduce
         # (0, 1, 2, 3) - dQ


### PR DESCRIPTION
The TmemAllocator commit (a79ee34) removed the mbarrier synchronization that prevented the MMA warp from deallocating tmem while compute warps were still using it.

TmemAllocator only provides cross-CTA sync (two_cta_tmem_dealloc_mbar_ptr, used between peer CTAs in 2-CTA mode) but has no within-CTA sync to ensure local consumer warps are done before deallocation.

Add a separate within_cta_tmem_dealloc_mbar_ptr for this purpose:
- Init barrier with arrival count = all compute warp threads
- Compute warps arrive after finishing with tmem
- MMA warp waits on the barrier before calling tmem.free()

Its logic is basically the same as what existed before the TmemAllocator commit.

Tested with:
```
export CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
export FLASH_ATTENTION_CUTE_DSL_CACHE_ENABLED=1
# test_flash_attn.py excluding the 'test_flash_attn_kvcache' known to hang (#2278)
FLASH_ATTENTION_FAKE_TENSOR=1 pytest -n 256 -x tests/cute/test_flash_attn.py
FLASH_ATTENTION_FAKE_TENSOR=0 pytest -n 8 -x tests/cute/test_flash_attn.py -k 'not test_flash_attn_kvcache'
# 27548 passed, 15552 skipped, 1260 warnings in 182.04s (0:03:02)
# All other tests
pytest -n 8 -x tests/cute/ --ignore=tests/cute/test_flash_attn.py
# 22030 passed, 18971 skipped, 78 xfailed, 143188 warnings in 1222.08s (0:20:22)
```

Before: error "torch.AcceleratorError: CUDA error: unspecified launch failure" when running tests. The error was also non-deterministic (run the failing single test would pass; run the whole test suite would fail).
After: passing all tests.