### PR TITLE
[CuTe, Sm100] PackGQA for backward

### DIFF
--- a/flash_attn/cute/block_info.py
+++ b/flash_attn/cute/block_info.py
@@ -56,18 +56,19 @@ class BlockInfo:
 
     @cute.jit
     def get_m_block_min_max(self, seqlen_info: SeqlenInfoQK, n_block: Int32) -> Tuple[Int32, Int32]:
-        m_block_max = cute.ceil_div(seqlen_info.seqlen_q, self.tile_m)
+        seqlen_q_packgqa = seqlen_info.seqlen_q * self.qhead_per_kvhead_packgqa
+        m_block_max = cute.ceil_div(seqlen_q_packgqa, self.tile_m)
         m_block_min = 0
         if const_expr(self.is_causal or (self.is_local and self.window_size_right is not None)):
             n_idx_min = n_block * self.tile_n
             m_idx = n_idx_min + seqlen_info.seqlen_q - seqlen_info.seqlen_k
             m_idx_right = m_idx if const_expr(self.is_causal) else m_idx - self.window_size_right
-            m_block_min = max(m_block_min, m_idx_right // self.tile_m)
+            m_block_min = max(m_block_min, m_idx_right * self.qhead_per_kvhead_packgqa // self.tile_m)
         if const_expr(self.is_local and self.window_size_left is not None):
             n_idx_max = (n_block + 1) * self.tile_n
             m_idx = n_idx_max + seqlen_info.seqlen_q - seqlen_info.seqlen_k
             m_idx_left = m_idx + self.window_size_left
-            m_block_max = min(m_block_max, cute.ceil_div(m_idx_left, self.tile_m))
+            m_block_max = min(m_block_max, cute.ceil_div(m_idx_left * self.qhead_per_kvhead_packgqa, self.tile_m))
         return m_block_min, m_block_max
 
     @cute.jit

--- a/flash_attn/cute/block_info.py
+++ b/flash_attn/cute/block_info.py
@@ -63,12 +63,16 @@ class BlockInfo:
             n_idx_min = n_block * self.tile_n
             m_idx = n_idx_min + seqlen_info.seqlen_q - seqlen_info.seqlen_k
             m_idx_right = m_idx if const_expr(self.is_causal) else m_idx - self.window_size_right
-            m_block_min = max(m_block_min, m_idx_right * self.qhead_per_kvhead_packgqa // self.tile_m)
+            m_block_min = max(
+                m_block_min, m_idx_right * self.qhead_per_kvhead_packgqa // self.tile_m
+            )
         if const_expr(self.is_local and self.window_size_left is not None):
             n_idx_max = (n_block + 1) * self.tile_n
             m_idx = n_idx_max + seqlen_info.seqlen_q - seqlen_info.seqlen_k
             m_idx_left = m_idx + self.window_size_left
-            m_block_max = min(m_block_max, cute.ceil_div(m_idx_left * self.qhead_per_kvhead_packgqa, self.tile_m))
+            m_block_max = min(
+                m_block_max, cute.ceil_div(m_idx_left * self.qhead_per_kvhead_packgqa, self.tile_m)
+            )
         return m_block_min, m_block_max
 
     @cute.jit

--- a/flash_attn/cute/flash_bwd_postprocess.py
+++ b/flash_attn/cute/flash_bwd_postprocess.py
@@ -43,6 +43,8 @@ class FlashAttentionBackwardPostprocess:
         dQ_swapAB: bool = False,
         use_2cta_instrs: bool = False,
         cluster_size: int = 1,  # for varlen offsets
+        pack_gqa: bool = False,
+        qhead_per_kvhead: cutlass.Constexpr[int] = 1,
     ):
         """
         :param head_dim: head dimension
@@ -56,6 +58,12 @@ class FlashAttentionBackwardPostprocess:
             "Only Ampere (8.x), Hopper (9.x), and Blackwell (10.x, 11.x, 12.x) are supported"
         )
         self.arch = arch
+        self.pack_gqa = pack_gqa
+        self.qhead_per_kvhead = qhead_per_kvhead
+        if pack_gqa:
+            assert tile_m % qhead_per_kvhead == 0, (
+                "For PackGQA, tile_m must be divisible by qhead_per_kvhead"
+            )
         # padding head_dim to a multiple of 32 as k_block_size
         hdim_multiple_of = 32
         self.tile_hdim = int(math.ceil(head_dim / hdim_multiple_of) * hdim_multiple_of)
@@ -227,6 +235,24 @@ class FlashAttentionBackwardPostprocess:
 
         mdQaccum, mdQ = [assume_tensor_aligned(t) for t in (mdQaccum, mdQ)]
 
+        if const_expr(self.pack_gqa):
+            # (..., s, n, h) -> (..., (qh/kvh, s), n_kv, h)
+            shape_mdQ_packed = (
+                *mdQ.shape[:-3],
+                (self.qhead_per_kvhead, mdQ.shape[-3]),
+                mdQ.shape[-2] // self.qhead_per_kvhead,
+                mdQ.shape[-1],
+            )
+            stride_mdQ_packed = (
+                *mdQ.stride[:-3],
+                (mdQ.stride[-2], mdQ.stride[-3]),
+                mdQ.stride[-2] * self.qhead_per_kvhead,
+                mdQ.stride[-1],
+            )
+            mdQ = cute.make_tensor(
+                mdQ.iterator, cute.make_layout(shape_mdQ_packed, stride=stride_mdQ_packed)
+            )
+
         self.tiled_mma = self._get_tiled_mma()
         self._setup_attributes()
 
@@ -239,12 +265,12 @@ class FlashAttentionBackwardPostprocess:
             TileScheduler = SingleTileVarlenScheduler
             num_head = mdQ.shape[1]
             num_batch = mCuSeqlensQ.shape[0] - 1
-            num_block = cute.ceil_div(mdQ.shape[0], self.tile_m)
+            num_block = cute.ceil_div(cute.size(mdQ.shape[0]), self.tile_m)
         else:
             TileScheduler = SingleTileScheduler
             num_head = mdQ.shape[2]
             num_batch = mdQ.shape[0]
-            num_block = cute.ceil_div(mdQ.shape[1], self.tile_m)
+            num_block = cute.ceil_div(cute.size(mdQ.shape[1]), self.tile_m)
 
         tile_sched_args = TileSchedulerArguments(
             num_block=num_block,
@@ -254,10 +280,11 @@ class FlashAttentionBackwardPostprocess:
             seqlen_k=0,
             headdim=mdQ.shape[2],
             headdim_v=0,
-            total_q=mdQ.shape[0],
+            total_q=cute.size(mdQ.shape[0]),
             tile_shape_mn=(self.tile_m, 1),
             mCuSeqlensQ=mCuSeqlensQ,
             mSeqUsedQ=mSeqUsedQ,
+            qhead_per_kvhead_packgqa=self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
         )
 
         tile_sched_params = TileScheduler.to_underlying_arguments(tile_sched_args)
@@ -335,13 +362,14 @@ class FlashAttentionBackwardPostprocess:
 
             seqlen = SeqlenInfoQK.create(
                 batch_idx,
-                mdQ.shape[1],
+                mdQ.shape[-3] if const_expr(not self.pack_gqa) else mdQ.shape[-3][1],
                 0,
                 mCuSeqlensQ=mCuSeqlensQ,
                 mCuSeqlensK=None,
                 mSeqUsedQ=mSeqUsedQ,
                 mSeqUsedK=None,
                 tile_m=self.tile_m * self.cluster_size,
+                qhead_per_kvhead_packgqa=self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
             )
             if const_expr(not seqlen.has_cu_seqlens_q):
                 mdQ_cur = mdQ[batch_idx, None, head_idx, None]
@@ -349,7 +377,8 @@ class FlashAttentionBackwardPostprocess:
                 head_dim = mdQ.shape[3]
             else:
                 padded_offset_q = seqlen.padded_offset_q
-                mdQ_cur = cute.domain_offset((seqlen.offset_q, 0), mdQ[None, head_idx, None])
+                dq_offset = (seqlen.offset_q, 0) if const_expr(not self.pack_gqa) else ((0, seqlen.offset_q), 0)
+                mdQ_cur = cute.domain_offset(dq_offset, mdQ[None, head_idx, None])
                 mdQaccum_cur = cute.domain_offset(
                     (padded_offset_q * self.tile_hdim,), mdQaccum[head_idx, None]
                 )
@@ -370,7 +399,7 @@ class FlashAttentionBackwardPostprocess:
             gdQaccum = cute.local_tile(mdQaccum_cur, (self.tile_m * self.tile_hdim,), (m_block,))
             gdQ = cute.local_tile(mdQ_cur, (self.tile_m, self.tile_hdim), (m_block, 0))
 
-            seqlen_q = seqlen.seqlen_q
+            seqlen_q = seqlen.seqlen_q * (self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1)
             seqlen_q_rounded = cute.round_up(seqlen_q, self.tile_m)
 
             if const_expr(self.arch // 10 in [10, 11] and self.use_2cta_instrs):

--- a/flash_attn/cute/flash_bwd_postprocess.py
+++ b/flash_attn/cute/flash_bwd_postprocess.py
@@ -377,7 +377,11 @@ class FlashAttentionBackwardPostprocess:
                 head_dim = mdQ.shape[3]
             else:
                 padded_offset_q = seqlen.padded_offset_q
-                dq_offset = (seqlen.offset_q, 0) if const_expr(not self.pack_gqa) else ((0, seqlen.offset_q), 0)
+                dq_offset = (
+                    (seqlen.offset_q, 0)
+                    if const_expr(not self.pack_gqa)
+                    else ((0, seqlen.offset_q), 0)
+                )
                 mdQ_cur = cute.domain_offset(dq_offset, mdQ[None, head_idx, None])
                 mdQaccum_cur = cute.domain_offset(
                     (padded_offset_q * self.tile_hdim,), mdQaccum[head_idx, None]

--- a/flash_attn/cute/flash_bwd_preprocess.py
+++ b/flash_attn/cute/flash_bwd_preprocess.py
@@ -226,7 +226,7 @@ class FlashAttentionBackwardPreprocess:
         mPdPsum = layout_utils.select(mPdPsum, transpose)
         if const_expr(mLSE is not None):
             mLSE = layout_utils.select(mLSE, transpose)
-            mLSElog2 = layout_utils.select(mLSElog2, transpose) 
+            mLSElog2 = layout_utils.select(mLSElog2, transpose)
         if const_expr(mdLSE is not None):
             mdLSE = layout_utils.select(mdLSE, transpose)
         if const_expr(mdQaccum is not None):

--- a/flash_attn/cute/flash_bwd_preprocess.py
+++ b/flash_attn/cute/flash_bwd_preprocess.py
@@ -44,6 +44,8 @@ class FlashAttentionBackwardPreprocess:
         tile_m: int = 128,
         num_threads: int = 256,
         use_padded_offsets: bool = True,
+        qhead_per_kvhead: cutlass.Constexpr[int] = 1,
+        pack_gqa: bool = False,
     ):
         """
         All contiguous dimensions must be at least 16 bytes aligned which indicates the head dimension
@@ -59,6 +61,12 @@ class FlashAttentionBackwardPreprocess:
         self.use_pdl = BaseDSL._get_dsl().get_arch_enum() >= Arch.sm_90a
         self.dtype = dtype
         self.tile_m = tile_m
+        self.pack_gqa = pack_gqa
+        self.qhead_per_kvhead = qhead_per_kvhead
+        if pack_gqa:
+            assert tile_m % qhead_per_kvhead == 0, (
+                "For PackGQA, tile_m must be divisible by qhead_per_kvhead"
+            )
         # padding head_dim to a multiple of 32 as k_block_size
         hdim_multiple_of = 32
         self.head_dim_padded = int(math.ceil(head_dim / hdim_multiple_of) * hdim_multiple_of)
@@ -159,6 +167,58 @@ class FlashAttentionBackwardPreprocess:
             if const_expr(mdLSE.element_type not in [Float32]):
                 raise TypeError("dLSE tensor must be Float32")
 
+        if const_expr(self.pack_gqa):
+            # (..., s, h, d) --> (..., (qhead_per_kvhead, s), h//qhead_per_kvhead, d)
+            shape_O_packed = (
+                *mO.shape[:-3],
+                (self.qhead_per_kvhead, mO.shape[-3]),
+                mO.shape[-2] // self.qhead_per_kvhead,
+                mO.shape[-1],
+            )
+            stride_O_packed = (
+                *mO.stride[:-3],
+                (mO.stride[-2], mO.stride[-3]),
+                mO.stride[-2] * self.qhead_per_kvhead,
+                mO.stride[-1],
+            )
+            mO = cute.make_tensor(
+                mO.iterator, cute.make_layout(shape_O_packed, stride=stride_O_packed)
+            )
+            mdO = cute.make_tensor(
+                mdO.iterator, cute.make_layout(shape_O_packed, stride=stride_O_packed)
+            )
+
+            if const_expr(mLSE is not None):
+                # (..., h, s) --> (..., h//qhead_per_kvhead, (qhead_per_kvhead, s))
+                shape_LSE_packed = (
+                    *mLSE.shape[:-2],
+                    mLSE.shape[-2] // self.qhead_per_kvhead,
+                    (self.qhead_per_kvhead, mLSE.shape[-1]),
+                )
+                stride_LSE_packed = (
+                    *mLSE.stride[:-2],
+                    mLSE.stride[-2] * self.qhead_per_kvhead,
+                    (mLSE.stride[-2], mLSE.stride[-1]),
+                )
+                mLSE = cute.make_tensor(
+                    mLSE.iterator, cute.make_layout(shape_LSE_packed, stride=stride_LSE_packed)
+                )
+
+            if const_expr(mdLSE is not None):
+                shape_dLSE_packed = (
+                    *mdLSE.shape[:-2],
+                    mdLSE.shape[-2] // self.qhead_per_kvhead,
+                    (self.qhead_per_kvhead, mdLSE.shape[-1]),
+                )
+                stride_dLSE_packed = (
+                    *mdLSE.stride[:-2],
+                    mdLSE.stride[-2] * self.qhead_per_kvhead,
+                    (mdLSE.stride[-2], mdLSE.stride[-1]),
+                )
+                mdLSE = cute.make_tensor(
+                    mdLSE.iterator, cute.make_layout(shape_dLSE_packed, stride=stride_dLSE_packed)
+                )
+
         self._setup_attributes()
 
         # (batch, nheads, seqlen) -> (seqlen, nheads, batch) or (total_q, nheads) -> (nheads, total_q)
@@ -166,7 +226,7 @@ class FlashAttentionBackwardPreprocess:
         mPdPsum = layout_utils.select(mPdPsum, transpose)
         if const_expr(mLSE is not None):
             mLSE = layout_utils.select(mLSE, transpose)
-            mLSElog2 = layout_utils.select(mLSElog2, transpose)
+            mLSElog2 = layout_utils.select(mLSElog2, transpose) 
         if const_expr(mdLSE is not None):
             mdLSE = layout_utils.select(mdLSE, transpose)
         if const_expr(mdQaccum is not None):
@@ -182,17 +242,18 @@ class FlashAttentionBackwardPreprocess:
             num_batch = mO.shape[0]
 
         tile_sched_args = TileSchedulerArguments(
-            num_block=cute.ceil_div(mO.shape[1], self.tile_m),
+            num_block=cute.ceil_div(cute.size(mO.shape[1]), self.tile_m),
             num_head=num_head,
             num_batch=num_batch,
             num_splits=1,
             seqlen_k=0,
             headdim=0,
             headdim_v=mO.shape[2],
-            total_q=mO.shape[0],
+            total_q=cute.size(mO.shape[0]),
             tile_shape_mn=(self.tile_m, 1),
             mCuSeqlensQ=mCuSeqlensQ,
             mSeqUsedQ=mSeqUsedQ,
+            qhead_per_kvhead_packgqa=self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
         )
 
         tile_sched_params = TileScheduler.to_underlying_arguments(tile_sched_args)
@@ -256,27 +317,39 @@ class FlashAttentionBackwardPreprocess:
             # Get the appropriate tiles for this thread block.
             # ///////////////////////////////////////////////////////////////////////////////
             seqlen = SeqlenInfo.create(
-                batch_idx, mO.shape[1], mCuSeqlensQ, mSeqUsedQ, tile=self.tile_m
+                batch_idx,
+                mO.shape[-3] if const_expr(not self.pack_gqa) else mO.shape[-3][1],
+                mCuSeqlensQ,
+                mSeqUsedQ,
+                tile=self.tile_m,
+                qhead_per_kvhead_packgqa=self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
             )
-            mO_cur = seqlen.offset_batch(mO, batch_idx, dim=0)[None, head_idx, None]
-            mdO_cur = seqlen.offset_batch(mdO, batch_idx, dim=0)[None, head_idx, None]
+            if const_expr(not seqlen.has_cu_seqlens):
+                mO_cur = mO[batch_idx, None, head_idx, None]
+                mdO_cur = mdO[batch_idx, None, head_idx, None]
+            else:
+                seq_off = seqlen.offset if const_expr(not self.pack_gqa) else (0, seqlen.offset)
+                mO_cur = cute.domain_offset((seq_off, 0), mO[None, head_idx, None])
+                mdO_cur = cute.domain_offset((seq_off, 0), mdO[None, head_idx, None])
             # Stats buffers (dpsum/lse_log2) are always consumed with padded q-offsets
             # on the generic backward path (mdQaccum is present). Keep dedicated hd256
             # behavior controlled by self.use_padded_offsets.
             stats_use_padded_offsets = self.use_padded_offsets
-            if const_expr(mdQaccum is not None):
-                stats_use_padded_offsets = True
-            mPdPsum_cur = seqlen.offset_batch(
-                mPdPsum, batch_idx, dim=2, padded=stats_use_padded_offsets
-            )[None, head_idx]
+            mPdPsum_cur = seqlen.offset_batch(mPdPsum, batch_idx, dim=2, padded=True)[
+                None, head_idx
+            ]
             headdim_v = mO_cur.shape[cute.rank(mO_cur) - 1]
-            seqlen_q = seqlen.seqlen
+            seqlen_q = seqlen.seqlen * (self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1)
             seqlen_q_rounded = cute.round_up(seqlen_q, self.tile_m)
             seqlen_limit = seqlen_q - m_block * self.tile_m
 
             lse = None
             if const_expr(mLSE is not None):
-                mLSE_cur = seqlen.offset_batch(mLSE, batch_idx, dim=2)[None, head_idx]
+                if const_expr(not seqlen.has_cu_seqlens):
+                    mLSE_cur = mLSE[None, head_idx, batch_idx]
+                else:
+                    lse_off = seqlen.offset if const_expr(not self.pack_gqa) else (0, seqlen.offset)
+                    mLSE_cur = cute.domain_offset((lse_off,), mLSE[head_idx, None])
                 gLSE = cute.local_tile(mLSE_cur, (self.tile_m,), (m_block,))
                 lse = Float32.inf
                 if tidx < seqlen_limit:
@@ -327,7 +400,11 @@ class FlashAttentionBackwardPreprocess:
             # If dLSE is provided, compute D' = D - dLSE (see module docstring for derivation).
             gdLSE = None
             if const_expr(mdLSE is not None):
-                mdLSE_cur = seqlen.offset_batch(mdLSE, batch_idx, dim=2)[None, head_idx]
+                if const_expr(not seqlen.has_cu_seqlens):
+                    mdLSE_cur = mdLSE[None, head_idx, batch_idx]
+                else:
+                    dlse_off = seqlen.offset if const_expr(not self.pack_gqa) else (0, seqlen.offset)
+                    mdLSE_cur = cute.domain_offset((dlse_off,), mdLSE[head_idx, None])
                 gdLSE = cute.local_tile(mdLSE_cur, (self.tile_m,), (m_block,))
 
             # Write PdPsum from rmem -> gmem

--- a/flash_attn/cute/flash_bwd_preprocess.py
+++ b/flash_attn/cute/flash_bwd_preprocess.py
@@ -348,8 +348,9 @@ class FlashAttentionBackwardPreprocess:
                 if const_expr(not seqlen.has_cu_seqlens):
                     mLSE_cur = mLSE[None, head_idx, batch_idx]
                 else:
-                    lse_off = seqlen.offset if const_expr(not self.pack_gqa) else (0, seqlen.offset)
-                    mLSE_cur = cute.domain_offset((lse_off,), mLSE[head_idx, None])
+                    mLSE_cur = seqlen.offset_batch(mLSE, batch_idx, dim=2, padded=False)[
+                        None, head_idx
+                    ]
                 gLSE = cute.local_tile(mLSE_cur, (self.tile_m,), (m_block,))
                 lse = Float32.inf
                 if tidx < seqlen_limit:
@@ -403,8 +404,9 @@ class FlashAttentionBackwardPreprocess:
                 if const_expr(not seqlen.has_cu_seqlens):
                     mdLSE_cur = mdLSE[None, head_idx, batch_idx]
                 else:
-                    dlse_off = seqlen.offset if const_expr(not self.pack_gqa) else (0, seqlen.offset)
-                    mdLSE_cur = cute.domain_offset((dlse_off,), mdLSE[head_idx, None])
+                    mdLSE_cur = seqlen.offset_batch(mdLSE, batch_idx, dim=2, padded=False)[
+                        None, head_idx
+                    ]
                 gdLSE = cute.local_tile(mdLSE_cur, (self.tile_m,), (m_block,))
 
             # Write PdPsum from rmem -> gmem

--- a/flash_attn/cute/flash_bwd_sm100.py
+++ b/flash_attn/cute/flash_bwd_sm100.py
@@ -67,6 +67,7 @@ class FlashAttentionBackwardSm100:
         mask_mod: cutlass.Constexpr | None = None,
         has_aux_tensors: cutlass.Constexpr = False,
         subtile_factor: cutlass.Constexpr[int] = 1,
+        pack_gqa: bool = False,
     ):
         # padding head_dim to a multiple of 16 as k_block_size
         hdim_multiple_of = 16
@@ -110,7 +111,7 @@ class FlashAttentionBackwardSm100:
         self.is_causal = is_causal
         self.is_local = is_local
         self.qhead_per_kvhead = qhead_per_kvhead
-        self.pack_gqa = False
+        self.pack_gqa = pack_gqa
         self.deterministic = deterministic
         self.spt_override = spt
 
@@ -477,9 +478,8 @@ class FlashAttentionBackwardSm100:
 
         self.is_varlen_k = mCuSeqlensK is not None or mSeqUsedK is not None
         self.is_varlen_q = mCuSeqlensQ is not None or mSeqUsedQ is not None
-        self.use_tma_store = not (self.qhead_per_kvhead == 1 and mCuSeqlensK is not None)
-        # self.use_tma_store = not self.qhead_per_kvhead == 1
-        self.dKV_postprocess = self.qhead_per_kvhead > 1
+        self.dKV_postprocess = self.qhead_per_kvhead > 1 and not self.pack_gqa
+        self.use_tma_store = self.dKV_postprocess or mCuSeqlensK is None
 
         if const_expr(self.dKV_postprocess):
             assert self.dk_dtype.width == 32, "Must accumulate dK in float precision for GQA"
@@ -510,6 +510,43 @@ class FlashAttentionBackwardSm100:
         dO_transpose = [1, 0, 2, 3] if const_expr(mCuSeqlensQ is None) else [1, 0, 2]
         mdO = layout_utils.select(mdO, mode=dO_transpose)
 
+        if const_expr(self.pack_gqa):
+            # Repack Q: (s, h, n, b) -> ((qh/kvh, s), h, n_kv, b)
+            # or varlen: (t, h, n) -> ((qh/kvh, t), h, n_kv)
+            shape_Q_packed = (
+                (self.qhead_per_kvhead, mQ.shape[0]),
+                mQ.shape[1],
+                mQ.shape[2] // self.qhead_per_kvhead,
+                *mQ.shape[3:],
+            )
+            stride_Q_packed = (
+                (mQ.stride[2], mQ.stride[0]),
+                mQ.stride[1],
+                mQ.stride[2] * self.qhead_per_kvhead,
+                *mQ.stride[3:],
+            )
+            mQ = cute.make_tensor(
+                mQ.iterator, cute.make_layout(shape_Q_packed, stride=stride_Q_packed)
+            )
+
+            # Repack dO: (h, s, n, b) -> (h, (qh/kvh, s), n_kv, b)
+            # or varlen: (h, t, n) -> (h, (qh/kvh, t), n_kv)
+            shape_dO_packed = (
+                mdO.shape[0],
+                (self.qhead_per_kvhead, mdO.shape[1]),
+                mdO.shape[2] // self.qhead_per_kvhead,
+                *mdO.shape[3:],
+            )
+            stride_dO_packed = (
+                mdO.stride[0],
+                (mdO.stride[2], mdO.stride[1]),
+                mdO.stride[2] * self.qhead_per_kvhead,
+                *mdO.stride[3:],
+            )
+            mdO = cute.make_tensor(
+                mdO.iterator, cute.make_layout(shape_dO_packed, stride=stride_dO_packed)
+            )
+
         # Transposes for 2-CTA K/Q paths (Q follows Q seqlens, K follows K seqlens)
         transpose_sh_q = dO_transpose
         transpose_sh_k = [1, 0, 2, 3] if const_expr(mCuSeqlensK is None) else [1, 0, 2]
@@ -520,7 +557,7 @@ class FlashAttentionBackwardSm100:
             assert mdQ_semaphore is not None
             mdQ_semaphore = layout_utils.select(mdQ_semaphore, mode=semaphore_transpose)
 
-        if const_expr(self.deterministic and self.qhead_per_kvhead > 1):
+        if const_expr(self.deterministic and self.qhead_per_kvhead > 1 and not self.pack_gqa):
             assert mdK_semaphore is not None
             assert mdV_semaphore is not None
             mdK_semaphore, mdV_semaphore = [
@@ -724,11 +761,12 @@ class FlashAttentionBackwardSm100:
             cluster_shape_mn=self.cluster_shape_mnk[:2],
             mCuSeqlensQ=mCuSeqlensK,
             mSeqUsedQ=mSeqUsedK,
-            qhead_per_kvhead_packgqa=1,  # pack_gqa disabled for bwd
+            qhead_per_kvhead_packgqa=self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
             element_size=self.k_dtype.width // 8,
             is_persistent=self.is_persistent,  # persistent mode not tested
             lpt=self.spt,
             head_swizzle=self.deterministic,
+            is_bwd=True,
         )
 
         tile_sched_params = TileScheduler.to_underlying_arguments(tile_sched_args)
@@ -1005,7 +1043,7 @@ class FlashAttentionBackwardSm100:
             min_blocks_per_mp=1,
         )
 
