### PR TITLE
Fix RuntimeError when out_ is specified in _flash_attn_forward (fix #2073)

### DIFF
--- a/hopper/flash_attn_interface.py
+++ b/hopper/flash_attn_interface.py
@@ -147,6 +147,9 @@ def _flash_attn_forward(
     if softmax_lse_accum is None:
         softmax_lse_accum = torch.tensor([], device=out.device)
 
+    if out_ is not None:
+        out = None
+
     return out, softmax_lse, out_accum, softmax_lse_accum
 
 


### PR DESCRIPTION
## Summary
This fix addresses issue #2073 by adding a check to handle the case when the out_ parameter is provided.

## Problem
When the out_ argument is specified in _flash_attn_forward, an error is raised because PyTorch custom operators cannot return an alias of an input tensor.

## Solution
Added a check: when out_ is specified, set out = None to avoid returning an alias of the input, which violates PyTorch custom operator rules.

## Error Before Fix
RuntimeError: The output of this custom operator (1) must not also be an input to this custom operator and (2) may not alias any inputs to this custom operator or other returns.

Closes #2073