### PR TITLE
Add Logging helper

### DIFF
--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -43,6 +43,7 @@ if os.environ.get("CUTE_DSL_PTXAS_PATH", None) is not None:
 
 
 from flash_attn.cute import utils
+from flash_attn.cute import logging as fa_logging
 from flash_attn.cute.cute_dsl_utils import (
     to_cute_tensor, to_cute_aux_tensor, get_aux_tensor_metadata, get_broadcast_dims,
 )
@@ -436,6 +437,7 @@ def _flash_attn_fwd(
         page_size not in [None, 128],  # paged KV non-TMA
         use_2cta_instrs,
         q_subtile_factor,
+        fa_logging.get_fa_log_level(),
     )
     if compile_key not in _flash_attn_fwd.compile_cache:
         (

--- a/flash_attn/cute/logging.py
+++ b/flash_attn/cute/logging.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2025, Tri Dao.
+
+"""Unified FlashAttention logging controlled by a single ``FA_LOG_LEVEL`` env var.
+
+Host-side messages go through Python ``logging`` (logger name ``flash_attn``).
+A default ``StreamHandler`` is attached automatically when ``FA_LOG_LEVEL >= 1``
+so that standalone scripts get output without extra setup; applications that
+configure their own logging can remove or replace it via the standard API.
+
+FA_LOG_LEVEL mapping::
+
+    0  off       nothing logged
+    1  host      host-side summaries only (no kernel printf)
+    2  kernel    host + curated kernel traces
+    3  max       host + all kernel traces (noisy, perf hit)
+
+Set via environment variable::
+
+    FA_LOG_LEVEL=1 python train.py
+
+Device-side ``cute.printf`` calls are compile-time eliminated via
+``cutlass.const_expr`` when the log level is below the callsite threshold,
+so there is zero performance cost when device logging is off.
+Changing the log level after kernel compilation requires a recompile
+(the level participates in the forward compile key).
+"""
+
+import logging
+import os
+import sys
+
+import cutlass.cute as cute
+from cutlass import const_expr
+
+_LOG_LEVEL_NAMES = {"off": 0, "host": 1, "kernel": 2, "max": 3}
+
+
+def _parse_log_level(raw: str) -> int:
+    if raw in _LOG_LEVEL_NAMES:
+        return _LOG_LEVEL_NAMES[raw]
+    try:
+        level = int(raw)
+    except ValueError:
+        return 0
+    return max(0, min(level, 3))
+
+
+_fa_log_level: int = _parse_log_level(os.environ.get("FA_LOG_LEVEL", "0"))
+
+_logger = logging.getLogger("flash_attn")
+_logger.addHandler(logging.NullHandler())
+_default_handler: logging.Handler | None = None
+
+
+def _configure_default_handler() -> None:
+    global _default_handler
+    if _fa_log_level >= 1:
+        if _default_handler is None:
+            _default_handler = logging.StreamHandler(sys.stdout)
+            _default_handler.setFormatter(logging.Formatter("[FA] %(message)s"))
+            _logger.addHandler(_default_handler)
+        _logger.setLevel(logging.DEBUG)
+    else:
+        if _default_handler is not None:
+            _logger.removeHandler(_default_handler)
+            _default_handler = None
+        _logger.setLevel(logging.WARNING)
+
+
+_configure_default_handler()
+
+
+def get_fa_log_level() -> int:
+    return _fa_log_level
+
+
+def set_fa_log_level(level: int | str) -> None:
+    """Set the FA log level programmatically.
+
+    Host logging takes effect immediately.  Device logging changes only
+    affect kernels compiled after this call (new compile-key selection).
+    """
+    global _fa_log_level
+    if isinstance(level, str):
+        level = _parse_log_level(level)
+    _fa_log_level = max(0, min(int(level), 3))
+    _configure_default_handler()
+
+
+def fa_log(level: int, msg: str):
+    if _fa_log_level >= level:
+        _logger.info(msg)
+
+
+def fa_printf(level: int, fmt, *args):
+    if const_expr(_fa_log_level >= level):
+        cute.printf(fmt, *args)


### PR DESCRIPTION
Stacked PRs:
 * #2326
 * #2218
 * __->__#2327


--- --- ---

Add Logging helper

For provenance, with this:

```
import os
os.environ.setdefault("FA4_CLC", "1")

import torch
from flash_attn.cute.logging import set_fa_log_level
from flash_attn.cute.interface import flash_attn_func

device = "cuda"
dtype = torch.bfloat16

q = torch.randn(2, 256, 4, 128, device=device, dtype=dtype)
k = torch.randn(2, 256, 4, 128, device=device, dtype=dtype)
v = torch.randn(2, 256, 4, 128, device=device, dtype=dtype)

for lvl in range(4):
    set_fa_log_level(lvl)
    print(f"{'='*60}")
    print(f"FA_LOG_LEVEL = {lvl}")
    print(f"{'='*60}")
    out, _ = flash_attn_func(q, k, v)
    torch.cuda.synchronize()
    print()

```

Prints 

```
python ../my_scripts/flex/logging_demo.py
============================================================
FA_LOG_LEVEL = 0
============================================================

============================================================
FA_LOG_LEVEL = 1
============================================================
[FA] use_clc_scheduler=True, TileScheduler=CLCDynamicTileScheduler, USE_2CTA=False

============================================================
FA_LOG_LEVEL = 2
============================================================
[FA] use_clc_scheduler=True, TileScheduler=CLCDynamicTileScheduler, USE_2CTA=False

============================================================
FA_LOG_LEVEL = 3
============================================================
[FA] use_clc_scheduler=True, TileScheduler=CLCDynamicTileScheduler, USE_2CTA=False
[CLC] query sm=0 cta=0 (m_blk=2,h=0,b=0,s=0) valid=0

[CLC] query sm=1 cta=0 (m_blk=2,h=0,b=0,s=0) valid=0

[CLC] query sm=147 cta=0 (m_blk=2,h=0,b=0,s=0) valid=0

[CLC] query sm=146 cta=0 (m_blk=2,h=0,b=0,s=0) valid=0

[CLC] query sm=145 cta=0 (m_blk=2,h=0,b=0,s=0) valid=0

[CLC] query sm=143 cta=0 (m_blk=2,h=0,b=0,s=0) valid=0

[CLC] query sm=144 cta=0 (m_blk=2,h=0,b=0,s=0) valid=0

[CLC] query sm=142 cta=0 (m_blk=2,h=0,b=0,s=0) valid=0

[CLC] map sm=0 cta=0/1 linear=6/8 (m_blk=0,h=2,b=1,s=0) valid=1

[CLC] map sm=147 cta=0/1 linear=5/8 (m_blk=0,h=1,b=1,s=0) valid=1

[CLC] map sm=142 cta=0/1 linear=0/8 (m_blk=0,h=0,b=0,s=0) valid=1

[CLC] map sm=1 cta=0/1 linear=7/8 (m_blk=0,h=3,b=1,s=0) valid=1

[CLC] map sm=146 cta=0/1 linear=4/8 (m_blk=0,h=0,b=1,s=0) valid=1

[CLC] map sm=144 cta=0/1 linear=2/8 (m_blk=0,h=2,b=0,s=0) valid=1

[CLC] map sm=143 cta=0/1 linear=1/8 (m_blk=0,h=1,b=0,s=0) valid=1

[CLC] map sm=145 cta=0/1 linear=3/8 (m_blk=0,h=3,b=0,s=0) valid=1

[CLC] pull sm=144 cta=0/1 linear=2/8 (m_blk=2,h=0,b=0,s=0) valid=0

[CLC] pull sm=146 cta=0/1 linear=2/8 (m_blk=2,h=0,b=0,s=0) valid=0

[CLC] pull sm=1 cta=0/1 linear=2/8 (m_blk=2,h=0,b=0,s=0) valid=0

[CLC] pull sm=0 cta=0/1 linear=2/8 (m_blk=2,h=0,b=0,s=0) valid=0

[CLC] pull sm=147 cta=0/1 linear=2/8 (m_blk=2,h=0,b=0,s=0) valid=0

[CLC] pull sm=145 cta=0/1 linear=2/8 (m_blk=2,h=0,b=0,s=0) valid=0

[CLC] pull sm=142 cta=0/1 linear=2/8 (m_blk=2,h=0,b=0,s=0) valid=0

[CLC] pull sm=143 cta=0/1 linear=2/8 (m_blk=2,h=0,b=0,s=0) valid=0


~/meta/clc clc *21 ❯                                                                        13s  clc dev@gpu-dev-796fc59d
```