### PR TITLE
[Cute, Fwd] Add return_row_max to expose per-head max attention logits

### DIFF
--- a/flash_attn/cute/flash_fwd.py
+++ b/flash_attn/cute/flash_fwd.py
@@ -328,6 +328,8 @@ class FlashAttentionForwardBase:
         m_block: Int32,
         head_idx: Int32,
         batch_idx: Int32,
+        row_max: Optional[cute.Tensor] = None,
+        mRowMax: Optional[cute.Tensor] = None,
     ):
         # store acc_O
         rO = cute.make_fragment_like(acc_O, self.dtype)
@@ -377,6 +379,33 @@ class FlashAttentionForwardBase:
                             taccOgLSE[m, 0] = lse[m]
             else:
                 pack_gqa.store_LSE(mLSE_cur, lse, tiled_mma, tidx, m_block, seqlen.seqlen_q)
+
+        # Write row_max from rmem -> gmem (same layout as LSE)
+        if const_expr(mRowMax is not None):
+            if const_expr(not seqlen.has_cu_seqlens_q):
+                mRowMax_cur = mRowMax[None, head_idx, batch_idx]
+            else:
+                offset = seqlen.offset_q if const_expr(not self.pack_gqa) else (0, seqlen.offset_q)
+                mRowMax_cur = cute.domain_offset((offset,), mRowMax[None, head_idx])
+            if const_expr(not self.pack_gqa):
+                gRowMax = cute.local_tile(mRowMax_cur, (self.tile_m,), (m_block,))
+                gRowMax_expanded_layout = cute.append(
+                    gRowMax.layout, cute.make_layout((self.tile_hdimv,), stride=(0,))
+                )
+                gRowMax_expanded = cute.make_tensor(gRowMax.iterator, gRowMax_expanded_layout)
+                thr_mma = tiled_mma.get_slice(tidx)
+                taccOgRowMax = layout_utils.reshape_acc_to_mn(thr_mma.partition_C(gRowMax_expanded))
+                taccOcO = layout_utils.reshape_acc_to_mn(thr_mma.partition_C(cO))
+                t0accOcO = layout_utils.reshape_acc_to_mn(thr_mma.get_slice(0).partition_C(cO))
+                if taccOcO[0][1] == 0:
+                    for m in cutlass.range_constexpr(cute.size(taccOgRowMax.shape[1])):
+                        if (
+                            t0accOcO[m, 0][0]
+                            < seqlen.seqlen_q - m_block * self.tile_m - taccOcO[0][0]
+                        ):
+                            taccOgRowMax[m, 0] = row_max[m]
+            else:
+                pack_gqa.store_LSE(mRowMax_cur, row_max, tiled_mma, tidx, m_block, seqlen.seqlen_q)
 
         if const_expr(not seqlen.has_cu_seqlens_q):
             mO_cur = mO[None, None, head_idx, batch_idx]
@@ -631,6 +660,7 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
         learnable_sink: Optional[cute.Tensor] = None,
         blocksparse_tensors: Optional[BlockSparseTensors] = None,
         aux_tensors=None,
