### PR TITLE
[Fwd,SM100,CuTe] Fix split KV OOM with diff headdim + fix SM100 kwarg mismatch

### DIFF
--- a/flash_attn/cute/flash_fwd_sm100.py
+++ b/flash_attn/cute/flash_fwd_sm100.py
@@ -274,7 +274,7 @@ class FlashAttentionForwardSm100:
             self.head_dim_padded == 192 and self.head_dim_v_padded == 128 and self.kv_stage == 3
         )
         self.uneven_kv_smem_offset = (
-            self.m_block_size * (self.head_dim_padded - self.head_dim_v_padded) // 2
+            self.n_block_size * (self.head_dim_padded - self.head_dim_v_padded) // 2
             if self.uneven_kv_smem
             else 0
         )

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -387,18 +387,24 @@ def _flash_attn_fwd(
     else:
         q_stage = 1
 
+    m_block_size_effective = q_stage * tile_m
+    seqlen_k_loaded = max_seqlen_k if not local else max(0, min(max_seqlen_k, window_size_right + window_size_left + 1 + tile_m))
+    num_m_blocks = (seqlen_q_packgqa + m_block_size_effective - 1) // m_block_size_effective
+    total_mblocks = batch_size * num_head_kv * num_m_blocks
+    num_n_blocks = (seqlen_k_loaded + tile_n - 1) // tile_n
+    num_SMs = torch.cuda.get_device_properties(device).multi_processor_count
     if num_splits < 1:
-        m_block_size_effective = q_stage * tile_m
-        seqlen_k_loaded = max_seqlen_k if not local else max(0, min(max_seqlen_k, window_size_right + window_size_left + 1 + tile_m))
-        num_n_blocks = (seqlen_k_loaded + tile_n - 1) // tile_n
-        num_m_blocks = (seqlen_q_packgqa + m_block_size_effective - 1) // m_block_size_effective
-        total_mblocks = batch_size * num_head_kv * num_m_blocks
-        num_splits = num_splits_heuristic(
-            total_mblocks,
-            torch.cuda.get_device_properties(device).multi_processor_count,
-            num_n_blocks,
-            128,
-        )
+        num_splits = num_splits_heuristic(total_mblocks, num_SMs, num_n_blocks, 128)
+
+    # SplitKV uses float32 partial output, which doubles the O buffer size
+    # in shared memory, causing OOM for diff-headdim (192, 128)
+    if arch // 10 in [10, 11] and head_dim != head_dim_v and num_splits > 1:
+        if num_n_blocks >= 64:
+            tile_n = 64
+            num_n_blocks = (seqlen_k_loaded + tile_n - 1) // tile_n
+            num_splits = num_splits_heuristic(total_mblocks, num_SMs, num_n_blocks, 128)
+        else:
+            num_splits = 1
 
     is_split_kv = num_splits > 1
     if is_split_kv:
@@ -583,8 +589,8 @@ def _flash_attn_fwd(
                 is_local=local,
                 is_split_kv=is_split_kv,
                 pack_gqa=pack_gqa,
-                tile_m=tile_m,
-                tile_n=tile_n,
+                m_block_size=tile_m,
+                n_block_size=tile_n,
                 q_stage=q_stage,
                 is_persistent=not causal
                     and not local


### PR DESCRIPTION
Using split KV with diff headdim (e.g. 192/128 for DeepSeek MLA prefill) exceeds SMEM due to float32 partial output doubling the O buffer size. This PR reduces tile size or disables splitting in that case, with a heuristic to ensure optimal performance.

Also fixes a bug introduced in 99d0148f where the SM100 constructor is called with `tile_m`/`tile_n` instead of `m_block_size`/`n_block_size`, which would cause a `TypeError`.

This change has been applied to [vLLM's FA fork](https://github.com/vllm-project/flash-attention) via https://github.com/vllm-project/flash-attention/pull/123 and https://github.com/vllm-project/flash-attention/pull/126 to enable using FA4 for MLA prefill in vLLM (https://github.com/vllm-project/vllm/pull/34732). This PR applies the fix upstream.

Benchmarking performed using vLLM attention benchmark tool:
<img width="625" height="971" alt="559494626-b96cdd34-9c9a-4a27-95ee-73f437e5d80d" src="https://github.com/user-attachments/assets/d2ff23b1-3203-4790-8083-09af3ee4ed2c" />
