### PR TITLE
[Bwd, SM80] Fix tdKrdS typo

### DIFF
--- a/flash_attn/cute/flash_bwd.py
+++ b/flash_attn/cute/flash_bwd.py
@@ -986,7 +986,7 @@ class FlashAttentionBackwardSm80:
 
         # MMA dK
         if cutlass.const_expr(self.Mma_dKV_is_RS):
-            tdVrP = layout_utils.reshape_acc_to_frgA(rdS)
+            tdKrdS = layout_utils.reshape_acc_to_frgA(rdS)
         else:
             tdKrdS = mma_params.tdKrdS
         sm80_utils.gemm(


### PR DESCRIPTION
The Mma_dKV_is_RS branch incorrectly assigned to `tdVrP` instead of `tdKrdS`, leaving `tdKrdS` unbound when the subsequent gemm uses it.

https://github.com/Dao-AILab/flash-attention/commit/b735ef24c2998848b0fa629456dc1bc38ddd3ddd