### PR TITLE
BUG: SeqlenInfo.create has a tile parameter that defaults to 128

### DIFF
--- a/flash_attn/cute/flash_bwd_preprocess.py
+++ b/flash_attn/cute/flash_bwd_preprocess.py
@@ -213,7 +213,7 @@ class FlashAttentionBackwardPreprocess:
             # ///////////////////////////////////////////////////////////////////////////////
             # Get the appropriate tiles for this thread block.
             # ///////////////////////////////////////////////////////////////////////////////
-            seqlen = SeqlenInfo.create(batch_idx, mO.shape[1], mCuSeqlensQ, mSeqUsedQ)
+            seqlen = SeqlenInfo.create(batch_idx, mO.shape[1], mCuSeqlensQ, mSeqUsedQ, tile=self.tile_m)
             mO_cur = seqlen.offset_batch(mO, batch_idx, dim=0)[None, head_idx, None]
             mdO_cur = seqlen.offset_batch(mdO, batch_idx, dim=0)[None, head_idx, None]
             offset_padded = None if const_expr(not seqlen.has_cu_seqlens) else seqlen.offset_padded


### PR DESCRIPTION
# Details

Line 216 flash_bwd_preprocess.py

```python
            seqlen = SeqlenInfo.create(batch_idx, mO.shape[1], mCuSeqlensQ, mSeqUsedQ)
```

SeqlenInfo.create has a tile parameter that defaults to 128:

```python
    def create(
        batch_idx: Int32,
        seqlen_static: Int32,
        cu_seqlens: Optional[cute.Tensor] = None,
        seqused: Optional[cute.Tensor] = None,
        tile: cutlass.Constexpr[int] = 128,
     )
```

This tile is used to compute offset_padded:

seqlen_info.py Line 35-26
```python
            else cute.assume((offset + batch_idx * tile) // tile * tile, divby=tile)
```

But the preprocess kernel's actual tile size is self.tile_m, which for SM90 with head_dim <= 64 is 64 (set at interface.py:856-858). The buffer dq_accum is allocated in interface.py:956-960 using m_block_size=64:

interface.py Line 956-960
```python
        total_q_rounded_padded = (
            (total_q + cu_seqlens_q.shape[0] * m_block_size - 1) // m_block_size * m_block_size
        )
        dq_accum = torch.empty(
            num_head, total_q_rounded_padded * head_dim_rounded, ...
```

The buffer is padded assuming 64-token tiles, but the preprocess kernel computes offsets assuming 128-token tiles. With enough batches, the 128-aligned offset exceeds the 64-aligned buffer.

This makes the preprocess kernel use the same padding alignment as the buffer allocation.
The same pattern when audited in the lse_log2 and dpsum  also use offset_padded from the same SeqlenInfo — but their allocations in interface.py:962-963 also use m_block_size, so fixing the SeqlenInfo.create call fixes all three.

# Validation
- compute-sanitizer: Verified 0 invalid global writes after the fix (down from 5+ consistent OOB writes on the crashing configs).
- Gradient Stability: Resolves the NaN/inf gradient norms observed at smaller batch sizes where the OOB write was previously corrupting adjacent GPU memory without triggering a segfault.
- Matrix Testing: Verified stability across GQA (16:2, 8:1), MHA, MQA, head_dim 64/128, causal/non-causal, and swept batch sizes from 1 to 64 without triggering illegal address errors.


# Reproduction Script 
_generated using Gemini_

