### PR TITLE
fix: duplicate softmax_scale param

### DIFF
--- a/flash_attn/cute/flash_fwd.py
+++ b/flash_attn/cute/flash_fwd.py
@@ -617,7 +617,6 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
         mV: cute.Tensor,
         mO: cute.Tensor,
         mLSE: Optional[cute.Tensor],
-        softmax_scale: Float32,
         stream: cuda.CUstream,
         softmax_scale: Optional[Float32] = None,
         mCuSeqlensQ: Optional[cute.Tensor] = None,


### PR DESCRIPTION
Small regression from PR #2297

Caught this while trying FA4 on H100. Keeping the Optional one following other interface APIs.