+        mRowMax: Optional[cute.Tensor] = None,
     ):
         """Configures and launches the flash attention kernel.
 
@@ -665,6 +695,9 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
         if const_expr(mLSE is not None):
             LSE_layout_transpose = [2, 1, 0] if const_expr(mCuSeqlensQ is None) else [1, 0]
             mLSE = cute.make_tensor(mLSE.iterator, cute.select(mLSE.layout, mode=LSE_layout_transpose))
+        if const_expr(mRowMax is not None):
+            RowMax_layout_transpose = [2, 1, 0] if const_expr(mCuSeqlensQ is None) else [1, 0]
+            mRowMax = cute.make_tensor(mRowMax.iterator, cute.select(mRowMax.layout, mode=RowMax_layout_transpose))
         # TileScheduler for varlen, simple grid for non-varlen
         if const_expr(mCuSeqlensQ is not None or mSeqUsedQ is not None):
             TileScheduler = SingleTileVarlenScheduler
@@ -726,6 +759,7 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
             TileScheduler,
             aux_tensors,
             fastdiv_mods,
+            mRowMax,
         ).launch(
             grid=grid_dim,
             block=[self.num_threads, 1, 1],
@@ -765,6 +799,7 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
         TileScheduler: cutlass.Constexpr[Callable],
         aux_tensors=None,
         fastdiv_mods=None,
+        mRowMax: Optional[cute.Tensor] = None,
     ):
         # Thread index, block index
         tidx, _, _ = cute.arch.thread_idx()
@@ -1070,6 +1105,8 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
             m_block,
             num_head,
             batch_size,
+            row_max=softmax.row_max,
+            mRowMax=mRowMax,
         )
 
     @cute.jit

--- a/flash_attn/cute/flash_fwd_sm100.py
+++ b/flash_attn/cute/flash_fwd_sm100.py
@@ -300,6 +300,7 @@ class FlashAttentionForwardSm100:
         learnable_sink: Optional[cute.Tensor] = None,
         blocksparse_tensors: Optional[BlockSparseTensors] = None,
         aux_tensors: Optional[list] = None,
+        mRowMax: Optional[cute.Tensor] = None,  # Not yet supported on SM100
     ):
         """Execute the Fused Multi-Head Attention operation on the provided tensors.
 

--- a/flash_attn/cute/flash_fwd_sm90.py
+++ b/flash_attn/cute/flash_fwd_sm90.py
@@ -164,6 +164,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         learnable_sink: Optional[cute.Tensor] = None,
         blocksparse_tensors: Optional[BlockSparseTensors] = None,
         aux_tensors: Optional[list] = None,
+        mRowMax: Optional[cute.Tensor] = None,
     ):
         """Configures and launches the flash attention kernel.
 
@@ -187,6 +188,11 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         mLSE = (
             layout_utils.select(mLSE, LSE_layout_transpose)
             if const_expr(mLSE is not None)
+            else None
+        )
+        mRowMax = (
+            layout_utils.select(mRowMax, LSE_layout_transpose)
+            if const_expr(mRowMax is not None)
             else None
         )
 
@@ -366,6 +372,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
             SharedStorage,
             aux_tensors,
             fastdiv_mods,
+            mRowMax,
         ).launch(
             grid=grid_dim,
             block=[self.num_threads, 1, 1],
@@ -411,6 +418,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         SharedStorage: cutlass.Constexpr[Callable],
         aux_tensors=Optional[list[cute.Tensor]],
         fastdiv_mods=None,
+        mRowMax: Optional[cute.Tensor] = None,
     ):
         warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
         # Prefetch tma descriptor
@@ -560,6 +568,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                 blocksparse_tensors,
                 aux_tensors,
                 fastdiv_mods,
+                mRowMax,
             )
 
     @cute.jit
@@ -716,6 +725,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         blocksparse_tensors: Optional[BlockSparseTensors],
         aux_tensors: Optional[list],
         fastdiv_mods=None,
+        mRowMax: Optional[cute.Tensor] = None,
     ):
         warp_group_idx = cute.arch.make_warp_uniform(tidx // self.num_threads_per_warp_group)
         warp_group_thread_layout = cute.make_layout(
@@ -1021,6 +1031,8 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                 m_block,
                 head_idx,
                 batch_idx,
+                row_max=softmax.row_max,
+                mRowMax=mRowMax,
             )
 
             tile_scheduler.advance_to_next_work()

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -313,10 +313,11 @@ def _flash_attn_fwd(
     mask_mod: Optional[Callable] = None,
     block_sparse_tensors: Optional[BlockSparseTensorsTorch] = None,
     return_lse: bool = False,
+    return_row_max: bool = False,
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
     aux_tensors: Optional[list[torch.Tensor]] = None,
-) -> Tuple[torch.Tensor, torch.Tensor]:
+) -> Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
     """Forward pass for FlashAttention.
 
     Args:
@@ -407,6 +408,8 @@ def _flash_attn_fwd(
         ), "inputs must be on CUDA device"
     arch = _get_device_arch() if _arch is None else _arch
     assert arch // 10 in [8, 9, 10, 11, 12], "Unsupported compute capability. Supported: 8.x, 9.x, 10.x, 11.x, 12.x"
