### PR TITLE
[CuTe, SM120] Forward kernel with optimized TMA path and full features support

### DIFF
--- a/flash_attn/cute/flash_fwd_sm120_tma_optimized.py
+++ b/flash_attn/cute/flash_fwd_sm120_tma_optimized.py
@@ -1,0 +1,1936 @@
+"""Optimized SM120 forward kernel definition.
+
+This file contains a full SM120 kernel class implementation (derived from
+FlashAttentionForwardSm80) with fixed behavior:
+- Non-causal/non-local: persistent scheduling with single-tile scheduler.
+- Causal/local: non-persistent scheduling with LPT ordering.
+"""
+
+import math
+from types import SimpleNamespace
+from typing import Type, Callable, Optional, List
+from functools import partial
+
+import cuda.bindings.driver as cuda
+
+import cutlass
+import cutlass.cute as cute
+from cutlass import Constexpr, Float32, Int32, const_expr
+from cutlass.cute.nvgpu import cpasync, warp, warpgroup
+from cutlass.cute.arch import ProxyKind, SharedSpace
+import cutlass.utils as utils_basic
+from cutlass.utils import LayoutEnum
+import cutlass.utils.hopper_helpers as sm90_utils_basic
+from cutlass.pipeline import Agent, CooperativeGroup
+
+from quack import layout_utils
+
+from flash_attn.cute import ampere_helpers as sm80_utils
+from flash_attn.cute import utils
+from flash_attn.cute import copy_utils
+from flash_attn.cute.mask import AttentionMask
+from flash_attn.cute.softmax import Softmax, apply_score_mod_inner
+from flash_attn.cute.seqlen_info import SeqlenInfoQK
+from flash_attn.cute.block_info import BlockInfo
+from flash_attn.cute.block_sparsity import BlockSparseTensors
+from flash_attn.cute.block_sparse_utils import (
+    produce_block_sparse_loads,
+    consume_block_sparse_loads,
+)
+from flash_attn.cute import pipeline
+from flash_attn.cute.pack_gqa import PackGQA, make_packgqa_tiled_tma_atom
+from flash_attn.cute.named_barrier import NamedBarrierFwd
+from flash_attn.cute.tile_scheduler import (
+    TileSchedulerArguments,
+    SingleTileScheduler,
+    SingleTileLPTScheduler,
+    SingleTileVarlenScheduler,
+    ParamsBase,
+)
+from flash_attn.cute.flash_fwd import FlashAttentionForwardSm80
+
+
+class FlashAttentionForwardSm120TMAOptimized(FlashAttentionForwardSm80):
+
+    arch = 120
+
+    def __init__(
+        self,
+        dtype: Type[cutlass.Numeric],
+        head_dim: int,
+        head_dim_v: Optional[int] = None,
+        qhead_per_kvhead: int = 1,
+        is_causal: bool = False,
+        is_local: bool = False,
+        pack_gqa: bool = False,
+        tile_m: int = None,
+        tile_n: int = None,
+        num_stages: int = None,
+        num_threads: int = 160,
+        use_tma_Q: bool = True,
+        score_mod: Optional[cutlass.Constexpr] = None,
+        mask_mod: Optional[cutlass.Constexpr] = None,
+        has_aux_tensors: bool = False,
+        direct_q_gmem_regs_decode: bool = False,
+    ):
+        # SM120 shared memory budget - max per block is ~101KB based on empirical testing
+        # (99KB documented limit may be conservative). We account for:
+        # - Pipeline barrier arrays (num_stages * 2 * 8 bytes = ~32 bytes)
+        # - Alignment padding (4 buffers * 1024 bytes = 4KB)
+        self.SM120_SMEM_BUDGET_BYTES = 101 * 1024
+        # Store basic config
+        self.dtype = dtype
+        self.head_dim = head_dim
+        self.head_dim_v = head_dim_v if head_dim_v is not None else head_dim
+        self.same_hdim_kv = head_dim == self.head_dim_v
+        self.qhead_per_kvhead = qhead_per_kvhead
+        self.is_causal = is_causal
+        self.is_local = is_local
+        self.pack_gqa = pack_gqa
+        # SM120 uses warp-level MMA (no warpgroup ops), and we keep all MMA operands in
+        # registers for both QK and PV paths by default.
+        self.Q_in_regs = True
+        self.K_in_regs = True
+        # Decode-only optimization: in causal q1 mode, load Q directly from GMEM to
+        # registers and reserve shared memory primarily for staged KV tiles.
+        self.use_direct_q_gmem_regs_decode = direct_q_gmem_regs_decode
+        self.score_mod = score_mod
+        self.mask_mod = mask_mod
+        self.has_aux_tensors = has_aux_tensors
+        self.alignment_width = 1024  # bytes
+        self.buffer_align_bytes = cutlass.const_expr(self.alignment_width)
+        self.use_tma_Q = use_tma_Q
+        self.use_tma_O = True
+        self.unroll_consumer = 0
+        self.unroll_producer_load = 0
+        self.unroll_producer_sync = 0
+
+        # KV TMA always uses shared-KV SMEM on SM120.
+        self.share_kv_smem = True
+
+        # Pad head dimensions to multiples of 16
+        hdim_multiple_of = 16
+        self.tile_hdim = int(math.ceil(head_dim / hdim_multiple_of) * hdim_multiple_of)
+        self.tile_hdimv = int(math.ceil(self.head_dim_v / hdim_multiple_of) * hdim_multiple_of)
+        self.check_hdim_oob = head_dim != self.tile_hdim
+        self.check_hdim_v_oob = self.head_dim_v != self.tile_hdimv
+
+        # MMA instruction shape
+        self.mma_inst_mnk = (16, 8, 16)
+        
+        bytes_per_elem = 2  # fp16/bf16
+        # Single-tile SM120 kernel: Q staging is dead by epilogue time, so O can reuse
+        # the same SMEM buffer even when the final O write uses TMA.
+        self.alias_sO_with_sQ = True
+        # Decode direct-Q mode keeps only a KV shared buffer; otherwise we keep
+        # both KV and aliased Q/O shared buffers.
+        num_aligned_buffers = 1 if self.use_direct_q_gmem_regs_decode else 2
+        alignment_overhead = num_aligned_buffers * self.alignment_width + 64
+
+        self.tile_m = tile_m
+        self.tile_n = tile_n
+        self.num_stages = num_stages
+
+        if use_tma_Q:
+            assert self.tile_m % self.qhead_per_kvhead == 0, "tile_m must be a multiple of qhead_per_kvhead when using TMA Q"
+
+        # Optimized SM120 launch topology is fixed to 1 DMA warp + 4 MMA warps.
+        self.num_producer_warps = 1
+        self.num_mma_warps = 4
+        expected_num_threads = (self.num_producer_warps + self.num_mma_warps) * 32
+        if num_threads is None:
+            num_threads = expected_num_threads
+        if num_threads != expected_num_threads:
+            raise ValueError(
+                "SM120 config invalid: num_threads must equal "
+                f"(num_dma_warps + num_mma_warps) * 32 = {expected_num_threads}, "
+                f"got {num_threads}."
+            )
+
+        self.k_num_stages = self.num_stages
+        self.v_num_stages = self.num_stages
+
+        # Match SM100-style shared K/V stage-offset scheduling when stage counts align.
+        self.share_kv_tma_stage_offset = self.num_stages > 1
+        self.shared_kv_mbar = self.share_kv_tma_stage_offset
+        self.use_tma_Q_mainloop = self.use_tma_Q and (not self.use_direct_q_gmem_regs_decode)
+        # In shared-KV stage-offset mode, piggyback the first Q TMA transaction on K's mbarrier.
+        self.unify_qk_tma_barrier = self.use_tma_Q_mainloop and self.shared_kv_mbar
+
+        # SM100-style mbarrier layout (no TMEM fields on SM120).
+        self.mbar_load_q_full_offset = 0
+        q_mbar_slots = 0 if self.unify_qk_tma_barrier else (2 if self.use_tma_Q_mainloop else 0)
+        self.mbar_load_q_empty_offset = self.mbar_load_q_full_offset + (1 if q_mbar_slots else 0)
+        self.mbar_load_k_full_offset = self.mbar_load_q_full_offset + q_mbar_slots
+        self.mbar_load_k_empty_offset = self.mbar_load_k_full_offset + self.k_num_stages
+        if self.shared_kv_mbar:
+            self.mbar_load_v_full_offset = self.mbar_load_k_full_offset
+            self.mbar_load_v_empty_offset = self.mbar_load_k_empty_offset
+            self.mbar_total = self.mbar_load_k_empty_offset + self.k_num_stages
+        else:
+            self.mbar_load_v_full_offset = self.mbar_load_k_empty_offset + self.k_num_stages
+            self.mbar_load_v_empty_offset = self.mbar_load_v_full_offset + self.v_num_stages
+            self.mbar_total = self.mbar_load_v_empty_offset + self.v_num_stages
+        
+        # Calculate and verify shared memory usage for shared-KV path.
+        kv_elems = max(self.tile_hdim, self.tile_hdimv)
+        kv_smem = self.tile_n * kv_elems * self.num_stages * bytes_per_elem
+        if self.use_direct_q_gmem_regs_decode:
+            # Q staging is removed. O is stored by reusing KV shared storage.
+            qo_smem = 0
+            kv_smem = max(kv_smem, self.tile_m * self.tile_hdimv * bytes_per_elem)
+        else:
+            q_elems = self.tile_hdim
+            o_elems = 0 if self.alias_sO_with_sQ else self.tile_hdimv
+            qo_smem = self.tile_m * (q_elems + o_elems) * bytes_per_elem
+        barrier_smem = self.mbar_total * 8  # Int64 barrier slots
+        total_smem = kv_smem + qo_smem + alignment_overhead + barrier_smem
+        
+        if total_smem > self.SM120_SMEM_BUDGET_BYTES:
+            raise ValueError(
+                f"SM120 kernel configuration exceeds shared memory budget: "
+                f"tile_m={self.tile_m}, tile_n={self.tile_n}, hdim={self.tile_hdim}, "
+                f"stages={self.num_stages} requires ~{total_smem // 1024}KB, limit is ~101KB"
+            )
+        
+        mma_m = self.mma_inst_mnk[0]
+        mma_m_factor = self.num_mma_warps
+        if self.tile_m % (mma_m_factor * mma_m) != 0:
+            raise ValueError(
+                "SM120 config invalid: tile_m must be divisible by "
+                "(mma_m_factor * mma_m). "
+                f"tile_m={self.tile_m}, mma_m_factor={mma_m_factor}, "
+                f"mma_m={mma_m}."
+            )
+
+        self.num_threads = expected_num_threads
+        # Cluster shape (single CTA for now, no multicast)
+        self.cluster_shape = (1, 1, 1)
+
+        # Optimized defaults baked into the kernel behavior:
+        # - non-causal/non-local: persistent + single scheduler
+        # - causal/local: non-persistent + LPT scheduler
+        self.use_persistent_schedule = (not self.is_causal) and (not self.is_local)
+        self.persistent_noncausal_scheduler = (
+            "single" if self.use_persistent_schedule else "lpt"
+        )
+    
+    @staticmethod
+    def can_implement(
+        dtype,
+        head_dim,
+        head_dim_v,
+        tile_m,
+        tile_n,
+        num_stages,
+        num_threads,
+        is_causal,
+        Q_in_regs=True,
+        use_tma_Q: bool = False,
+        pack_gqa: bool = False,
+        decode_q1_direct_q_g2r: bool = False,
+    ) -> bool:
+        """Check whether the optimized SM120 forward kernel is implementable."""
+        del is_causal, Q_in_regs, pack_gqa
+        if dtype not in [cutlass.Float16, cutlass.BFloat16]:
+            return False
+        if head_dim is None or head_dim_v is None:
+            return False
+        if head_dim % 8 != 0 or head_dim_v % 8 != 0:
+            return False
+        if tile_m is None or tile_n is None or num_stages is None:
+            return False
+        if tile_m <= 0 or tile_n <= 0 or num_stages <= 0:
+            return False
+        if tile_n % 16 != 0:
+            return False
+        # Optimized SM120 launch topology is fixed to 1 DMA warp + 4 MMA warps.
+        expected_num_threads = (1 + 4) * 32
+        if num_threads != expected_num_threads:
+            return False
+
+        # MMA shape requires tile_m to be divisible by (num_mma_warps * mma_m) = 64.
+        if tile_m % (4 * 16) != 0:
+            return False
+
+        tile_hdim = int(math.ceil(head_dim / 16) * 16)
+        tile_hdimv = int(math.ceil(head_dim_v / 16) * 16)
+        bytes_per_elem = 2  # fp16/bf16
+        # shared_kv_smem=True and alias_sO_with_sQ=True in optimized SM120.
+        kv_smem = tile_n * max(tile_hdim, tile_hdimv) * num_stages * bytes_per_elem
+        o_smem = tile_m * tile_hdimv * bytes_per_elem
+        if decode_q1_direct_q_g2r:
+            # Decode q1 direct-Q path aliases O with KV shared storage and keeps only
+            # one aligned shared buffer.
+            qo_smem = 0
+            kv_smem = max(kv_smem, o_smem)
+            alignment_overhead = 1 * 1024 + 64
+            use_tma_Q_effective = False
+        else:
+            qo_smem = tile_m * tile_hdim * bytes_per_elem
+            alignment_overhead = 2 * 1024 + 64
+            use_tma_Q_effective = use_tma_Q
+
+        k_num_stages = num_stages
+        v_num_stages = num_stages
+        shared_kv_mbar = (num_stages > 1) and (k_num_stages == v_num_stages)
+        unify_qk_tma_barrier = use_tma_Q_effective and shared_kv_mbar
+        q_mbar_slots = 0 if unify_qk_tma_barrier else (2 if use_tma_Q_effective else 0)
+        mbar_load_k_full_offset = q_mbar_slots
+        mbar_load_k_empty_offset = mbar_load_k_full_offset + k_num_stages
+        if shared_kv_mbar:
+            mbar_total = mbar_load_k_empty_offset + k_num_stages
+        else:
+            mbar_load_v_full_offset = mbar_load_k_empty_offset + k_num_stages
+            mbar_load_v_empty_offset = mbar_load_v_full_offset + v_num_stages
+            mbar_total = mbar_load_v_empty_offset + v_num_stages
+        barrier_smem = mbar_total * 8
+
+        total_smem = kv_smem + qo_smem + alignment_overhead + barrier_smem
+        return total_smem <= 101 * 1024
+
+    def _setup_attributes(self, use_decode_q1_direct_q_g2r: bool = False):
+        tiled_mma_qk, tiled_mma_pv = self._get_tiled_mma()
+        # Epilogue only involves MMA warps (not DMA warp).
+        self.num_epilogue_threads = self.num_mma_warps * 32
+        self._setup_layouts()
+        if use_decode_q1_direct_q_g2r:
+            SharedStorage = self._get_shared_storage_cls_decode_q1()
+        else:
+            SharedStorage = self._get_shared_storage_cls()
+        return tiled_mma_qk, tiled_mma_pv, SharedStorage
+
+    @cute.jit
+    def advance_pipeline(self, pipeline_index):
+        return pipeline_index + 1 if pipeline_index < self.num_stages - 1 else 0
+
+    @cute.jit
+    def load_Q(
+        self,
+        gmem_thr_copy: cute.TiledCopy,
+        gQ: cute.Tensor,
+        sQ: cute.Tensor,
+        block: Int32,
+        seqlen: Int32,
+        headdim: Int32,
+    ):
+        FlashAttentionForwardSm80.load_Q(
+            self,
+            gmem_thr_copy,
+            gQ,
+            sQ,
+            block,
+            seqlen,
+            headdim,
+        )
+
+    @cute.jit
+    def load_K(
+        self,
+        tma_atom: cute.CopyAtom,
+        tKgK_tma: cute.Tensor,
+        tKsK_tma: cute.Tensor,
+        block: Int32,
+        smem_pipe_write: Int32,
+        smem_pipe_phase: Int32,
+        tma_bar_ptr: cutlass.Pointer,
+    ):
+        self.load_tma_partitioned(
+            tma_atom,
+            tKgK_tma,
+            tKsK_tma,
+            src_idx=block,
+            dst_idx=smem_pipe_write,
+            dst_phase=smem_pipe_phase,
+            tma_bar_ptr=tma_bar_ptr,
+        )
+
+    @cute.jit
+    def load_V(
+        self,
+        tma_atom: cute.CopyAtom,
+        tVgV_tma: cute.Tensor,
+        tVsV_tma: cute.Tensor,
+        block: Int32,
+        smem_pipe_write: Int32,
+        smem_pipe_phase: Int32,
+        tma_bar_ptr: cutlass.Pointer,
+    ):
+        self.load_tma_partitioned(
+            tma_atom,
+            tVgV_tma,
+            tVsV_tma,
+            src_idx=block,
+            dst_idx=smem_pipe_write,
+            dst_phase=smem_pipe_phase,
+            tma_bar_ptr=tma_bar_ptr,
+        )
+
+    def _check_type(
+        self,
+        mQ_type: Type[cutlass.Numeric],
+        mK_type: Type[cutlass.Numeric],
+        mV_type: Type[cutlass.Numeric],
+        mO_type: Type[cutlass.Numeric],
+        mLSE_type: Type[cutlass.Numeric] | None,
+        mCuSeqlensQ_type: Type[cutlass.Numeric] | None = None,
+        mCuSeqlensK_type: Type[cutlass.Numeric] | None = None,
+        mSeqUsedQ_type: Type[cutlass.Numeric] | None = None,
+        mSeqUsedK_type: Type[cutlass.Numeric] | None = None,
+        mPageTable_type: Type[cutlass.Numeric] | None = None,
+    ):
+        if const_expr(not (mQ_type == mK_type == mV_type == mO_type)):
+            raise TypeError("All tensors must have the same data type")
+        if const_expr(mQ_type not in [cutlass.Float16, cutlass.BFloat16]):
+            raise TypeError("Tensors must be either FP16 or BF16")
+        if const_expr(mLSE_type not in [None, Float32]):
+            raise TypeError("LSE tensor must be Float32")
+        if const_expr(mCuSeqlensQ_type not in [None, Int32]):
+            raise TypeError("mCuSeqlensQ tensor must be Int32")
+        if const_expr(mCuSeqlensK_type not in [None, Int32]):
+            raise TypeError("mCuSeqlensK tensor must be Int32")
+        if const_expr(mSeqUsedQ_type not in [None, Int32]):
+            raise TypeError("mSeqUsedQ tensor must be Int32")
+        if const_expr(mSeqUsedK_type not in [None, Int32]):
+            raise TypeError("mSeqUsedK tensor must be Int32")
+        if const_expr(mPageTable_type not in [None, Int32]):
+            raise TypeError("mPageTable tensor must be Int32")
+        assert mQ_type == self.dtype
+
+    def _setup_layouts(self):
+        def _make_smem_layout(
+            dtype: Type[cutlass.Numeric],
+            layout: LayoutEnum,
+            shape: tuple[int, int],
+            stage: Optional[int] = None,
+            return_atom: bool = False,
+        ):
+            major_mode_size = shape[1] if layout.is_n_major_c() else shape[0]
+            smem_layout_atom = warpgroup.make_smem_layout_atom(
+                sm90_utils_basic.get_smem_layout_atom(layout, dtype, major_mode_size),
+                dtype,
+            )
+            order = (1, 0, 2) if const_expr(layout.is_m_major_c()) else (0, 1, 2)
+            tiled_layout = cute.tile_to_shape(
+                smem_layout_atom,
+                cute.append(shape, stage) if const_expr(stage is not None) else shape,
+                order=order if const_expr(stage is not None) else order[:2],
+            )
+            return (tiled_layout, smem_layout_atom) if return_atom else tiled_layout
+
+        if self.use_tma_Q:
+            self.sQ_layout = _make_smem_layout(
+                self.dtype, LayoutEnum.ROW_MAJOR, (self.tile_m, self.tile_hdim), None
+            )
+        else:
+            self.sQ_layout_atom = sm80_utils.get_smem_layout_atom(self.dtype, self.tile_hdim)
+            self.sQ_layout = cute.tile_to_shape(
+                self.sQ_layout_atom,
+                (self.tile_m, self.tile_hdim),
+                (0, 1),
+            )
+        self.sK_layout = _make_smem_layout(
+            self.dtype, LayoutEnum.ROW_MAJOR, (self.tile_n, self.tile_hdim), self.num_stages
+        )
+        self.sV_layout = _make_smem_layout(
+            self.dtype, LayoutEnum.ROW_MAJOR, (self.tile_n, self.tile_hdimv), self.num_stages
+        )
+        self.sO_layout, self.sO_layout_atom = _make_smem_layout(
+            self.dtype, LayoutEnum.ROW_MAJOR, (self.tile_m, self.tile_hdimv), None, return_atom=True
+        )
+
+    def _get_tiled_mma(self):
+        # Reuse the SM80 tiled-MMA construction with SM120's MMA warp count
+        # (exclude the producer warp from MMA partitioning).
+        orig_num_threads = self.num_threads
+        self.num_threads = self.num_mma_warps * 32
+        try:
+            return FlashAttentionForwardSm80._get_tiled_mma(self)
+        finally:
+            self.num_threads = orig_num_threads
+    
+    def _get_q_gmem_tiled_copy(self):
+        """Create cp.async tiled copy for Q using all threads (SM80-style)."""
+        universal_copy_bits = 128
+        async_copy_elems = universal_copy_bits // self.dtype.width
+        atom_async_copy = cute.make_copy_atom(
+            cpasync.CopyG2SOp(cache_mode=cpasync.LoadCacheMode.GLOBAL),
+            self.dtype,
+            num_bits_per_copy=universal_copy_bits,
+        )
+        tQK_shape_dim_1 = self.sQ_layout_atom.outer.shape[1] // async_copy_elems
+        num_q_threads = self.num_mma_warps * 32
+        assert num_q_threads % tQK_shape_dim_1 == 0
+        tQ_layout = cute.make_ordered_layout(
+            (num_q_threads // tQK_shape_dim_1, tQK_shape_dim_1), order=(1, 0)
+        )
+        assert self.tile_m % tQ_layout.shape[0] == 0
+        vQ_layout = cute.make_layout((1, async_copy_elems))
+        return cute.make_tiled_copy_tv(atom_async_copy, tQ_layout, vQ_layout)
+
+    def _get_o_gmem_tiled_copy(self):
+        """Create cp.async tiled copy for O using thread dedicated to MMA warps."""
+        universal_copy_bits = 128
+        async_copy_elems = universal_copy_bits // self.dtype.width
+        atom_universal_copy = cute.make_copy_atom(
+            cute.nvgpu.CopyUniversalOp(),
+            self.dtype,
+            num_bits_per_copy=universal_copy_bits,
+        )
+        tV_shape_dim_1 = self.sO_layout_atom.outer.shape[1] // async_copy_elems
+        tO_layout = cute.make_ordered_layout(
+            (self.num_epilogue_threads // tV_shape_dim_1, tV_shape_dim_1),
+            order=(1, 0),
+        )
+        vO_layout = cute.make_layout((1, async_copy_elems))
+        return cute.make_tiled_copy_tv(atom_universal_copy, tO_layout, vO_layout)
+
+    def _get_shared_storage_cls(self):
+        # SM120 forward keeps a single shared-KV path and aliases O with Q.
+        assert self.share_kv_smem
+        assert self.alias_sO_with_sQ
+
+        align_bytes = cutlass.const_expr(self.alignment_width)
+        sQ_cosize = max(cute.cosize(self.sQ_layout), cute.cosize(self.sO_layout))
+        sK_cosize = cute.cosize(self.sK_layout)
+        sV_cosize = cute.cosize(self.sV_layout)
+        sKV_cosize = max(sK_cosize, sV_cosize)
+        sK_shared_struct = cute.struct.Align[
+            cute.struct.MemRange[self.dtype, sKV_cosize], align_bytes
+        ]
+
+        @cute.struct
+        class SharedStorage:
+            mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.mbar_total]
+            sQ: cute.struct.Align[
+                cute.struct.MemRange[self.dtype, sQ_cosize], align_bytes
+            ]
+            sK: sK_shared_struct
+
+        return SharedStorage
+
+    def _get_shared_storage_cls_decode_q1(self):
+        # Decode q1 direct-Q path keeps only KV shared storage. O reuses this
+        # storage during epilogue after mainloop consumption is complete.
+        assert self.share_kv_smem
+        align_bytes = cutlass.const_expr(self.alignment_width)
+        sK_cosize = cute.cosize(self.sK_layout)
+        sV_cosize = cute.cosize(self.sV_layout)
+        sO_cosize = cute.cosize(self.sO_layout)
+        sKV_cosize = max(sK_cosize, sV_cosize, sO_cosize)
+        sK_shared_struct = cute.struct.Align[
+            cute.struct.MemRange[self.dtype, sKV_cosize], align_bytes
+        ]
+
+        @cute.struct
+        class SharedStorage:
+            mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.mbar_total]
+            sK: sK_shared_struct
+
+        return SharedStorage
+
+    @cute.jit
+    def __call__(
+        self,
+        mQ: cute.Tensor,
+        mK: cute.Tensor,
+        mV: cute.Tensor,
+        mO: cute.Tensor,
+        mLSE: Optional[cute.Tensor],
+        softmax_scale: Float32,
+        mCuSeqlensQ: Optional[cute.Tensor] = None,
+        mCuSeqlensK: Optional[cute.Tensor] = None,
+        mSeqUsedQ: Optional[cute.Tensor] = None,
+        mSeqUsedK: Optional[cute.Tensor] = None,
+        mPageTable: Optional[cute.Tensor] = None,
+        window_size_left: Int32 | int | None = None,
+        window_size_right: Int32 | int | None = None,
+        learnable_sink: Optional[cute.Tensor] = None,
+        blocksparse_tensors: Optional[BlockSparseTensors] = None,
+        aux_tensors: Optional[list] = None,
+        stream: cuda.CUstream = None,
+    ):
+        if const_expr(blocksparse_tensors is not None):
+            raise NotImplementedError("SM120 TMA kernel does not support block sparsity.")
+        if const_expr(mPageTable is not None and (mCuSeqlensK is not None or mSeqUsedK is not None)):
+            raise NotImplementedError(
+                "SM120 optimized paged KV currently requires batched (non-varlen) K/V."
+            )
+        self._check_type(
+            *(
+                t.element_type
+                if t is not None
+                else None
+                for t in (
+                    mQ,
+                    mK,
+                    mV,
+                    mO,
+                    mLSE,
+                    mCuSeqlensQ,
+                    mCuSeqlensK,
+                    mSeqUsedQ,
+                    mSeqUsedK,
+                    mPageTable,
+                )
+            )
+        )
+        is_split_kv = cute.rank(mO) == cute.rank(mQ) + 1
+        num_splits = Int32(mO.shape[0]) if const_expr(is_split_kv) else Int32(1)
+        if const_expr(is_split_kv and mLSE is None):
+            raise ValueError("SplitKV mode requires mLSE partial tensor.")
+        varlen_q = mCuSeqlensQ is not None or mSeqUsedQ is not None
+        use_decode_q1_direct_q_g2r = self.use_direct_q_gmem_regs_decode
+        if const_expr(use_decode_q1_direct_q_g2r and varlen_q):
+            raise NotImplementedError(
+                "direct_q_gmem_regs_decode supports only dense inputs."
+            )
+        tiled_mma_qk, tiled_mma_pv, SharedStorage = self._setup_attributes(
+            use_decode_q1_direct_q_g2r=use_decode_q1_direct_q_g2r
+        )
+
+        # Align strides
+        new_stride = lambda t: (
+            *(cute.assume(s, divby=128 // t.element_type.width) for s in t.stride[:-1]),
+            t.stride[-1],
+        )
+        mQ, mK, mV, mO = [
+            cute.make_tensor(t.iterator, cute.make_layout(t.shape, stride=new_stride(t)))
+            for t in (mQ, mK, mV, mO)
+        ]
+        page_blocks_per_entry = Int32(1)
+        if const_expr(mPageTable is not None):
+            page_blocks_per_entry = cute.ceil_div(cute.size(mK.shape[1]), self.tile_n)
+            # Normalize paged-KV storage so source block indices are tile_n-granular.
+            shape_K_blocked = (
+                mK.shape[0] * page_blocks_per_entry,
+                self.tile_n,
+                mK.shape[2],
+                mK.shape[3],
+            )
+            stride_K_blocked = (
+                self.tile_n * mK.stride[1],
+                mK.stride[1],
+                mK.stride[2],
+                mK.stride[3],
+            )
+            shape_V_blocked = (
+                mV.shape[0] * page_blocks_per_entry,
+                self.tile_n,
+                mV.shape[2],
+                mV.shape[3],
+            )
+            stride_V_blocked = (
+                self.tile_n * mV.stride[1],
+                mV.stride[1],
+                mV.stride[2],
+                mV.stride[3],
+            )
+            mK = cute.make_tensor(
+                mK.iterator, cute.make_layout(shape_K_blocked, stride=stride_K_blocked)
+            )
+            mV = cute.make_tensor(
+                mV.iterator, cute.make_layout(shape_V_blocked, stride=stride_V_blocked)
+            )
+        Q_layout_transpose = [1, 3, 2, 0] if const_expr(mCuSeqlensQ is None) else [0, 2, 1]
+        if const_expr(not is_split_kv):
+            O_layout_transpose = Q_layout_transpose
+            LSE_layout_transpose = [2, 1, 0] if const_expr(mCuSeqlensQ is None) else [1, 0]
+        else:
+            O_layout_transpose = [2, 4, 3, 1, 0] if const_expr(mCuSeqlensQ is None) else [1, 3, 2, 0]
+            LSE_layout_transpose = [3, 2, 1, 0] if const_expr(mCuSeqlensQ is None) else [2, 1, 0]
+        KV_layout_transpose = [1, 3, 2, 0] if const_expr(mCuSeqlensK is None) else [0, 2, 1]
+        mQ = cute.make_tensor(mQ.iterator, cute.select(mQ.layout, mode=Q_layout_transpose))
+        mO = cute.make_tensor(mO.iterator, cute.select(mO.layout, mode=O_layout_transpose))
+        mK, mV = [
+            cute.make_tensor(t.iterator, cute.select(t.layout, mode=KV_layout_transpose))
+            for t in (mK, mV)
+        ]
+        mQ_tma = mQ
+        if const_expr(mLSE is not None):
+            mLSE = cute.make_tensor(mLSE.iterator, cute.select(mLSE.layout, mode=LSE_layout_transpose))
+        if const_expr(self.pack_gqa):
+            shape_Q_packed = (
+                (self.qhead_per_kvhead, mQ.shape[0]),
+                mQ.shape[1],
+                mK.shape[2],
+                *mQ.shape[3:],
+            )
+            stride_Q_packed = (
+                (mQ.stride[2], mQ.stride[0]),
+                mQ.stride[1],
+                mQ.stride[2] * self.qhead_per_kvhead,
+                *mQ.stride[3:],
+            )
+            mQ = cute.make_tensor(
+                mQ.iterator, cute.make_layout(shape_Q_packed, stride=stride_Q_packed)
+            )
+            shape_O_packed = (
+                (self.qhead_per_kvhead, mO.shape[0]),
+                mO.shape[1],
+                mK.shape[2],
+                *mO.shape[3:],
+            )
+            stride_O_packed = (
+                (mO.stride[2], mO.stride[0]),
+                mO.stride[1],
+                mO.stride[2] * self.qhead_per_kvhead,
+                *mO.stride[3:],
+            )
+            mO = cute.make_tensor(
+                mO.iterator, cute.make_layout(shape_O_packed, stride=stride_O_packed)
+            )
+            if const_expr(mLSE is not None):
+                shape_LSE_packed = (
+                    (self.qhead_per_kvhead, mLSE.shape[0]),
+                    mK.shape[2],
+                    *mLSE.shape[2:],
+                )
+                stride_LSE_packed = (
+                    (mLSE.stride[1], mLSE.stride[0]),
+                    mLSE.stride[1] * self.qhead_per_kvhead,
+                    *mLSE.stride[2:],
+                )
+                mLSE = cute.make_tensor(
+                    mLSE.iterator, cute.make_layout(shape_LSE_packed, stride=stride_LSE_packed)
+                )
+
+        # TMA atoms for Q/K/V
+        self.tma_copy_bytes = {}
+        gmem_tiled_copy_Q, tma_atom_Q, tma_tensor_Q = None, None, None
+        if const_expr(self.use_tma_Q and not use_decode_q1_direct_q_g2r):
+            tma_copy_Q = cpasync.CopyBulkTensorTileG2SOp()
+            self.tma_copy_bytes["Q"] = cute.size_in_bytes(
+                self.dtype, cute.select(self.sQ_layout, mode=[0, 1])
+            )
+            if const_expr(self.pack_gqa):
+                tma_atom_Q, tma_tensor_Q = make_packgqa_tiled_tma_atom(
+                    tma_copy_Q,
+                    mQ_tma,
+                    self.sQ_layout,
+                    (self.tile_m, self.tile_hdim),
+                    qhead_per_kvhead=self.qhead_per_kvhead,
+                    head_idx=2,
+                )
+            else:
+                tma_atom_Q, tma_tensor_Q = cpasync.make_tiled_tma_atom(
+                    tma_copy_Q, mQ, self.sQ_layout, (self.tile_m, self.tile_hdim)
+                )
+        elif const_expr(not self.use_tma_Q):
+            gmem_tiled_copy_Q = self._get_q_gmem_tiled_copy()
+        tma_copy_KV = cpasync.CopyBulkTensorTileG2SOp()
+        tma_atom_K, tma_tensor_K = cpasync.make_tiled_tma_atom(
+            tma_copy_KV,
+            mK,
+            cute.select(self.sK_layout, mode=[0, 1]),
+            (self.tile_n, self.tile_hdim),
+        )
+        tma_atom_V, tma_tensor_V = cpasync.make_tiled_tma_atom(
+            tma_copy_KV,
+            mV,
+            cute.select(self.sV_layout, mode=[0, 1]),
+            (self.tile_n, self.tile_hdimv),
+        )
+        gmem_tiled_copy_O = self._get_o_gmem_tiled_copy()
+        tma_atom_O, tma_tensor_O = None, None
+        if const_expr(
+            self.use_tma_O
+            and not self.pack_gqa
+            and not varlen_q
+            and not use_decode_q1_direct_q_g2r
+        ):
+            tma_copy_O = cpasync.CopyBulkTensorTileS2GOp()
+            tma_atom_O, tma_tensor_O = cpasync.make_tiled_tma_atom(
+                tma_copy_O,
+                mO,
+                self.sO_layout,
+                (self.tile_m, self.tile_hdimv),
+            )
+
+        is_varlen_q = mCuSeqlensQ is not None or mSeqUsedQ is not None
+        use_persistent_schedule = self.use_persistent_schedule and const_expr(not is_varlen_q)
+        if const_expr(use_persistent_schedule):
+            if const_expr(self.is_causal or self.is_local):
+                raise NotImplementedError(
+                    "Dedicated SM120 persistent kernel currently supports only non-causal, non-local attention."
+                )
+            if const_expr(self.persistent_noncausal_scheduler == "lpt"):
+                TileScheduler = SingleTileLPTScheduler
+            else:
+                TileScheduler = SingleTileScheduler
+        elif const_expr(is_varlen_q):
+            TileScheduler = SingleTileVarlenScheduler
+        else:
+            TileScheduler = (
+                SingleTileLPTScheduler if const_expr(self.is_causal or self.is_local) else SingleTileScheduler
+            )
+        num_m_blocks = cute.ceil_div(cute.size(mQ.shape[0]), self.tile_m)
+        num_heads = cute.size(mQ.shape[2])
+        num_batches = (
+            cute.size(mQ.shape[3])
+            if const_expr(mCuSeqlensQ is None)
+            else cute.size(mCuSeqlensQ.shape[0] - 1)
+        )
+        tile_sched_args = TileSchedulerArguments(
+            num_m_blocks,
+            num_heads,
+            num_batches,
+            num_splits,
+            cute.size(mK.shape[0])
+            if const_expr(mPageTable is None)
+            else cute.size(mK.shape[0])
+            * cute.size(mPageTable.shape[1])
+            * page_blocks_per_entry,
+            mQ.shape[1],
+            mV.shape[1],
+            total_q=cute.size(mQ.shape[0])
+            if const_expr(mCuSeqlensQ is not None)
+            else cute.size(mQ.shape[0]) * cute.size(mQ.shape[3]),
+            tile_shape_mn=(self.tile_m, self.tile_n),
+            cluster_shape_mn=(self.cluster_shape[0], self.cluster_shape[1]),
+            mCuSeqlensQ=mCuSeqlensQ,
+            mSeqUsedQ=mSeqUsedQ,
+            qhead_per_kvhead_packgqa=self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
+            is_persistent=use_persistent_schedule,
+            element_size=self.dtype.width // 8,
+            is_split_kv=is_split_kv,
+        )
+        tile_sched_params = TileScheduler.to_underlying_arguments(tile_sched_args)
+        grid_dim = TileScheduler.get_grid_shape(tile_sched_params)
+
+        LOG2_E = math.log2(math.e)
+        if const_expr(self.score_mod is None):
+            softmax_scale_log2 = Float32(softmax_scale * LOG2_E)
+            softmax_scale = None
+        else:
+            softmax_scale_log2 = Float32(LOG2_E)
+            softmax_scale = Float32(softmax_scale)
+
+        fastdiv_mods = utils.compute_fastdiv_mods(
+            mQ, mK, self.qhead_per_kvhead, self.pack_gqa, aux_tensors, mPageTable
+        )
+
+        self.kernel(
+            gmem_tiled_copy_Q,
+            tma_atom_Q,
+            tma_tensor_Q if const_expr(self.use_tma_Q and not use_decode_q1_direct_q_g2r) else mQ,
+            tma_atom_K,
+            tma_tensor_K,
+            tma_atom_V,
+            tma_tensor_V,
+            gmem_tiled_copy_O,
+            tma_atom_O,
+            tma_tensor_O if const_expr(tma_atom_O is not None) else mO,
+            mLSE,
+            mCuSeqlensQ,
+            mCuSeqlensK,
+            mSeqUsedQ,
+            mSeqUsedK,
+            mPageTable,
+            self.qhead_per_kvhead,
+            num_splits,
+            softmax_scale_log2, softmax_scale,
+            window_size_left, window_size_right,
+            self.sQ_layout,
+            self.sK_layout,
+            self.sV_layout,
+            self.sO_layout,
+            tiled_mma_qk, tiled_mma_pv,
+            SharedStorage,
+            tile_sched_params,
+            TileScheduler,
+            use_decode_q1_direct_q_g2r,
+            aux_tensors=aux_tensors,
+            fastdiv_mods=fastdiv_mods,
+        ).launch(
+            grid=grid_dim,
+            block=[self.num_threads, 1, 1],
+            cluster=list(self.cluster_shape),
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        gmem_tiled_copy_Q: Optional[cute.TiledCopy],
+        tma_atom_Q: Optional[cute.CopyAtom],
+        mQ: cute.Tensor,
+        tma_atom_K: Optional[cute.CopyAtom],
+        mK: cute.Tensor,
+        tma_atom_V: Optional[cute.CopyAtom],
+        mV: cute.Tensor,
+        gmem_tiled_copy_O: cute.TiledCopy,
+        tma_atom_O: Optional[cute.CopyAtom],
+        mO: cute.Tensor,
+        mLSE: Optional[cute.Tensor],
+        mCuSeqlensQ: Optional[cute.Tensor],
+        mCuSeqlensK: Optional[cute.Tensor],
+        mSeqUsedQ: Optional[cute.Tensor],
+        mSeqUsedK: Optional[cute.Tensor],
+        mPageTable: Optional[cute.Tensor],
+        qhead_per_kvhead: cutlass.Int32,
+        num_splits: Int32,
+        softmax_scale_log2: Float32,
+        softmax_scale: Optional[Float32],
+        window_size_left: Optional[Int32],
+        window_size_right: Optional[Int32],
+        sQ_layout: cute.ComposedLayout,
+        sK_layout: cute.ComposedLayout,
+        sV_layout: cute.ComposedLayout,
+        sO_layout: cute.ComposedLayout,
+        tiled_mma_qk: cute.TiledMma,
+        tiled_mma_pv: cute.TiledMma,
+        SharedStorage: cutlass.Constexpr,
+        tile_sched_params: ParamsBase,
+        TileScheduler: cutlass.Constexpr[Callable],
+        use_decode_q1_direct_q_g2r: cutlass.Constexpr[bool],
+        aux_tensors=None,
+        fastdiv_mods=None,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+        dma_local_tidx = Int32(0)
+        
+        # Prefetch TMA descriptors
+        if warp_idx == 0:
+            if const_expr(self.use_tma_Q and not use_decode_q1_direct_q_g2r):
+                cpasync.prefetch_descriptor(tma_atom_Q)
+            cpasync.prefetch_descriptor(tma_atom_K)
+            cpasync.prefetch_descriptor(tma_atom_V)
+            if const_expr(tma_atom_O is not None):
+                cpasync.prefetch_descriptor(tma_atom_O)
+        
+        # Block info / seqlen
+        is_split_kv = const_expr(cute.rank(mO) in (4, 5))
+        block_info = BlockInfo(
+            self.tile_m,
+            self.tile_n,
+            self.is_causal,
+            self.is_local,
+            is_split_kv,
+            window_size_left,
+            window_size_right,
+            qhead_per_kvhead_packgqa=self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
+        )
+
+        # Allocate SMEM
+        smem = cutlass.utils.SmemAllocator()
+        storage = smem.allocate(SharedStorage)
+        mbar_ptr = storage.mbar_ptr.data_ptr()
+
+        sK = storage.sK.get_tensor(sK_layout.outer, swizzle=sK_layout.inner)
+        sV = storage.sK.get_tensor(sV_layout.outer, swizzle=sV_layout.inner)
+        # Q uses SM90-style layout for TMA or SM80-style layout for cp.async fallback.
+        # In decode q1 direct-Q mode, we alias Q and O onto KV shared storage.
+        if const_expr(use_decode_q1_direct_q_g2r):
+            sQ = storage.sK.get_tensor(sQ_layout.outer, swizzle=sQ_layout.inner)
+        elif const_expr(self.use_tma_Q):
+            sQ = storage.sQ.get_tensor(sQ_layout.outer, swizzle=sQ_layout.inner)
+        else:
+            sQ = storage.sQ.get_tensor(sQ_layout)
+        if const_expr(self.alias_sO_with_sQ):
+            if const_expr(use_decode_q1_direct_q_g2r):
+                sO = storage.sK.get_tensor(sO_layout.outer, swizzle=sO_layout.inner, dtype=self.dtype)
+            else:
+                sO = storage.sQ.get_tensor(sO_layout.outer, swizzle=sO_layout.inner, dtype=self.dtype)
+        else:
+            sO = storage.sO.get_tensor(sO_layout.outer, swizzle=sO_layout.inner)
+        # V for P*V gemm: transposed view for B operand dimension matching
+        # (tile_n, tile_hdimv, stages) -> (tile_hdimv, tile_n, stages)
+        sVt = layout_utils.transpose_view(sV)
+        sQ_stage0 = sQ
+        sO_stage0 = sO
+
+        # SM100-style barrier layout packed in one shared mbarrier array.
+        mainloop_pipeline_array_ptr_K = mbar_ptr + self.mbar_load_k_full_offset
+        mainloop_pipeline_array_ptr_V = (
+            mainloop_pipeline_array_ptr_K
+            if const_expr(self.shared_kv_mbar)
+            else mbar_ptr + self.mbar_load_v_full_offset
+        )
+        kv_producer_group = CooperativeGroup(Agent.Thread)
+        kv_consumer_group = CooperativeGroup(Agent.Thread, self.num_mma_warps)
+        sK_single = cute.slice_(sK_layout, (None, None, 0))
+        sV_single = cute.slice_(sV_layout, (None, None, 0))
+        tma_k_bytes = cute.size_in_bytes(self.dtype, sK_single)
+        tma_v_bytes = cute.size_in_bytes(self.dtype, sV_single)
+        if cute.size(self.cluster_shape) > 1:
+            cute.arch.cluster_arrive_relaxed()
+
+        cutlass.pipeline.sync(barrier_id=1)
+
+        if cute.size(self.cluster_shape) > 1:
+            cute.arch.cluster_wait()
+
+        TileSchedulerCls = partial(TileScheduler.create, tile_sched_params)
+        tile_scheduler = TileSchedulerCls()
+        work_tile = tile_scheduler.initial_work_tile_info()
+
+        while work_tile.is_valid_tile:
+            m_block, head_idx, batch_idx, split_idx = work_tile.tile_idx
+            seqlen_k_static = (
+                mK.shape[0]
+                if const_expr(mPageTable is None)
+                else mK.shape[0]
+                * mPageTable.shape[1]
+                * (
+                    mK.shape[3]
+                    // (mPageTable.shape[0] * mPageTable.shape[1])
+                )
+            )
+            seqlen = SeqlenInfoQK.create(
+                batch_idx,
+                seqlen_q_static=mQ.shape[0]
+                if const_expr(not self.pack_gqa)
+                else mQ.shape[0][1],
+                seqlen_k_static=seqlen_k_static,
+                mCuSeqlensQ=mCuSeqlensQ,
+                mCuSeqlensK=mCuSeqlensK,
+                mSeqUsedQ=mSeqUsedQ,
+                mSeqUsedK=mSeqUsedK,
+                tile_m=self.tile_m,
+                tile_n=self.tile_n,
+            )
+            n_block_min, n_block_max = block_info.get_n_block_min_max(
+                seqlen,
+                m_block,
+                split_idx=split_idx,
+                num_splits=num_splits,
+            )
+            n_block = n_block_max - 1
+
+            kv_head_idx = head_idx if const_expr(self.pack_gqa) else head_idx // qhead_per_kvhead
+
+            mQ_cur = seqlen.offset_batch_Q(mQ, batch_idx, dim=3)[None, None, head_idx]
+            gQ = cute.local_tile(mQ_cur, (self.tile_m, self.tile_hdim), (m_block, 0))
+            if const_expr(mPageTable is None):
+                mK_cur = seqlen.offset_batch_K(mK, batch_idx, dim=3)[None, None, kv_head_idx]
+                mV_cur = seqlen.offset_batch_K(mV, batch_idx, dim=3)[None, None, kv_head_idx]
+                gK = cute.local_tile(mK_cur, (self.tile_n, self.tile_hdim), (None, 0))
+                gV = cute.local_tile(mV_cur, (self.tile_n, self.tile_hdimv), (None, 0))
+            else:
+                mK_cur = mK[None, None, kv_head_idx, None]
+                mV_cur = mV[None, None, kv_head_idx, None]
+                gK = cute.local_tile(mK_cur, (self.tile_n, self.tile_hdim), (0, 0, None))
+                gV = cute.local_tile(mV_cur, (self.tile_n, self.tile_hdimv), (0, 0, None))
+    
+            # SM100-style TMA partitioning for K/V.
+            tKsK_tma, tKgK_tma = cpasync.tma_partition(
+                tma_atom_K,
+                0,
+                cute.make_layout(1),
+                cute.group_modes(sK, 0, 2),
+                cute.group_modes(gK, 0, 2),
+            )
+            tVsV_tma, tVgV_tma = cpasync.tma_partition(
+                tma_atom_V,
+                0,
+                cute.make_layout(1),
+                cute.group_modes(sV, 0, 2),
+                cute.group_modes(gV, 0, 2),
+            )
+            # Reinitialize per tile to avoid phase carryover across scheduler iterations.
+            pipeline_K = pipeline.PipelineTmaAsync.create(
+                num_stages=self.k_num_stages,
+                producer_group=kv_producer_group,
+                consumer_group=kv_consumer_group,
+                tx_count=tma_k_bytes,
+                barrier_storage=mainloop_pipeline_array_ptr_K,
+                defer_sync=True,
+            )
+            pipeline_V = pipeline.PipelineTmaAsync.create(
+                num_stages=self.v_num_stages,
+                producer_group=kv_producer_group,
+                consumer_group=kv_consumer_group,
+                tx_count=tma_v_bytes,
+                barrier_storage=mainloop_pipeline_array_ptr_V,
+                defer_sync=False,
+            )
+            q_pipeline = None
+            if const_expr(self.use_tma_Q and not self.unify_qk_tma_barrier and not use_decode_q1_direct_q_g2r):
+                q_pipeline = pipeline.PipelineTmaAsync.create(
+                    num_stages=1,
+                    producer_group=CooperativeGroup(Agent.Thread),
+                    consumer_group=CooperativeGroup(Agent.Thread, self.num_mma_warps),
+                    tx_count=self.tma_copy_bytes["Q"],
+                    barrier_storage=mbar_ptr + self.mbar_load_q_full_offset,
+                )
+    
+            if const_expr(self.use_tma_Q and not use_decode_q1_direct_q_g2r):
+                load_Q, _, _ = copy_utils.tma_get_copy_fn(
+                    tma_atom_Q, 0, cute.make_layout(1), gQ, sQ_stage0, single_stage=True
+                )
+    
+            # Load Q (cp.async) BEFORE the main if/elif split
+            # This ensures Q is loaded before MMA warps need it (when using SMEM staging)
+            if const_expr(not self.use_tma_Q and not use_decode_q1_direct_q_g2r):
+                if (
+                    warp_idx >= self.num_producer_warps
+                    and warp_idx < self.num_producer_warps + self.num_mma_warps
+                ):
+                    mma_tidx = tidx - self.num_producer_warps * 32
+                    if const_expr(self.pack_gqa):
+                        pack_gqa = PackGQA(
+                            self.tile_m, self.tile_hdim, self.check_hdim_oob, self.qhead_per_kvhead
+                        )
+                        pack_gqa.load_Q(
+                            mQ_cur, sQ_stage0, gmem_tiled_copy_Q, mma_tidx, m_block, seqlen.seqlen_q
+                        )
+                    else:
+                        gmem_thr_copy_Q = gmem_tiled_copy_Q.get_slice(mma_tidx)
+                        self.load_Q(
+                            gmem_thr_copy_Q,
+                            gQ,
+                            sQ_stage0,
+                            m_block,
+                            seqlen=seqlen.seqlen_q,
+                            headdim=mQ.shape[1],
+                        )
+                cute.arch.cp_async_commit_group()
+                cute.arch.cp_async_wait_group(0)
+
+            # All threads sync after Q is loaded (cp.async only).
+            if const_expr(not self.use_tma_Q and not use_decode_q1_direct_q_g2r):
+                cute.arch.barrier()
+
+            # MMA warps
+            if (
+                warp_idx >= self.num_producer_warps
+                and warp_idx < self.num_producer_warps + self.num_mma_warps
+                and n_block_max > 0
+            ):
+                mma_tidx = tidx - self.num_producer_warps * 32
+                thr_mma_qk = tiled_mma_qk.get_slice(mma_tidx)
+                thr_mma_pv = tiled_mma_pv.get_slice(mma_tidx)
+    
+                tSsQ = thr_mma_qk.partition_A(sQ_stage0)
+                tSsK = thr_mma_qk.partition_B(sK)
+                tOrVt = thr_mma_pv.partition_B(sVt)
+
+                tSrQ = thr_mma_qk.make_fragment_A(tSsQ)
+                tSrK = thr_mma_qk.make_fragment_B(tSsK[None, None, None, 0])
+                tOrV = thr_mma_pv.make_fragment_B(tOrVt[None, None, None, 0])
+    
+                smem_copy_atom_Q = cute.make_copy_atom(
+                    warp.LdMatrix8x8x16bOp(transpose=False, num_matrices=4),
+                    self.dtype,
+                )
+                smem_copy_atom_K = cute.make_copy_atom(
+                    warp.LdMatrix8x8x16bOp(transpose=False, num_matrices=4),
+                    self.dtype,
+                )
+                smem_copy_atom_V = cute.make_copy_atom(
+                    warp.LdMatrix8x8x16bOp(transpose=True, num_matrices=4),
+                    self.dtype,
+                )
+
+                smem_tiled_copy_Q = cute.make_tiled_copy_A(smem_copy_atom_Q, tiled_mma_qk)
+                smem_tiled_copy_K = cute.make_tiled_copy_B(smem_copy_atom_K, tiled_mma_qk)
+                smem_tiled_copy_V = cute.make_tiled_copy_B(smem_copy_atom_V, tiled_mma_pv)
+                thr_copy_Q = smem_tiled_copy_Q.get_slice(mma_tidx)
+                thr_copy_K = smem_tiled_copy_K.get_slice(mma_tidx)
+                thr_copy_V = smem_tiled_copy_V.get_slice(mma_tidx)
+                tSsQ_copy = thr_copy_Q.partition_S(sQ_stage0)
+                tSrQ_copy = thr_copy_Q.retile(tSrQ)
+                tSsK_copy = thr_copy_K.partition_S(sK)
+                tSrK_copy = thr_copy_K.retile(tSrK)
+                tOsVt_copy = thr_copy_V.partition_S(sVt)
+    
+                acc_shape_O = thr_mma_pv.partition_shape_C((self.tile_m, self.tile_hdimv))
+                acc_O = cute.make_rmem_tensor(acc_shape_O, Float32)
+                acc_O.fill(0.0)
+                acc_shape_S = thr_mma_qk.partition_shape_C((self.tile_m, self.tile_n))
+    
+                softmax = Softmax.create(
+                    softmax_scale_log2,
+                    num_rows=(acc_O.shape[0][0] * acc_O.shape[1]),
+                    softmax_scale=softmax_scale if const_expr(self.score_mod is not None) else None,
+                )
+                softmax.reset()
+                mask = AttentionMask(
+                    self.tile_m,
+                    self.tile_n,
+                    seqlen,
+                    window_size_left,
+                    window_size_right,
+                    self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
+                )
+
+                if const_expr(self.share_kv_tma_stage_offset and self.num_stages > 1):
+                    # SM100-style interleaving: K and V consume consecutive states from one stream.
+                    consumer_state_kv = pipeline.make_pipeline_state(
+                        pipeline.PipelineUserType.Consumer, self.k_num_stages
+                    )
+                else:
+                    consumer_state_k = pipeline.make_pipeline_state(
+                        pipeline.PipelineUserType.Consumer, self.k_num_stages
+                    )
+                    consumer_state_v = pipeline.make_pipeline_state(
+                        pipeline.PipelineUserType.Consumer, self.v_num_stages
+                    )
+
+                num_k_blocks = cute.size(tSrQ, mode=[2])
+                if const_expr(use_decode_q1_direct_q_g2r and self.Q_in_regs):
+                    copy_atom_q_g2r = cute.make_copy_atom(
+                        cute.nvgpu.CopyUniversalOp(),
+                        self.dtype,
+                        num_bits_per_copy=32,
+                    )
+                    gmem_tiled_copy_q_g2r = cute.make_tiled_copy_A(copy_atom_q_g2r, tiled_mma_qk)
+                    gmem_thr_copy_q_g2r = gmem_tiled_copy_q_g2r.get_slice(mma_tidx)
+                    tQgQ_copy = gmem_thr_copy_q_g2r.partition_S(gQ)
+                    tQrQ_copy = gmem_thr_copy_q_g2r.retile(tSrQ)
+                    cQ = cute.make_identity_tensor((self.tile_m, self.tile_hdim))
+                    tQcQ = gmem_thr_copy_q_g2r.partition_S(cQ)
+                    t0QcQ = gmem_tiled_copy_q_g2r.get_slice(0).partition_S(cQ)
+                    tQpQ = utils.predicate_k(tQcQ, limit=mQ.shape[1])
+                    q_rows_total = seqlen.seqlen_q
+                    if const_expr(self.pack_gqa):
+                        q_rows_total *= self.qhead_per_kvhead
+                    for m in cutlass.range_constexpr(cute.size(tQrQ_copy.shape[1])):
+                        if t0QcQ[0, m, 0][0] < q_rows_total - m_block * self.tile_m - tQcQ[0][0]:
+                            cute.copy(
+                                gmem_tiled_copy_q_g2r,
+                                tQgQ_copy[None, m, None],
+                                tQrQ_copy[None, m, None],
+                                pred=tQpQ[None, m, None] if const_expr(self.check_hdim_oob) else None,
+                            )
+
+                if const_expr(self.use_tma_Q and not use_decode_q1_direct_q_g2r):
+                    if const_expr(not self.unify_qk_tma_barrier):
+                        q_consumer_state = pipeline.make_pipeline_state(
+                            pipeline.PipelineUserType.Consumer, 1
+                        )
+                        q_pipeline.consumer_wait(
+                            q_consumer_state,
+                            q_pipeline.consumer_try_wait(q_consumer_state),
+                        )
+                        if const_expr(self.Q_in_regs):
+                            for k in cutlass.range_constexpr(num_k_blocks):
+                                cute.copy(
+                                    smem_tiled_copy_Q,
+                                    tSsQ_copy[None, None, k],
+                                    tSrQ_copy[None, None, k],
+                                )
+                        q_pipeline.consumer_release(q_consumer_state)
+                elif const_expr(not use_decode_q1_direct_q_g2r):
+                    if const_expr(self.Q_in_regs):
+                        for k in cutlass.range_constexpr(num_k_blocks):
+                            cute.copy(smem_tiled_copy_Q, tSsQ_copy[None, None, k], tSrQ_copy[None, None, k])
+    
+                if n_block_max > 0:
+                    # First n-block
+                    current_n_block = n_block_max - 1
+    
+                    if const_expr(self.share_kv_tma_stage_offset and self.num_stages > 1):
+                        pipeline_K.consumer_wait(
+                            consumer_state_kv,
+                            pipeline_K.consumer_try_wait(consumer_state_kv),
+                        )
+                        stage_k = consumer_state_kv.index
+                        stage_k_phase = consumer_state_kv.phase
+                    else:
+                        pipeline_K.consumer_wait(
+                            consumer_state_k,
+                            pipeline_K.consumer_try_wait(consumer_state_k),
+                        )
+                        stage_k = consumer_state_k.index
+                        stage_k_phase = consumer_state_k.phase
+
+                    if const_expr(
+                        self.use_tma_Q
+                        and self.unify_qk_tma_barrier
+                        and self.Q_in_regs
+                        and not use_decode_q1_direct_q_g2r
+                    ):
+                        # Q and first-stage K share the same TMA barrier. Once K is available,
+                        # Q is guaranteed available as well.
+                        for k in cutlass.range_constexpr(num_k_blocks):
+                            cute.copy(
+                                smem_tiled_copy_Q,
+                                tSsQ_copy[None, None, k],
+                                tSrQ_copy[None, None, k],
+                            )
+    
+                    acc_S = cute.make_rmem_tensor(acc_shape_S, Float32)
+                    acc_S.fill(0.0)
+                    tSsK_stage = tSsK_copy[None, None, None, stage_k]
+
+                    # Pre-copy K to registers if enabled (allows earlier SMEM release)
+                    if const_expr(self.K_in_regs):
+                        for k in cutlass.range_constexpr(num_k_blocks):
+                            cute.copy(
+                                smem_tiled_copy_K,
+                                tSsK_stage[None, None, k],
+                                tSrK_copy[None, None, k],
+                            )
+
+                    sm80_utils.gemm(
+                        tiled_mma_qk,
+                        acc_S,
+                        tSrQ,
+                        tSrK,
+                        tSsQ_copy,
+                        tSsK_stage,
+                        thr_copy_Q,
+                        thr_copy_K,
+                        A_in_regs=cutlass.const_expr(self.Q_in_regs),
+                        B_in_regs=cutlass.const_expr(self.K_in_regs),
+                    )
+                    if const_expr(not (self.share_kv_tma_stage_offset and self.num_stages > 1)):
+                        cute.arch.barrier(
+                            barrier_id=int(NamedBarrierFwd.PFull),
+                            number_of_threads=self.num_threads,
+                        )
+
+                    # Release K immediately after QK GEMM so producer can refill while we run
+                    # masking + softmax before the V wait point.
+                    if const_expr(self.share_kv_tma_stage_offset and self.num_stages > 1):
+                        pipeline_K.consumer_release(consumer_state_kv)
+                        consumer_state_kv.advance()
+                        v_wait_token = pipeline_V.consumer_try_wait(consumer_state_kv)
+                    else:
+                        pipeline_K.consumer_release(consumer_state_k)
+                        consumer_state_k.advance()
+                        v_wait_token = pipeline_V.consumer_try_wait(consumer_state_v)
+
+                    mask.apply_mask(
+                        acc_S,
+                        batch_idx,
+                        head_idx,
+                        m_block,
+                        current_n_block,
+                        thr_mma_qk,
+                        mask_seqlen=True,
+                        mask_causal=self.is_causal,
+                        mask_local=self.is_local,
+                    )
+
+                    # Rescale acc_O before P*V gemm (no-op for first block).
+                    row_scale = softmax.online_softmax(
+                        acc_S,
+                        is_first=cutlass.const_expr(True),
+                    )
+                    softmax.rescale_O(acc_O, row_scale)
+
+                    # Wait for V stage after softmax work.
+                    if const_expr(self.share_kv_tma_stage_offset and self.num_stages > 1):
+                        pipeline_V.consumer_wait(
+                            consumer_state_kv,
+                            v_wait_token,
+                        )
+                        stage_v = consumer_state_kv.index
+                        stage_v_phase = consumer_state_kv.phase
+                    else:
+                        pipeline_V.consumer_wait(
+                            consumer_state_v,
+                            v_wait_token,
+                        )
+                        stage_v = consumer_state_v.index
+                        stage_v_phase = consumer_state_v.phase
+
+                    tOsVt_stage = tOsVt_copy[None, None, None, stage_v]
+
+                    # Convert acc_S to A fragment layout for PV gemm (back-to-back gemm pattern)
+                    rP = cute.make_fragment_like(acc_S, self.dtype)
+                    rP.store(acc_S.load().to(self.dtype))
+
+                    tOrP = cute.make_tensor(
+                        rP.iterator,
+                        layout_utils.convert_layout_acc_frgA(rP.layout),
+                    )
+                    sm80_utils.gemm_rs(
+                        tiled_mma_pv,
+                        acc_O,
+                        tOrP,
+                        tOrV,
+                        tOsVt_stage,
+                        thr_copy_V,
+                    )
+
+                    if const_expr(self.share_kv_tma_stage_offset and self.num_stages > 1):
+                        pipeline_V.consumer_release(consumer_state_kv)
+                        consumer_state_kv.advance()
+                    else:
+                        pipeline_V.consumer_release(consumer_state_v)
+                        consumer_state_v.advance()
+                    if const_expr(not (self.share_kv_tma_stage_offset and self.num_stages > 1)):
+                        cute.arch.barrier(
+                            barrier_id=int(NamedBarrierFwd.PEmpty),
+                            number_of_threads=self.num_threads,
+                        )
+    
+                    # Remaining n-blocks
+                    for n_tile in cutlass.range(n_block_max - 1, unroll=self.unroll_consumer):
+                        current_n_block = n_block_max - 2 - n_tile
+    
+                        if const_expr(self.share_kv_tma_stage_offset and self.num_stages > 1):
+                            pipeline_K.consumer_wait(
+                                consumer_state_kv,
+                                pipeline_K.consumer_try_wait(consumer_state_kv),
+                            )
+                            stage_k = consumer_state_kv.index
+                            stage_k_phase = consumer_state_kv.phase
+                        else:
+                            pipeline_K.consumer_wait(
+                                consumer_state_k,
+                                pipeline_K.consumer_try_wait(consumer_state_k),
+                            )
+                            stage_k = consumer_state_k.index
+                            stage_k_phase = consumer_state_k.phase
+    
+                        acc_S = cute.make_rmem_tensor(acc_shape_S, Float32)
+                        acc_S.fill(0.0)
+                        tSsK_stage = tSsK_copy[None, None, None, stage_k]
+
+                        # Pre-copy K to registers if enabled (allows earlier SMEM release)
+                        if const_expr(self.K_in_regs):
+                            for k in cutlass.range_constexpr(num_k_blocks):
+                                cute.copy(
+                                    smem_tiled_copy_K,
+                                    tSsK_stage[None, None, k],
+                                    tSrK_copy[None, None, k],
+                                )
+
+                        sm80_utils.gemm(
+                            tiled_mma_qk,
+                            acc_S,
+                            tSrQ,
+                            tSrK,
+                            tSsQ_copy,
+                            tSsK_stage,
+                            thr_copy_Q,
+                            thr_copy_K,
+                            A_in_regs=cutlass.const_expr(self.Q_in_regs),
+                            B_in_regs=cutlass.const_expr(self.K_in_regs),
+                        )
+                        if const_expr(not (self.share_kv_tma_stage_offset and self.num_stages > 1)):
+                            cute.arch.barrier(
+                                barrier_id=int(NamedBarrierFwd.PFull),
+                                number_of_threads=self.num_threads,
+                            )
+
+                        # Release K immediately after QK GEMM so producer can refill while
+                        # mask/softmax runs.
+                        if const_expr(self.share_kv_tma_stage_offset and self.num_stages > 1):
+                            pipeline_K.consumer_release(consumer_state_kv)
+                            consumer_state_kv.advance()
+                            v_wait_token = pipeline_V.consumer_try_wait(consumer_state_kv)
+                        else:
+                            pipeline_K.consumer_release(consumer_state_k)
+                            consumer_state_k.advance()
+                            v_wait_token = pipeline_V.consumer_try_wait(consumer_state_v)
+
+                        if const_expr(self.is_causal):
+                            mask.apply_mask(
+                                acc_S,
+                                batch_idx,
+                                head_idx,
+                                m_block,
+                                current_n_block,
+                                thr_mma_qk,
+                                mask_seqlen=False,
+                                mask_causal=self.is_causal,
+                                mask_local=self.is_local,
+                            )
+
+                        # Rescale acc_O before adding new P*V contribution.
+                        row_scale = softmax.online_softmax(
+                            acc_S,
+                            is_first=cutlass.const_expr(False),
+                        )
+                        softmax.rescale_O(acc_O, row_scale)
+
+                        # Wait for V stage after softmax work.
+                        if const_expr(self.share_kv_tma_stage_offset and self.num_stages > 1):
+                            pipeline_V.consumer_wait(
+                                consumer_state_kv,
+                                v_wait_token,
+                            )
+                            stage_v = consumer_state_kv.index
+                            stage_v_phase = consumer_state_kv.phase
+                        else:
+                            pipeline_V.consumer_wait(
+                                consumer_state_v,
+                                v_wait_token,
+                            )
+                            stage_v = consumer_state_v.index
+                            stage_v_phase = consumer_state_v.phase
+
+                        tOsVt_stage = tOsVt_copy[None, None, None, stage_v]
+
+                        # Convert acc_S to A fragment layout for PV gemm (back-to-back gemm pattern)
+                        rP = cute.make_fragment_like(acc_S, self.dtype)
+                        rP.store(acc_S.load().to(self.dtype))
+
+                        tOrP = cute.make_tensor(
+                            rP.iterator,
+                            layout_utils.convert_layout_acc_frgA(rP.layout),
+                        )
+                        sm80_utils.gemm_rs(
+                            tiled_mma_pv,
+                            acc_O,
+                            tOrP,
+                            tOrV,
+                            tOsVt_stage,
+                            thr_copy_V,
+                        )
+
+                        if const_expr(self.share_kv_tma_stage_offset and self.num_stages > 1):
+                            pipeline_V.consumer_release(consumer_state_kv)
+                            consumer_state_kv.advance()
+                        else:
+                            pipeline_V.consumer_release(consumer_state_v)
+                            consumer_state_v.advance()
+                        if const_expr(not (self.share_kv_tma_stage_offset and self.num_stages > 1)):
+                            cute.arch.barrier(
+                                barrier_id=int(NamedBarrierFwd.PEmpty),
+                                number_of_threads=self.num_threads,
+                            )
+    
+                row_scale = softmax.finalize()
+                softmax.rescale_O(acc_O, row_scale)
+                lse = softmax.row_sum
+                self.epilogue(
+                    acc_O,
+                    lse,
+                    mO,
+                    mLSE,
+                    sO_stage0,
+                    seqlen,
+                    gmem_tiled_copy_O,
+                    tma_atom_O,
+                    tiled_mma_pv,
+                    mma_tidx,
+                    m_block,
+                    head_idx,
+                    batch_idx,
+                    split_idx,
+                )
+    
+            # Producer warps - load K/V tiles via TMA
+            elif warp_idx < self.num_producer_warps and n_block_max > 0:
+                producer_warp_idx = warp_idx
+                page_blocks_per_entry = (
+                    Int32(1)
+                    if const_expr(mPageTable is None)
+                    else mK.shape[3] // (mPageTable.shape[0] * mPageTable.shape[1])
+                )
+                if const_expr(self.share_kv_tma_stage_offset and self.num_stages > 1):
+                    # SM100-style K/V interleaving: both streams advance one shared state.
+                    producer_state_kv = pipeline.make_pipeline_state(
+                        pipeline.PipelineUserType.Producer, self.k_num_stages
+                    )
+                else:
+                    producer_state_k = pipeline.make_pipeline_state(
+                        pipeline.PipelineUserType.Producer, self.k_num_stages
+                    )
+                    producer_state_v = pipeline.make_pipeline_state(
+                        pipeline.PipelineUserType.Producer, self.v_num_stages
+                    )
+                if producer_warp_idx == 0:
+                    if const_expr(
+                        self.use_tma_Q and not self.unify_qk_tma_barrier and not use_decode_q1_direct_q_g2r
+                    ):
+                        q_producer_state = pipeline.make_pipeline_state(
+                            pipeline.PipelineUserType.Producer, 1
+                        )
+                        q_pipeline.producer_acquire(q_producer_state)
+                        load_Q(tma_bar_ptr=q_pipeline.producer_get_barrier(q_producer_state))
+                        q_pipeline.producer_commit(q_producer_state)
+                        q_producer_state.advance()
+                    if const_expr(
+                        self.shared_kv_mbar and self.unify_qk_tma_barrier and not use_decode_q1_direct_q_g2r
+                    ):
+                        # First stage: load Q and K together, using K pipeline's mbarrier.
+                        first_n_block = n_block_max - 1
+                        first_kv_block = (
+                            mPageTable[batch_idx, first_n_block // page_blocks_per_entry]
+                            * page_blocks_per_entry
+                            + (first_n_block % page_blocks_per_entry)
+                            if const_expr(mPageTable is not None)
+                            else first_n_block
+                        )
+                        pipeline_K.producer_acquire(
+                            producer_state_kv,
+                            extra_tx_count=self.tma_copy_bytes["Q"],
+                        )
+                        load_Q(tma_bar_ptr=pipeline_K.producer_get_barrier(producer_state_kv))
+                        self.load_K(
+                            tma_atom_K,
+                            tKgK_tma,
+                            tKsK_tma,
+                            block=first_kv_block,
+                            smem_pipe_write=producer_state_kv.index,
+                            smem_pipe_phase=producer_state_kv.phase,
+                            tma_bar_ptr=pipeline_K.producer_get_barrier(producer_state_kv),
+                        )
+                        pipeline_K.producer_commit(producer_state_kv)
+                        producer_state_kv.advance()
+                        pipeline_V.producer_acquire(producer_state_kv)
+                        self.load_V(
+                            tma_atom_V,
+                            tVgV_tma,
+                            tVsV_tma,
+                            block=first_kv_block,
+                            smem_pipe_write=producer_state_kv.index,
+                            smem_pipe_phase=producer_state_kv.phase,
+                            tma_bar_ptr=pipeline_V.producer_get_barrier(producer_state_kv),
+                        )
+                        pipeline_V.producer_commit(producer_state_kv)
+                        producer_state_kv.advance()
+                        for n_tile in cutlass.range(n_block_max - 1, unroll=self.unroll_producer_load):
+                            n_block_to_load = n_block_max - 2 - n_tile
+                            kv_block_to_load = (
+                                mPageTable[batch_idx, n_block_to_load // page_blocks_per_entry]
+                                * page_blocks_per_entry
+                                + (n_block_to_load % page_blocks_per_entry)
+                                if const_expr(mPageTable is not None)
+                                else n_block_to_load
+                            )
+                            pipeline_K.producer_acquire(producer_state_kv)
+                            self.load_K(
+                                tma_atom_K,
+                                tKgK_tma,
+                                tKsK_tma,
+                                block=kv_block_to_load,
+                                smem_pipe_write=producer_state_kv.index,
+                                smem_pipe_phase=producer_state_kv.phase,
+                                tma_bar_ptr=pipeline_K.producer_get_barrier(producer_state_kv),
+                            )
+                            pipeline_K.producer_commit(producer_state_kv)
+                            producer_state_kv.advance()
+                            pipeline_V.producer_acquire(producer_state_kv)
+                            self.load_V(
+                                tma_atom_V,
+                                tVgV_tma,
+                                tVsV_tma,
+                                block=kv_block_to_load,
+                                smem_pipe_write=producer_state_kv.index,
+                                smem_pipe_phase=producer_state_kv.phase,
+                                tma_bar_ptr=pipeline_V.producer_get_barrier(producer_state_kv),
+                            )
+                            pipeline_V.producer_commit(producer_state_kv)
+                            producer_state_kv.advance()
+                    else:
+                        for n_tile in cutlass.range(n_block_max, unroll=self.unroll_producer_load):
+                            n_block_to_load = n_block_max - 1 - n_tile
+                            kv_block_to_load = (
+                                mPageTable[batch_idx, n_block_to_load // page_blocks_per_entry]
+                                * page_blocks_per_entry
+                                + (n_block_to_load % page_blocks_per_entry)
+                                if const_expr(mPageTable is not None)
+                                else n_block_to_load
+                            )
+                            if const_expr(self.shared_kv_mbar):
+                                pipeline_K.producer_acquire(producer_state_kv)
+                                self.load_K(
+                                    tma_atom_K,
+                                    tKgK_tma,
+                                    tKsK_tma,
+                                    block=kv_block_to_load,
+                                    smem_pipe_write=producer_state_kv.index,
+                                    smem_pipe_phase=producer_state_kv.phase,
+                                    tma_bar_ptr=pipeline_K.producer_get_barrier(producer_state_kv),
+                                )
+                                pipeline_K.producer_commit(producer_state_kv)
+                                producer_state_kv.advance()
+                                pipeline_V.producer_acquire(producer_state_kv)
+                                self.load_V(
+                                    tma_atom_V,
+                                    tVgV_tma,
+                                    tVsV_tma,
+                                    block=kv_block_to_load,
+                                    smem_pipe_write=producer_state_kv.index,
+                                    smem_pipe_phase=producer_state_kv.phase,
+                                    tma_bar_ptr=pipeline_V.producer_get_barrier(producer_state_kv),
+                                )
+                                pipeline_V.producer_commit(producer_state_kv)
+                                producer_state_kv.advance()
+                            else:
+                                pipeline_K.producer_acquire(producer_state_k)
+                                self.load_K(
+                                    tma_atom_K,
+                                    tKgK_tma,
+                                    tKsK_tma,
+                                    block=kv_block_to_load,
+                                    smem_pipe_write=producer_state_k.index,
+                                    smem_pipe_phase=producer_state_k.phase,
+                                    tma_bar_ptr=pipeline_K.producer_get_barrier(producer_state_k),
+                                )
+                                pipeline_K.producer_commit(producer_state_k)
+                                producer_state_k.advance()
+                                if const_expr(
+                                    not (self.share_kv_tma_stage_offset and self.num_stages > 1)
+                                ):
+                                    cute.arch.barrier(
+                                        barrier_id=int(NamedBarrierFwd.PFull),
+                                        number_of_threads=self.num_threads,
+                                    )
+                                pipeline_V.producer_acquire(producer_state_v)
+                                self.load_V(
+                                    tma_atom_V,
+                                    tVgV_tma,
+                                    tVsV_tma,
+                                    block=kv_block_to_load,
+                                    smem_pipe_write=producer_state_v.index,
+                                    smem_pipe_phase=producer_state_v.phase,
+                                    tma_bar_ptr=pipeline_V.producer_get_barrier(producer_state_v),
+                                )
+                                pipeline_V.producer_commit(producer_state_v)
+                                producer_state_v.advance()
+                                if const_expr(
+                                    not (self.share_kv_tma_stage_offset and self.num_stages > 1)
+                                ):
+                                    cute.arch.barrier(
+                                        barrier_id=int(NamedBarrierFwd.PEmpty),
+                                        number_of_threads=self.num_threads,
+                                    )
+                    if const_expr(self.shared_kv_mbar):
+                        # Avoid relying on PipelineTmaAsync.producer_tail(loc=..., ip=...)
+                        # because local pipeline overrides may not accept loc/ip in producer_acquire.
+                        for _ in cutlass.range(self.k_num_stages - 1, unroll_full=True):
+                            producer_state_kv.advance()
+                        pipeline_K.producer_acquire(producer_state_kv)
+                    else:
+                        for _ in cutlass.range(self.k_num_stages - 1, unroll_full=True):
+                            producer_state_k.advance()
+                        pipeline_K.producer_acquire(producer_state_k)
+                        for _ in cutlass.range(self.v_num_stages - 1, unroll_full=True):
+                            producer_state_v.advance()
+                        pipeline_V.producer_acquire(producer_state_v)
+                else:
+                    # Keep extra producer warps synchronized with the producer hand-off.
+                    if const_expr(
+                        not (self.share_kv_tma_stage_offset and self.num_stages > 1)
+                    ):
+                        for _ in cutlass.range(n_block_max, unroll=self.unroll_producer_sync):
+                            cute.arch.barrier(
+                                barrier_id=int(NamedBarrierFwd.PFull),
+                                number_of_threads=self.num_threads,
+                            )
+                            cute.arch.barrier(
+                                barrier_id=int(NamedBarrierFwd.PEmpty),
+                                number_of_threads=self.num_threads,
+                            )
+            cute.arch.barrier()
+            tile_scheduler.prefetch_next_work()
+            tile_scheduler.advance_to_next_work()
+            work_tile = tile_scheduler.get_current_work()
+
+        return
+
+    @cute.jit
+    def load_tma_partitioned(
+        self,
+        tma_atom: cute.CopyAtom,
+        tXgX: cute.Tensor,
+        tXsX: cute.Tensor,
+        src_idx: Int32,
+        dst_idx: Int32,
+        dst_phase: Int32,
+        tma_bar_ptr: cutlass.Pointer,
+    ):
+        tXsX_cur = tXsX[None, dst_idx]
+        cute.copy(
+            tma_atom,
+            tXgX[None, src_idx],
+            tXsX_cur,
+            tma_bar_ptr=tma_bar_ptr,
+        )
+
+    @cute.jit
+    def store_lse(
+        self,
+        lse: cute.Tensor,
+        mLSE: Optional[cute.Tensor],
+        seqlen: SeqlenInfoQK,
+        tiled_mma: cute.TiledMma,
+        tidx: Int32,
+        m_block: Int32,
+        head_idx: Int32,
+        batch_idx: Int32,
+        split_idx: Int32,
+    ):
+        if const_expr(mLSE is None):
+            return
+        is_split_kv = const_expr(
+            (seqlen.has_cu_seqlens_q and cute.rank(mLSE) == 3)
+            or (not seqlen.has_cu_seqlens_q and cute.rank(mLSE) == 4)
+        )
+        if const_expr(not seqlen.has_cu_seqlens_q):
+            mLSE_cur = (
+                mLSE[None, head_idx, batch_idx, split_idx]
+                if const_expr(is_split_kv)
+                else mLSE[None, head_idx, batch_idx]
+            )
+        else:
+            offset = seqlen.offset_q if const_expr(not self.pack_gqa) else (0, seqlen.offset_q)
+            mLSE_base = (
+                mLSE[None, head_idx, split_idx]
+                if const_expr(is_split_kv)
+                else mLSE[None, head_idx]
+            )
+            mLSE_cur = cute.domain_offset((offset,), mLSE_base)
+        if const_expr(not self.pack_gqa):
+            gLSE = cute.local_tile(mLSE_cur, (self.tile_m,), (m_block,))
+            gLSE_expanded_layout = cute.append(
+                gLSE.layout, cute.make_layout((self.tile_hdimv,), stride=(0,))
+            )
+            gLSE_expanded = cute.make_tensor(gLSE.iterator, gLSE_expanded_layout)
+            thr_mma = tiled_mma.get_slice(tidx)
+            taccOgLSE = layout_utils.reshape_acc_to_mn(thr_mma.partition_C(gLSE_expanded))
+            assert cute.size(taccOgLSE, mode=[0]) == cute.size(lse)
+            cO = cute.make_identity_tensor((self.tile_m, self.tile_hdimv))
+            taccOcO = layout_utils.reshape_acc_to_mn(thr_mma.partition_C(cO))
+            t0accOcO = layout_utils.reshape_acc_to_mn(thr_mma.get_slice(0).partition_C(cO))
+            if taccOcO[0][1] == 0:
+                for m in cutlass.range_constexpr(cute.size(taccOgLSE.shape[1])):
+                    if t0accOcO[m, 0][0] < seqlen.seqlen_q - m_block * self.tile_m - taccOcO[0][0]:
+                        taccOgLSE[m, 0] = lse[m]
+        else:
+            pack_gqa = PackGQA(
+                self.tile_m, self.tile_hdimv, self.check_hdim_v_oob, self.qhead_per_kvhead
+            )
+            pack_gqa.store_LSE(mLSE_cur, lse, tiled_mma, tidx, m_block, seqlen.seqlen_q)
+
+    @cute.jit
+    def store_O_from_smem(
+        self,
+        mO: cute.Tensor,
+        sO: cute.Tensor,
+        seqlen: SeqlenInfoQK,
+        gmem_tiled_copy_O: cute.TiledCopy,
+        tma_atom_O: Optional[cute.CopyAtom],
+        tiled_mma: cute.TiledMma,
+        tidx: Int32,
+        m_block: Int32,
+        head_idx: Int32,
+        batch_idx: Int32,
+        split_idx: Int32,
+    ):
+        cO = cute.make_identity_tensor((self.tile_m, self.tile_hdimv))
+        pack_gqa = PackGQA(
+            self.tile_m, self.tile_hdimv, self.check_hdim_v_oob, self.qhead_per_kvhead
+        )
+        is_split_kv = const_expr(
+            (seqlen.has_cu_seqlens_q and cute.rank(mO) == 4)
+            or (not seqlen.has_cu_seqlens_q and cute.rank(mO) == 5)
+        )
+        if const_expr(not seqlen.has_cu_seqlens_q):
+            mO_cur = (
+                mO[None, None, head_idx, batch_idx, split_idx]
+                if const_expr(is_split_kv)
+                else mO[None, None, head_idx, batch_idx]
+            )
+        else:
+            offset = seqlen.offset_q if const_expr(not self.pack_gqa) else (0, seqlen.offset_q)
+            mO_base = (
+                mO[None, None, head_idx, split_idx]
+                if const_expr(is_split_kv)
+                else mO[None, None, head_idx]
+            )
+            mO_cur = cute.domain_offset((offset, 0), mO_base)
+        if const_expr(tma_atom_O is not None and not self.pack_gqa and not self.check_hdim_v_oob):
+            cute.arch.fence_proxy(ProxyKind.async_shared, space=SharedSpace.shared_cta)
+            cute.arch.barrier_arrive(
+                barrier_id=int(NamedBarrierFwd.Epilogue),
+                number_of_threads=self.num_epilogue_threads + cute.arch.WARP_SIZE,
+            )
+            gO = cute.local_tile(mO_cur, (self.tile_m, self.tile_hdimv), (m_block, 0))
+            store_O, _, _ = copy_utils.tma_get_copy_fn(
+                tma_atom_O, 0, cute.make_layout(1), sO, gO, single_stage=True
+            )
+            warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+            if warp_idx == (self.num_producer_warps + self.num_mma_warps - 1):
+                cute.arch.barrier(
+                    barrier_id=int(NamedBarrierFwd.Epilogue),
+                    number_of_threads=self.num_epilogue_threads + cute.arch.WARP_SIZE,
+                )
+                store_O()
+                cute.arch.cp_async_bulk_commit_group()
+                cute.arch.cp_async_bulk_wait_group(0, read=True)
+        else:
+            cute.arch.barrier(
+                barrier_id=int(NamedBarrierFwd.Epilogue),
+                number_of_threads=self.num_epilogue_threads,
+            )
+            gmem_thr_copy_O = gmem_tiled_copy_O.get_slice(tidx)
+            tOsO = gmem_thr_copy_O.partition_S(sO)
+            tOrO = cute.make_fragment_like(tOsO, self.dtype)
+            cute.autovec_copy(tOsO, tOrO)
+            if const_expr(not self.pack_gqa):
+                gO = cute.local_tile(mO_cur, (self.tile_m, self.tile_hdimv), (m_block, 0))
+                tOgO = gmem_thr_copy_O.partition_D(gO)
+                tOcO = gmem_thr_copy_O.partition_S(cO)
+                t0OcO = gmem_tiled_copy_O.get_slice(0).partition_S(cO)
+                tOpO = utils.predicate_k(tOcO, limit=mO.shape[1])
+                for rest_m in cutlass.range_constexpr(cute.size(tOrO.shape[1])):
+                    if t0OcO[0, rest_m, 0][0] < seqlen.seqlen_q - m_block * self.tile_m - tOcO[0][0]:
+                        cute.copy(
+                            gmem_tiled_copy_O,
+                            tOrO[None, rest_m, None],
+                            tOgO[None, rest_m, None],
+                            pred=tOpO[None, rest_m, None] if const_expr(self.check_hdim_v_oob) else None,
+                        )
+            else:
+                pack_gqa.store_O(mO_cur, tOrO, gmem_tiled_copy_O, tidx, m_block, seqlen.seqlen_q)
+
+    @cute.jit
+    def epilogue(
+        self,
+        acc_O: cute.Tensor,
+        lse: cute.Tensor,
+        mO: cute.Tensor,
+        mLSE: Optional[cute.Tensor],
+        sO: cute.Tensor,
+        seqlen: SeqlenInfoQK,
+        gmem_tiled_copy_O: cute.TiledCopy,
+        tma_atom_O: Optional[cute.CopyAtom],
+        tiled_mma: cute.TiledMma,
+        tidx: Int32,
+        m_block: Int32,
+        head_idx: Int32,
+        batch_idx: Int32,
+        split_idx: Int32,
+    ):
+        rO = cute.make_fragment_like(acc_O, self.dtype)
+        rO.store(acc_O.load().to(self.dtype))
+        cute.arch.barrier(
+            barrier_id=int(NamedBarrierFwd.Epilogue), number_of_threads=self.num_epilogue_threads
+        )
+        smem_copy_atom_O = cute.make_copy_atom(
+            warp.StMatrix8x8x16bOp(
+                transpose=False,  # ROW_MAJOR
+                num_matrices=4,
+            ),
+            self.dtype,
+        )
+        smem_thr_copy_O = cute.make_tiled_copy_C(smem_copy_atom_O, tiled_mma).get_slice(tidx)
+        taccOrO = smem_thr_copy_O.retile(rO)
+        taccOsO = smem_thr_copy_O.partition_D(sO)
+        cute.copy(smem_copy_atom_O, taccOrO, taccOsO)
+        self.store_lse(
+            lse,
+            mLSE,
+            seqlen,
+            tiled_mma,
+            tidx,
+            m_block,
+            head_idx,
+            batch_idx,
+            split_idx,
+        )
+        self.store_O_from_smem(
+            mO,
+            sO,
+            seqlen,
+            gmem_tiled_copy_O,
+            tma_atom_O,
+            tiled_mma,
+            tidx,
+            m_block,
+            head_idx,
+            batch_idx,
+            split_idx,
+        )

--- a/flash_attn/cute/flash_fwd_sm120_tma_optimized.py
+++ b/flash_attn/cute/flash_fwd_sm120_tma_optimized.py
@@ -151,7 +151,10 @@ class FlashAttentionForwardSm120TMAOptimized(FlashAttentionForwardSm80):
         self.v_num_stages = self.num_stages
 
         # Match SM100-style shared K/V stage-offset scheduling when stage counts align.
-        self.share_kv_tma_stage_offset = self.num_stages > 1
+        # When K and V head dims differ, interleaving the shared-KV stage stream can alias
+        # incompatible K/V stage footprints and corrupt V tiles. Keep separate K/V stage
+        # progression in that case.
+        self.share_kv_tma_stage_offset = self.num_stages > 1 and self.same_hdim_kv
         self.shared_kv_mbar = self.share_kv_tma_stage_offset
         self.use_tma_Q_mainloop = self.use_tma_Q and (not self.use_direct_q_gmem_regs_decode)
         # In shared-KV stage-offset mode, piggyback the first Q TMA transaction on K's mbarrier.
@@ -273,7 +276,8 @@ class FlashAttentionForwardSm120TMAOptimized(FlashAttentionForwardSm80):
 
         k_num_stages = num_stages
         v_num_stages = num_stages
-        shared_kv_mbar = (num_stages > 1) and (k_num_stages == v_num_stages)
+        same_hdim_kv = head_dim == head_dim_v
+        shared_kv_mbar = (num_stages > 1) and (k_num_stages == v_num_stages) and same_hdim_kv
         unify_qk_tma_barrier = use_tma_Q_effective and shared_kv_mbar
         q_mbar_slots = 0 if unify_qk_tma_barrier else (2 if use_tma_Q_effective else 0)
         mbar_load_k_full_offset = q_mbar_slots

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -54,6 +54,9 @@ from flash_attn.cute.flash_fwd import FlashAttentionForwardSm80
 from flash_attn.cute.flash_fwd_sm90 import FlashAttentionForwardSm90
 from flash_attn.cute.flash_fwd_sm100 import FlashAttentionForwardSm100
 from flash_attn.cute.flash_fwd_sm120 import FlashAttentionForwardSm120
+from flash_attn.cute.flash_fwd_sm120_tma_optimized import (
+    FlashAttentionForwardSm120TMAOptimized,
+)
 from flash_attn.cute.flash_bwd_preprocess import FlashAttentionBackwardPreprocess
 from flash_attn.cute.flash_bwd import FlashAttentionBackwardSm80
 from flash_attn.cute.flash_bwd_sm90 import FlashAttentionBackwardSm90
@@ -451,20 +454,17 @@ def _flash_attn_fwd(
     # In fake mode (CPU-only compilation), use a fake stream placeholder.
     current_stream = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
 
-    # SM80/SM120: uses SM80 MMA, 128 threads (4 warps)
-    if arch // 10 in [8, 12]:
+    # SM80 path uses 128 threads (4 warps); optimized SM120 path uses 160.
+    if arch // 10 == 8:
         num_threads = 128
+    elif arch // 10 == 12:
+        num_threads = 160
 
     fwd_cfg = FwdConfig(128, 128, True, True)  # default
     if tile_mn is None:
         if arch // 10 == 12:
-            # SM120 tile sizes tuned for 99 KB SMEM capacity:
-            # D<=64:  128x128 → 48 KB (good occupancy)
-            # D>64:   128x64  → 64 KB (128x128 would use 96 KB, hurting occupancy)
-            if head_dim <= 64:
-                fwd_cfg = FwdConfig(128, 128, True, True)
-            else:
-                fwd_cfg = FwdConfig(128, 64, True, True)
+            # Use the validated optimized-SM120 configuration by default.
+            fwd_cfg = FwdConfig(64, 64, True, True)
         elif arch // 10 == 8:
             fwd_cfg = FwdConfig(128, 64, True, True)  # SM80, should tune
         elif arch // 10 == 9:
@@ -730,11 +730,11 @@ def _flash_attn_fwd(
                 use_2cta_instrs=use_2cta_instrs,
             )
         elif arch // 10 == 12:
-            # SM120 (Blackwell GeForce / DGX Spark): uses SM80 MMA with SM120 SMEM capacity
+            # SM120 optimized TMA forward.
             assert not use_block_sparsity, "Block sparsity not supported on SM 12.0"
             assert page_table is None, "Paged KV not supported on SM 12.0 in this PR"
             assert not is_split_kv, "SplitKV not supported on SM 12.0 in this PR"
-            fa_fwd = FlashAttentionForwardSm120(
+            fa_fwd = FlashAttentionForwardSm120TMAOptimized(
                 dtype,
                 head_dim,
                 head_dim_v,
@@ -744,9 +744,9 @@ def _flash_attn_fwd(
                 pack_gqa=pack_gqa,
                 tile_m=tile_m,
                 tile_n=tile_n,
-                num_stages=1,
+                num_stages=2,
                 num_threads=num_threads,
-                Q_in_regs=False,
+                use_tma_Q=True,
                 score_mod=score_mod,
                 mask_mod=mask_mod,
                 has_aux_tensors=aux_tensors is not None,
@@ -1001,6 +1001,7 @@ def _flash_attn_bwd(
     causal, local, window_size_left, window_size_right = _resolve_causal_local_window(
         causal, window_size_left, window_size_right
     )
+    dQ_single_wg = False
 
     if arch // 10 == 12:
         # SM120: uses SM80 MMA with 99 KB SMEM, 128 threads (4 warps).

--- a/flash_attn/cute/pack_gqa.py
+++ b/flash_attn/cute/pack_gqa.py
@@ -131,13 +131,15 @@ class PackGQA:
     ):
         num_ptr_per_thread = cute.ceil_div(cute.size(cRows), threads_per_row)
         tPrPtr = cute.make_fragment(num_ptr_per_thread, cutlass.Int64)
+        tPrRow = cute.make_fragment(num_ptr_per_thread, cutlass.Int32)
         for i in cutlass.range_constexpr(num_ptr_per_thread):
             row = i * num_threads + cRows[tidx % threads_per_row][0]
             idx = block * self.m_block_size + row
             m_idx = idx // self.qhead_per_kvhead
             h_idx = idx - m_idx * self.qhead_per_kvhead
             tPrPtr[i] = utils.elem_pointer(tensor, ((h_idx, m_idx),)).toint()
-        return tPrPtr
+            tPrRow[i] = row
+        return tPrPtr, tPrRow
 
     @cute.jit
     def load_Q(
@@ -157,31 +159,63 @@ class PackGQA:
         tQpQ = utils.predicate_k(tQcQ, limit=mQ.shape[1])
         tQcQ_row = tQcQ[0, None, 0]
         threads_per_row = gmem_tiled_copy.layout_tv_tiled.shape[0][0]
-        assert cute.arch.WARP_SIZE % threads_per_row == 0, "threads_per_row must divide WARP_SIZE"
-        num_threads = gmem_tiled_copy.size
-        tPrQPtr = self.compute_ptr(mQ[None, 0], tQcQ_row, tidx, block, threads_per_row, num_threads)
-        for m in cutlass.range_constexpr(cute.size(tQsQ.shape[1])):
-            q_ptr_i64 = utils.shuffle_sync(
-                tPrQPtr[m // threads_per_row], m % threads_per_row, width=threads_per_row
+        if cutlass.const_expr(cute.arch.WARP_SIZE % threads_per_row == 0):
+            num_threads = gmem_tiled_copy.size
+            tPrQPtr, tPrQRow = self.compute_ptr(
+                mQ[None, 0], tQcQ_row, tidx, block, threads_per_row, num_threads
             )
-            q_gmem_ptr = cute.make_ptr(
-                mQ.element_type, q_ptr_i64, cute.AddressSpace.gmem, assumed_align=16
-            )
-            if (
-                t0QcQ[0, m, 0][0]
-                < seqlen * self.qhead_per_kvhead - block * self.m_block_size - tQcQ_row[0][0]
-            ):
-                mQ_cur = cute.make_tensor(q_gmem_ptr, (self.head_dim_padded,))
-                elems_per_load = cute.size(tQsQ.shape[0][0])
-                mQ_cur_copy = cute.tiled_divide(mQ_cur, (elems_per_load,))
-                for k in cutlass.range_constexpr(cute.size(tQsQ.shape[2])):
-                    ki = tQcQ[0, 0, k][1] // elems_per_load
-                    cute.copy(
-                        gmem_thr_copy,
-                        mQ_cur_copy[None, ki],
-                        tQsQ[None, m, k],
-                        pred=tQpQ[None, m, k] if cutlass.const_expr(self.check_hdim_oob) else None,
-                    )
+            for m in cutlass.range_constexpr(cute.size(tQsQ.shape[1])):
+                q_ptr_i64 = utils.shuffle_sync(
+                    tPrQPtr[m // threads_per_row], m % threads_per_row, width=threads_per_row
+                )
+                row = utils.shuffle_sync(
+                    tPrQRow[m // threads_per_row], m % threads_per_row, width=threads_per_row
+                )
+                q_gmem_ptr = cute.make_ptr(
+                    mQ.element_type, q_ptr_i64, cute.AddressSpace.gmem, assumed_align=16
+                )
+                if row < seqlen * self.qhead_per_kvhead - block * self.m_block_size:
+                    mQ_cur = cute.make_tensor(q_gmem_ptr, (self.head_dim_padded,))
+                    elems_per_load = cute.size(tQsQ.shape[0][0])
+                    mQ_cur_copy = cute.tiled_divide(mQ_cur, (elems_per_load,))
+                    for k in cutlass.range_constexpr(cute.size(tQsQ.shape[2])):
+                        ki = tQcQ[0, 0, k][1] // elems_per_load
+                        cute.copy(
+                            gmem_thr_copy,
+                            mQ_cur_copy[None, ki],
+                            tQsQ[None, m, k],
+                            pred=tQpQ[None, m, k] if cutlass.const_expr(self.check_hdim_oob) else None,
+                        )
+        else:
+            mQ_ptr_base = mQ[None, 0]
+            active_copy_thread = tidx < gmem_tiled_copy.size
+            for m in cutlass.range_constexpr(cute.size(tQsQ.shape[1])):
+                row = cutlass.Int32(0)
+                q_ptr_i64 = cutlass.Int64(0)
+                if active_copy_thread:
+                    row = tQcQ_row[m][0]
+                    idx = block * self.m_block_size + row
+                    m_idx = idx // self.qhead_per_kvhead
+                    h_idx = idx - m_idx * self.qhead_per_kvhead
+                    q_ptr_i64 = utils.elem_pointer(mQ_ptr_base, ((h_idx, m_idx),)).toint()
+                q_gmem_ptr = cute.make_ptr(
+                    mQ.element_type, q_ptr_i64, cute.AddressSpace.gmem, assumed_align=16
+                )
+                if (
+                    active_copy_thread
+                    and row < seqlen * self.qhead_per_kvhead - block * self.m_block_size
+                ):
+                    mQ_cur = cute.make_tensor(q_gmem_ptr, (self.head_dim_padded,))
+                    elems_per_load = cute.size(tQsQ.shape[0][0])
+                    mQ_cur_copy = cute.tiled_divide(mQ_cur, (elems_per_load,))
+                    for k in cutlass.range_constexpr(cute.size(tQsQ.shape[2])):
+                        ki = tQcQ[0, 0, k][1] // elems_per_load
+                        cute.copy(
+                            gmem_thr_copy,
+                            mQ_cur_copy[None, ki],
+                            tQsQ[None, m, k],
+                            pred=tQpQ[None, m, k] if cutlass.const_expr(self.check_hdim_oob) else None,
+                        )
             # We don't need to clear the sQ smem tiles since we'll only write out the valid outputs
 
     @cute.jit
@@ -200,24 +234,47 @@ class PackGQA:
         taccOcO_row = layout_utils.reshape_acc_to_mn(taccOcO)[None, 0]
         assert cute.size(tLSErLSE) == cute.size(taccOcO_row)
         threads_per_row = tiled_mma.tv_layout_C.shape[0][0]
-        assert cute.arch.WARP_SIZE % threads_per_row == 0, "threads_per_row must divide WARP_SIZE"
-        assert cute.size(tLSErLSE) <= threads_per_row
-        num_threads = tiled_mma.size
-        tPrLSEPtr = self.compute_ptr(mLSE, taccOcO_row, tidx, block, threads_per_row, num_threads)
-        for m in cutlass.range_constexpr(cute.size(tLSErLSE)):
-            lse_ptr_i64 = utils.shuffle_sync(
-                tPrLSEPtr[m // threads_per_row],
-                m % threads_per_row,
-                width=threads_per_row,
+        if cutlass.const_expr(cute.arch.WARP_SIZE % threads_per_row == 0):
+            assert cute.size(tLSErLSE) <= threads_per_row
+            num_threads = tiled_mma.size
+            tPrLSEPtr, tPrLSERow = self.compute_ptr(
+                mLSE, taccOcO_row, tidx, block, threads_per_row, num_threads
             )
-            lse_gmem_ptr = cute.make_ptr(
-                mLSE.element_type, lse_ptr_i64, cute.AddressSpace.gmem, assumed_align=4
-            )
-            row = block * self.m_block_size + taccOcO_row[m][0]
-            # Only the thread corresponding to column 0 writes out the lse to gmem
-            if taccOcO[0][1] == 0 and row < seqlen * self.qhead_per_kvhead:
-                mLSE_copy = cute.make_tensor(lse_gmem_ptr, (1,))
-                mLSE_copy[0] = tLSErLSE[m]
+            for m in cutlass.range_constexpr(cute.size(tLSErLSE)):
+                lse_ptr_i64 = utils.shuffle_sync(
+                    tPrLSEPtr[m // threads_per_row],
+                    m % threads_per_row,
+                    width=threads_per_row,
+                )
+                row = utils.shuffle_sync(
+                    tPrLSERow[m // threads_per_row], m % threads_per_row, width=threads_per_row
+                )
+                lse_gmem_ptr = cute.make_ptr(
+                    mLSE.element_type, lse_ptr_i64, cute.AddressSpace.gmem, assumed_align=4
+                )
+                row = block * self.m_block_size + row
+                # Only the thread corresponding to column 0 writes out the lse to gmem
+                if taccOcO[0][1] == 0 and row < seqlen * self.qhead_per_kvhead:
+                    mLSE_copy = cute.make_tensor(lse_gmem_ptr, (1,))
+                    mLSE_copy[0] = tLSErLSE[m]
+        else:
+            num_threads = tiled_mma.size
+            for m in cutlass.range_constexpr(cute.size(tLSErLSE)):
+                row = (
+                    (m // threads_per_row) * num_threads
+                    + taccOcO_row[m % threads_per_row][0]
+                )
+                idx = block * self.m_block_size + row
+                m_idx = idx // self.qhead_per_kvhead
+                h_idx = idx - m_idx * self.qhead_per_kvhead
+                lse_ptr_i64 = utils.elem_pointer(mLSE, ((h_idx, m_idx),)).toint()
+                lse_gmem_ptr = cute.make_ptr(
+                    mLSE.element_type, lse_ptr_i64, cute.AddressSpace.gmem, assumed_align=4
+                )
+                # Only the thread corresponding to column 0 writes out the lse to gmem
+                if taccOcO[0][1] == 0 and idx < seqlen * self.qhead_per_kvhead:
+                    mLSE_copy = cute.make_tensor(lse_gmem_ptr, (1,))
+                    mLSE_copy[0] = tLSErLSE[m]
 
     @cute.jit
     def store_O(
@@ -236,28 +293,60 @@ class PackGQA:
         tOpO = utils.predicate_k(tOcO, limit=mO.shape[1])
         tOcO_row = tOcO[0, None, 0]
         threads_per_row = gmem_tiled_copy.layout_tv_tiled.shape[0][0]
-        assert cute.arch.WARP_SIZE % threads_per_row == 0, "threads_per_row must divide WARP_SIZE"
-        num_threads = gmem_tiled_copy.size
-        tPrOPtr = self.compute_ptr(mO[None, 0], tOcO_row, tidx, block, threads_per_row, num_threads)
-        for m in cutlass.range_constexpr(cute.size(tOrO.shape[1])):
-            o_ptr_i64 = utils.shuffle_sync(
-                tPrOPtr[m // threads_per_row], m % threads_per_row, width=threads_per_row
+        if cutlass.const_expr(cute.arch.WARP_SIZE % threads_per_row == 0):
+            num_threads = gmem_tiled_copy.size
+            tPrOPtr, tPrORow = self.compute_ptr(
+                mO[None, 0], tOcO_row, tidx, block, threads_per_row, num_threads
             )
-            o_gmem_ptr = cute.make_ptr(
-                mO.element_type, o_ptr_i64, cute.AddressSpace.gmem, assumed_align=16
-            )
-            if (
-                t0OcO[0, m, 0][0]
-                < seqlen * self.qhead_per_kvhead - block * self.m_block_size - tOcO_row[0][0]
-            ):
-                mO_cur = cute.make_tensor(o_gmem_ptr, (self.head_dim_padded,))
-                elems_per_load = cute.size(tOrO.shape[0][0])
-                mO_cur_copy = cute.tiled_divide(mO_cur, (elems_per_load,))
-                for k in cutlass.range_constexpr(cute.size(tOrO.shape[2])):
-                    ki = tOcO[0, 0, k][1] // elems_per_load
-                    cute.copy(
-                        gmem_thr_copy,
-                        tOrO[None, m, k],
-                        mO_cur_copy[None, ki],
-                        pred=tOpO[None, m, k] if cutlass.const_expr(self.check_hdim_oob) else None,
-                    )
+            for m in cutlass.range_constexpr(cute.size(tOrO.shape[1])):
+                o_ptr_i64 = utils.shuffle_sync(
+                    tPrOPtr[m // threads_per_row], m % threads_per_row, width=threads_per_row
+                )
+                row = utils.shuffle_sync(
+                    tPrORow[m // threads_per_row], m % threads_per_row, width=threads_per_row
+                )
+                o_gmem_ptr = cute.make_ptr(
+                    mO.element_type, o_ptr_i64, cute.AddressSpace.gmem, assumed_align=16
+                )
+                if row < seqlen * self.qhead_per_kvhead - block * self.m_block_size:
+                    mO_cur = cute.make_tensor(o_gmem_ptr, (self.head_dim_padded,))
+                    elems_per_load = cute.size(tOrO.shape[0][0])
+                    mO_cur_copy = cute.tiled_divide(mO_cur, (elems_per_load,))
+                    for k in cutlass.range_constexpr(cute.size(tOrO.shape[2])):
+                        ki = tOcO[0, 0, k][1] // elems_per_load
+                        cute.copy(
+                            gmem_thr_copy,
+                            tOrO[None, m, k],
+                            mO_cur_copy[None, ki],
+                            pred=tOpO[None, m, k] if cutlass.const_expr(self.check_hdim_oob) else None,
+                        )
+        else:
+            mO_ptr_base = mO[None, 0]
+            active_copy_thread = tidx < gmem_tiled_copy.size
+            for m in cutlass.range_constexpr(cute.size(tOrO.shape[1])):
+                row = cutlass.Int32(0)
+                o_ptr_i64 = cutlass.Int64(0)
+                if active_copy_thread:
+                    row = tOcO_row[m][0]
+                    idx = block * self.m_block_size + row
+                    m_idx = idx // self.qhead_per_kvhead
+                    h_idx = idx - m_idx * self.qhead_per_kvhead
+                    o_ptr_i64 = utils.elem_pointer(mO_ptr_base, ((h_idx, m_idx),)).toint()
+                o_gmem_ptr = cute.make_ptr(
+                    mO.element_type, o_ptr_i64, cute.AddressSpace.gmem, assumed_align=16
+                )
+                if (
+                    active_copy_thread
+                    and row < seqlen * self.qhead_per_kvhead - block * self.m_block_size
+                ):
+                    mO_cur = cute.make_tensor(o_gmem_ptr, (self.head_dim_padded,))
+                    elems_per_load = cute.size(tOrO.shape[0][0])
+                    mO_cur_copy = cute.tiled_divide(mO_cur, (elems_per_load,))
+                    for k in cutlass.range_constexpr(cute.size(tOrO.shape[2])):
+                        ki = tOcO[0, 0, k][1] // elems_per_load
+                        cute.copy(
+                            gmem_thr_copy,
+                            tOrO[None, m, k],
+                            mO_cur_copy[None, ki],
+                            pred=tOpO[None, m, k] if cutlass.const_expr(self.check_hdim_oob) else None,
+                        )


### PR DESCRIPTION
This PR introduces separate sm120 forward kernel with optimized TMA path and full features support (except block sparsity).

I started developing it about two months ago with primary focus on improving performance relative to sm80 (which also executable on sm120 hardware), then this PR was opened 
 https://github.com/Dao-AILab/flash-attention/pull/2349 and I discovered that its performance is slightly worse than mine and other features were split into separate PR's

Summary about performance relative to sm80 kernel: 
- In most cases TMA version is slightly better by 2-3%, but there are cases of about 5% better and worth both. Detailed performance and correctness tables are below.
- Its performance slightly improves with greater batches and degrades with greater heads count. Performance delta with `pack_gqa` is smaller.
- I think further speed up attempts should utilize quantization in some way, not necessary in using sm120 mma ops for quantized inputs, but maybe transferring big quantized tiles into smem and upcast to half in registers. TMA benefits are limited on sm120 because of its smem capacity.

## Feature matrix comparing with https://github.com/Dao-AILab/flash-attention/pull/2349

| Area | `Sm120Tma` | `Sm120TMAOptimized` |
|---|---|---|
| Core transfer model | TMA for Q/K/V | TMA for K/V always; Q can be TMA, cp.async, or direct gmem->regs decode |
| O global store | SMEM->GMEM copy path only (`use_tma_O = False`) | Supports TMA S2G O-store in eligible cases; otherwise SMEM/copy path |
| Decode q1 direct Q gmem->regs | Not implemented | Implemented via `direct_q_gmem_regs_decode`, it can be faster in some cases |
| pack-GQA handling | Supports pack-GQA mode, but no dedicated packed-Q TMA atom path | Dedicated pack-GQA Q TMA atom path (`make_packgqa_tiled_tma_atom`) + pack-aware load/store helpers. Changes in pack_gqa.py were necessary for kernel correctness when `cute.arch.WARP_SIZE % threads_per_row != 0` (head dims 96, 192) |
| Split-KV | Not supported (`num_splits = 1`, `is_split_kv = False`) | Supported (rank-based split detection, split-aware LSE/O writes) |
| Paged KV (`mPageTable`) | Explicitly unsupported (assert) | Supported with restriction: K/V must be batched dense (no varlen K with page table) |
| Varlen (`cu_seqlens`) | Supported | Supported |
| SeqUsed (`mSeqUsedQ`, `mSeqUsedK`) | Supported | Supported |
| Persistent scheduling | Not used (`is_persistent=False`) | Used for non-causal non-local dense Q; varlen and causal/local use non-persistent schedulers |
| Scheduler variants | SingleTile / SingleTileVarlen | SingleTile / SingleTileLPT / SingleTileVarlen with dynamic selection |
| Pipeline/barrier model | Separate Q/K/V TMA pipelines | Unified SM100-style configurable barrier layout, optional Q-K barrier sharing, K/V stage-offset interleaving |
| Shared-memory reuse | Separate sQ, sK, sV regions | Aliases O with Q, and in decode-direct mode aliases Q/O into KV region |
| Register policy | `Q_in_regs=False` | `Q_in_regs=True`, `K_in_regs=True` (default), with explicit preload behavior |
| Block sparsity | Not implemented (no active path) | Explicitly rejected (`NotImplementedError`) |

Currently I don't wired my kernel into interface.py, I can either:
- rename it to `flash_fwd_sm120_tma.py` and wire this into interface, if this PR won't be merged https://github.com/Dao-AILab/flash-attention/pull/2349
- when https://github.com/Dao-AILab/flash-attention/pull/2349 will be merged - can rebase my features onto it

# Performance and tests reports (RTX 5090):
For each kernel (tile_m, tile_n, num_stages, threads_number) were preselected as one which gives best performance in a majority of cases

Default attn

<details>
<summary> batch=64, heads=16, head_dim=128 </summary>

| mode | sq | sk | optimized_ms | optimized_TF/s | sm120_ms | sm120_TF/s | sm80_ms | sm80_TF/s | spd_vs_sm120 | spd_vs_sm80 | optimized_cfg | sm120_cfg | sm80_cfg | optimized_tests |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- | --- | :---: |
| non_causal | 512 | 512 | 0.680 | 202.25 | 0.702 | 195.67 | 0.689 | 199.56 | 1.03x | 1.01x | tm64-tn64-s2-th160-kr1-dq0 | tm64-tn64-s1-th160-kr0-dq0 | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| non_causal | 512 | 1024 | 1.325 | 207.49 | 1.366 | 201.20 | 1.350 | 203.63 | 1.03x | 1.02x | tm64-tn64-s2-th160-kr1-dq0 | tm64-tn64-s1-th160-kr0-dq0 | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| non_causal | 512 | 2048 | 2.610 | 210.62 | 2.691 | 204.29 | 2.668 | 206.08 | 1.03x | 1.02x | tm64-tn64-s2-th160-kr1-dq0 | tm64-tn64-s1-th160-kr0-dq0 | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| non_causal | 512 | 4096 | 5.175 | 212.47 | 5.340 | 205.90 | 5.306 | 207.21 | 1.03x | 1.03x | tm64-tn64-s2-th160-kr1-dq0 | tm64-tn64-s1-th160-kr0-dq0 | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| non_causal | 1024 | 512 | 1.340 | 205.15 | 1.382 | 198.93 | 1.353 | 203.16 | 1.03x | 1.01x | tm64-tn64-s2-th160-kr1-dq0 | tm64-tn64-s1-th160-kr0-dq0 | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| non_causal | 1024 | 1024 | 2.599 | 211.54 | 2.682 | 204.94 | 2.642 | 208.09 | 1.03x | 1.02x | tm64-tn64-s2-th160-kr1-dq0 | tm64-tn64-s1-th160-kr0-dq0 | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| non_causal | 1024 | 2048 | 5.118 | 214.82 | 5.275 | 208.43 | 5.227 | 210.35 | 1.03x | 1.02x | tm64-tn64-s2-th160-kr1-dq0 | tm64-tn64-s1-th160-kr0-dq0 | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| non_causal | 1024 | 4096 | 10.123 | 217.24 | 10.431 | 210.82 | 10.385 | 211.76 | 1.03x | 1.03x | tm64-tn64-s2-th160-kr1-dq0 | tm64-tn64-s1-th160-kr0-dq0 | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| non_causal | 2048 | 512 | 2.652 | 207.30 | 2.737 | 200.87 | 2.675 | 205.53 | 1.03x | 1.01x | tm64-tn64-s2-th160-kr1-dq0 | tm64-tn64-s1-th160-kr0-dq0 | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| non_causal | 2048 | 1024 | 5.141 | 213.85 | 5.304 | 207.29 | 5.226 | 210.40 | 1.03x | 1.02x | tm64-tn64-s2-th160-kr1-dq0 | tm64-tn64-s1-th160-kr0-dq0 | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| non_causal | 2048 | 2048 | 10.103 | 217.67 | 10.408 | 211.28 | 10.325 | 212.98 | 1.03x | 1.02x | tm64-tn64-s2-th160-kr1-dq0 | tm64-tn64-s1-th160-kr0-dq0 | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| non_causal | 2048 | 4096 | 20.048 | 219.38 | 20.616 | 213.34 | 20.566 | 213.85 | 1.03x | 1.03x | tm64-tn64-s2-th160-kr1-dq0 | tm64-tn64-s1-th160-kr0-dq0 | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| non_causal | 4096 | 512 | 5.274 | 208.46 | 5.443 | 202.02 | 5.324 | 206.51 | 1.03x | 1.01x | tm64-tn64-s2-th160-kr1-dq0 | tm64-tn64-s1-th160-kr0-dq0 | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| non_causal | 4096 | 1024 | 10.194 | 215.72 | 10.517 | 209.09 | 10.371 | 212.03 | 1.03x | 1.02x | tm64-tn64-s2-th160-kr1-dq0 | tm64-tn64-s1-th160-kr0-dq0 | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| non_causal | 4096 | 2048 | 20.121 | 218.57 | 20.683 | 212.64 | 20.584 | 213.66 | 1.03x | 1.02x | tm64-tn64-s2-th160-kr1-dq0 | tm64-tn64-s1-th160-kr0-dq0 | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| non_causal | 4096 | 4096 | 39.928 | 220.30 | 41.026 | 214.41 | 40.869 | 215.23 | 1.03x | 1.02x | tm64-tn64-s2-th160-kr1-dq0 | tm64-tn64-s1-th160-kr0-dq0 | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| causal_square | 512 | 512 | 0.426 | 322.65 | 0.428 | 321.23 | 0.420 | 326.92 | 1.00x | 0.99x | tm64-tn64-s2-th160-kr1-dq0 | tm64-tn64-s1-th160-kr0-dq0 | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| causal_square | 1024 | 1024 | 1.446 | 380.23 | 1.490 | 368.97 | 1.477 | 372.12 | 1.03x | 1.02x | tm64-tn64-s2-th160-kr1-dq0 | tm64-tn64-s1-th160-kr0-dq0 | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| causal_square | 2048 | 2048 | 5.344 | 411.49 | 5.541 | 396.84 | 5.520 | 398.34 | 1.04x | 1.03x | tm64-tn64-s2-th160-kr1-dq0 | tm64-tn64-s1-th160-kr0-dq0 | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| causal_square | 4096 | 4096 | 20.634 | 426.30 | 21.185 | 415.20 | 21.258 | 413.78 | 1.03x | 1.03x | tm64-tn64-s2-th160-kr1-dq0 | tm64-tn64-s1-th160-kr0-dq0 | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| causal_q1 | 1 | 512 | 0.167 | 1.60 | 0.168 | 1.59 | 0.172 | 1.56 | 1.01x | 1.03x | tm64-tn64-s2-th160-kr1-dq0 | tm64-tn64-s1-th160-kr0-dq0 | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| causal_q1 | 1 | 1024 | 0.329 | 1.63 | 0.330 | 1.63 | 0.340 | 1.58 | 1.00x | 1.03x | tm64-tn64-s2-th160-kr1-dq0 | tm64-tn64-s1-th160-kr0-dq0 | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| causal_q1 | 1 | 2048 | 0.654 | 1.64 | 0.655 | 1.64 | 0.672 | 1.60 | 1.00x | 1.03x | tm64-tn64-s2-th160-kr1-dq0 | tm64-tn64-s1-th160-kr0-dq0 | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| causal_q1 | 1 | 4096 | 1.305 | 1.64 | 1.311 | 1.64 | 1.339 | 1.60 | 1.00x | 1.03x | tm64-tn64-s2-th160-kr1-dq0 | tm64-tn64-s1-th160-kr0-dq0 | tm64-tn64-s1-th128-kr0-dq0 | PASS |

## Optimized Only: Default Decoding vs Split-KV (+combine, configurable splits)

| case | default_ms | sm80_default_ms | default_TF/s | feature_ms | feature_TF/s | spd_vs_opt_default | spd_vs_sm80_default | tests | test_max_diff | test_threshold | notes |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | :---: | ---: | ---: | --- |
| sq=1 sk=512 | 0.167 | 0.172 | 1.60 | 0.167 | 1.60 | 1.00x | 1.03x | PASS | 0 | 0.03467 | split_kv auto-disabled (num_splits=1, min_n_blocks=16, sat_frac=1.00, total_mblocks=1024, sat_limit=170, num_sms=170) |
| sq=1 sk=1024 | 0.330 | 0.340 | 1.63 | 0.330 | 1.63 | 1.00x | 1.03x | PASS | 0 | 0.0249 | split_kv auto-disabled (num_splits=1, min_n_blocks=16, sat_frac=1.00, total_mblocks=1024, sat_limit=170, num_sms=170) |
| sq=1 sk=2048 | 0.654 | 0.672 | 1.64 | 0.654 | 1.64 | 1.00x | 1.03x | PASS | 0 | 0.0238 | split_kv auto-disabled (num_splits=1, min_n_blocks=16, sat_frac=1.00, total_mblocks=1024, sat_limit=170, num_sms=170) |
| sq=1 sk=4096 | 1.304 | 1.335 | 1.65 | 1.304 | 1.65 | 1.00x | 1.02x | PASS | 0 | 0.02246 | split_kv auto-disabled (num_splits=1, min_n_blocks=16, sat_frac=1.00, total_mblocks=1024, sat_limit=170, num_sms=170) |

## Optimized Only: Causal q1 Direct Q GMEM->Regs (A/B)

| case | default_ms | sm80_default_ms | default_TF/s | feature_ms | feature_TF/s | spd_vs_opt_default | spd_vs_sm80_default | tests | test_max_diff | test_threshold | notes |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | :---: | ---: | ---: | --- |
| batch=1 heads=16 sq=1 sk=512 | 0.016 | 0.016 | 0.26 | 0.016 | 0.26 | 1.00x | 1.00x | PASS | 0 | 0.02502 | default:tn=128,dq=0 ; feature:tn=128,dq=1 |
| batch=1 heads=16 sq=1 sk=1024 | 0.029 | 0.029 | 0.29 | 0.029 | 0.29 | 1.00x | 1.00x | PASS | 0 | 0.02344 | default:tn=128,dq=0 ; feature:tn=128,dq=1 |
| batch=1 heads=16 sq=1 sk=2048 | 0.055 | 0.055 | 0.30 | 0.055 | 0.30 | 1.00x | 1.00x | PASS | 0.0004883 | 0.02246 | default:tn=128,dq=0 ; feature:tn=192,dq=1 |
| batch=1 heads=16 sq=1 sk=4096 | 0.107 | 0.109 | 0.31 | 0.108 | 0.31 | 0.98x | 1.00x | PASS | 0.0002441 | 0.02197 | default:tn=128,dq=0 ; feature:tn=192,dq=1 |
| batch=1 heads=64 sq=1 sk=512 | 0.016 | 0.016 | 1.02 | 0.016 | 1.02 | 1.00x | 1.00x | PASS | 0 | 0.02612 | default:tn=128,dq=0 ; feature:tn=128,dq=1 |
| batch=1 heads=64 sq=1 sk=1024 | 0.029 | 0.029 | 1.17 | 0.029 | 1.17 | 1.00x | 1.00x | PASS | 0 | 0.02417 | default:tn=128,dq=0 ; feature:tn=128,dq=1 |
| batch=1 heads=64 sq=1 sk=2048 | 0.055 | 0.055 | 1.21 | 0.057 | 1.18 | 0.97x | 0.97x | PASS | 0.0004883 | 0.02271 | default:tn=128,dq=0 ; feature:tn=192,dq=1 |
| batch=1 heads=64 sq=1 sk=4096 | 0.109 | 0.110 | 1.24 | 0.109 | 1.24 | 1.00x | 1.02x | PASS | 0.0004883 | 0.02258 | default:tn=128,dq=0 ; feature:tn=192,dq=1 |
| batch=4 heads=16 sq=1 sk=512 | 0.016 | 0.016 | 1.02 | 0.016 | 1.02 | 1.00x | 1.00x | PASS | 0.0009766 | 0.02686 | default:tn=64,dq=0 ; feature:tn=128,dq=1 |
| batch=4 heads=16 sq=1 sk=1024 | 0.031 | 0.029 | 1.09 | 0.029 | 1.17 | 1.07x | 1.00x | PASS | 0.0009766 | 0.02405 | default:tn=64,dq=0 ; feature:tn=128,dq=1 |
| batch=4 heads=16 sq=1 sk=2048 | 0.057 | 0.055 | 1.17 | 0.057 | 1.19 | 1.01x | 0.98x | PASS | 0.0004883 | 0.02258 | default:tn=64,dq=0 ; feature:tn=192,dq=1 |
| batch=4 heads=16 sq=1 sk=4096 | 0.113 | 0.111 | 1.19 | 0.109 | 1.24 | 1.04x | 1.02x | PASS | 0.0004883 | 0.02209 | default:tn=64,dq=0 ; feature:tn=192,dq=1 |
| batch=4 heads=64 sq=1 sk=512 | 0.031 | 0.029 | 2.19 | 0.032 | 2.08 | 0.95x | 0.89x | PASS | 0.001953 | 0.02856 | default:tn=64,dq=0 ; feature:tn=128,dq=1 |
| batch=4 heads=64 sq=1 sk=1024 | 0.087 | 0.084 | 1.54 | 0.086 | 1.56 | 1.02x | 0.98x | PASS | 0.0009766 | 0.02515 | default:tn=64,dq=0 ; feature:tn=128,dq=1 |
| batch=4 heads=64 sq=1 sk=2048 | 0.168 | 0.164 | 1.60 | 0.166 | 1.62 | 1.01x | 0.99x | PASS | 0.0004883 | 0.02307 | default:tn=64,dq=0 ; feature:tn=192,dq=1 |
| batch=4 heads=64 sq=1 sk=4096 | 0.328 | 0.323 | 1.64 | 0.330 | 1.63 | 0.99x | 0.98x | PASS | 0.0004883 | 0.02209 | default:tn=64,dq=0 ; feature:tn=192,dq=1 |
| batch=16 heads=16 sq=1 sk=512 | 0.031 | 0.029 | 2.19 | 0.031 | 2.13 | 0.98x | 0.91x | PASS | 0.0009766 | 0.02783 | default:tn=64,dq=0 ; feature:tn=128,dq=1 |
| batch=16 heads=16 sq=1 sk=1024 | 0.087 | 0.085 | 1.54 | 0.086 | 1.56 | 1.01x | 0.99x | PASS | 0.0009766 | 0.02454 | default:tn=64,dq=0 ; feature:tn=128,dq=1 |
| batch=16 heads=16 sq=1 sk=2048 | 0.168 | 0.167 | 1.59 | 0.166 | 1.61 | 1.01x | 1.00x | PASS | 0.0004883 | 0.02295 | default:tn=64,dq=0 ; feature:tn=192,dq=1 |
| batch=16 heads=16 sq=1 sk=4096 | 0.327 | 0.324 | 1.64 | 0.331 | 1.62 | 0.99x | 0.98x | PASS | 0.0004883 | 0.02234 | default:tn=64,dq=0 ; feature:tn=192,dq=1 |
| batch=16 heads=64 sq=1 sk=512 | 0.167 | 0.172 | 1.60 | 0.168 | 1.60 | 1.00x | 1.03x | PASS | 0 | 0.02991 | default:tn=64,dq=0 ; feature:tn=64,dq=1 |
| batch=16 heads=64 sq=1 sk=1024 | 0.329 | 0.341 | 1.63 | 0.330 | 1.63 | 1.00x | 1.03x | PASS | 0 | 0.02551 | default:tn=64,dq=0 ; feature:tn=64,dq=1 |
| batch=16 heads=64 sq=1 sk=2048 | 0.655 | 0.673 | 1.64 | 0.643 | 1.67 | 1.02x | 1.05x | PASS | 0.0009766 | 0.02332 | default:tn=64,dq=0 ; feature:tn=192,dq=1 |
| batch=16 heads=64 sq=1 sk=4096 | 1.301 | 1.335 | 1.65 | 1.277 | 1.68 | 1.02x | 1.04x | PASS | 0.0004883 | 0.02234 | default:tn=64,dq=0 ; feature:tn=192,dq=1 |

## Optimized Only: Default Dense vs Paged KV

| case | default_ms | sm80_default_ms | default_TF/s | feature_ms | feature_TF/s | spd_vs_opt_default | spd_vs_sm80_default | tests | test_max_diff | test_threshold | notes |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | :---: | ---: | ---: | --- |
| causal_q1 batch=64 sq=1 sk=512 page_size=128 | 0.168 | 0.173 | 1.60 | 0.168 | 1.60 | 1.00x | 1.03x | PASS | 0 | 0.02893 | feature=paged_kv causal_q1 |
| causal_q1 batch=64 sq=1 sk=1024 page_size=128 | 0.330 | 0.340 | 1.63 | 0.330 | 1.63 | 1.00x | 1.03x | PASS | 0 | 0.02649 | feature=paged_kv causal_q1 |
| causal_q1 batch=64 sq=1 sk=2048 page_size=128 | 0.654 | 0.671 | 1.64 | 0.654 | 1.64 | 1.00x | 1.03x | PASS | 0 | 0.02417 | feature=paged_kv causal_q1 |
| causal_q1 batch=64 sq=1 sk=4096 page_size=128 | 1.307 | 1.340 | 1.64 | 1.307 | 1.64 | 1.00x | 1.03x | PASS | 0 | 0.02258 | feature=paged_kv causal_q1 |
</details>

<details>
<summary> batch=64, heads=16, head_dim=256 </summary>

| mode | sq | sk | optimized_ms | optimized_TF/s | sm120_ms | sm120_TF/s | sm80_ms | sm80_TF/s | spd_vs_sm120 | spd_vs_sm80 | optimized_cfg | sm120_cfg | sm80_cfg | optimized_tests |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- | --- | :---: |
| non_causal | 512 | 512 | 1.455 | 188.91 | 1.502 | 182.96 | 1.465 | 187.65 | 1.03x | 1.01x | tm64-tn64-s2-th160-kr1-dq0 | tm64-tn64-s1-th160-kr0-dq0 | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| non_causal | 512 | 1024 | 2.778 | 197.93 | 2.877 | 191.10 | 2.797 | 196.52 | 1.04x | 1.01x | tm64-tn64-s2-th160-kr1-dq0 | tm64-tn64-s1-th160-kr0-dq0 | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| non_causal | 512 | 2048 | 5.423 | 202.75 | 5.621 | 195.60 | 5.462 | 201.31 | 1.04x | 1.01x | tm64-tn64-s2-th160-kr1-dq0 | tm64-tn64-s1-th160-kr0-dq0 | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| non_causal | 512 | 4096 | 10.633 | 206.80 | 11.022 | 199.51 | 10.689 | 205.72 | 1.04x | 1.01x | tm64-tn64-s2-th160-kr1-dq0 | tm64-tn64-s1-th160-kr0-dq0 | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| non_causal | 1024 | 512 | 2.868 | 191.69 | 2.961 | 185.69 | 2.879 | 190.93 | 1.03x | 1.00x | tm64-tn64-s2-th160-kr1-dq0 | tm64-tn64-s1-th160-kr0-dq0 | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| non_causal | 1024 | 1024 | 5.449 | 201.79 | 5.642 | 194.90 | 5.493 | 200.16 | 1.04x | 1.01x | tm64-tn64-s2-th160-kr1-dq0 | tm64-tn64-s1-th160-kr0-dq0 | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| non_causal | 1024 | 2048 | 10.528 | 208.88 | 10.931 | 201.17 | 10.604 | 207.38 | 1.04x | 1.01x | tm64-tn64-s2-th160-kr1-dq0 | tm64-tn64-s1-th160-kr0-dq0 | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| non_causal | 1024 | 4096 | 20.856 | 210.87 | 21.626 | 203.37 | 21.004 | 209.39 | 1.04x | 1.01x | tm64-tn64-s2-th160-kr1-dq0 | tm64-tn64-s1-th160-kr0-dq0 | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| non_causal | 2048 | 512 | 5.683 | 193.48 | 5.869 | 187.34 | 5.716 | 192.37 | 1.03x | 1.01x | tm64-tn64-s2-th160-kr1-dq0 | tm64-tn64-s1-th160-kr0-dq0 | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| non_causal | 2048 | 1024 | 10.715 | 205.22 | 11.098 | 198.14 | 10.803 | 203.55 | 1.04x | 1.01x | tm64-tn64-s2-th160-kr1-dq0 | tm64-tn64-s1-th160-kr0-dq0 | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| non_causal | 2048 | 2048 | 20.899 | 210.44 | 21.666 | 202.99 | 21.075 | 208.68 | 1.04x | 1.01x | tm64-tn64-s2-th160-kr1-dq0 | tm64-tn64-s1-th160-kr0-dq0 | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| non_causal | 2048 | 4096 | 41.304 | 212.96 | 42.833 | 205.36 | 41.658 | 211.15 | 1.04x | 1.01x | tm64-tn64-s2-th160-kr1-dq0 | tm64-tn64-s1-th160-kr0-dq0 | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| non_causal | 4096 | 512 | 11.243 | 195.60 | 11.609 | 189.42 | 11.300 | 194.61 | 1.03x | 1.01x | tm64-tn64-s2-th160-kr1-dq0 | tm64-tn64-s1-th160-kr0-dq0 | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| non_causal | 4096 | 1024 | 21.386 | 205.65 | 22.138 | 198.67 | 21.554 | 204.05 | 1.04x | 1.01x | tm64-tn64-s2-th160-kr1-dq0 | tm64-tn64-s1-th160-kr0-dq0 | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| non_causal | 4096 | 2048 | 41.660 | 211.14 | 43.164 | 203.78 | 42.069 | 209.09 | 1.04x | 1.01x | tm64-tn64-s2-th160-kr1-dq0 | tm64-tn64-s1-th160-kr0-dq0 | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| non_causal | 4096 | 4096 | 82.390 | 213.52 | 85.403 | 205.99 | 83.265 | 211.28 | 1.04x | 1.01x | tm64-tn64-s2-th160-kr1-dq0 | tm64-tn64-s1-th160-kr0-dq0 | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| causal_square | 512 | 512 | 0.933 | 294.57 | 0.942 | 291.73 | 0.902 | 304.81 | 1.01x | 0.97x | tm64-tn64-s2-th160-kr1-dq0 | tm64-tn64-s1-th160-kr0-dq0 | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| causal_square | 1024 | 1024 | 3.083 | 356.65 | 3.267 | 336.60 | 3.125 | 351.82 | 1.06x | 1.01x | tm64-tn64-s2-th160-kr1-dq0 | tm64-tn64-s1-th160-kr0-dq0 | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| causal_square | 2048 | 2048 | 11.256 | 390.74 | 11.946 | 368.17 | 11.358 | 387.21 | 1.06x | 1.01x | tm64-tn64-s2-th160-kr1-dq0 | tm64-tn64-s1-th160-kr0-dq0 | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| causal_square | 4096 | 4096 | 43.290 | 406.38 | 45.547 | 386.24 | 43.442 | 404.96 | 1.05x | 1.00x | tm64-tn64-s2-th160-kr1-dq0 | tm64-tn64-s1-th160-kr0-dq0 | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| causal_q1 | 1 | 512 | 0.334 | 1.61 | 0.330 | 1.63 | 0.342 | 1.57 | 0.99x | 1.02x | tm64-tn64-s2-th160-kr1-dq0 | tm64-tn64-s1-th160-kr0-dq0 | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| causal_q1 | 1 | 1024 | 0.653 | 1.64 | 0.649 | 1.65 | 0.679 | 1.58 | 0.99x | 1.04x | tm64-tn64-s2-th160-kr1-dq0 | tm64-tn64-s1-th160-kr0-dq0 | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| causal_q1 | 1 | 2048 | 1.289 | 1.67 | 1.284 | 1.67 | 1.348 | 1.59 | 1.00x | 1.05x | tm64-tn64-s2-th160-kr1-dq0 | tm64-tn64-s1-th160-kr0-dq0 | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| causal_q1 | 1 | 4096 | 2.575 | 1.67 | 2.579 | 1.67 | 2.687 | 1.60 | 1.00x | 1.04x | tm64-tn64-s2-th160-kr1-dq0 | tm64-tn64-s1-th160-kr0-dq0 | tm64-tn64-s1-th128-kr0-dq0 | PASS |

## Optimized Only: Default Decoding vs Split-KV (+combine, configurable splits)

| case | default_ms | sm80_default_ms | default_TF/s | feature_ms | feature_TF/s | spd_vs_opt_default | spd_vs_sm80_default | tests | test_max_diff | test_threshold | notes |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | :---: | ---: | ---: | --- |
| sq=1 sk=512 | 0.335 | 0.342 | 1.60 | 0.335 | 1.60 | 1.00x | 1.02x | PASS | 0 | 0.02808 | split_kv auto-disabled (num_splits=1, min_n_blocks=16, sat_frac=1.00, total_mblocks=1024, sat_limit=170, num_sms=170) |
| sq=1 sk=1024 | 0.650 | 0.678 | 1.65 | 0.650 | 1.65 | 1.00x | 1.04x | PASS | 0 | 0.02502 | split_kv auto-disabled (num_splits=1, min_n_blocks=16, sat_frac=1.00, total_mblocks=1024, sat_limit=170, num_sms=170) |
| sq=1 sk=2048 | 1.284 | 1.347 | 1.67 | 1.284 | 1.67 | 1.00x | 1.05x | PASS | 0 | 0.02344 | split_kv auto-disabled (num_splits=1, min_n_blocks=16, sat_frac=1.00, total_mblocks=1024, sat_limit=170, num_sms=170) |
| sq=1 sk=4096 | 2.566 | 2.688 | 1.67 | 2.566 | 1.67 | 1.00x | 1.05x | PASS | 0 | 0.02271 | split_kv auto-disabled (num_splits=1, min_n_blocks=16, sat_frac=1.00, total_mblocks=1024, sat_limit=170, num_sms=170) |

## Optimized Only: Default Dense vs Paged KV

| case | default_ms | sm80_default_ms | default_TF/s | feature_ms | feature_TF/s | spd_vs_opt_default | spd_vs_sm80_default | tests | test_max_diff | test_threshold | notes |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | :---: | ---: | ---: | --- |
| causal_q1 batch=64 sq=1 sk=512 page_size=128 | 0.337 | 0.341 | 1.59 | 0.337 | 1.59 | 1.00x | 1.01x | PASS | 0 | 0.03027 | feature=paged_kv causal_q1 |
| causal_q1 batch=64 sq=1 sk=1024 page_size=128 | 0.652 | 0.677 | 1.65 | 0.652 | 1.65 | 1.00x | 1.04x | PASS | 0 | 0.02551 | feature=paged_kv causal_q1 |
| causal_q1 batch=64 sq=1 sk=2048 page_size=128 | 1.290 | 1.349 | 1.67 | 1.291 | 1.66 | 1.00x | 1.04x | PASS | 0 | 0.02356 | feature=paged_kv causal_q1 |
| causal_q1 batch=64 sq=1 sk=4096 page_size=128 | 2.566 | 2.689 | 1.67 | 2.567 | 1.67 | 1.00x | 1.05x | PASS | 0 | 0.02258 | feature=paged_kv causal_q1 |
</details>


GQA (taken Qwen3.5 heads count from full_attention and its dim is 256)
<details>
<summary> batch=64, heads=16, kv_heads=2, head_dim=128 </summary>

| mode | sq | sk | optimized_ms | optimized_TF/s | sm120_ms | sm120_TF/s | sm80_ms | sm80_TF/s | spd_vs_sm120 | spd_vs_sm80 | optimized_cfg | sm120_cfg | sm80_cfg | optimized_tests |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- | --- | :---: |
| non_causal | 512 | 512 | 0.668 | 205.66 | nan | nan | 0.669 | 205.51 | nanx | 1.00x | tm64-tn64-s2-th160-kr1-dq0 | N/A | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| non_causal | 512 | 1024 | 1.293 | 212.54 | nan | nan | 1.305 | 210.59 | nanx | 1.01x | tm64-tn64-s2-th160-kr1-dq0 | N/A | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| non_causal | 512 | 2048 | 2.538 | 216.63 | nan | nan | 2.572 | 213.77 | nanx | 1.01x | tm64-tn64-s2-th160-kr1-dq0 | N/A | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| non_causal | 512 | 4096 | 5.012 | 219.37 | nan | nan | 5.088 | 216.12 | nanx | 1.02x | tm64-tn64-s2-th160-kr1-dq0 | N/A | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| non_causal | 1024 | 512 | 1.325 | 207.51 | nan | nan | 1.323 | 207.75 | nanx | 1.00x | tm64-tn64-s2-th160-kr1-dq0 | N/A | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| non_causal | 1024 | 1024 | 2.557 | 215.04 | nan | nan | 2.578 | 213.25 | nanx | 1.01x | tm64-tn64-s2-th160-kr1-dq0 | N/A | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| non_causal | 1024 | 2048 | 5.029 | 218.64 | nan | nan | 5.101 | 215.55 | nanx | 1.01x | tm64-tn64-s2-th160-kr1-dq0 | N/A | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| non_causal | 1024 | 4096 | 9.900 | 222.13 | nan | nan | 10.064 | 218.51 | nanx | 1.02x | tm64-tn64-s2-th160-kr1-dq0 | N/A | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| non_causal | 2048 | 512 | 2.640 | 208.23 | nan | nan | 2.637 | 208.46 | nanx | 1.00x | tm64-tn64-s2-th160-kr1-dq0 | N/A | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| non_causal | 2048 | 1024 | 5.094 | 215.85 | nan | nan | 5.138 | 213.99 | nanx | 1.01x | tm64-tn64-s2-th160-kr1-dq0 | N/A | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| non_causal | 2048 | 2048 | 9.980 | 220.35 | nan | nan | 10.122 | 217.26 | nanx | 1.01x | tm64-tn64-s2-th160-kr1-dq0 | N/A | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| non_causal | 2048 | 4096 | 19.792 | 222.22 | nan | nan | 20.096 | 218.86 | nanx | 1.02x | tm64-tn64-s2-th160-kr1-dq0 | N/A | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| non_causal | 4096 | 512 | 5.277 | 208.35 | nan | nan | 5.272 | 208.56 | nanx | 1.00x | tm64-tn64-s2-th160-kr1-dq0 | N/A | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| non_causal | 4096 | 1024 | 10.163 | 216.38 | nan | nan | 10.255 | 214.43 | nanx | 1.01x | tm64-tn64-s2-th160-kr1-dq0 | N/A | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| non_causal | 4096 | 2048 | 19.999 | 219.91 | nan | nan | 20.261 | 217.06 | nanx | 1.01x | tm64-tn64-s2-th160-kr1-dq0 | N/A | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| non_causal | 4096 | 4096 | 39.631 | 221.95 | nan | nan | 40.256 | 218.51 | nanx | 1.02x | tm64-tn64-s2-th160-kr1-dq0 | N/A | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| causal_square | 512 | 512 | 0.393 | 349.32 | nan | nan | 0.410 | 335.01 | nanx | 1.04x | tm64-tn64-s2-th160-kr1-dq0 | N/A | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| causal_square | 1024 | 1024 | 1.398 | 393.11 | nan | nan | 1.444 | 380.77 | nanx | 1.03x | tm64-tn64-s2-th160-kr1-dq0 | N/A | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| causal_square | 2048 | 2048 | 5.265 | 417.67 | nan | nan | 5.406 | 406.76 | nanx | 1.03x | tm64-tn64-s2-th160-kr1-dq0 | N/A | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| causal_square | 4096 | 4096 | 20.350 | 432.23 | nan | nan | 20.865 | 421.56 | nanx | 1.03x | tm64-tn64-s2-th160-kr1-dq0 | N/A | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| causal_q1 | 1 | 512 | 0.018 | 14.95 | nan | nan | 0.016 | 16.38 | nanx | 0.91x | tm64-tn64-s2-th160-kr1-dq0 | N/A | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| causal_q1 | 1 | 1024 | 0.031 | 17.47 | nan | nan | 0.031 | 17.48 | nanx | 1.00x | tm64-tn64-s2-th160-kr1-dq0 | N/A | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| causal_q1 | 1 | 2048 | 0.087 | 12.40 | nan | nan | 0.085 | 12.68 | nanx | 0.98x | tm64-tn64-s2-th160-kr1-dq0 | N/A | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| causal_q1 | 1 | 4096 | 0.167 | 12.89 | nan | nan | 0.164 | 13.06 | nanx | 0.99x | tm64-tn64-s2-th160-kr1-dq0 | N/A | tm64-tn64-s1-th128-kr0-dq0 | PASS |

## Optimized Only: Default Decoding vs Split-KV (+combine, configurable splits)

| case | default_ms | sm80_default_ms | default_TF/s | feature_ms | feature_TF/s | spd_vs_opt_default | spd_vs_sm80_default | tests | test_max_diff | test_threshold | notes |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | :---: | ---: | ---: | --- |
| sq=1 sk=512 | 0.018 | 0.016 | 15.07 | 0.018 | 15.07 | 1.00x | 0.92x | PASS | 0 | 0.02881 | split_kv disabled for gqa (requested_fixed=0, auto_default=2) |
| sq=1 sk=1024 | 0.031 | 0.031 | 17.47 | 0.031 | 17.47 | 1.00x | 1.00x | PASS | 0 | 0.02673 | split_kv disabled for gqa (requested_fixed=0, auto_default=2) |
| sq=1 sk=2048 | 0.087 | 0.085 | 12.37 | 0.087 | 12.37 | 1.00x | 0.98x | PASS | 0 | 0.02393 | split_kv disabled for gqa (requested_fixed=0, auto_default=2) |
| sq=1 sk=4096 | 0.167 | 0.166 | 12.88 | 0.167 | 12.88 | 1.00x | 0.99x | PASS | 0 | 0.02356 | split_kv disabled for gqa (requested_fixed=0, auto_default=2) |

## Optimized Only: Causal q1 Direct Q GMEM->Regs (A/B)

| case | default_ms | sm80_default_ms | default_TF/s | feature_ms | feature_TF/s | spd_vs_opt_default | spd_vs_sm80_default | tests | test_max_diff | test_threshold | notes |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | :---: | ---: | ---: | --- |
| batch=1 heads=16 sq=1 sk=512 | 0.016 | 0.016 | 0.26 | 0.016 | 0.26 | 1.00x | 1.00x | PASS | 0 | 0.02527 | default:tn=128,dq=0 ; feature:tn=128,dq=1 |
| batch=1 heads=16 sq=1 sk=1024 | 0.029 | 0.029 | 0.29 | 0.029 | 0.29 | 1.00x | 1.00x | PASS | 0 | 0.02368 | default:tn=128,dq=0 ; feature:tn=128,dq=1 |
| batch=1 heads=16 sq=1 sk=2048 | 0.055 | 0.055 | 0.30 | 0.055 | 0.30 | 0.99x | 1.00x | PASS | 0.0004883 | 0.02295 | default:tn=128,dq=0 ; feature:tn=192,dq=1 |
| batch=1 heads=16 sq=1 sk=4096 | 0.105 | 0.108 | 0.32 | 0.109 | 0.31 | 0.97x | 1.00x | PASS | 0.0002441 | 0.02197 | default:tn=128,dq=0 ; feature:tn=192,dq=1 |
| batch=1 heads=64 sq=1 sk=512 | 0.016 | 0.016 | 1.02 | 0.016 | 1.02 | 1.00x | 1.00x | PASS | 0 | 0.02576 | default:tn=128,dq=0 ; feature:tn=128,dq=1 |
| batch=1 heads=64 sq=1 sk=1024 | 0.029 | 0.029 | 1.17 | 0.029 | 1.17 | 1.00x | 1.00x | PASS | 0 | 0.02478 | default:tn=128,dq=0 ; feature:tn=128,dq=1 |
| batch=1 heads=64 sq=1 sk=2048 | 0.055 | 0.055 | 1.22 | 0.056 | 1.21 | 0.99x | 1.00x | PASS | 0.0004883 | 0.02283 | default:tn=128,dq=0 ; feature:tn=192,dq=1 |
| batch=1 heads=64 sq=1 sk=4096 | 0.105 | 0.108 | 1.27 | 0.109 | 1.24 | 0.97x | 1.00x | PASS | 0.0004883 | 0.02222 | default:tn=128,dq=0 ; feature:tn=192,dq=1 |
| batch=4 heads=16 sq=1 sk=512 | 0.016 | 0.016 | 1.02 | 0.016 | 1.02 | 1.00x | 1.00x | PASS | 0.0009766 | 0.02649 | default:tn=64,dq=0 ; feature:tn=128,dq=1 |
| batch=4 heads=16 sq=1 sk=1024 | 0.031 | 0.029 | 1.09 | 0.029 | 1.17 | 1.07x | 1.00x | PASS | 0.0009766 | 0.02478 | default:tn=64,dq=0 ; feature:tn=128,dq=1 |
| batch=4 heads=16 sq=1 sk=2048 | 0.057 | 0.055 | 1.17 | 0.056 | 1.19 | 1.02x | 0.98x | PASS | 0.0004883 | 0.02295 | default:tn=64,dq=0 ; feature:tn=192,dq=1 |
| batch=4 heads=16 sq=1 sk=4096 | 0.111 | 0.108 | 1.21 | 0.109 | 1.24 | 1.02x | 1.00x | PASS | 0.0004883 | 0.02234 | default:tn=64,dq=0 ; feature:tn=192,dq=1 |
| batch=4 heads=64 sq=1 sk=512 | 0.016 | 0.016 | 4.09 | 0.016 | 4.10 | 1.00x | 1.00x | PASS | 0.0009766 | 0.0271 | default:tn=64,dq=0 ; feature:tn=128,dq=1 |
| batch=4 heads=64 sq=1 sk=1024 | 0.031 | 0.029 | 4.37 | 0.029 | 4.68 | 1.07x | 1.00x | PASS | 0.0009766 | 0.0249 | default:tn=64,dq=0 ; feature:tn=128,dq=1 |
| batch=4 heads=64 sq=1 sk=2048 | 0.057 | 0.055 | 4.68 | 0.056 | 4.76 | 1.02x | 0.98x | PASS | 0.0004883 | 0.02307 | default:tn=64,dq=0 ; feature:tn=192,dq=1 |
| batch=4 heads=64 sq=1 sk=4096 | 0.111 | 0.109 | 4.82 | 0.109 | 4.94 | 1.02x | 1.00x | PASS | 0.0004883 | 0.02209 | default:tn=64,dq=0 ; feature:tn=192,dq=1 |
| batch=16 heads=16 sq=1 sk=512 | 0.016 | 0.016 | 4.09 | 0.016 | 4.10 | 1.00x | 1.00x | PASS | 0.0009766 | 0.02722 | default:tn=64,dq=0 ; feature:tn=128,dq=1 |
| batch=16 heads=16 sq=1 sk=1024 | 0.031 | 0.029 | 4.37 | 0.029 | 4.68 | 1.07x | 1.00x | PASS | 0.0009766 | 0.02515 | default:tn=64,dq=0 ; feature:tn=128,dq=1 |
| batch=16 heads=16 sq=1 sk=2048 | 0.057 | 0.055 | 4.68 | 0.057 | 4.74 | 1.01x | 0.98x | PASS | 0.0009766 | 0.02319 | default:tn=64,dq=0 ; feature:tn=192,dq=1 |
| batch=16 heads=16 sq=1 sk=4096 | 0.112 | 0.109 | 4.81 | 0.109 | 4.94 | 1.03x | 1.00x | PASS | 0.0004883 | 0.02258 | default:tn=64,dq=0 ; feature:tn=192,dq=1 |
| batch=16 heads=64 sq=1 sk=512 | 0.016 | 0.016 | 16.38 | 0.016 | 16.38 | 1.00x | 1.00x | PASS | 0 | 0.02942 | default:tn=64,dq=0 ; feature:tn=64,dq=1 |
| batch=16 heads=64 sq=1 sk=1024 | 0.031 | 0.029 | 17.48 | 0.031 | 17.48 | 1.00x | 0.93x | PASS | 0 | 0.02673 | default:tn=64,dq=0 ; feature:tn=64,dq=1 |
| batch=16 heads=64 sq=1 sk=2048 | 0.057 | 0.055 | 18.72 | 0.057 | 18.89 | 1.01x | 0.97x | PASS | 0.0009766 | 0.02356 | default:tn=64,dq=0 ; feature:tn=192,dq=1 |
| batch=16 heads=64 sq=1 sk=4096 | 0.112 | 0.108 | 19.17 | 0.109 | 19.77 | 1.03x | 1.00x | PASS | 0.0004883 | 0.02258 | default:tn=64,dq=0 ; feature:tn=192,dq=1 |

## Optimized Only: Default Dense vs Paged KV

| case | default_ms | sm80_default_ms | default_TF/s | feature_ms | feature_TF/s | spd_vs_opt_default | spd_vs_sm80_default | tests | test_max_diff | test_threshold | notes |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | :---: | ---: | ---: | --- |
| causal_q1 batch=64 sq=1 sk=512 page_size=128 | 0.018 | 0.016 | 14.57 | 0.018 | 14.57 | 1.00x | 0.89x | PASS | 0 | 0.02966 | feature=paged_kv causal_q1 |
| causal_q1 batch=64 sq=1 sk=1024 page_size=128 | 0.031 | 0.031 | 17.46 | 0.031 | 17.45 | 1.00x | 1.00x | PASS | 0 | 0.02649 | feature=paged_kv causal_q1 |
| causal_q1 batch=64 sq=1 sk=2048 page_size=128 | 0.087 | 0.086 | 12.33 | 0.087 | 12.29 | 1.00x | 0.98x | PASS | 0 | 0.02368 | feature=paged_kv causal_q1 |
| causal_q1 batch=64 sq=1 sk=4096 page_size=128 | 0.166 | 0.164 | 12.95 | 0.166 | 12.93 | 1.00x | 0.99x | PASS | 0 | 0.02258 | feature=paged_kv causal_q1 |
</details>

<details>
<summary> batch=64, heads=16, kv_heads=2, head_dim=256 </summary>

| mode | sq | sk | optimized_ms | optimized_TF/s | sm120_ms | sm120_TF/s | sm80_ms | sm80_TF/s | spd_vs_sm120 | spd_vs_sm80 | optimized_cfg | sm120_cfg | sm80_cfg | optimized_tests |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- | --- | :---: |
| non_causal | 512 | 512 | 1.426 | 192.73 | nan | nan | 1.421 | 193.41 | nanx | 1.00x | tm64-tn64-s2-th160-kr1-dq0 | N/A | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| non_causal | 512 | 1024 | 2.684 | 204.86 | nan | nan | 2.690 | 204.39 | nanx | 1.00x | tm64-tn64-s2-th160-kr1-dq0 | N/A | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| non_causal | 512 | 2048 | 5.247 | 209.55 | nan | nan | 5.262 | 208.96 | nanx | 1.00x | tm64-tn64-s2-th160-kr1-dq0 | N/A | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| non_causal | 512 | 4096 | 10.380 | 211.85 | nan | nan | 10.398 | 211.49 | nanx | 1.00x | tm64-tn64-s2-th160-kr1-dq0 | N/A | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| non_causal | 1024 | 512 | 2.828 | 194.39 | nan | nan | 2.815 | 195.32 | nanx | 1.00x | tm64-tn64-s2-th160-kr1-dq0 | N/A | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| non_causal | 1024 | 1024 | 5.365 | 204.93 | nan | nan | 5.363 | 205.02 | nanx | 1.00x | tm64-tn64-s2-th160-kr1-dq0 | N/A | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| non_causal | 1024 | 2048 | 10.409 | 211.27 | nan | nan | 10.417 | 211.09 | nanx | 1.00x | tm64-tn64-s2-th160-kr1-dq0 | N/A | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| non_causal | 1024 | 4096 | 20.587 | 213.63 | nan | nan | 20.630 | 213.19 | nanx | 1.00x | tm64-tn64-s2-th160-kr1-dq0 | N/A | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| non_causal | 2048 | 512 | 5.635 | 195.13 | nan | nan | 5.614 | 195.86 | nanx | 1.00x | tm64-tn64-s2-th160-kr1-dq0 | N/A | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| non_causal | 2048 | 1024 | 10.631 | 206.86 | nan | nan | 10.630 | 206.86 | nanx | 1.00x | tm64-tn64-s2-th160-kr1-dq0 | N/A | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| non_causal | 2048 | 2048 | 20.737 | 212.09 | nan | nan | 20.791 | 211.54 | nanx | 1.00x | tm64-tn64-s2-th160-kr1-dq0 | N/A | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| non_causal | 2048 | 4096 | 41.052 | 214.27 | nan | nan | 41.149 | 213.76 | nanx | 1.00x | tm64-tn64-s2-th160-kr1-dq0 | N/A | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| non_causal | 4096 | 512 | 11.199 | 196.36 | nan | nan | 11.168 | 196.91 | nanx | 1.00x | tm64-tn64-s2-th160-kr1-dq0 | N/A | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| non_causal | 4096 | 1024 | 21.306 | 206.42 | nan | nan | 21.306 | 206.42 | nanx | 1.00x | tm64-tn64-s2-th160-kr1-dq0 | N/A | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| non_causal | 4096 | 2048 | 41.556 | 211.67 | nan | nan | 41.682 | 211.03 | nanx | 1.00x | tm64-tn64-s2-th160-kr1-dq0 | N/A | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| non_causal | 4096 | 4096 | 82.243 | 213.90 | nan | nan | 82.625 | 212.91 | nanx | 1.00x | tm64-tn64-s2-th160-kr1-dq0 | N/A | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| causal_square | 512 | 512 | 0.860 | 319.55 | nan | nan | 0.869 | 316.45 | nanx | 1.01x | tm64-tn64-s2-th160-kr1-dq0 | N/A | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| causal_square | 1024 | 1024 | 2.975 | 369.62 | nan | nan | 3.013 | 364.98 | nanx | 1.01x | tm64-tn64-s2-th160-kr1-dq0 | N/A | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| causal_square | 2048 | 2048 | 10.961 | 401.23 | nan | nan | 11.066 | 397.42 | nanx | 1.01x | tm64-tn64-s2-th160-kr1-dq0 | N/A | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| causal_square | 4096 | 4096 | 42.298 | 415.91 | nan | nan | 42.664 | 412.34 | nanx | 1.01x | tm64-tn64-s2-th160-kr1-dq0 | N/A | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| causal_q1 | 1 | 512 | 0.031 | 17.48 | nan | nan | 0.029 | 18.71 | nanx | 0.93x | tm64-tn64-s2-th160-kr1-dq0 | N/A | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| causal_q1 | 1 | 1024 | 0.088 | 12.24 | nan | nan | 0.087 | 12.28 | nanx | 1.00x | tm64-tn64-s2-th160-kr1-dq0 | N/A | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| causal_q1 | 1 | 2048 | 0.165 | 13.05 | nan | nan | 0.168 | 12.81 | nanx | 1.02x | tm64-tn64-s2-th160-kr1-dq0 | N/A | tm64-tn64-s1-th128-kr0-dq0 | PASS |
| causal_q1 | 1 | 4096 | 0.322 | 13.32 | nan | nan | 0.327 | 13.14 | nanx | 1.01x | tm64-tn64-s2-th160-kr1-dq0 | N/A | tm64-tn64-s1-th128-kr0-dq0 | PASS |


## Optimized Only: Default Decoding vs Split-KV (+combine, configurable splits)

| case | default_ms | sm80_default_ms | default_TF/s | feature_ms | feature_TF/s | spd_vs_opt_default | spd_vs_sm80_default | tests | test_max_diff | test_threshold | notes |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | :---: | ---: | ---: | --- |
| sq=1 sk=512 | 0.031 | 0.029 | 17.48 | 0.031 | 17.48 | 1.00x | 0.93x | PASS | 0 | 0.02979 | split_kv disabled for gqa (requested_fixed=0, auto_default=2) |
| sq=1 sk=1024 | 0.088 | 0.088 | 12.15 | 0.088 | 12.15 | 1.00x | 0.99x | PASS | 0 | 0.02551 | split_kv disabled for gqa (requested_fixed=0, auto_default=2) |
| sq=1 sk=2048 | 0.167 | 0.167 | 12.89 | 0.167 | 12.89 | 1.00x | 1.01x | PASS | 0 | 0.02344 | split_kv disabled for gqa (requested_fixed=0, auto_default=2) |
| sq=1 sk=4096 | 0.324 | 0.328 | 13.27 | 0.324 | 13.27 | 1.00x | 1.01x | PASS | 0 | 0.02246 | split_kv disabled for gqa (requested_fixed=0, auto_default=2) |

## Optimized Only: Default Dense vs Paged KV

| case | default_ms | sm80_default_ms | default_TF/s | feature_ms | feature_TF/s | spd_vs_opt_default | spd_vs_sm80_default | tests | test_max_diff | test_threshold | notes |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | :---: | ---: | ---: | --- |
| causal_q1 batch=64 sq=1 sk=512 page_size=128 | 0.031 | 0.029 | 17.48 | 0.031 | 17.48 | 1.00x | 0.93x | PASS | 0 | 0.03064 | feature=paged_kv causal_q1 |
| causal_q1 batch=64 sq=1 sk=1024 page_size=128 | 0.089 | 0.089 | 12.11 | 0.088 | 12.14 | 1.00x | 1.00x | PASS | 0 | 0.02625 | feature=paged_kv causal_q1 |
| causal_q1 batch=64 sq=1 sk=2048 page_size=128 | 0.166 | 0.168 | 12.92 | 0.167 | 12.86 | 0.99x | 1.00x | PASS | 0 | 0.0238 | feature=paged_kv causal_q1 |
| causal_q1 batch=64 sq=1 sk=4096 page_size=128 | 0.328 | 0.331 | 13.11 | 0.328 | 13.08 | 1.00x | 1.01x | PASS | 0 | 0.02258 | feature=paged_kv causal_q1 |
</details>

Correctness is verified for 64, 96, 192, 256 dims. I can add tables for other dims and can test kernel on RTX 6000 PRO Blackwell if needed.