-    def _generate_attention_mask_cls(self, window_size_left, window_size_right):
+    def _generate_attention_mask_cls(self, window_size_left, window_size_right, qhead_per_kvhead_packgqa=1):
         return partial(
             AttentionMask,
             self.tile_m,
@@ -1013,6 +1051,7 @@ class FlashAttentionBackwardSm100:
             swap_AB=True,
             window_size_left=window_size_left,
             window_size_right=window_size_right,
+            qhead_per_kvhead_packgqa=qhead_per_kvhead_packgqa,
         )
 
     @cute.kernel
@@ -1394,6 +1433,7 @@ class FlashAttentionBackwardSm100:
         tdQtdQ = thr_mma_dQ.make_fragment_C(dQacc_shape)
         tdQtdQ = cute.make_tensor(tmem_ptr + self.tmem_dQ_offset, tdQtdQ.layout)
 
+        qhead_per_kvhead_packgqa = self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1
         block_info = BlockInfo(
             self.tile_m,
             # self.tile_n,
@@ -1403,11 +1443,11 @@ class FlashAttentionBackwardSm100:
             False,  # is_split_kv
             window_size_left,
             window_size_right,
-            qhead_per_kvhead_packgqa=1,
+            qhead_per_kvhead_packgqa=qhead_per_kvhead_packgqa,
         )
         SeqlenInfoCls = partial(
             SeqlenInfoQK.create,
-            seqlen_q_static=mQ.shape[0],
+            seqlen_q_static=mQ.shape[0] if const_expr(not self.pack_gqa) else mQ.shape[0][1],
             seqlen_k_static=mK.shape[0],
             mCuSeqlensQ=mCuSeqlensQ,
             mCuSeqlensK=mCuSeqlensK,
@@ -1415,10 +1455,12 @@ class FlashAttentionBackwardSm100:
             mSeqUsedK=mSeqUsedK,
             tile_m=self.tile_m,
             tile_n=self.tile_n * self.cluster_shape_mnk[0],
+            qhead_per_kvhead_packgqa=qhead_per_kvhead_packgqa,
         )
         TileSchedulerCls = partial(self.tile_scheduler_cls.create, tile_sched_params)
 