```python
"""
Minimal repro: single-layer attention using CuTE DSL flash_attn_varlen_func backward.
Mirrors the Qwen3-TTS Talker config: head_dim=64, num_heads=16, num_kv_heads=2 (GQA 8:1).
"""

import torch
import torch.nn as nn

from flash_attn.cute import flash_attn_varlen_func


def make_varlen_inputs(
    batch_size: int,
    num_heads_q: int,
    num_heads_kv: int,
    head_dim: int,
    min_seqlen: int,
    max_seqlen: int,
    dtype: torch.dtype = torch.bfloat16,
    device: str = "cuda",
):
    seqlens = torch.randint(min_seqlen, max_seqlen + 1, (batch_size,))
    cu_seqlens = torch.cat([torch.zeros(1, dtype=torch.int32), seqlens.cumsum(0).to(torch.int32)])
    total = cu_seqlens[-1].item()
    max_s = seqlens.max().item()
    cu_seqlens = cu_seqlens.to(device)

    q = torch.randn(total, num_heads_q, head_dim, device=device, dtype=dtype, requires_grad=True)
    k = torch.randn(total, num_heads_kv, head_dim, device=device, dtype=dtype, requires_grad=True)
    v = torch.randn(total, num_heads_kv, head_dim, device=device, dtype=dtype, requires_grad=True)
    return q, k, v, cu_seqlens, max_s


class SingleAttentionLayer(nn.Module):
    def __init__(self, hidden_size: int, num_heads: int, num_kv_heads: int):
        super().__init__()
        self.num_heads = num_heads
        self.num_kv_heads = num_kv_heads
        self.head_dim = hidden_size // num_heads
        self.hidden_size = hidden_size

        self.q_proj = nn.Linear(hidden_size, num_heads * self.head_dim, bias=False)
        self.k_proj = nn.Linear(hidden_size, num_kv_heads * self.head_dim, bias=False)
        self.v_proj = nn.Linear(hidden_size, num_kv_heads * self.head_dim, bias=False)
        self.o_proj = nn.Linear(num_heads * self.head_dim, hidden_size, bias=False)

    def forward(self, x, cu_seqlens, max_seqlen):
        q = self.q_proj(x).view(-1, self.num_heads, self.head_dim)
        k = self.k_proj(x).view(-1, self.num_kv_heads, self.head_dim)
        v = self.v_proj(x).view(-1, self.num_kv_heads, self.head_dim)

        out, _ = flash_attn_varlen_func(
            q, k, v,
            cu_seqlens_q=cu_seqlens,
            cu_seqlens_k=cu_seqlens,
            max_seqlen_q=max_seqlen,
            max_seqlen_k=max_seqlen,
            causal=True,
            softmax_scale=self.head_dim ** -0.5,
        )

        out = out.view(-1, self.num_heads * self.head_dim)
        return self.o_proj(out)


def main():
    torch.manual_seed(42)
    device = "cuda"
    dtype = torch.bfloat16

    hidden_size = 1024
    num_heads = 16
    num_kv_heads = 2
    head_dim = hidden_size // num_heads  # 64

    print(f"Config: hidden={hidden_size}, heads={num_heads}, kv_heads={num_kv_heads}, "
          f"head_dim={head_dim}, GQA ratio={num_heads // num_kv_heads}:1")

    model = SingleAttentionLayer(hidden_size, num_heads, num_kv_heads).to(device, dtype)
    optimizer = torch.optim.AdamW(model.parameters(), lr=1e-4)

    num_steps = 10
    for step in range(num_steps):
        batch_size = torch.randint(1, 5, (1,)).item()
        min_sl = 32
        max_sl = 256

        q, k, v, cu_seqlens, max_s = make_varlen_inputs(
            batch_size, num_heads, num_kv_heads, head_dim,
            min_sl, max_sl, dtype, device,
        )
        total_tokens = q.shape[0]

        x = torch.randn(total_tokens, hidden_size, device=device, dtype=dtype)

        optimizer.zero_grad()

        out = model(x, cu_seqlens, max_s)
        loss = out.sum()

        print(f"Step {step}: batch_size={batch_size}, total_tokens={total_tokens}, "
              f"max_seqlen={max_s}, loss={loss.item():.4f} ... ", end="", flush=True)

        loss.backward()
        optimizer.step()

        print("OK")

    print("\nAll steps completed successfully — CuTE DSL varlen backward is working.")


    print("\n--- Direct Q/K/V grad test (no linear layers) ---")
    for step in range(5):
        batch_size = torch.randint(1, 8, (1,)).item()
        q, k, v, cu_seqlens, max_s = make_varlen_inputs(
            batch_size, num_heads, num_kv_heads, head_dim,
            16, 512, dtype, device,
        )

        out, _ = flash_attn_varlen_func(
            q, k, v,
            cu_seqlens_q=cu_seqlens,
            cu_seqlens_k=cu_seqlens,
            max_seqlen_q=max_s,
            max_seqlen_k=max_s,
            causal=True,
            softmax_scale=head_dim ** -0.5,
        )

        grad_out = torch.randn_like(out)
        out.backward(grad_out)

        has_nan = q.grad.isnan().any() or k.grad.isnan().any() or v.grad.isnan().any()
        print(f"  Direct step {step}: batch={batch_size}, tokens={q.shape[0]}, "
              f"max_s={max_s}, dQ norm={q.grad.norm():.4f}, "
              f"dK norm={k.grad.norm():.4f}, dV norm={v.grad.norm():.4f}, "
              f"NaN={'YES' if has_nan else 'no'}")

    print("\nDone.")


if __name__ == "__main__":
    main()
```

