### PR TITLE
[varlen] add autograd function to zero out nan padding

### DIFF
--- a/flash_attn/flash_attn_interface.py
+++ b/flash_attn/flash_attn_interface.py
@@ -219,7 +219,7 @@ def _flash_attn_varlen_forward_fake(
     paged_kv = block_table is not None
     batch_size = cu_seqlens_q.numel() - 1
     total_q, num_heads, _ = q.shape
-    
+
     out = torch.empty_like(q)
     softmax_lse = torch.empty((num_heads, total_q), dtype=torch.float32, device=q.device, layout=q.layout)
     p = torch.empty((0,), dtype=q.dtype, device=q.device, layout=q.layout)
@@ -323,7 +323,7 @@ def _flash_attn_backward_fake(
         softmax_d = torch.empty((batch_size, num_heads, seqlen_q), device=q.device, dtype=torch.float32)
     else:
         softmax_d = torch.empty((batch_size, num_heads, round_multiple(seqlen_q, 128)), device=q.device, dtype=torch.float32)
-    
+
     return softmax_d
 
 
@@ -437,7 +437,7 @@ def _flash_attn_varlen_backward_fake(
         softmax_d = torch.empty((num_heads, total_q), device=q.device, dtype=torch.float32)
     else:
         softmax_d = torch.empty((num_heads, total_q + 128 * batch_size), device=q.device, dtype=torch.float32)
-    
+
     return softmax_d
 
 
@@ -1614,3 +1614,43 @@ def flash_attn_with_kvcache(
         num_splits,
     )
     return (out, softmax_lse) if return_softmax_lse else out
+
+
+class _NoGradForwardSliceBackward(torch.autograd.Function):
+    """Identity in forward, zeros out padding gradients in backward.
+
+    When using varlen attention with padded inputs (input length > cu_seqlens[-1]),
+    the backward kernel only writes gradients for valid positions. Uninitialized
+    positions may contain NaN/inf that corrupt upstream gradients.
+
+    Wrap q, k, v with this before calling flash_attn_varlen_func to clean up
+    the padding gradients without adding unconditional overhead to the kernel.
+    """
+
+    @staticmethod
+    def forward(x, valid_len):
+        return x
+
+    @staticmethod
+    def setup_context(ctx, inputs, output):
+        _, valid_len = inputs
+        ctx.save_for_backward(valid_len)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        valid_len, = ctx.saved_tensors
+        mask = torch.arange(grad_output.shape[0], device=grad_output.device) < valid_len
+        return torch.where(mask[:, None, None], grad_output, 0.0), None
+
+
+def no_grad_forward_slice_backward(x, valid_len):
+    """Identity in forward, zeros out gradients beyond valid_len in backward.
+
+    Usage::
+
+        q = no_grad_forward_slice_backward(q, cu_seqlens_q[-1])
+        k = no_grad_forward_slice_backward(k, cu_seqlens_k[-1])
+        v = no_grad_forward_slice_backward(v, cu_seqlens_k[-1])
+        out = flash_attn_varlen_func(q, k, v, cu_seqlens_q, cu_seqlens_k, ...)
+    """
+    return _NoGradForwardSliceBackward.apply(x, valid_len)

--- a/hopper/flash_attn_interface.py
+++ b/hopper/flash_attn_interface.py
@@ -1130,3 +1130,43 @@ def get_scheduler_metadata(
         sm_margin,
     )
     return scheduler_metadata
+
+
+class _NoGradForwardSliceBackward(torch.autograd.Function):
+    """Identity in forward, zeros out padding gradients in backward.
+
+    When using varlen attention with padded inputs (input length > cu_seqlens[-1]),
+    the backward kernel only writes gradients for valid positions. Uninitialized
+    positions may contain NaN/inf that corrupt upstream gradients.
+
+    Wrap q, k, v with this before calling flash_attn_varlen_func to clean up
+    the padding gradients without adding unconditional overhead to the kernel.
+    """
+
+    @staticmethod
+    def forward(x, valid_len):
+        return x
+
+    @staticmethod
+    def setup_context(ctx, inputs, output):
+        _, valid_len = inputs
+        ctx.save_for_backward(valid_len)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        valid_len, = ctx.saved_tensors
+        mask = torch.arange(grad_output.shape[0], device=grad_output.device) < valid_len
+        return torch.where(mask[:, None, None], grad_output, 0.0), None
+
+
+def no_grad_forward_slice_backward(x, valid_len):
+    """Identity in forward, zeros out gradients beyond valid_len in backward.
+
+    Usage::
+
+        q = no_grad_forward_slice_backward(q, cu_seqlens_q[-1])
+        k = no_grad_forward_slice_backward(k, cu_seqlens_k[-1])
+        v = no_grad_forward_slice_backward(v, cu_seqlens_k[-1])
+        out = flash_attn_varlen_func(q, k, v, cu_seqlens_q, cu_seqlens_k, ...)
+    """
+    return _NoGradForwardSliceBackward.apply(x, valid_len)

--- a/hopper/test_flash_attn.py
+++ b/hopper/test_flash_attn.py
@@ -285,9 +285,9 @@ def test_flash_attn_output(
             assert (out - out_ref).abs().max().item() <= rtol * (out_pt - out_ref).abs().max().item() + fwd_atol
 
         if (
-            not DISABLE_BACKWARD 
-            and dtype != torch.float8_e4m3fn 
-            and not V_colmajor 
+            not DISABLE_BACKWARD
+            and dtype != torch.float8_e4m3fn
+            and not V_colmajor
             and not has_qv
             and not dv > 256
             and not attention_chunk != 0
@@ -418,7 +418,7 @@ def test_flash_attn_varlen_output(
     # batch_size = 2
     # nheads = 1
     # nheads_kv = nheads
-    
+
     dtype_ref = torch.bfloat16 if dtype == torch.float8_e4m3fn else dtype
     dv_vals = [128, d] if d > 128 and d <= 192 else ([256, 512, d] if d <= 64 else [d])
     if dtype == torch.float8_e4m3fn:
@@ -580,8 +580,8 @@ def test_flash_attn_varlen_output(
 
 
         if (
-            not DISABLE_BACKWARD 
-            and dtype != torch.float8_e4m3fn 
+            not DISABLE_BACKWARD
+            and dtype != torch.float8_e4m3fn
             and not has_qv
             and not dv > 256
             and not attention_chunk != 0
@@ -1261,3 +1261,69 @@ def test_flash3_bw_compatibility() -> None:
         "int attention_chunk=0, bool has_softcap=False, int num_splits=0, bool? pack_gqa=None, "
         "int sm_margin=0) -> Tensor"
     ))
+
+
+@pytest.mark.skipif(
+    torch.cuda.get_device_capability()[0] < 9,
+    reason="FA3 requires SM90+",
+)
+@pytest.mark.parametrize("use_compile", [False, True], ids=["eager", "compile"])
+def test_no_grad_forward_slice_backward_varlen(use_compile):
+    from flash_attn.flash_attn_interface import no_grad_forward_slice_backward
+
+    d_model, nhead, head_dim = 64, 4, 16
+    seq_lengths = [8, 12, 16]
+    total = sum(seq_lengths)
+    pad = 4
+    device = "cuda"
+
+    cu_seqlens = torch.tensor(
+        [0] + list(torch.tensor(seq_lengths).cumsum(0).tolist()),
+        dtype=torch.int32, device=device,
+    )
+    max_seqlen = max(seq_lengths)
+
+    linear = torch.nn.Linear(d_model, 3 * d_model, device=device, dtype=torch.float16)
+    x_padded = torch.randn(total + pad, d_model, device=device, dtype=torch.float16)
+
+    # reference, no call to no_grad_forward_slice_backward
+    linear.zero_grad()
+    qkv_ref = linear(x_padded).view(-1, nhead * 3, head_dim)
+    q_ref, k_ref, v_ref = qkv_ref.chunk(3, dim=-2)
+    out_ref = flash_attn_varlen_func(
+        q_ref, k_ref, v_ref, cu_seqlens, cu_seqlens, max_seqlen, max_seqlen,
+    )
+    loss_ref = out_ref[:cu_seqlens[-1]].abs().sum()
+
+    # poison gpu with NaNs
+    torch.cuda.empty_cache()
+    poison_shape = (total + pad, nhead, head_dim)
+    poisons = [torch.full(poison_shape, float('nan'), device=device, dtype=torch.float16)
+               for _ in range(8)]
+    del poisons
+
+    loss_ref.backward()
+    has_nan = torch.isnan(linear.weight.grad).any() or torch.isnan(linear.bias.grad).any()
+    assert has_nan
+
+    def run(x, cu_seqlens, max_seqlen):
+        qkv = linear(x).view(-1, nhead * 3, head_dim)
+        q, k, v = qkv.chunk(3, dim=-2)
+        q = no_grad_forward_slice_backward(q, cu_seqlens[-1])
+        k = no_grad_forward_slice_backward(k, cu_seqlens[-1])
+        v = no_grad_forward_slice_backward(v, cu_seqlens[-1])
+        out = flash_attn_varlen_func(
+            q, k, v, cu_seqlens, cu_seqlens, max_seqlen, max_seqlen,
+        )
+        return out
+
+    linear.zero_grad()
+    if use_compile:
+        run = torch.compile(run)
+
+    out = run(x_padded, cu_seqlens, max_seqlen)
+    loss = out[:cu_seqlens[-1]].abs().sum()
+    loss.backward()
+    assert torch.equal(loss, loss_ref)
+    assert not torch.isnan(linear.weight.grad).any()
+    assert not torch.isnan(linear.bias.grad).any()

--- a/tests/test_flash_attn.py
+++ b/tests/test_flash_attn.py
@@ -2523,3 +2523,65 @@ def test_flash_attn_varlen_deterministic(seqlen_q, seqlen_k, swap_sq_sk, d, caus
         assert torch.equal(dv, dv0)
         assert torch.equal(dk, dk0)
         assert torch.equal(dq, dq0)
+
+
+@pytest.mark.parametrize("use_compile", [False, True], ids=["eager", "compile"])
+def test_no_grad_forward_slice_backward_varlen(use_compile):
+    from flash_attn.flash_attn_interface import no_grad_forward_slice_backward
+
+    d_model, nhead, head_dim = 64, 4, 16
+    seq_lengths = [8, 12, 16]
+    total = sum(seq_lengths)
+    pad = 4
+    device = "cuda"
+
+    cu_seqlens = torch.tensor(
+        [0] + list(torch.tensor(seq_lengths).cumsum(0).tolist()),
+        dtype=torch.int32, device=device,
+    )
+    max_seqlen = max(seq_lengths)
+
+    linear = torch.nn.Linear(d_model, 3 * d_model, device=device, dtype=torch.float16)
+    x_padded = torch.randn(total + pad, d_model, device=device, dtype=torch.float16)
+
+    # reference, no call to no_grad_forward_slice_backward
+    linear.zero_grad()
+    qkv_ref = linear(x_padded).view(-1, nhead * 3, head_dim)
+    q_ref, k_ref, v_ref = qkv_ref.chunk(3, dim=-2)
+    out_ref = flash_attn_varlen_func(
+        q_ref, k_ref, v_ref, cu_seqlens, cu_seqlens, max_seqlen, max_seqlen,
+    )
+    loss_ref = out_ref[:cu_seqlens[-1]].abs().sum()
+
+    # poison gpu with NaNs
+    torch.cuda.empty_cache()
+    poison_shape = (total + pad, nhead, head_dim)
+    poisons = [torch.full(poison_shape, float('nan'), device=device, dtype=torch.float16)
+               for _ in range(8)]
+    del poisons
+
+    loss_ref.backward()
+    has_nan = torch.isnan(linear.weight.grad).any() or torch.isnan(linear.bias.grad).any()
+    assert has_nan
+
+    def run(x, cu_seqlens, max_seqlen):
+        qkv = linear(x).view(-1, nhead * 3, head_dim)
+        q, k, v = qkv.chunk(3, dim=-2)
+        q = no_grad_forward_slice_backward(q, cu_seqlens[-1])
+        k = no_grad_forward_slice_backward(k, cu_seqlens[-1])
+        v = no_grad_forward_slice_backward(v, cu_seqlens[-1])
+        out = flash_attn_varlen_func(
+            q, k, v, cu_seqlens, cu_seqlens, max_seqlen, max_seqlen,
+        )
+        return out
+
+    linear.zero_grad()
+    if use_compile:
+        run = torch.compile(run)
+
+    out = run(x_padded, cu_seqlens, max_seqlen)
+    loss = out[:cu_seqlens[-1]].abs().sum()
+    loss.backward()
+    assert torch.equal(loss, loss_ref)
+    assert not torch.isnan(linear.weight.grad).any()
+    assert not torch.isnan(linear.bias.grad).any()


### PR DESCRIPTION
**Summary**

in FA2 and FA3, gradients are initialized using torch.empty() and it uses the length of the `q, k, v`. but when using varlen attention where `q, k, v` are initialized with extra padding (ie the length > `cu_seqlens[-1]`), this results in invalid entries in the gradients remaining uninitialized which can lead to NaNs getting returned and propagating through model layers. 

as a fix, i've added an autograd function `no_grad_forward_slice_backward` and you can call as follows
 
```python
q = no_grad_forward_slice_backward(q, cu_seqlens_q[-1])
k = no_grad_forward_slice_backward(k, cu_seqlens_k[-1])
v = no_grad_forward_slice_backward(v, cu_seqlens_k[-1])
out = flash_attn_varlen_func(q, k, v, cu_seqlens_q, cu_seqlens_k, ...)
```
before you run `flash_attn_varlen_func` which zeroes out the extra padding. and since this is a user opt-in function, it doesn't add any additional unwanted overhead. 

**Testing**

i added `test_no_grad_forward_slice_backward_varlen` to both FA2 and FA3 which runs a reference forward, "poisons" the GPU with NaNs (so we guarantee dq, dk, dv are initialized with NaNs) and then i test functionality and correctness with `no_grad_forward_slice_backward`. i also add a negative test to first verify that we see NaNs in the gradients without the new autgrad function.