### PR TITLE
docs: add gitcgr code graph badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # FlashAttention
+
+[![gitcgr](https://gitcgr.com/badge/Dao-AILab/flash-attention.svg)](https://gitcgr.com/Dao-AILab/flash-attention)
 This repository provides the official implementation of FlashAttention and
 FlashAttention-2 from the
 following papers.


### PR DESCRIPTION
Adds a [gitcgr](https://gitcgr.com) badge to the README showing code graph statistics for this repository.

**Badge preview:**

[![gitcgr](https://gitcgr.com/badge/Dao-AILab/flash-attention.svg)](https://gitcgr.com/Dao-AILab/flash-attention)

---

[gitcgr.com](https://gitcgr.com) visualizes any GitHub repo as an interactive code graph — just change `hub` to `cgr` in the URL.

Generated automatically by [gitcgr](https://gitcgr.com).