### PR TITLE
Fix edge case when tag has no delta from previous

### DIFF
--- a/.github/workflows/publish-fa4.yml
+++ b/.github/workflows/publish-fa4.yml
@@ -59,9 +59,16 @@ jobs:
         python-version: '3.12'
     - name: Install build dependencies
       run: pip install build twine
+    - name: Extract version from tag
+      id: strip-prefix
+      run: |
+        TAG="${{ needs.prepare-release.outputs.release_tag }}"
+        echo "version=${TAG#fa4-v}" >> "$GITHUB_OUTPUT"
     - name: Build package
       run: python -m build
       working-directory: flash_attn/cute
+      env:
+        SETUPTOOLS_SCM_PRETEND_VERSION: ${{ steps.strip-prefix.outputs.version }}
     - name: Check package metadata
       run: twine check dist/*
       working-directory: flash_attn/cute


### PR DESCRIPTION
# Summary

When the automatic flow creates a tag n and there is no changes from tag n-1 git describe can pick which ever. If we pick n-1 the upload will fail. Its not really a problem since 
there isn't really anything to upload. But for provenance i think its good we still upload the wheel and have 1 per pre-release.
