### PR TITLE
Fix SM80 forward+backward API drift in CuTe DSL kernels

### DIFF
--- a/flash_attn/cute/flash_bwd.py
+++ b/flash_attn/cute/flash_bwd.py
@@ -794,9 +794,10 @@ class FlashAttentionBackwardSm80:
             # Mainloop
             # ///////////////////////////////////////////////////////////////////////////////
             # Start processing of the first n-block.
-            mask = AttentionMask(self.m_block_size, self.n_block_size, seqlen.seqlen_q, seqlen.seqlen_k)
+            mask = AttentionMask(self.m_block_size, self.n_block_size, seqlen)
             mask_fn = partial(
-                mask.apply_mask, n_block=n_block, thr_mma=thr_mma_sdp,
+                mask.apply_mask, batch_idx=batch_idx, head_idx=head_idx,
+                n_block=n_block, thr_mma=thr_mma_sdp,
                 mask_seqlen=True, mask_causal=self.is_causal
             )
             smem_pipe_read_q = cutlass.Int32(0)

--- a/flash_attn/cute/flash_fwd.py
+++ b/flash_attn/cute/flash_fwd.py
@@ -631,7 +631,8 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
         """
         assert learnable_sink is None, "Learnable sink is not supported in this kernel"
         self._check_type(
-            *(t.element_type if t is not None else None for t in (mQ, mK, mV, mO, mLSE))
+            *(t.element_type if t is not None else None for t in (mQ, mK, mV, mO, mLSE)),
+            None, None, None, None,  # SM80 kernel does not support varlen
         )
         tiled_mma_qk, tiled_mma_pv = self._get_tiled_mma()
         self.num_mma_threads = tiled_mma_pv.size
@@ -729,7 +730,7 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
             window_size_right,
             qhead_per_kvhead_packgqa=self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
         )
-        seqlen = SeqlenInfoQK.create(seqlen_q_static=mQ.shape[0], seqlen_k_static=mK.shape[0])
+        seqlen = SeqlenInfoQK.create(batch_size, seqlen_q_static=mQ.shape[0], seqlen_k_static=mK.shape[0])
         n_block_min, n_block_max = block_info.get_n_block_min_max(seqlen, m_block)
         # TODO: return early if n_block_max == 0
         # if self.is_causal:
@@ -867,6 +868,7 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
             batch_idx=batch_size,
             head_idx=num_head,
             m_block=m_block,
+            seqlen=seqlen,
             aux_tensors=aux_tensors,
             fastdiv_mods=fastdiv_mods,
         )
@@ -918,14 +920,15 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
         mask = AttentionMask(
             self.tile_m,
             self.tile_n,
-            seqlen.seqlen_q,
-            seqlen.seqlen_k,
+            seqlen,
             window_size_left,
             window_size_right,
             self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
         )
         mask_fn = partial(
             mask.apply_mask,
+            batch_idx=batch_size,
+            head_idx=num_head,
             m_block=m_block,
             thr_mma=thr_mma_qk,
             mask_causal=self.is_causal,


### PR DESCRIPTION
## Summary

The SM80 base classes (`FlashAttentionForwardSm80` in `flash_fwd.py`, `FlashAttentionBackwardSm80` in `flash_bwd.py`) have 7 latent bugs where their code fell out of sync with upstream API changes to `SeqlenInfoQK`, `AttentionMask`, and `_check_type`.

**Forward** (`flash_fwd.py`, 5 fixes):
- `_check_type`: pass `None` for 4 varlen type args (signature expanded for varlen support)
- `SeqlenInfoQK.create`: pass `batch_size` as required first positional arg
- `compute_one_n_block`: pass `seqlen=` (required by `score_mod` path)
- `AttentionMask`: pass `SeqlenInfoQK` object instead of separate `seqlen_q`/`seqlen_k`
- `mask.apply_mask`: pass `batch_idx` and `head_idx` (required by `mask_mod` path)

**Backward** (`flash_bwd.py`, 2 fixes):
- `AttentionMask`: same constructor signature fix as forward
- `mask.apply_mask`: same `batch_idx`/`head_idx` fix as forward

These are all minimal one-line fixes. None of these paths are exercised by SM90/SM100 dispatch (they have their own `__call__` implementations), so this is a no-op for existing users. The SM80 classes become callable again, which is a prerequisite for SM120 support (which reuses the SM80 MMA code path).

## Test plan

- [ ] Verify no SM90/SM100 regressions (`pytest tests/cute/test_flash_attn.py`)
- [ ] Code inspection: each fix matches the current upstream API signatures of `SeqlenInfoQK.create`, `AttentionMask.__init__`, and `AttentionMask.apply_mask`

Contributed by Second Nature Computing (https://joinsecondnature.com)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>