### PR TITLE
fix the create_ragged_tensor_for_tma issue

### DIFF
--- a/flash_attn/cute/pyproject.toml
+++ b/flash_attn/cute/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "typing_extensions",
     "apache-tvm-ffi>=0.1.5,<0.2",
     "torch-c-dlpack-ext",
-    "quack-kernels>=0.2.10",
+    "quack-kernels>=0.3.0",
     "setuptools",
 ]
 


### PR DESCRIPTION
#2344 

The quack-kernels 0.2.10 doesn't have the create_ragged_tensor_for_tma issue function in quack.utils.