-        AttentionMaskCls = self._generate_attention_mask_cls(window_size_left, window_size_right)
+        AttentionMaskCls = self._generate_attention_mask_cls(window_size_left, window_size_right, qhead_per_kvhead_packgqa)
+
         #  EMPTY
         # (15)
         if warp_idx == self.empty_warp_id:
@@ -1642,7 +1684,7 @@ class FlashAttentionBackwardSm100:
             m_block_min, m_block_max = block_info.get_m_block_min_max(
                 seqlen, n_block // self.cluster_shape_mnk[0]
             )
-            head_idx_kv = head_idx // self.qhead_per_kvhead
+            head_idx_kv = head_idx // self.qhead_per_kvhead if const_expr(not self.pack_gqa) else head_idx
 
             process_tile = (
                 const_expr(not self.is_local and not self.is_varlen_q) or m_block_min < m_block_max
@@ -1663,6 +1705,23 @@ class FlashAttentionBackwardSm100:
             tile_scheduler.prefetch_next_work()
             tile_scheduler.advance_to_next_work()
             work_tile = tile_scheduler.get_current_work()
+
+    @cute.jit 
+    def get_m_block_from_iter(self, iter_idx, m_block_min, m_block_max):
+        if const_expr(self.pack_gqa):
+            num_m_blocks = m_block_max - m_block_min 
+            num_m_blocks_per_head = num_m_blocks // self.qhead_per_kvhead
+            boundary = num_m_blocks_per_head * self.qhead_per_kvhead
+            qhead_swizzled = Int32(0)
+            pos_block = Int32(0)
+            if iter_idx < boundary:
+                qhead_swizzled = iter_idx // num_m_blocks_per_head
+                pos_block = iter_idx - qhead_swizzled * num_m_blocks_per_head
+            else:
+                qhead_swizzled = iter_idx 
+            return m_block_min + pos_block * self.qhead_per_kvhead + qhead_swizzled 
+        else:
+            return m_block_min + iter_idx
 
     @cute.jit
     def load(
@@ -1753,7 +1812,7 @@ class FlashAttentionBackwardSm100:
             m_block_min, m_block_max = block_info.get_m_block_min_max(
                 seqlen, n_block // self.cluster_shape_mnk[0]
             )
-            head_idx_kv = head_idx // self.qhead_per_kvhead
+            head_idx_kv = head_idx // self.qhead_per_kvhead if const_expr(not self.pack_gqa) else head_idx
             n_block_cta_group = n_block // self.cta_group_size
 
             # GMEM tensors (varlen-aware)
@@ -1763,7 +1822,8 @@ class FlashAttentionBackwardSm100:
             if const_expr(not seqlen.has_cu_seqlens_q):
                 mdO_cur = mdO[None, None, head_idx, batch_idx]
             else:
-                mdO_cur = cute.domain_offset((0, seqlen.offset_q), mdO[None, None, head_idx])
+                dO_seq_offset = seqlen.offset_q if const_expr(not self.pack_gqa) else (0, seqlen.offset_q)
+                mdO_cur = cute.domain_offset((0, dO_seq_offset), mdO[None, None, head_idx])
             mLSE_cur = seqlen.offset_batch_Q(mLSE, batch_idx, dim=2, padded=True)[None, head_idx]
             mdPsum_cur = seqlen.offset_batch_Q(mdPsum, batch_idx, dim=2, padded=True)[
                 None, head_idx
@@ -1774,8 +1834,9 @@ class FlashAttentionBackwardSm100:
                     mQt_cur = mQt[None, None, head_idx, batch_idx]
                     mdOt_cur = mdOt[None, None, head_idx, batch_idx]
                 else:
-                    mQt_cur = cute.domain_offset((0, seqlen.offset_q, 0), mQt)[None, None, head_idx]
-                    mdOt_cur = cute.domain_offset((seqlen.offset_q, 0, 0), mdOt)[
+                    qt_seq_offset = seqlen.offset_q if const_expr(not self.pack_gqa) else (0, seqlen.offset_q)
+                    mQt_cur = cute.domain_offset((0, qt_seq_offset, 0), mQt)[None, None, head_idx]
+                    mdOt_cur = cute.domain_offset((qt_seq_offset, 0, 0), mdOt)[
                         None, None, head_idx
                     ]
                 if const_expr(not seqlen.has_cu_seqlens_k):
@@ -1952,7 +2013,7 @@ class FlashAttentionBackwardSm100:
                         )
                     )
                 else:
-                    first_m_block = m_block_min
+                    first_m_block = self.get_m_block_from_iter(Int32(0), m_block_min, m_block_max)
                     if const_expr(self.use_2cta_instrs and self.tile_hdim == 192):
                         #### Prologue ####
                         assert should_load_Q and should_load_dO
@@ -3042,6 +3103,10 @@ class FlashAttentionBackwardSm100:
                         m_block_max=m_block_max,
                     )
                     m_block_oob = m_block >= m_block_max
+                else:
+                    m_block = self.get_m_block_from_iter(iter_idx, m_block_min, m_block_max)
+                    m_block_oob = False
+                    is_full_block = False
                 # Prefetch 1 stage of LSE
                 pipeline_LSE.consumer_wait(consumer_state_LSE)
                 tSrLSE_s2r = cute.make_rmem_tensor(tScS_t2r[None, 0, 0, 0].shape, Float32)
@@ -3090,7 +3155,8 @@ class FlashAttentionBackwardSm100:
                     )
 
                 #### APPLY MASK (after score_mod, matching forward pass order)
-                check_m_boundary = (m_block + 1) * self.tile_m > seqlen.seqlen_q
+                seqlen_q_packgqa = seqlen.seqlen_q * (self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1)
+                check_m_boundary = (m_block + 1) * self.tile_m > seqlen_q_packgqa
                 mask_fn(
                     tSrS_t2r,
                     m_block=m_block,
@@ -3588,6 +3654,10 @@ class FlashAttentionBackwardSm100:
                         m_block_max=m_block_max,
                     )
                     m_block_oob_upper = m_block >= m_block_max
