### PR TITLE
fix(cute): SM120 forward/bwd and atomic add compatibility

### DIFF
--- a/flash_attn/cute/flash_fwd.py
+++ b/flash_attn/cute/flash_fwd.py
@@ -17,7 +17,6 @@ import cutlass.cute as cute
 from cutlass import Constexpr, Float32, Int32, const_expr, Boolean
 from cutlass.cute.nvgpu import cpasync, warp
 import cutlass.utils as utils_basic
-from cutlass.base_dsl.arch import Arch
 from cutlass.cutlass_dsl import BaseDSL
 
 from quack import copy_utils
@@ -648,8 +647,10 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
         self.num_producer_threads = self.num_threads
         self.num_Q_load_threads = self.num_threads
         self.num_epilogue_threads = self.num_threads
-        # self.use_tma_O = self.arch >= 90 and mCuSeqlensQ is None
-        self.use_tma_O = self.arch >= Arch.sm_90
+        # Sm80 path always uses the cpasync/universal epilogue for O. `self.arch` is the runtime
+        # GPU (e.g. sm_120 on RTX 5090), not the kernel family; comparing to sm_90 incorrectly
+        # enables TMA-O and hits tma_atom_O=None (Dao-AILab/flash-attention#2386).
+        self.use_tma_O = False
         self._setup_attributes()
         SharedStorage = self._get_shared_storage_cls()
         mQ, mK, mV, mO = [assume_tensor_aligned(t) for t in (mQ, mK, mV, mO)]

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -1027,6 +1027,10 @@ def _flash_attn_bwd(
         cluster_size = 1
         use_2cta_instrs = False
         num_threads = 128
+        # Match SM90 BwdConfig: dQ_single_wg is only set on the Hopper path; SM120 must set it
+        # explicitly for compile_key (Dao-AILab/flash-attention#2386).
+        dQ_single_wg = False
+        num_stages_PdS = 2 if head_dim <= 64 else 1
         assert not (block_sparse_tensors is not None), "Block sparsity backward not supported on SM 12.0"
         assert score_mod is None and score_mod_bwd is None, "score_mod backward not supported on SM 12.0"
         assert mask_mod is None, "mask_mod backward not supported on SM 12.0"

--- a/flash_attn/cute/utils.py
+++ b/flash_attn/cute/utils.py
@@ -418,8 +418,17 @@ def atomic_add_fp32(a: float | Float32, gmem_ptr: cute.Pointer, *, loc=None, ip=
     #     is_align_stack=False,
     #     asm_dialect=llvm.AsmDialect.AD_ATT,
     # )
-    nvvm.atomicrmw(
-        res=T.f32(), op=nvvm.AtomicOpKind.FADD, ptr=gmem_ptr.llvm_ptr, a=Float32(a).ir_value()
+    # Use PTX red.global.add.f32 for compatibility across NVVM Python binding versions
+    # (nvvm.atomicrmw(res=...) is not supported on some stacks; see #2386).
+    gmem_ptr_i64 = gmem_ptr.toint(loc=loc, ip=ip).ir_value()
+    llvm.inline_asm(
+        None,
+        [gmem_ptr_i64, Float32(a).ir_value(loc=loc, ip=ip)],
+        "red.global.add.f32 [$0], $1;",
+        "l,f",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
     )
 
 


### PR DESCRIPTION
## Summary

Addresses #2386 (sm_120 smoke test: forward + backward).

1. **Forward (Sm80 path on Blackwell):** FlashAttentionForwardSm80 set use_tma_O from runtime arch (\\>= sm_90\\), but the Sm80/CpAsync epilogue does not provide a valid TMA O atom. On RTX 5090 the runtime arch is sm_120, so the TMA-O branch was taken with 	ma_atom_O=None. The Sm80 forward path now always disables TMA for the output store.

2. **Backward (SM120):** Initialize dQ_single_wg and 
um_stages_PdS in the SM120 tile branch so the shared compile_key tuple is well-defined.

3. **Atomic add:** Replace 
vvm.atomicrmw(..., res=...) with inline PTX ed.global.add.f32 for compatibility with newer NVVM Python bindings.

## Testing

- Not run on sm_120 hardware in this environment; please verify with the minimal repro in #2386 if possible.

Fixes #2386

Made with [Cursor](https://cursor.com)