### PR TITLE
fix: use LSE accum strides from params instead of hardcoded ones

### DIFF
--- a/hopper/flash_fwd_launch_template.h
+++ b/hopper/flash_fwd_launch_template.h
@@ -140,7 +140,7 @@ void run_flash_fwd(Flash_fwd_params &params, cudaStream_t stream) {
         static_cast<float*>(params.softmax_lse_ptr),
         {_1{}, seqlen_q, !is_varlen_q ? params.h * seqlen_q : 0, 0},  // stride_LSE
         static_cast<float*>(params.softmax_lseaccum_ptr),
-        {_1{}, seqlen_q, !is_varlen_q ? params.h * seqlen_q : 0, params.h * seqlen_q * batch_q},  // stride_LSE_partial
+        {_1{}, params.lseaccum_head_stride, !is_varlen_q ? params.lseaccum_batch_stride : 0, params.lseaccum_split_stride},  // stride_LSE_partial
         params.h_k,
         params.cu_seqlens_q, params.seqused_q
     };


### PR DESCRIPTION
In the Split-KV path, the forward kernel computes LSE accumulator addresses using hardcoded strides instead of the stride values provided in the params structure. The combine kernel already uses the explicit strides from params, so this creates an inconsistency between the two kernels.

As a result, when the caller supplies an LSE accumulator layout that differs from the layout assumed by the forward kernel, the forward pass writes to incorrect locations and produces wrong output.

This change updates the forward kernel to use the LSE accumulator strides from params, matching the behavior of the combine kernel and ensuring correct results for arbitrary accumulator layouts.