+                    if m_block_max > 0:
+                        m_block = cutlass.min(m_block, m_block_max - 1)
+                else:
+                    m_block = self.get_m_block_from_iter(iter_idx, m_block_min, m_block_max)
                 pipeline_dQ.consumer_wait(dQ_consumer_state)
                 # TMEM -> RMEM
                 tdQrdQ_t2r = cute.make_rmem_tensor(tdQrdQ_t2r_shape, Float32)
@@ -3653,9 +3723,10 @@ class FlashAttentionBackwardSm100:
                     dQ_tma_store_producer_state.advance()
 
                     if const_expr(self.deterministic and stage == 0 and delay_semaphore_release):
-                        if m_block > m_block_min:
+                        if iter_idx > 0:
+                            prev_m_block = self.get_m_block_from_iter(iter_idx - 1, m_block_min, m_block_max)
                             barrier.arrive_inc(
-                                mdQ_semaphore_cur[(m_block - 1, None)].iterator,
+                                mdQ_semaphore_cur[(prev_m_block, None)].iterator,
                                 tidx,
                                 cta_rank_in_cluster,
                                 1,
@@ -3687,8 +3758,9 @@ class FlashAttentionBackwardSm100:
                 self.reduce_sync_barrier.arrive_and_wait()
                 # final semaphore release
                 if const_expr(self.deterministic and delay_semaphore_release):
+                    last_m_block = self.get_m_block_from_iter(loop_count - 1, m_block_min, m_block_max)
                     barrier.arrive_inc(
-                        mdQ_semaphore_cur[(m_block_max - 1, None)].iterator,
+                        mdQ_semaphore_cur[(last_m_block, None)].iterator,
                         tidx,
                         cta_rank_in_cluster,
                         1,
@@ -3736,7 +3808,7 @@ class FlashAttentionBackwardSm100:
         ) // 128
         num_wg = cute.arch.WARP_SIZE * len(self.compute_warp_ids) // 128
 
-        assert self.qhead_per_kvhead == 1, "This epilogue path is only for MHA"
+        assert self.qhead_per_kvhead == 1 or self.pack_gqa, "This epilogue path is only for MHA or pack_gqa"
         mdV_cur = seqlen.offset_batch_K(mdV, batch_idx, dim=3)[None, None, head_idx]
         mdK_cur = seqlen.offset_batch_K(mdK, batch_idx, dim=3)[None, None, head_idx]
 
@@ -3892,7 +3964,7 @@ class FlashAttentionBackwardSm100:
         # (8, tile_n / 128, 64 / 8) = (8, 1, 8) or (4, tile_n * 32 / (128 * 4)) = (4, 8)
         tdKVsdKV_r2s = thr_copy_r2s_dKV.partition_D(sdKV)
 
-        head_idx_kv = head_idx // self.qhead_per_kvhead
+        head_idx_kv = head_idx // self.qhead_per_kvhead if const_expr(not self.pack_gqa) else head_idx
         if const_expr(not self.dKV_postprocess):
             assert not seqlen.has_cu_seqlens_k, "varlen uses non tma store path"
             mdKV_cur = mdKV[None, None, head_idx_kv, batch_idx]  # (seqlen, hdim)
@@ -3921,7 +3993,7 @@ class FlashAttentionBackwardSm100:
                 gdKV, (flat_epi_tile,)
             )  # (tile_n * hdim / 2 / epi_stage, epi_stage)
 
-        deterministic_KV = self.deterministic and self.qhead_per_kvhead > 1
+        deterministic_KV = self.deterministic and self.qhead_per_kvhead > 1 and not self.pack_gqa
         if const_expr(deterministic_KV):
             assert mdKV_semaphore is not None
             mdKV_semaphore_cur = mdKV_semaphore[n_block, None, head_idx_kv, batch_idx]

--- a/flash_attn/cute/flash_bwd_sm100.py
+++ b/flash_attn/cute/flash_bwd_sm100.py
@@ -1706,10 +1706,10 @@ class FlashAttentionBackwardSm100:
             tile_scheduler.advance_to_next_work()
             work_tile = tile_scheduler.get_current_work()
 
-    @cute.jit 
+    @cute.jit
     def get_m_block_from_iter(self, iter_idx, m_block_min, m_block_max):
         if const_expr(self.pack_gqa):
-            num_m_blocks = m_block_max - m_block_min 
+            num_m_blocks = m_block_max - m_block_min
             num_m_blocks_per_head = num_m_blocks // self.qhead_per_kvhead
             boundary = num_m_blocks_per_head * self.qhead_per_kvhead
             qhead_swizzled = Int32(0)
@@ -1718,8 +1718,8 @@ class FlashAttentionBackwardSm100:
                 qhead_swizzled = iter_idx // num_m_blocks_per_head
                 pos_block = iter_idx - qhead_swizzled * num_m_blocks_per_head
             else:
-                qhead_swizzled = iter_idx 
-            return m_block_min + pos_block * self.qhead_per_kvhead + qhead_swizzled 
+                qhead_swizzled = iter_idx
+            return m_block_min + pos_block * self.qhead_per_kvhead + qhead_swizzled
         else:
             return m_block_min + iter_idx
 
@@ -2013,6 +2013,7 @@ class FlashAttentionBackwardSm100:
                         )
                     )
                 else:
+                    loop_count = m_block_max - m_block_min
                     first_m_block = self.get_m_block_from_iter(Int32(0), m_block_min, m_block_max)
                     if const_expr(self.use_2cta_instrs and self.tile_hdim == 192):
                         #### Prologue ####
@@ -2073,7 +2074,8 @@ class FlashAttentionBackwardSm100:
 
                         #### Mainloop ####
                         # 2CTA: [lse | Q | dOt | dPsum | Qt | dO]
-                        for m_block in cutlass.range(m_block_min + 1, m_block_max, unroll=1):
+                        for iter_idx in cutlass.range(1, loop_count, unroll=1):
+                            m_block = self.get_m_block_from_iter(iter_idx, m_block_min, m_block_max)
                             # LSE
                             pipeline_LSE.producer_acquire(producer_state_LSE)
                             with cute.arch.elect_one():
@@ -2180,11 +2182,15 @@ class FlashAttentionBackwardSm100:
                             pipeline_Kt.producer_commit(producer_state_Kt)
                             producer_state_Kt.advance()
                         #### Main Loop ####
-                        for m_block in cutlass.range(m_block_min + 1, m_block_max, unroll=1):
+                        for iter_idx in cutlass.range(1, loop_count, unroll=1):
+                            m_block = self.get_m_block_from_iter(iter_idx, m_block_min, m_block_max)
+                            m_block_prev = self.get_m_block_from_iter(
+                                iter_idx - 1, m_block_min, m_block_max
+                            )
                             if const_expr(should_load_Q):
                                 if const_expr(tma_atom_Qt is not None):
                                     pipeline_Qt.producer_acquire(producer_state_Qt)
-                                    load_Qt(m_block - 1, producer_state=producer_state_Qt)
+                                    load_Qt(m_block_prev, producer_state=producer_state_Qt)
                                     pipeline_Qt.producer_commit(producer_state_Qt)
                                     producer_state_Qt.advance()
 
@@ -2233,7 +2239,12 @@ class FlashAttentionBackwardSm100:
                         if const_expr(should_load_Q):
                             if const_expr(tma_atom_Qt is not None):
                                 pipeline_Qt.producer_acquire(producer_state_Qt)
-                                load_Qt(m_block_max - 1, producer_state=producer_state_Qt)
+                                load_Qt(
+                                    self.get_m_block_from_iter(
+                                        loop_count - 1, m_block_min, m_block_max
+                                    ),
+                                    producer_state=producer_state_Qt,
+                                )
                                 pipeline_Qt.producer_commit(producer_state_Qt)
                                 producer_state_Qt.advance()
 

--- a/flash_attn/cute/flash_bwd_sm100.py
+++ b/flash_attn/cute/flash_bwd_sm100.py
@@ -1043,7 +1043,9 @@ class FlashAttentionBackwardSm100:
             min_blocks_per_mp=1,
         )
 
-    def _generate_attention_mask_cls(self, window_size_left, window_size_right, qhead_per_kvhead_packgqa=1):
+    def _generate_attention_mask_cls(
+        self, window_size_left, window_size_right, qhead_per_kvhead_packgqa=1
+    ):
         return partial(
             AttentionMask,
             self.tile_m,
@@ -1459,7 +1461,9 @@ class FlashAttentionBackwardSm100:
         )
         TileSchedulerCls = partial(self.tile_scheduler_cls.create, tile_sched_params)
 
-        AttentionMaskCls = self._generate_attention_mask_cls(window_size_left, window_size_right, qhead_per_kvhead_packgqa)
+        AttentionMaskCls = self._generate_attention_mask_cls(
+            window_size_left, window_size_right, qhead_per_kvhead_packgqa
+        )
 
         #  EMPTY
         # (15)
@@ -1684,7 +1688,9 @@ class FlashAttentionBackwardSm100:
             m_block_min, m_block_max = block_info.get_m_block_min_max(
                 seqlen, n_block // self.cluster_shape_mnk[0]
             )
