### PR TITLE
Initial Windows ROCm build support for FlashAttention-2 ROCm/aiter Triton backend

### DIFF
--- a/flash_attn/utils/distributed.py
+++ b/flash_attn/utils/distributed.py
@@ -8,9 +8,9 @@ from torch.distributed import ProcessGroup
 # `_all_gather_base` and `_reduce_scatter_base`. They require the most recent
 # version of PyTorch. The following 4 lines are for backward compatibility with
 # older PyTorch.
-if "all_gather_into_tensor" not in dir(torch.distributed):
+if "all_gather_into_tensor" not in dir(torch.distributed) and hasattr(torch.distributed, "_all_gather_base"):
     torch.distributed.all_gather_into_tensor = torch.distributed._all_gather_base
-if "reduce_scatter_tensor" not in dir(torch.distributed):
+if "reduce_scatter_tensor" not in dir(torch.distributed) and hasattr(torch.distributed, "_reduce_scatter_base"):
     torch.distributed.reduce_scatter_tensor = torch.distributed._reduce_scatter_base
 
 

--- a/setup.py
+++ b/setup.py
@@ -214,15 +214,27 @@ ext_modules = []
 # files included in the source distribution, in case the user compiles from source.
 if IS_ROCM:
     if ROCM_BACKEND == "triton":
-        if os.path.isdir(".git"):
+        if os.path.isdir("third_party/aiter"):
+            # If the submodule is already present (possibly with local patches applied),
+            # skip `git submodule update` to avoid overwriting local changes.
+            pass
+        elif os.path.isdir(".git"):
             subprocess.run(["git", "submodule", "update", "--init", "third_party/aiter"], check=True)
         else:
             assert os.path.isdir("third_party/aiter"), (
                 "third_party/aiter is missing, please use source distribution or git clone"
             )
+        aiter_install_env = os.environ.copy()
+        if sys.platform == "win32":
+            # CK (composable_kernel) is not available on Windows; disable it
+            # and skip pre-building HIP C++ kernels so only the pure-Triton
+            # flash-attention path is installed.
+            aiter_install_env["ENABLE_CK"] = "0"
+            aiter_install_env["PREBUILD_KERNELS"] = "0"
         subprocess.run(
             [sys.executable, "-m", "pip", "install", "--no-build-isolation", "third_party/aiter"],
             check=True,
+            env=aiter_install_env,
         )
     elif ROCM_BACKEND == "ck":
         if os.path.isdir(".git"):
@@ -615,8 +627,12 @@ if ROCM_BACKEND == "triton":
     # Note: torch is excluded because pip resolves it to CUDA PyTorch from PyPI, overwriting any pre-installed ROCm PyTorch. Users must have torch installed.
     install_requires = [
         "einops",
-        "triton==3.5.1",
     ]
+    if sys.platform == "win32":
+        # triton-windows is the community port of Triton for Windows ROCm
+        install_requires.append("triton-windows>=3.2.0")
+    else:
+        install_requires.append("triton==3.5.1")
 else:
     install_requires = [
         "torch",
@@ -650,6 +666,7 @@ setup(
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: BSD License",
         "Operating System :: Unix",
+        "Operating System :: Microsoft :: Windows",
     ],
     ext_modules=ext_modules,
     cmdclass={"bdist_wheel": CachedWheelsCommand, "build_ext": NinjaBuildExtension}


### PR DESCRIPTION
## Motivation

Enable building and running FlashAttention-2 on Windows with AMD GPUs via the `ROCm/aiter` Triton backend after the [migration](https://github.com/Dao-AILab/flash-attention/pull/2230). Three small issues blocked this entirely: a crash on import when `torch.distributed` attributes are missing, a broken aiter submodule setup step, and a hard dependency on the Linux-only `triton` package.

> [!NOTE]
> This PR depends on Windows build support being merged in `ROCm/aiter` first (or applied locally). See the corresponding PR: ROCm/aiter#2428

## Technical Details

**`setup.py`**
- Skip `git submodule update` for `third_party/aiter` if the directory already exists, to avoid overwriting locally cloned versions
- Pass `ENABLE_CK=0` and `PREBUILD_KERNELS=0` when installing aiter on Windows, since Composable Kernel and its pre-built HIP C++ kernels are not available there - the pure-Triton FA path is used instead
- Replace the hard `triton==3.5.1` dependency with `triton-windows>=3.2.0` on Windows (`triton-windows` is the community port of Triton for Windows ROCm)
- Add `Operating System :: Microsoft :: Windows` classifier

**`flash_attn/utils/distributed.py`**
- Guard the `torch.distributed` backward-compatibility assignments with `hasattr` checks before assigning, preventing an `AttributeError` crash on Windows ROCm builds where `_all_gather_base` / `_reduce_scatter_base` may not exist

## Test Plan
- Source build and install (using both PRs for now):
```
git clone -b fa2-aiter-triton-win-support https://github.com/0xDELUXA/flash-attention.git
cd flash-attention\third_party
git clone -b fa2-triton-win-support https://github.com/0xDELUXA/aiter.git
cd ..
$env:ENABLE_CK = "0"
$env:PREBUILD_KERNELS = "0"
$env:FLASH_ATTENTION_TRITON_AMD_ENABLE = "TRUE"
pip install --no-build-isolation -e .
```
- Run basic tests via `from flash_attn import flash_attn_func`.

## Test Result

- Successfully built FlashAttention-2 with aiter on Windows with an AMD GPU (`gfx1200`), ROCm `7.13.0a20260321`, PyTorch `2.12.0a0+rocm7.13.0a20260321`, Python `3.12`.

- All tests passed.