### PR TITLE
[ROCm] Auto-detect Triton backend if C++ extension is missing

### DIFF
--- a/flash_attn/flash_attn_interface.py
+++ b/flash_attn/flash_attn_interface.py
@@ -5,6 +5,7 @@ from typing import Optional, Sequence, Tuple, Union
 import torch
 import torch.nn as nn
 import os
+import warnings
 
 # isort: off
 # We need to import the CUDA kernels after importing torch
@@ -13,6 +14,7 @@ if not USE_TRITON_ROCM and getattr(torch.version, 'hip', None) is not None:
     try:
         import flash_attn_2_cuda
     except ImportError:
+        warnings.warn("flash_attn_2_cuda (which has ROCm/HIP kernels) not found, falling back to Triton implementation")
         USE_TRITON_ROCM = True
 
 if USE_TRITON_ROCM:

--- a/hopper/flash_attn_interface.py
+++ b/hopper/flash_attn_interface.py
@@ -5,6 +5,7 @@ from typing import Optional, Union, List, Tuple
 import os
 import torch
 import torch.nn as nn
+import warnings
 
 
 USE_TRITON_ROCM = os.getenv("FLASH_ATTENTION_TRITON_AMD_ENABLE", "FALSE") == "TRUE"
@@ -12,6 +13,7 @@ if not USE_TRITON_ROCM and getattr(torch.version, 'hip', None) is not None:
     try:
         import flash_attn_3._C
     except ImportError:
+        warnings.warn("flash_attn_3._C (which has ROCm/HIP kernels) not found, falling back to Triton implementation")
         USE_TRITON_ROCM = True
 
 if USE_TRITON_ROCM:
@@ -23,7 +25,7 @@ else:
 
     # isort: on
 
-    flash_attn_3_gpu = torch.ops.flash_attn_3_gpu
+    flash_attn_3_gpu = torch.ops.flash_attn_3
 
 def maybe_contiguous(x):
     return x.contiguous() if x is not None and x.stride(-1) != 1 else x


### PR DESCRIPTION
On AMD/ROCm systems, especially with RDNA-based GPUs (where only the Triton backend is supported), it's currently necessary to manually set `FLASH_ATTENTION_TRITON_AMD_ENABLE=TRUE`. This change implements a fallback that automatically switches to the Triton backend if it's a HIP system and the main C++ extension (`flash_attn_2_cuda`) is not available. Tested on gfx1201.