### PR TITLE
chore(tests): move benchmarks to benchmarks/cute/ and reduce test prints

### DIFF
--- a/benchmarks/cute/benchmark_block_sparsity.py
+++ b/benchmarks/cute/benchmark_block_sparsity.py
@@ -2,12 +2,17 @@
 Comparative benchmark: CuTe DSL vs Native PyTorch block sparsity computation.
 """
 
+import os
+import sys
 import torch
 from dataclasses import dataclass
 from typing import Callable, Optional, List
 from tabulate import tabulate
 from tqdm import tqdm
 import itertools
+
+# mask_mod_definitions lives in tests/cute/ alongside the test files
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../tests/cute"))
 
 from cutlass.cute.runtime import from_dlpack
 from cutlass.cute.testing import benchmark as cute_benchmark

--- a/benchmarks/cute/benchmark_mask_mod.py
+++ b/benchmarks/cute/benchmark_mask_mod.py
@@ -3,6 +3,8 @@ FlashAttention benchmarking script with Flex Attention-style
 mask mod support and varlen sequences.
 """
 
+import os
+import sys
 from dataclasses import dataclass
 import math
 from typing import Any, Dict, Optional, Tuple
@@ -13,6 +15,9 @@ import cutlass.cute as cute
 from cutlass.cute.runtime import from_dlpack
 import numpy as np
 import torch
+
+# mask_mod_definitions lives in tests/cute/ alongside the test files
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../tests/cute"))
 
 from flash_attn.cute.flash_fwd_sm90 import FlashAttentionForwardSm90
 from mask_mod_definitions import (

--- a/tests/cute/test_block_sparsity.py
+++ b/tests/cute/test_block_sparsity.py
@@ -1,5 +1,6 @@
 """Tests for block sparsity computation in flash attention."""
 
+import logging
 import pytest
 import torch
 from torch.nn.attention.flex_attention import create_block_mask
@@ -249,16 +250,17 @@ def test_fixed_length_masks(
         *_,
     ) = block_mask.as_tuple()
 
-    print("CuTe results:")
-    print(f"    mask_block_cnt: {mask_block_cnt}")
-    print(f"    full_block_cnt: {full_block_cnt}")
-    print(f"    mask_block_idx: {mask_block_idx}")
-    print(f"    full_block_idx: {full_block_idx}")
-    print("Torch results:")
-    print(f"    mask_block_cnt: {mask_block_cnt_ref}")
-    print(f"    full_block_cnt: {full_block_cnt_ref}")
-    print(f"    mask_block_idx: {mask_block_idx_ref}")
-    print(f"    full_block_idx: {full_block_idx_ref}")
+    logger = logging.getLogger(__name__)
+    logger.debug("CuTe results:")
+    logger.debug("    mask_block_cnt: %s", mask_block_cnt)
+    logger.debug("    full_block_cnt: %s", full_block_cnt)
+    logger.debug("    mask_block_idx: %s", mask_block_idx)
+    logger.debug("    full_block_idx: %s", full_block_idx)
+    logger.debug("Torch results:")
+    logger.debug("    mask_block_cnt: %s", mask_block_cnt_ref)
+    logger.debug("    full_block_cnt: %s", full_block_cnt_ref)
+    logger.debug("    mask_block_idx: %s", mask_block_idx_ref)
+    logger.debug("    full_block_idx: %s", full_block_idx_ref)
 
     all_match, error_msg = _compare_block_sparsity(
         mask_block_cnt,


### PR DESCRIPTION
## Summary

- Move `benchmark_block_sparsity.py` and `benchmark_mask_mod.py` from `tests/cute/` to `benchmarks/cute/` where they belong
- Both benchmarks add `tests/cute/` to `sys.path` so they can still import `mask_mod_definitions` (shared with tests)
- Replace verbose `print()` statements in `test_block_sparsity.py` with `logging.debug()` so output is suppressed by default (visible with `pytest --log-cli-level=DEBUG`)

## Test plan

- [ ] Verify `pytest tests/cute/test_block_sparsity.py` still passes (no verbose prints by default)
- [ ] Verify `python benchmarks/cute/benchmark_block_sparsity.py` still runs (imports resolve)
- [ ] Verify `python benchmarks/cute/benchmark_mask_mod.py` still runs

Fixes #2183

🤖 Generated with [Claude Code](https://claude.com/claude-code)