+    if return_row_max and arch // 10 in [10, 11]:
+        raise NotImplementedError("return_row_max is not yet supported on SM100/SM110")
     assert num_head % num_head_kv == 0, "num_head must be divisible by num_head_kv"
     alignment = 16 // q.element_size()
     if arch // 10 not in [8, 12]:
@@ -440,6 +443,12 @@ def _flash_attn_fwd(
         )
     elif lse is not None:
         _validate_tensor(lse, "lse", lse_shape, torch.float32, device)
+
+    row_max_out = (
+        torch.empty(lse_shape, dtype=torch.float32, device=device)
+        if return_row_max
+        else None
+    )
 
     dtype = torch2cute_dtype_map[q.dtype]
     use_block_sparsity = block_sparse_tensors is not None
@@ -608,6 +617,7 @@ def _flash_attn_fwd(
         block_sparse_broadcast_pattern,
         aux_tensor_metadata,
         lse is None,
+        row_max_out is None,
         cu_seqlens_q is None,
         cu_seqlens_k is None,
         seqused_q is None,
@@ -657,6 +667,8 @@ def _flash_attn_fwd(
             lse_tensor = to_cute_tensor(lse, assumed_align=4)
         else:
             lse_tensor = None
+
+        row_max_tensor = to_cute_tensor(row_max_out, assumed_align=4) if row_max_out is not None else None
 
         sparse_tensors = None
         if normalized_block_sparse_tensors is not None:
@@ -782,6 +794,7 @@ def _flash_attn_fwd(
             learnable_sink_tensor,
             sparse_tensors,
             cute_aux_tensors,
+            row_max_tensor,
             options="--enable-tvm-ffi",
         )
 
@@ -808,6 +821,7 @@ def _flash_attn_fwd(
             learnable_sink,
             normalized_block_sparse_tensors[:4] if normalized_block_sparse_tensors is not None else None,
             aux_tensors,
+            row_max_out,
         )
     if is_split_kv:
         _flash_attn_fwd_combine(
@@ -818,7 +832,7 @@ def _flash_attn_fwd(
             cu_seqlens_q,
             seqused_q,
         )
-    return out, lse
+    return out, lse, row_max_out
 
 
 _flash_attn_fwd.compile_cache = get_jit_cache("fwd")
@@ -1594,6 +1608,7 @@ class FlashAttnFunc(torch.autograd.Function):
         mask_block_idx: Optional[torch.Tensor] = None,
         block_size: Optional[Tuple[int, int]] = None,
         return_lse: bool = False,
+        return_row_max: bool = False,
     ):
         # Only create block sparse tensors if at least one block sparse parameter is provided
         block_sparse_tensors = None
@@ -1605,7 +1620,7 @@ class FlashAttnFunc(torch.autograd.Function):
                 mask_block_idx=mask_block_idx,
                 block_size=block_size,
             )
-        out, lse = _flash_attn_fwd(
+        out, lse, row_max_out = _flash_attn_fwd(
             q,
             k,
             v,
@@ -1620,6 +1635,7 @@ class FlashAttnFunc(torch.autograd.Function):
             mask_mod=mask_mod,
             block_sparse_tensors=block_sparse_tensors,
             return_lse=return_lse,
+            return_row_max=return_row_max,
         )
         ctx.save_for_backward(q, k, v, out, lse)
         ctx.softmax_scale = softmax_scale
@@ -1628,11 +1644,12 @@ class FlashAttnFunc(torch.autograd.Function):
         ctx.softcap = softcap
         ctx.deterministic = deterministic
         ctx.return_lse = return_lse
+        ctx.return_row_max = return_row_max
         ctx.set_materialize_grads(False)
-        return out, lse
+        return out, lse, row_max_out
 
     @staticmethod
-    def backward(ctx, dout, dlse):
+    def backward(ctx, dout, dlse, _drow_max):
         q, k, v, out, lse = ctx.saved_tensors
         if not ctx.return_lse:
             dlse = None
@@ -1681,8 +1698,9 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
         score_mod: Optional[Callable] = None,
         aux_tensors: Optional[list] = None,
         return_lse: bool = False,
+        return_row_max: bool = False,
     ):
-        out, lse = _flash_attn_fwd(
+        out, lse, row_max_out = _flash_attn_fwd(
             q,
             k,
             v,
@@ -1704,6 +1722,7 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
             score_mod=score_mod,
             aux_tensors=aux_tensors,
             return_lse=return_lse,
+            return_row_max=return_row_max,
         )
         ctx.save_for_backward(q, k, v, out, lse, cu_seqlens_q, cu_seqlens_k, seqused_q, seqused_k)
         ctx.softmax_scale = softmax_scale
@@ -1714,11 +1733,12 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
         ctx.max_seqlen_q = max_seqlen_q
         ctx.max_seqlen_k = max_seqlen_k
         ctx.return_lse = return_lse
+        ctx.return_row_max = return_row_max
         ctx.set_materialize_grads(False)
-        return out, lse
+        return out, lse, row_max_out
 
     @staticmethod
-    def backward(ctx, dout, dlse):
+    def backward(ctx, dout, dlse, _drow_max):
         q, k, v, out, lse, cu_seqlens_q, cu_seqlens_k, seqused_q, seqused_k = ctx.saved_tensors
         assert ctx.softcap == 0.0
         if not ctx.return_lse:
@@ -1769,6 +1789,7 @@ def flash_attn_func(
     mask_block_idx: Optional[torch.Tensor] = None,
     block_size: Optional[Tuple[int, int]] = None,
     return_lse: bool = False,
+    return_row_max: bool = False,
 ):
     return FlashAttnFunc.apply(
         q,
@@ -1789,6 +1810,7 @@ def flash_attn_func(
         mask_block_idx,
         block_size,
         return_lse,
+        return_row_max,
     )
 
 
@@ -1814,6 +1836,7 @@ def flash_attn_varlen_func(
     score_mod: Optional[Callable] = None,
     aux_tensors: Optional[list] = None,
     return_lse: bool = False,
+    return_row_max: bool = False,
 ):
     return FlashAttnVarlenFunc.apply(
         q,
@@ -1837,6 +1860,7 @@ def flash_attn_varlen_func(
         score_mod,
         aux_tensors,
         return_lse,
+        return_row_max,
     )
 
 


### PR DESCRIPTION
## Summary
- Add `return_row_max` parameter to `flash_attn_func` and `flash_attn_varlen_func` that returns per-head attention logit maximums (`softmax.row_max`) alongside the existing LSE output
- The row_max values are written to global memory using the same pattern as LSE in the forward epilogue
- Useful for QK clipping in optimizers like Muon (Kimi K2 paper)

## Details
- `row_max` values are the raw maximums **before** multiplying by `softmax_scale` (typically `1/sqrt(d)`)
- Same tensor shape as `lse`: `(batch, num_heads, seqlen_q)` or `(num_heads, total_q)` for varlen
- Supported on SM80, SM90, SM120. SM100/SM110 raises `NotImplementedError` (different epilogue system, will be addressed in a follow-up)

## Files changed
- `flash_attn/cute/interface.py` — parameter threading, tensor allocation, compile key, autograd functions
- `flash_attn/cute/flash_fwd.py` — base epilogue row_max write, SM80 `__call__`/`kernel` parameter threading
- `flash_attn/cute/flash_fwd_sm90.py` — SM90 `__call__`/`kernel`/`mma` parameter threading
- `flash_attn/cute/flash_fwd_sm100.py` — accept parameter (no-op, not yet implemented)

## Test plan
- [ ] Verify `return_row_max=True` returns correct per-head max logits on SM80/SM90/SM120
- [ ] Verify `return_row_max=False` (default) has no impact on existing behavior
- [ ] Verify SM100/SM110 raises `NotImplementedError`
- [ ] Compare row_max values against reference PyTorch computation: `(q @ k.T).max(dim=-1).values`

Closes #1876