-            head_idx_kv = head_idx // self.qhead_per_kvhead if const_expr(not self.pack_gqa) else head_idx
+            head_idx_kv = (
+                head_idx // self.qhead_per_kvhead if const_expr(not self.pack_gqa) else head_idx
+            )
 
             process_tile = (
                 const_expr(not self.is_local and not self.is_varlen_q) or m_block_min < m_block_max
@@ -1812,7 +1818,9 @@ class FlashAttentionBackwardSm100:
             m_block_min, m_block_max = block_info.get_m_block_min_max(
                 seqlen, n_block // self.cluster_shape_mnk[0]
             )
-            head_idx_kv = head_idx // self.qhead_per_kvhead if const_expr(not self.pack_gqa) else head_idx
+            head_idx_kv = (
+                head_idx // self.qhead_per_kvhead if const_expr(not self.pack_gqa) else head_idx
+            )
             n_block_cta_group = n_block // self.cta_group_size
 
             # GMEM tensors (varlen-aware)
@@ -1822,7 +1830,9 @@ class FlashAttentionBackwardSm100:
             if const_expr(not seqlen.has_cu_seqlens_q):
                 mdO_cur = mdO[None, None, head_idx, batch_idx]
             else:
-                dO_seq_offset = seqlen.offset_q if const_expr(not self.pack_gqa) else (0, seqlen.offset_q)
+                dO_seq_offset = (
+                    seqlen.offset_q if const_expr(not self.pack_gqa) else (0, seqlen.offset_q)
+                )
                 mdO_cur = cute.domain_offset((0, dO_seq_offset), mdO[None, None, head_idx])
             mLSE_cur = seqlen.offset_batch_Q(mLSE, batch_idx, dim=2, padded=True)[None, head_idx]
             mdPsum_cur = seqlen.offset_batch_Q(mdPsum, batch_idx, dim=2, padded=True)[
@@ -1834,11 +1844,11 @@ class FlashAttentionBackwardSm100:
                     mQt_cur = mQt[None, None, head_idx, batch_idx]
                     mdOt_cur = mdOt[None, None, head_idx, batch_idx]
                 else:
-                    qt_seq_offset = seqlen.offset_q if const_expr(not self.pack_gqa) else (0, seqlen.offset_q)
+                    qt_seq_offset = (
+                        seqlen.offset_q if const_expr(not self.pack_gqa) else (0, seqlen.offset_q)
+                    )
                     mQt_cur = cute.domain_offset((0, qt_seq_offset, 0), mQt)[None, None, head_idx]
-                    mdOt_cur = cute.domain_offset((qt_seq_offset, 0, 0), mdOt)[
-                        None, None, head_idx
-                    ]
+                    mdOt_cur = cute.domain_offset((qt_seq_offset, 0, 0), mdOt)[None, None, head_idx]
                 if const_expr(not seqlen.has_cu_seqlens_k):
                     mKt_cur = mKt[None, None, head_idx_kv, batch_idx]
                 else:
@@ -3166,7 +3176,9 @@ class FlashAttentionBackwardSm100:
                     )
 
                 #### APPLY MASK (after score_mod, matching forward pass order)
-                seqlen_q_packgqa = seqlen.seqlen_q * (self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1)
+                seqlen_q_packgqa = seqlen.seqlen_q * (
+                    self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1
+                )
                 check_m_boundary = (m_block + 1) * self.tile_m > seqlen_q_packgqa
                 mask_fn(
                     tSrS_t2r,
@@ -3735,7 +3747,9 @@ class FlashAttentionBackwardSm100:
 
                     if const_expr(self.deterministic and stage == 0 and delay_semaphore_release):
                         if iter_idx > 0:
-                            prev_m_block = self.get_m_block_from_iter(iter_idx - 1, m_block_min, m_block_max)
+                            prev_m_block = self.get_m_block_from_iter(
+                                iter_idx - 1, m_block_min, m_block_max
+                            )
                             barrier.arrive_inc(
                                 mdQ_semaphore_cur[(prev_m_block, None)].iterator,
                                 tidx,
@@ -3769,7 +3783,9 @@ class FlashAttentionBackwardSm100:
                 self.reduce_sync_barrier.arrive_and_wait()
                 # final semaphore release
                 if const_expr(self.deterministic and delay_semaphore_release):
-                    last_m_block = self.get_m_block_from_iter(loop_count - 1, m_block_min, m_block_max)
+                    last_m_block = self.get_m_block_from_iter(
+                        loop_count - 1, m_block_min, m_block_max
+                    )
                     barrier.arrive_inc(
                         mdQ_semaphore_cur[(last_m_block, None)].iterator,
                         tidx,
@@ -3819,7 +3835,9 @@ class FlashAttentionBackwardSm100:
         ) // 128
         num_wg = cute.arch.WARP_SIZE * len(self.compute_warp_ids) // 128
 
-        assert self.qhead_per_kvhead == 1 or self.pack_gqa, "This epilogue path is only for MHA or pack_gqa"
+        assert self.qhead_per_kvhead == 1 or self.pack_gqa, (
+            "This epilogue path is only for MHA or pack_gqa"
+        )
         mdV_cur = seqlen.offset_batch_K(mdV, batch_idx, dim=3)[None, None, head_idx]
         mdK_cur = seqlen.offset_batch_K(mdK, batch_idx, dim=3)[None, None, head_idx]
 
@@ -3975,7 +3993,9 @@ class FlashAttentionBackwardSm100:
         # (8, tile_n / 128, 64 / 8) = (8, 1, 8) or (4, tile_n * 32 / (128 * 4)) = (4, 8)
         tdKVsdKV_r2s = thr_copy_r2s_dKV.partition_D(sdKV)
 
-        head_idx_kv = head_idx // self.qhead_per_kvhead if const_expr(not self.pack_gqa) else head_idx
+        head_idx_kv = (
+            head_idx // self.qhead_per_kvhead if const_expr(not self.pack_gqa) else head_idx
+        )
         if const_expr(not self.dKV_postprocess):
             assert not seqlen.has_cu_seqlens_k, "varlen uses non tma store path"
             mdKV_cur = mdKV[None, None, head_idx_kv, batch_idx]  # (seqlen, hdim)

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -1107,7 +1107,7 @@ def _flash_attn_fwd(
 _flash_attn_fwd.compile_cache = get_jit_cache("fwd")
 
 
-def make_fake_bwd_tensors(dtype, has_gqa, varlen_q, varlen_k):
+def make_fake_bwd_tensors(dtype, has_gqa, varlen_q, varlen_k, pack_gqa=False):
     sym = cute.sym_int
     # divisibility in elements: assumed_align_bytes = divisibility * dtype.width // 8
     # For 16-byte align: fp16/bf16 → divisibility=8, float32 → divisibility=4
@@ -1115,6 +1115,8 @@ def make_fake_bwd_tensors(dtype, has_gqa, varlen_q, varlen_k):
     # Shared sym_ints for dimensions that must match across tensors
     b, seqlen_q, seqlen_k, h_q, d, d_v = sym(), sym(), sym(), sym(), sym(), sym()
     h_kv = h_q if not has_gqa else sym()
+    # When pack_gqa, accumulators (dpsum, lse_log2, dq_accum) use h_kv heads
+    h_accum = h_kv if pack_gqa else h_q
     seqlen_q_rounded, seqlen_k_rounded = sym(), sym()
     seqlen_q_d_rounded, seqlen_k_d_rounded, seqlen_k_dv_rounded = sym(), sym(), sym()
     total_q, total_k, total_q_rounded, total_k_rounded = sym(), sym(), sym(), sym()
@@ -1131,14 +1133,14 @@ def make_fake_bwd_tensors(dtype, has_gqa, varlen_q, varlen_k):
     mdV = fake_tensor(dtype, (*b_seqlenk, h_kv, d_v), divisibility=div)
     if not varlen_q:
         mLSE = fake_tensor(Float32, (b, h_q, seqlen_q), divisibility=1)
-        mLSElog2 = fake_tensor(Float32, (b, h_q, seqlen_q_rounded), divisibility=4)
-        mPdPsum = fake_tensor(Float32, (b, h_q, seqlen_q_rounded), divisibility=4)
-        dQaccum = fake_tensor(Float32, (b, h_q, seqlen_q_d_rounded), divisibility=4)
+        mLSElog2 = fake_tensor(Float32, (b, h_accum, seqlen_q_rounded), divisibility=4)
+        mPdPsum = fake_tensor(Float32, (b, h_accum, seqlen_q_rounded), divisibility=4)
+        dQaccum = fake_tensor(Float32, (b, h_accum, seqlen_q_d_rounded), divisibility=4)
     else:
         mLSE = fake_tensor(Float32, (h_q, total_q), divisibility=1)
-        mLSElog2 = fake_tensor(Float32, (h_q, total_q_rounded), divisibility=4)
-        mPdPsum = fake_tensor(Float32, (h_q, total_q_rounded), divisibility=4)
-        dQaccum = fake_tensor(Float32, (h_q, total_q_d_rounded), divisibility=4)
+        mLSElog2 = fake_tensor(Float32, (h_accum, total_q_rounded), divisibility=4)
+        mPdPsum = fake_tensor(Float32, (h_accum, total_q_rounded), divisibility=4)
+        dQaccum = fake_tensor(Float32, (h_accum, total_q_d_rounded), divisibility=4)
     if not has_gqa:
         mdKaccum, mdVaccum = None, None
     else:
@@ -1153,11 +1155,11 @@ def make_fake_bwd_tensors(dtype, has_gqa, varlen_q, varlen_k):
 
 def _compile_bwd_preprocess(
     dtype, head_dim, head_dim_v, m_block_size, has_cuseqlens_q, has_seqused_q, has_dlse, has_dq_accum,
-    use_padded_offsets,
+    use_padded_offsets, pack_gqa=False, qhead_per_kvhead=1,
 ):
     """Compile bwd preprocess kernel using cute fake tensors (no real GPU tensors needed)."""
     mQ, mK, mV, mO, mdO, mdQ, mdK, mdV, mLSE, mLSElog2, mPdPsum, mdQaccum, mdKaccum, mdVaccum = make_fake_bwd_tensors(
-        dtype, has_gqa=True, varlen_q=has_cuseqlens_q, varlen_k=False
+        dtype, has_gqa=True, varlen_q=has_cuseqlens_q, varlen_k=False, pack_gqa=pack_gqa,
     )
     batch = mQ.shape[0] if not has_cuseqlens_q else cute.sym_int()
     batchp1 = cute.sym_int()
@@ -1166,7 +1168,8 @@ def _compile_bwd_preprocess(
     mdLSE = fake_tensor(Float32, mLSE.shape, divisibility=1) if has_dlse else None
     mdQaccum = mdQaccum if has_dq_accum else None
     fa_bwd_pre = FlashAttentionBackwardPreprocess(
-        dtype, head_dim, head_dim_v, m_block_size, use_padded_offsets=use_padded_offsets
+        dtype, head_dim, head_dim_v, m_block_size, use_padded_offsets=use_padded_offsets,
+        qhead_per_kvhead=qhead_per_kvhead, pack_gqa=pack_gqa,
     )
     return cute.compile(
         fa_bwd_pre, mO, mdO, mPdPsum, mLSE, mLSElog2, mdQaccum, mCuSeqlensQ, mSequsedQ, mdLSE,
@@ -1180,15 +1183,19 @@ def _bwd_preprocess(
     cu_seqlens_q, seqused_q, dlse,
     dtype, head_dim, head_dim_v, m_block_size,
     use_padded_offsets=True,
+    pack_gqa=False, qhead_per_kvhead=1,
 ):
     """Backward preprocess: compute (o * dout).sum(dim=-1) - dLSE, lse * log2_e, and zero out dq_accum."""
     is_varlen = cu_seqlens_q is not None
     compile_key = (
         dtype, head_dim, head_dim_v, m_block_size, is_varlen, seqused_q is not None, dlse is not None, dq_accum is not None,
-        use_padded_offsets,
+        use_padded_offsets, pack_gqa, qhead_per_kvhead,
     )
     if compile_key not in _bwd_preprocess.compile_cache:
-        _bwd_preprocess.compile_cache[compile_key] = _compile_bwd_preprocess(*compile_key)
+        _bwd_preprocess.compile_cache[compile_key] = _compile_bwd_preprocess(
+            dtype, head_dim, head_dim_v, m_block_size, is_varlen, seqused_q is not None, dlse is not None, dq_accum is not None, 
+            use_padded_offsets, pack_gqa=pack_gqa, qhead_per_kvhead=qhead_per_kvhead,
+        )
     if not is_fake_mode():
         _bwd_preprocess.compile_cache[compile_key](
             out, dout, dpsum, lse, lse_log2, dq_accum, cu_seqlens_q, seqused_q, dlse
@@ -1202,10 +1209,11 @@ def _compile_bwd_postprocess(
     dtype, hdim, block_size, num_threads, atom_layout, swap_ab,
     has_cuseqlens_q, has_seqused_q,
     use_2cta_instrs, cluster_size, arch,
+    pack_gqa=False, qhead_per_kvhead=1,
 ):
     """Compile bwd postprocess kernel using cute fake tensors."""
     mQ, mK, mV, mO, mdO, mdQ, mdK, mdV, mLSE, mLSElog2, mPdPsum, mdQaccum, mdKaccum, mdVaccum = make_fake_bwd_tensors(
-        dtype, has_gqa=True, varlen_q=has_cuseqlens_q, varlen_k=False
+        dtype, has_gqa=True, varlen_q=has_cuseqlens_q, varlen_k=False, pack_gqa=pack_gqa,
     )
     batch = mQ.shape[0] if not has_cuseqlens_q else cute.sym_int()
     batchp1 = cute.sym_int()
@@ -1215,6 +1223,8 @@ def _compile_bwd_postprocess(
         dtype, hdim, arch, block_size, num_threads, atom_layout, swap_ab,
         use_2cta_instrs=use_2cta_instrs,
         cluster_size=cluster_size,
+        pack_gqa=pack_gqa,
+        qhead_per_kvhead=qhead_per_kvhead,
     )
     return cute.compile(
         fa_bwd_post, mdQaccum, mdQ, Float32(0.0), mCuSeqlensQ, mSeqUsedQ,
@@ -1229,15 +1239,22 @@ def _bwd_postprocess_convert(
     arch, dtype, hdim, block_size, num_threads,
     atom_layout, swap_ab,
     use_2cta_instrs=False, cluster_size=1,
+    pack_gqa=False, qhead_per_kvhead=1,
 ):
     """Backward postprocess: convert float32 accumulator to bf16/fp16 output."""
     compile_key = (
         dtype, hdim, block_size, num_threads, atom_layout, swap_ab,
         cu_seqlens is not None, seqused is not None,
         use_2cta_instrs, cluster_size, arch,
+        pack_gqa, qhead_per_kvhead,
     )
     if compile_key not in _bwd_postprocess_convert.compile_cache:
-        _bwd_postprocess_convert.compile_cache[compile_key] = _compile_bwd_postprocess(*compile_key)
+        _bwd_postprocess_convert.compile_cache[compile_key] = _compile_bwd_postprocess(
+            dtype, hdim, block_size, num_threads, atom_layout, swap_ab,
+            cu_seqlens is not None, seqused is not None,
+            use_2cta_instrs, cluster_size, arch,
+            pack_gqa=pack_gqa, qhead_per_kvhead=qhead_per_kvhead,
+        )
     if not is_fake_mode():
         _bwd_postprocess_convert.compile_cache[compile_key](
             accum, output, scale, cu_seqlens, seqused,
@@ -1400,7 +1417,14 @@ def _flash_attn_bwd(
 
     use_block_sparsity = block_sparse_tensors is not None
     subtile_factor = sparse_q // m_block_size if sparse_q is not None else 2
-    seqlen_q_rounded = (seqlen_q + m_block_size - 1) // m_block_size * m_block_size
+
+    qhead_per_kvhead = num_head // num_head_kv
+    num_head_packgqa = num_head_kv if pack_gqa else num_head
+    seqlen_q_rounded = (
+        (seqlen_q * (qhead_per_kvhead if pack_gqa else 1) + m_block_size - 1)
+        // m_block_size
+        * m_block_size
+    )
     seqlen_k_rounded = (seqlen_k + n_block_size - 1) // n_block_size * n_block_size
     num_n_blocks = seqlen_k_rounded // n_block_size
     if cluster_size == 2 and num_n_blocks % cluster_size != 0:
@@ -1451,12 +1475,11 @@ def _flash_attn_bwd(
         _validate_head_dims(head_dim, head_dim_v, arch // 10, alignment)
     if softmax_scale is None:
         softmax_scale = 1.0 / math.sqrt(head_dim)
-    qhead_per_kvhead = num_head // num_head_kv
     if pack_gqa is None:
         pack_gqa = qhead_per_kvhead > 1
-    # pack_gqa backward not yet supported in bwd
-    pack_gqa = False
-    
+    if arch // 10 not in [10, 11]:
+        pack_gqa = False
+
     if softcap != 0.0:
         assert score_mod is None and score_mod_bwd is None, (
             "softcap and score_mod/score_mod_bwd cannot be used together"
@@ -1497,37 +1520,47 @@ def _flash_attn_bwd(
             if use_dedicated_hd256_kernel
             else torch.empty(
                 batch_size,
-                num_head,
+                num_head_packgqa,
                 seqlen_q_rounded * head_dim_rounded,
                 dtype=torch.float32,
                 device=device,
             )
         )
         dpsum = torch.empty(
-            batch_size, num_head, seqlen_q_rounded, dtype=torch.float32, device=device
+            batch_size, num_head_packgqa, seqlen_q_rounded, dtype=torch.float32, device=device
         )
         lse_log2 = torch.empty(
-            batch_size, num_head, seqlen_q_rounded, dtype=torch.float32, device=device
+            batch_size, num_head_packgqa, seqlen_q_rounded, dtype=torch.float32, device=device
         )
     else:
+        total_q_packgqa = total_q if not pack_gqa else total_q * qhead_per_kvhead
         total_q_rounded_padded = (
-            (total_q + cu_seqlens_q.shape[0] * m_block_size - 1) // m_block_size * m_block_size
+            (total_q_packgqa + cu_seqlens_q.shape[0] * m_block_size - 1) // m_block_size * m_block_size
         )
         dq_accum = (
             None
             if use_dedicated_hd256_kernel
             else torch.empty(
-                num_head, total_q_rounded_padded * head_dim_rounded, dtype=torch.float32, device=device
+                num_head_packgqa,
+                total_q_rounded_padded * head_dim_rounded,
+                dtype=torch.float32,
+                device=device,
             )
         )
-        dpsum = torch.empty(num_head, total_q_rounded_padded, dtype=torch.float32, device=device)
-        lse_log2 = torch.empty(num_head, total_q_rounded_padded, dtype=torch.float32, device=device)
+        dpsum = torch.empty(num_head_packgqa, total_q_rounded_padded, dtype=torch.float32, device=device)
+        lse_log2 = torch.empty(num_head_packgqa, total_q_rounded_padded, dtype=torch.float32, device=device)
 
     # GQA (qhead_per_kvhead > 1) needs dK/dV accum+postprocess since multiple Q heads
     # accumulate into the same dK/dV. SM90 varlen_k with qhead_per_kvhead==1 now uses
     # ragged TMA tensors for direct store, so no longer needs accum+postprocess.
+
     # hd=256 2CTA backward has its own internal postprocess for dK/dV.
-    dKV_postprocess = qhead_per_kvhead > 1 and not use_dedicated_hd256_kernel
+    # With pack_gqa, Q heads are folded into M so each KV head only sees its own blocks.
+    dKV_postprocess = (
+        qhead_per_kvhead > 1 
+        and not pack_gqa 
+        and not use_dedicated_hd256_kernel
+    )
     if dKV_postprocess:
         head_dim_v_rounded = (head_dim_v + 32 - 1) // 32 * 32
         if cu_seqlens_k is None:
@@ -1567,11 +1600,11 @@ def _flash_attn_bwd(
     current_stream = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
 
     if deterministic:
-        dQ_semaphore = torch.zeros(batch_size, num_head, seqlen_q_rounded // m_block_size, cluster_size, dtype=torch.int32, device=device)
+        dQ_semaphore = torch.zeros(batch_size, num_head_packgqa, seqlen_q_rounded // m_block_size, cluster_size, dtype=torch.int32, device=device)
     else:
         dQ_semaphore = None
 
-    if deterministic and qhead_per_kvhead > 1:
+    if deterministic and qhead_per_kvhead > 1 and not pack_gqa:
         dK_semaphore = torch.zeros(batch_size, num_head_kv, seqlen_k_rounded // n_block_size, 2, dtype=torch.int32, device=device)
         dV_semaphore = torch.zeros(batch_size, num_head_kv, seqlen_k_rounded // n_block_size, 2, dtype=torch.int32, device=device)
     else:
@@ -1585,6 +1618,7 @@ def _flash_attn_bwd(
         cu_seqlens_q, seqused_q, dlse,
         dtype, head_dim, head_dim_v, m_block_size,
         use_padded_offsets=use_dedicated_hd256_kernel,
+        pack_gqa=pack_gqa, qhead_per_kvhead=qhead_per_kvhead,
     )
     # num_threads: SM90 derives from BwdConfig.num_wg, SM120 is set to 128 above,
     # SM100/SM110 uses default from function signature (384).
@@ -1845,6 +1879,7 @@ def _flash_attn_bwd(
                     mask_mod=mask_mod,
                     has_aux_tensors=aux_tensors is not None,
                     subtile_factor=subtile_factor,
+                    pack_gqa=pack_gqa,
                 )
 
         # Block sparse tensors for backward use Q-direction indexing (transposed from forward).
@@ -1933,6 +1968,7 @@ def _flash_attn_bwd(
             arch, dtype, head_dim, m_block_size, num_threads_post_dQ,
             AtomLayoutMdQ, dQ_swapAB,
             use_2cta_instrs=use_2cta_instrs, cluster_size=1,
+            pack_gqa=pack_gqa, qhead_per_kvhead=qhead_per_kvhead,
         )
 
         if dKV_postprocess:
@@ -2020,6 +2056,7 @@ class FlashAttnFunc(torch.autograd.Function):
         ctx.window_size = window_size
         ctx.softcap = softcap
         ctx.deterministic = deterministic
+        ctx.pack_gqa = pack_gqa
         ctx.return_lse = return_lse
         ctx.score_mod = score_mod 
         ctx.score_mod_bwd = score_mod_bwd 
@@ -2056,6 +2093,7 @@ class FlashAttnFunc(torch.autograd.Function):
             aux_tensors=aux_tensors,
             aux_scalars=ctx.aux_scalars,
             block_sparse_tensors=ctx.block_sparse_tensors_bwd,
+            pack_gqa=ctx.pack_gqa,
             dlse=dlse,
         )
         return dq, dk, dv, *((None,) * 31)
@@ -2148,6 +2186,7 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
         ctx.window_size = window_size
         ctx.softcap = softcap
         ctx.deterministic = deterministic
+        ctx.pack_gqa = pack_gqa
         ctx.max_seqlen_q = max_seqlen_q
         ctx.max_seqlen_k = max_seqlen_k
         ctx.return_lse = return_lse
@@ -2190,6 +2229,7 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
             aux_tensors=aux_tensors,
             aux_scalars=ctx.aux_scalars,
             mask_mod=ctx.mask_mod,
+            pack_gqa=ctx.pack_gqa,
             dlse=dlse,
         )
 

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -1476,8 +1476,9 @@ def _flash_attn_bwd(
     if softmax_scale is None:
         softmax_scale = 1.0 / math.sqrt(head_dim)
     if pack_gqa is None:
-        pack_gqa = qhead_per_kvhead > 1
+        pack_gqa = qhead_per_kvhead > 1 and m_block_size % qhead_per_kvhead == 0
     if arch // 10 not in [10, 11]:
+        # pack_gqa in backward not yet supported on Sm90
         pack_gqa = False
 
     if softcap != 0.0:

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -1419,6 +1419,11 @@ def _flash_attn_bwd(
     subtile_factor = sparse_q // m_block_size if sparse_q is not None else 2
 
     qhead_per_kvhead = num_head // num_head_kv
+    if pack_gqa is None:
+        pack_gqa = qhead_per_kvhead > 1 and m_block_size % qhead_per_kvhead == 0
+    if arch // 10 not in [10, 11]:
+        # pack_gqa in backward not yet supported on Sm90
+        pack_gqa = False
     num_head_packgqa = num_head_kv if pack_gqa else num_head
     seqlen_q_rounded = (
         (seqlen_q * (qhead_per_kvhead if pack_gqa else 1) + m_block_size - 1)
@@ -1475,11 +1480,6 @@ def _flash_attn_bwd(
         _validate_head_dims(head_dim, head_dim_v, arch // 10, alignment)
     if softmax_scale is None:
         softmax_scale = 1.0 / math.sqrt(head_dim)
-    if pack_gqa is None:
-        pack_gqa = qhead_per_kvhead > 1 and m_block_size % qhead_per_kvhead == 0
-    if arch // 10 not in [10, 11]:
-        # pack_gqa in backward not yet supported on Sm90
-        pack_gqa = False
 
     if softcap != 0.0:
         assert score_mod is None and score_mod_bwd is None, (

--- a/flash_attn/cute/mask.py
+++ b/flash_attn/cute/mask.py
@@ -892,8 +892,8 @@ class AttentionMask:
                         acc_S[i] = -cutlass.Float32.inf
         else:  # Causal or local
             thr_row_offset = tScS_t2r[0][ROW]
-            seqlenq_row_limit = self.seqlen_q - m_block * self.tile_m - thr_row_offset
-            causal_offset = seqlenq_row_limit - seqlenk_col_limit
+            seqlenq_row_limit = self.seqlen_q * self.qhead_per_kvhead_packgqa - m_block * self.tile_m - thr_row_offset
+            causal_offset = seqlenq_row_limit - seqlenk_col_limit * self.qhead_per_kvhead_packgqa
             if const_expr(mask_causal):
                 # tidx = cute.arch.thread_idx()[0] % 256
                 # if tidx < 32:
@@ -921,11 +921,11 @@ class AttentionMask:
                     )
             else:
                 if const_expr(self.window_size_right is not None):
-                    row_limit_top = causal_offset - self.window_size_right
+                    row_limit_top = causal_offset - self.window_size_right * self.qhead_per_kvhead_packgqa
                 else:
                     row_limit_top = 0
                 if const_expr(self.window_size_left is not None):
-                    row_limit_bot = causal_offset + self.window_size_left
+                    row_limit_bot = causal_offset + (self.window_size_left + 1) * self.qhead_per_kvhead_packgqa - 1
                 if const_expr(mask_seqlen):
                     if seqlenk_col_limit <= 0:
                         row_limit_top = self.tile_m

--- a/flash_attn/cute/mask.py
+++ b/flash_attn/cute/mask.py
@@ -892,7 +892,11 @@ class AttentionMask:
                         acc_S[i] = -cutlass.Float32.inf
         else:  # Causal or local
             thr_row_offset = tScS_t2r[0][ROW]
-            seqlenq_row_limit = self.seqlen_q * self.qhead_per_kvhead_packgqa - m_block * self.tile_m - thr_row_offset
+            seqlenq_row_limit = (
+                self.seqlen_q * self.qhead_per_kvhead_packgqa
+                - m_block * self.tile_m
+                - thr_row_offset
+            )
             causal_offset = seqlenq_row_limit - seqlenk_col_limit * self.qhead_per_kvhead_packgqa
             if const_expr(mask_causal):
                 # tidx = cute.arch.thread_idx()[0] % 256
@@ -921,11 +925,17 @@ class AttentionMask:
                     )
             else:
                 if const_expr(self.window_size_right is not None):
-                    row_limit_top = causal_offset - self.window_size_right * self.qhead_per_kvhead_packgqa
+                    row_limit_top = (
+                        causal_offset - self.window_size_right * self.qhead_per_kvhead_packgqa
+                    )
                 else:
                     row_limit_top = 0
                 if const_expr(self.window_size_left is not None):
-                    row_limit_bot = causal_offset + (self.window_size_left + 1) * self.qhead_per_kvhead_packgqa - 1
+                    row_limit_bot = (
+                        causal_offset
+                        + (self.window_size_left + 1) * self.qhead_per_kvhead_packgqa
+                        - 1
+                    )
                 if const_expr(mask_seqlen):
                     if seqlenk_col_limit <= 0:
                         row_limit_top = self.tile_m

--- a/flash_attn/cute/seqlen_info.py
+++ b/flash_attn/cute/seqlen_info.py
@@ -35,7 +35,9 @@ class SeqlenInfo:
             0
             if const_expr(cu_seqlens is None)
             # Add divby so that the compiler knows the alignment when moving by offset_padded
-            else cute.assume((offset * qhead_per_kvhead_packgqa + batch_idx * tile) // tile * tile, divby=tile)
+            else cute.assume(
+                (offset * qhead_per_kvhead_packgqa + batch_idx * tile) // tile * tile, divby=tile
+            )
         )
         if const_expr(seqused is not None):
             seqlen = seqused[batch_idx]
@@ -100,7 +102,10 @@ class SeqlenInfoQK:
         padded_offset_q = (
             0
             if const_expr(mCuSeqlensQ is None)
-            else cute.assume((offset_q * qhead_per_kvhead_packgqa + batch_idx * tile_m) // tile_m * tile_m, divby=tile_m)
+            else cute.assume(
+                (offset_q * qhead_per_kvhead_packgqa + batch_idx * tile_m) // tile_m * tile_m,
+                divby=tile_m,
+            )
         )
         padded_offset_k = (
             0

--- a/flash_attn/cute/seqlen_info.py
+++ b/flash_attn/cute/seqlen_info.py
@@ -28,13 +28,14 @@ class SeqlenInfo:
         cu_seqlens: Optional[cute.Tensor] = None,
         seqused: Optional[cute.Tensor] = None,
         tile: cutlass.Constexpr[int] = 128,
+        qhead_per_kvhead_packgqa: cutlass.Constexpr[int] = 1,
     ):
         offset = 0 if const_expr(cu_seqlens is None) else cu_seqlens[batch_idx]
         offset_padded = (
             0
             if const_expr(cu_seqlens is None)
             # Add divby so that the compiler knows the alignment when moving by offset_padded
-            else cute.assume((offset + batch_idx * tile) // tile * tile, divby=tile)
+            else cute.assume((offset * qhead_per_kvhead_packgqa + batch_idx * tile) // tile * tile, divby=tile)
         )
         if const_expr(seqused is not None):
             seqlen = seqused[batch_idx]
@@ -92,13 +93,14 @@ class SeqlenInfoQK:
         mCuBlockIdxOffsets: Optional[cute.Tensor] = None,
         tile_m: cutlass.Constexpr[Int32] = 128,
         tile_n: cutlass.Constexpr[Int32] = 128,
+        qhead_per_kvhead_packgqa: cutlass.Constexpr[int] = 1,
     ):
         offset_q = 0 if const_expr(mCuSeqlensQ is None) else mCuSeqlensQ[batch_idx]
         offset_k = 0 if const_expr(mCuSeqlensK is None) else mCuSeqlensK[batch_idx]
         padded_offset_q = (
             0
             if const_expr(mCuSeqlensQ is None)
-            else cute.assume((offset_q + batch_idx * tile_m) // tile_m * tile_m, divby=tile_m)
+            else cute.assume((offset_q * qhead_per_kvhead_packgqa + batch_idx * tile_m) // tile_m * tile_m, divby=tile_m)
         )
         padded_offset_k = (
             0

--- a/flash_attn/cute/tile_scheduler.py
+++ b/flash_attn/cute/tile_scheduler.py
@@ -164,6 +164,7 @@ class TileSchedulerArguments(ParamsBase):
     is_split_kv: cutlass.Constexpr[bool] = False
     head_swizzle: cutlass.Constexpr[bool] = False
     use_cluster_idx: cutlass.Constexpr[bool] = False
+    is_bwd: cutlass.Constexpr[bool] = False
 
 
 class SingleTileScheduler:
@@ -785,6 +786,7 @@ class SingleTileVarlenScheduler:
         head_swizzle: cutlass.Constexpr[bool] = False
         cluster_shape_m: cutlass.Constexpr[int] = 1
         scheduling_mode: cutlass.Constexpr[SchedulingMode] = SchedulingMode.STATIC
+        is_bwd: cutlass.Constexpr[bool] = False
 
         @staticmethod
         @cute.jit
@@ -831,6 +833,7 @@ class SingleTileVarlenScheduler:
                 head_swizzle=args.head_swizzle,
                 cluster_shape_m=args.cluster_shape_mn[0],
                 scheduling_mode=scheduling_mode,
+                is_bwd=args.is_bwd,
             )
 
     def __init__(
@@ -923,7 +926,7 @@ class SingleTileVarlenScheduler:
                 cur_cu_seqlen = params.mCuSeqlensQ[batch_idx]
             next_cu_seqlen = cute.arch.shuffle_sync_down(cur_cu_seqlen, offset=1)
             seqlen = next_cu_seqlen - cur_cu_seqlen
-        if cutlass.const_expr(params.qhead_per_kvhead_packgqa > 1):
+        if cutlass.const_expr(params.qhead_per_kvhead_packgqa > 1 and not params.is_bwd):
             seqlen *= params.qhead_per_kvhead_packgqa
         return (
             cute.ceil_div(cute.ceil_div(seqlen, params.tile_shape_mn[0]), params.cluster_shape_m)
@@ -984,11 +987,21 @@ class SingleTileVarlenScheduler:
                 # TODO: is there any case where num_m_blocks is 0?
                 # TODO: by right we should read the seqlen_kv but we're assuming seqlen_q == seqlen_k here
                 num_n_blocks = (
-                    num_m_blocks
-                    * params.tile_shape_mn[0]
-                    * params.cluster_shape_m
-                    // params.qhead_per_kvhead_packgqa
-                    // params.tile_shape_mn[1]
+                    (
+                        num_m_blocks
+                        * params.tile_shape_mn[0]
+                        * params.cluster_shape_m
+                        // params.qhead_per_kvhead_packgqa
+                        // params.tile_shape_mn[1]
+                    )
+                    if const_expr(not params.is_bwd)
+                    else (
+                        num_m_blocks
+                        * params.tile_shape_mn[0]
+                        * params.cluster_shape_m
+                        * params.qhead_per_kvhead_packgqa
+                        // params.tile_shape_mn[1]
+                    )
                 )
                 # nheads_in_l2 = min(max(self.max_kvblock_in_l2 // num_n_blocks, 1), self.num_head)
                 # Seems faster to have this be a power of 2

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -66,16 +66,16 @@ VERBOSE = True
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 @pytest.mark.parametrize("mha_type", ["mha", "mqa", "gqa"])
 # @pytest.mark.parametrize("mha_type", ["mha"])
-@pytest.mark.parametrize("has_learnable_sink", [False, True])
-# @pytest.mark.parametrize("has_learnable_sink", [False])
+# @pytest.mark.parametrize("has_learnable_sink", [False, True])
+@pytest.mark.parametrize("has_learnable_sink", [False])
 # @pytest.mark.parametrize("has_qv", [False, True])
 @pytest.mark.parametrize("has_qv", [False])
 @pytest.mark.parametrize("deterministic", [False, True])
 # @pytest.mark.parametrize("deterministic", [False])
-@pytest.mark.parametrize("softcap", [0.0, 15.0])
-# @pytest.mark.parametrize("softcap", [0.0])
-@pytest.mark.parametrize("local_enum", [0, 1, 2, 3])
-# @pytest.mark.parametrize("local_enum", [0])
+# @pytest.mark.parametrize("softcap", [0.0, 15.0])
+@pytest.mark.parametrize("softcap", [0.0])
+# @pytest.mark.parametrize("local_enum", [0, 1, 2, 3])
+@pytest.mark.parametrize("local_enum", [0])
 @pytest.mark.parametrize("causal", [False, True])
 # @pytest.mark.parametrize("causal", [False])
 # @pytest.mark.parametrize("d", [32, 64, 96, 128, 160, 192, 224, 256])
@@ -86,37 +86,37 @@ VERBOSE = True
 # @pytest.mark.parametrize('d', [32, 40, 64, 80, 96, 128])
 # @pytest.mark.parametrize("d", [64, 96, 128, 192])
 # @pytest.mark.parametrize("d", [128, 192])
-@pytest.mark.parametrize("d", [64, 96, 128, 192, 256])
-# @pytest.mark.parametrize("d", [128])
+# @pytest.mark.parametrize("d", [64, 96, 128, 192, 256])
+@pytest.mark.parametrize("d", [128])
 @pytest.mark.parametrize(
     "seqlen_q,seqlen_k",
     [
-        (1, 1),
-        (3, 3),
-        (64, 32),
-        (64, 128),
-        (64, 1),  # SM100 hd256 2CTA test case
-        (128, 128),
-        (128, 192),
-        (256, 256),
-        (255, 256),  # SM100 hd256 2CTA test case
-        (239, 1),
-        (799, 3),
-        (113, 203),
-        (113, 128),
-        (128, 217),
-        (113, 211),
-        (108, 256),
-        (256, 512),
-        (384, 256),
-        (640, 128),
+        # (1, 1),
+        # (3, 3),
+        # (64, 32),
+        # (64, 128),
+        # (64, 1),  # SM100 hd256 2CTA test case
+        # (128, 128),
+        # (128, 192),
+        # (256, 256),
+        # (255, 256),  # SM100 hd256 2CTA test case
+        # (239, 1),
+        # (799, 3),
+        # (113, 203),
+        # (113, 128),
+        # (128, 217),
+        # (113, 211),
+        # (108, 256),
+        # (256, 512),
+        # (384, 256),
+        # (640, 128),
         (512, 256),
         (1024, 1024),
-        (1023, 1024),
-        (1024, 1023),
-        (2048, 2048),
-        (4096, 4096),
-        (4224, 4224),
+        # (1023, 1024),
+        # (1024, 1023),
+        # (2048, 2048),
+        # (4096, 4096),
+        # (4224, 4224),
     ],
 )
 # @pytest.mark.parametrize('seqlen_q,seqlen_k', [(128, 128)])

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -293,7 +293,11 @@ def test_flash_attn_output(
             print(f"Pytorch max diff: {(out_pt - out_ref).abs().max().item()}")
             print(f"Pytorch mean diff: {(out_pt - out_ref).abs().mean().item()}")
         # num_splits_vals = [1, 3]
+<<<<<<< HEAD
         pack_gqa_vals = [True] if has_qv else [False, True, None] if not TEST_BWD_ONLY else [False]
+=======
+        pack_gqa_vals = [False, True, None]
+>>>>>>> 1462be86 (guard pack_gqa for tile_m % qhead_per_kvhead == 0 and remove restriction in test)
         # SplitKV is not supported for hdim >= 192
         # pack_gqa_vals = [False]
         num_splits_vals = [1, 3] if d < 192 and not DISABLE_SPLIT and not TEST_BWD_ONLY and not has_qv else [1]
@@ -800,7 +804,7 @@ def test_flash_attn_varlen_output(
             fwd_atol = 2 * (out_ref + 0.3 - 0.3 - out_ref).abs().max().item()
             rtol = 2 if softcap == 0.0 else 3
 
-        pack_gqa_vals = [False, True, None] if not TEST_BWD_ONLY else [False]
+        pack_gqa_vals = [False, True, None]
         # pack_gqa_vals = [False]
         # num_splits_vals = [1, 3]
         # SplitKV is not supported for hdim >= 192

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -66,16 +66,16 @@ VERBOSE = True
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 @pytest.mark.parametrize("mha_type", ["mha", "mqa", "gqa"])
 # @pytest.mark.parametrize("mha_type", ["mha"])
-# @pytest.mark.parametrize("has_learnable_sink", [False, True])
-@pytest.mark.parametrize("has_learnable_sink", [False])
+@pytest.mark.parametrize("has_learnable_sink", [False, True])
+# @pytest.mark.parametrize("has_learnable_sink", [False])
 # @pytest.mark.parametrize("has_qv", [False, True])
 @pytest.mark.parametrize("has_qv", [False])
 @pytest.mark.parametrize("deterministic", [False, True])
 # @pytest.mark.parametrize("deterministic", [False])
-# @pytest.mark.parametrize("softcap", [0.0, 15.0])
-@pytest.mark.parametrize("softcap", [0.0])
-# @pytest.mark.parametrize("local_enum", [0, 1, 2, 3])
-@pytest.mark.parametrize("local_enum", [0])
+@pytest.mark.parametrize("softcap", [0.0, 15.0])
+# @pytest.mark.parametrize("softcap", [0.0])
+@pytest.mark.parametrize("local_enum", [0, 1, 2, 3])
+# @pytest.mark.parametrize("local_enum", [0])
 @pytest.mark.parametrize("causal", [False, True])
 # @pytest.mark.parametrize("causal", [False])
 # @pytest.mark.parametrize("d", [32, 64, 96, 128, 160, 192, 224, 256])
@@ -86,37 +86,37 @@ VERBOSE = True
 # @pytest.mark.parametrize('d', [32, 40, 64, 80, 96, 128])
 # @pytest.mark.parametrize("d", [64, 96, 128, 192])
 # @pytest.mark.parametrize("d", [128, 192])
-# @pytest.mark.parametrize("d", [64, 96, 128, 192, 256])
-@pytest.mark.parametrize("d", [128])
+@pytest.mark.parametrize("d", [64, 96, 128, 192, 256])
+# @pytest.mark.parametrize("d", [128])
 @pytest.mark.parametrize(
     "seqlen_q,seqlen_k",
     [
-        # (1, 1),
-        # (3, 3),
-        # (64, 32),
-        # (64, 128),
-        # (64, 1),  # SM100 hd256 2CTA test case
-        # (128, 128),
-        # (128, 192),
-        # (256, 256),
-        # (255, 256),  # SM100 hd256 2CTA test case
-        # (239, 1),
-        # (799, 3),
-        # (113, 203),
-        # (113, 128),
-        # (128, 217),
-        # (113, 211),
-        # (108, 256),
-        # (256, 512),
-        # (384, 256),
-        # (640, 128),
+        (1, 1),
+        (3, 3),
+        (64, 32),
+        (64, 128),
+        (64, 1),  # SM100 hd256 2CTA test case
+        (128, 128),
+        (128, 192),
+        (256, 256),
+        (255, 256),  # SM100 hd256 2CTA test case
+        (239, 1),
+        (799, 3),
+        (113, 203),
+        (113, 128),
+        (128, 217),
+        (113, 211),
+        (108, 256),
+        (256, 512),
+        (384, 256),
+        (640, 128),
         (512, 256),
         (1024, 1024),
-        # (1023, 1024),
-        # (1024, 1023),
-        # (2048, 2048),
-        # (4096, 4096),
-        # (4224, 4224),
+        (1023, 1024),
+        (1024, 1023),
+        (2048, 2048),
+        (4096, 4096),
+        (4224, 4224),
     ],
 )
 # @pytest.mark.parametrize('seqlen_q,seqlen_k', [(128, 128)])
@@ -293,11 +293,7 @@ def test_flash_attn_output(
             print(f"Pytorch max diff: {(out_pt - out_ref).abs().max().item()}")
             print(f"Pytorch mean diff: {(out_pt - out_ref).abs().mean().item()}")
         # num_splits_vals = [1, 3]
-<<<<<<< HEAD
-        pack_gqa_vals = [True] if has_qv else [False, True, None] if not TEST_BWD_ONLY else [False]
-=======
         pack_gqa_vals = [False, True, None]
->>>>>>> 1462be86 (guard pack_gqa for tile_m % qhead_per_kvhead == 0 and remove restriction in test)
         # SplitKV is not supported for hdim >= 192
         # pack_gqa_vals = [False]
         num_splits_vals = [1, 3] if d < 192 and not DISABLE_SPLIT and not TEST_BWD_ONLY and not has_qv else [1]


### PR DESCRIPTION
EDIT 2026-06-10: Re-opening (as draft, until I've rebased), because we've found pack-gqa to beneficial in SWA.

This PR implements PackGQA for the backward pass of Sm100. This is beneficial for two reasons:
1. Bitwise equivalence with PackGQA in the forward pass, which is not currently the case when using e2e
2. Meaningful performance increase at shorter sequence lengths, coming in part from the fact that dK/dV postprocess is no longer needed. Some benchmarks are attached below. 
There is nothing preventing this from being added to Sm90, I just haven't done so yet. It's less necessary as there is no bitwise invariance issue. 

One design choice comment: I have introduced a `get_m_block_from_iter` method into the main bwd kernel to "unswizzle" the head swizzle inherent in packgqa, which had led to significant L2 spilling and a meaningful performance decrease. This could be tuned further, both for packgqa and other configurations. 

cc @tridao @jayhshah 

```
### hdim=128, causal=False, s_q=32768, b=1, nheads=32, nheads_kv=4, varlen=False, det=False ###
FA Python bwd:          34.999ms, 1256.6 TFLOPS
FA Python bwd pack_gqa: 33.994ms, 1293.8 TFLOPS

### hdim=128, causal=True, s_q=32768, b=1, nheads=32, nheads_kv=4, varlen=False, det=False ###
FA Python bwd:          17.597ms, 1249.6 TFLOPS
FA Python bwd pack_gqa: 18.099ms, 1215.0 TFLOPS

### hdim=128, causal=False, s_q=16384, b=2, nheads=32, nheads_kv=4, varlen=False, det=False ###
FA Python bwd:          17.952ms, 1225.0 TFLOPS
FA Python bwd pack_gqa: 17.435ms, 1261.3 TFLOPS

### hdim=128, causal=True, s_q=16384, b=2, nheads=32, nheads_kv=4, varlen=False, det=False ###
FA Python bwd:          9.369ms, 1173.6 TFLOPS
FA Python bwd pack_gqa: 9.693ms, 1134.3 TFLOPS

### hdim=128, causal=False, s_q=8192, b=4, nheads=32, nheads_kv=4, varlen=False, det=False ###
FA Python bwd:          9.353ms, 1175.6 TFLOPS
FA Python bwd pack_gqa: 8.862ms, 1240.7 TFLOPS

### hdim=128, causal=True, s_q=8192, b=4, nheads=32, nheads_kv=4, varlen=False, det=False ###
FA Python bwd:          5.114ms, 1075.1 TFLOPS
FA Python bwd pack_gqa: 5.366ms, 1024.5 TFLOPS

### hdim=128, causal=False, s_q=4096, b=8, nheads=32, nheads_kv=4, varlen=False, det=False ###
FA Python bwd:          5.062ms, 1086.0 TFLOPS
FA Python bwd pack_gqa: 4.605ms, 1193.8 TFLOPS

### hdim=128, causal=True, s_q=4096, b=8, nheads=32, nheads_kv=4, varlen=False, det=False ###
FA Python bwd:          3.142ms, 874.7 TFLOPS
FA Python bwd pack_gqa: 2.937ms, 936.0 TFLOPS

### hdim=128, causal=False, s_q=2048, b=16, nheads=32, nheads_kv=4, varlen=False, det=False ###
FA Python bwd:          2.975ms, 924.1 TFLOPS
FA Python bwd pack_gqa: 2.443ms, 1125.3 TFLOPS

### hdim=128, causal=True, s_q=2048, b=16, nheads=32, nheads_kv=4, varlen=False, det=False ###
FA Python bwd:          2.180ms, 630.5 TFLOPS
FA Python bwd pack_gqa: 1.799ms, 763.8 TFLOPS

### hdim=128, causal=False, s_q=1024, b=32, nheads=32, nheads_kv=4, varlen=False, det=False ###
FA Python bwd:          2.001ms, 686.8 TFLOPS
FA Python bwd pack_gqa: 1.391ms, 987.9 TFLOPS

### hdim=128, causal=True, s_q=1024, b=32, nheads=32, nheads_kv=4, varlen=False, det=False ###
FA Python bwd:          1.572ms, 437.2 TFLOPS
FA Python bwd pack_gqa: 1.156ms, 594.5 TFLOPS
```