### PR TITLE
[cutlass] Allow compilation of cutlass FA3 for sm100 via enable_sm90

### DIFF
--- a/hopper/flash_bwd_launch_template.h
+++ b/hopper/flash_bwd_launch_template.h
@@ -100,7 +100,7 @@ void run_flash_bwd(Flash_bwd_params &params, cudaStream_t stream) {
     >;
     using AttnKernel = std::conditional_t<
         Arch >= 90,
-        flash::enable_sm9x<flash::FlashAttnBwdSm90<CollectiveMainloop, CollectiveEpilogue, Scheduler>>,
+        flash::enable_sm90<flash::FlashAttnBwdSm90<CollectiveMainloop, CollectiveEpilogue, Scheduler>>,
         flash::enable_sm80_to_sm89<flash::FlashAttnBwdSm80<CollectiveMainloop, CollectiveEpilogue, Scheduler>>
     >;
 

--- a/hopper/flash_fwd_launch_template.h
+++ b/hopper/flash_fwd_launch_template.h
@@ -76,7 +76,7 @@ void run_flash_fwd(Flash_fwd_params &params, cudaStream_t stream) {
     using Scheduler = std::conditional_t<!UsePersistentScheduler, SchedulerSingleTile, SchedulerPersistent>;
     using AttnKernel = std::conditional_t<
         Arch >= 90,
-        flash::enable_sm9x<flash::FlashAttnFwdSm90<CollectiveMainloop, CollectiveEpilogue, Scheduler>>,
+        flash::enable_sm90<flash::FlashAttnFwdSm90<CollectiveMainloop, CollectiveEpilogue, Scheduler>>,
         flash::enable_sm80_to_sm89<flash::FlashAttnFwdSm80<CollectiveMainloop, CollectiveEpilogue, Scheduler>>
     >;
 

--- a/hopper/utils.h
+++ b/hopper/utils.h
@@ -34,10 +34,10 @@ using namespace cute;
 // reduce the size of the compiled binary.
 // Adapted from https://github.com/vllm-project/vllm/blob/4d29e91be84d27ca313d657eee92c067439a4c23/csrc/quantization/cutlass_w8a8/scaled_mm_c2x.cuh#L55
 template <typename Kernel>
-struct enable_sm9x : Kernel {
+struct enable_sm90 : Kernel {
     template <typename... Args>
     CUTLASS_DEVICE void operator()(Args&&... args) {
-#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900) && (__CUDA_ARCH__ < 1000)
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ == 900)
         Kernel::operator()(std::forward<Args>(args)...);
 #endif
     }


### PR DESCRIPTION
Rename enable_sm90_or_later to enable_sm90 and restrict the arch guard from `__CUDA_ARCH__ == 900` to `__CUDA_ARCH__ == 900`.

FA3's sm90 kernels use CUTLASS GMMA (wgmma) instructions that are gated behind CUTE_ARCH_MMA_SM90A_ENABLED, which requires `__CUDA_ARCH__ == 900` (exact match). On sm100 (Blackwell), these instructions are not available and the code paths fall into CUTE_INVALID_CONTROL_PATH traps.

By restricting the guard to == 900, the kernel body becomes dead code on sm100, allowing FA3 to compile cleanly for all default architectures (sm80 + sm90a + sm100a) in a single fat binary without needing to hardcode -gencode flags. This mirrors the existing enable_sm80_to_sm89 pattern.