### PR TITLE
[Sm75] Add README link for initial Turing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,9 +122,7 @@ We recommend the
 container from Nvidia, which has all the required tools to install FlashAttention.
 
 FlashAttention-2 with CUDA currently supports:
-1. Ampere, Ada, or Hopper GPUs (e.g., A100, RTX 3090, RTX 4090, H100). Support for Turing
-   GPUs (T4, RTX 2080) is coming soon, please use FlashAttention 1.x for Turing
-   GPUs for now.
+1. Ampere, Ada, or Hopper GPUs (e.g., A100, RTX 3090, RTX 4090, H100). For Turing GPUs (T4, RTX 2080), see the separate [flash-attention-turing](https://github.com/ssiu/flash-attention-turing) repo, which supports a core subset of FlashAttention features on Turing.
 2. Datatype fp16 and bf16 (bf16 requires Ampere, Ada, or Hopper GPUs).
 3. All head dimensions up to 256. ~~Head dim > 192 backward requires A100/A800 or H100/H800~~. Head dim 256 backward now works on consumer GPUs (if there's no dropout) as of flash-attn 2.5.5.
 


### PR DESCRIPTION
# FlashAttention Turing

This PR adds a link to the [flash-attention-turing](https://github.com/ssiu/flash-attention-turing) repo that provides support for Turing (SM75) architecture in FlashAttention, following #1533.

## Features

Supports:

 - fwd and bwd
 - head dim 64, 128
 - causal mask
 - grouped-query attention (GQA)
 - variable sequence lengths (varlen)

Does not support:

 - dropout
 - local mask
 - kv cache

## Performance

Benchmarks are reported on Nvidia T4 GPUs.

### Forward pass 

Up to 2.19x and 1.95x faster than PyTorch's [Attention](https://pytorch.org/docs/stable/generated/torch.nn.functional.scaled_dot_product_attention.html) for non-causal and causal workloads.

On Turing GPUs, PyTorch's Attention uses Memory-Efficient Attention from [xformers](https://github.com/facebookresearch/xformers), since FlashAttention does not provide optimized kernels for SM75.

For long sequences, the forward kernel reaches up to 66% compute throughput.

<img src="https://raw.githubusercontent.com/ssiu/flash-attention-turing/main/utils/forward_128_combined.png" alt="Forward pass benchmark for head dimension 128" width="1000">
<img src="https://raw.githubusercontent.com/ssiu/flash-attention-turing/main/utils/forward_64_combined.png" alt="Forward pass benchmark for head dimension 64" width="1000">

### Backward pass 

The backward pass is split into two kernels: one for `dQ` and one for `dK` and `dV`.

Up to 1.35x and 1.51x faster than PyTorch's Attention for non-causal and causal workloads.

For long sequences, the backward kernels reach up to 49% compute throughput for `dK` and `dV`, and 45% for `dQ`.

<img src="https://raw.githubusercontent.com/ssiu/flash-attention-turing/main/utils/backward_128_combined.png" alt="Backward pass benchmark for head dimension 128" width="1000">
<img src="https://raw.githubusercontent.com/ssiu/flash-attention-turing/main/utils/backward_64_combined.png" alt="Backward pass benchmark for head dimension 64" width="1000">


## Correctness and numerical differences

From our tests in `test_flash_attn.py`, we consistently observe maximum and mean absolute differences of ~1e-3 and ~1e-5 respectively relative to PyTorch's attention kernels.


Thanks!
