### PR TITLE
[Fwd,Sm100] Tune ex2 emulation for softmax

### DIFF
--- a/flash_attn/cute/softmax.py
+++ b/flash_attn/cute/softmax.py
@@ -270,7 +270,8 @@ class SoftmaxSm100(Softmax):
                             acc_S_row_frg[k + 1, j], fastmath=True
                         )
                     else:
-                        acc_S_row_frg[k, j], acc_S_row_frg[k + 1, j] = utils.e2e_asm2(
+                        # acc_S_row_frg[k, j], acc_S_row_frg[k + 1, j] = utils.e2e_asm2(acc_S_row_frg[k, j], acc_S_row_frg[k + 1, j])
+                        acc_S_row_frg[k, j], acc_S_row_frg[k + 1, j] = utils.ex2_emulation_2(
                             acc_S_row_frg[k, j], acc_S_row_frg[k + 1, j]
                         )
             acc_S_row_converted_frg[None, j].store(


### PR DESCRIPTION
## Description:
This PR mitigates the hardware exp2 unit pressure during softmax computation by shifting more workload to software emulation, yielding an average performance improvement of ~3% TFLOPS on sm100a architectures.

## Key Changes:
* Increased Software Emulation: Decreased `ex2_emu_freq` from 16 to 10 to increase the emulation ratio.
* Early Emulation: Changed `ex2_emu_start_frg` from 1 to 0, applying emulation starting directly from the first fragment.
* Cheaper Approximation: Switched to a degree-2 polynomial approximation (lowered poly_degree from 3 to 2) to reduce compute overhead.
* Parameter Exposure: Exposed the `ex2_emu_res` parameter through `apply_exp2_convert` to allow for finer-grained configurability.

## Performance Impact:

Achieved ~3% average TFLOPS improvement.
Evaluated configurations: MHA/GQA, causal/non-causal, and bf16/fp16.
<img width="2779" height="3850" alt="image" src="https://github.com/user-attachments/assets/286117da-04a9-4b02-818b-2eb4ec1f2237" />