### PR TITLE
[Cute, SM90, bwd] Fix MMA tiling for non-power-of-2 head dims

### DIFF
--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -173,6 +173,11 @@ def _tile_size_bwd_sm90(head_dim, causal, local):
     Configs based on C++ FA3 hopper/flash_bwd_launch_template.h,
     benchmarked on H100 SXM.
     """
+    head_dim_padded = ((head_dim + 15) // 16) * 16
+    # When dQ_swapAB=True, the dQ WGMMA's M-mode becomes (head_dim_padded // 2),
+    # which must be a multiple of 64 (the WGMMA atom M).
+    dQ_swap_valid = (head_dim_padded // 2) % 64 == 0
+    non_causal = not (causal or local)
     if head_dim <= 64:
         # C++ FA3: 128, 128, 64, ..., 2, 2, true, false, false, 2, 1, 2, 2
         return BwdConfig(
@@ -191,12 +196,13 @@ def _tile_size_bwd_sm90(head_dim, causal, local):
         )
     elif head_dim <= 128:
         # C++ FA3: causal/local: 64, 128; non-causal: 80, 128 with dQ_swapAB
+        dQ_swapAB = non_causal and dQ_swap_valid
         return BwdConfig(
-            m_block_size=80 if not (causal or local) else 64,
+            m_block_size=80 if dQ_swapAB else 64,
             n_block_size=128,
             num_stages_Q=2, num_stages_dO=2, num_stages_PdS=2,
             SdP_swapAB=True, dKV_swapAB=False,
-            dQ_swapAB=not (causal or local),
+            dQ_swapAB=dQ_swapAB,
             AtomLayoutMSdP=1, AtomLayoutNdKV=2, AtomLayoutMdQ=1,
         )
     elif head_dim <= 192:
@@ -204,7 +210,7 @@ def _tile_size_bwd_sm90(head_dim, causal, local):
         return BwdConfig(
             m_block_size=64, n_block_size=96,
             num_stages_Q=1, num_stages_dO=1, num_stages_PdS=1,
-            SdP_swapAB=False, dKV_swapAB=True, dQ_swapAB=True,
+            SdP_swapAB=False, dKV_swapAB=True, dQ_swapAB=(non_causal and dQ_swap_valid),
             AtomLayoutMSdP=1, AtomLayoutNdKV=1, AtomLayoutMdQ=1,
         )
     else:

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -299,8 +299,8 @@ def test_flash_attn_output(
         ):
             if d == 192 and local:
                 pytest.xfail("hdim 192 backward: local attention not supported yet")
-            if d > 128 and IS_SM90:
-                pytest.xfail("hdim > 128 backward: SM90 not supported yet")
+            if d == 256 and IS_SM90:
+                pytest.xfail("hdim 256 backward: SM90 not supported yet")
             g = torch.randn_like(out)
             # do_o = ((g.float() * out.float()).sum(-1)).transpose(1, 2)
             dq, dk, dv = torch.autograd.grad(out, (q, k, v), g)
@@ -737,8 +737,8 @@ def test_flash_attn_varlen_output(
         ):
             if d == 192 and local:
                 pytest.xfail("hdim 192 backward: local attention not supported yet")
-            if d > 128 and IS_SM90:
-                pytest.xfail("hdim > 128 backward: SM90 not supported yet")
+            if d == 256 and IS_SM90:
+                pytest.xfail("hdim 256 backward: SM90 not supported yet")
             g_unpad = torch.randn_like(out_unpad)
             # do_o = ((g_unpad.float() * out_unpad.float()).sum(-1)).transpose(-1, -2)
             # import flash_attn_3_cuda


### PR DESCRIPTION
﻿## Summary

Fix SM90 (H100) FA4/CuTe backward crash for `head_dim=192` in non-causal mode by preventing an invalid `dQ_swapAB` WGMMA tiling configuration.

Fixes #2087.

## Root cause

When `dQ_swapAB=True`, the dQ WGMMA's M-mode becomes `(head_dim_padded // 2)`, which must be a multiple of 64 (the WGMMA atom M). For `head_dim=192`, this becomes 96 and triggers runtime errors like:

```
OpError: expects the M-mode to be 64, but got 96
```

## Fix

- `flash_attn/cute/interface.py`: gate `dQ_swapAB` behind `((head_dim_padded // 2) % 64 == 0)` in SM90 backward tile selection, and select `m_block_size=64` when swap is disabled in non-causal mode.
- `tests/cute/test_flash_attn.py`: allow backward tests to run for `head_dim=192` on SM90 (keep `head_dim=256` xfail for now).

## Notes / testing

I can?t run SM90 locally; would appreciate a quick verification on H100.
