### PR TITLE
Add compress_factor for compressed causal attention

### DIFF
--- a/flash_attn/cute/block_info.py
+++ b/flash_attn/cute/block_info.py
@@ -19,6 +19,7 @@ class BlockInfo:
     window_size_left: Optional[Int32] = None
     window_size_right: Optional[Int32] = None
     qhead_per_kvhead_packgqa: cutlass.Constexpr[int] = 1
+    compress_factor: cutlass.Constexpr[int] = 1
 
     @cute.jit
     def get_n_block_min_max(
@@ -33,7 +34,12 @@ class BlockInfo:
             m_idx_max = (m_block + 1) * self.tile_m
             if const_expr(self.qhead_per_kvhead_packgqa > 1):
                 m_idx_max = cute.ceil_div(m_idx_max, self.qhead_per_kvhead_packgqa)
-            n_idx = m_idx_max + seqlen_info.seqlen_k - seqlen_info.seqlen_q
+            if const_expr(self.compress_factor > 1):
+                # Compressed causal: kv_idx * compress_factor <= q_idx
+                # Max KV index for Q tile ending at m_idx_max is m_idx_max // compress_factor
+                n_idx = m_idx_max // self.compress_factor + 1
+            else:
+                n_idx = m_idx_max + seqlen_info.seqlen_k - seqlen_info.seqlen_q
             n_idx_right = n_idx if const_expr(self.is_causal) else n_idx + self.window_size_right
             n_block_max = min(n_block_max, cute.ceil_div(n_idx_right, self.tile_n))
         n_block_min = 0
@@ -60,7 +66,11 @@ class BlockInfo:
         m_block_min = 0
         if const_expr(self.is_causal or (self.is_local and self.window_size_right is not None)):
             n_idx_min = n_block * self.tile_n
-            m_idx = n_idx_min + seqlen_info.seqlen_q - seqlen_info.seqlen_k
+            if const_expr(self.compress_factor > 1):
+                # Compressed causal: q >= kv * compress_factor
+                m_idx = n_idx_min * self.compress_factor
+            else:
+                m_idx = n_idx_min + seqlen_info.seqlen_q - seqlen_info.seqlen_k
             m_idx_right = m_idx if const_expr(self.is_causal) else m_idx - self.window_size_right
             m_block_min = max(m_block_min, m_idx_right // self.tile_m)
         if const_expr(self.is_local and self.window_size_left is not None):

--- a/flash_attn/cute/flash_bwd_sm100.py
+++ b/flash_attn/cute/flash_bwd_sm100.py
@@ -65,6 +65,7 @@ class FlashAttentionBackwardSm100:
         mask_mod: cutlass.Constexpr | None = None,
         has_aux_tensors: cutlass.Constexpr = False,
         subtile_factor: cutlass.Constexpr[int] = 1,
+        compress_factor: cutlass.Constexpr[int] = 1,
     ):
         # padding head_dim to a multiple of 16 as k_block_size
         hdim_multiple_of = 16
@@ -123,6 +124,7 @@ class FlashAttentionBackwardSm100:
         self.mask_mod = mask_mod
         self.has_aux_tensors = has_aux_tensors
         self.subtile_factor = subtile_factor
+        self.compress_factor = compress_factor
         # For score_mod, use vec_size=1 (like forward) to handle per-element indices
         if cutlass.const_expr(has_aux_tensors):
             self.vec_size: cutlass.Constexpr = 1
@@ -1394,6 +1396,7 @@ class FlashAttentionBackwardSm100:
             window_size_left,
             window_size_right,
             qhead_per_kvhead_packgqa=1,
+            compress_factor=self.compress_factor,
         )
         SeqlenInfoCls = partial(
             SeqlenInfoQK.create,
@@ -1415,6 +1418,7 @@ class FlashAttentionBackwardSm100:
             swap_AB=True,
             window_size_left=window_size_left,
             window_size_right=window_size_right,
+            compress_factor=self.compress_factor,
         )
         #  EMPTY
         # (15)

--- a/flash_attn/cute/flash_bwd_sm90.py
+++ b/flash_attn/cute/flash_bwd_sm90.py
@@ -73,6 +73,7 @@ class FlashAttentionBackwardSm90:
         has_aux_tensors: cutlass.Constexpr = False,
         subtile_factor: cutlass.Constexpr[int] = 1,
         dQ_single_wg: bool = False,
+        compress_factor: cutlass.Constexpr[int] = 1,
     ):
         self.dtype = dtype
         # padding head_dim to a multiple of 16 as k_block_size
@@ -129,6 +130,7 @@ class FlashAttentionBackwardSm90:
         self.mask_mod = mask_mod
         self.has_aux_tensors = has_aux_tensors
         self.subtile_factor = subtile_factor
+        self.compress_factor = compress_factor
         if cutlass.const_expr(has_aux_tensors):
             self.vec_size: cutlass.Constexpr = 1
         else:
@@ -718,6 +720,7 @@ class FlashAttentionBackwardSm90:
             window_size_left,
             window_size_right,
             qhead_per_kvhead_packgqa=1,
+            compress_factor=self.compress_factor,
         )
         SeqlenInfoCls = partial(
             SeqlenInfoQK.create,
@@ -737,6 +740,7 @@ class FlashAttentionBackwardSm90:
             window_size_left=window_size_left,
             window_size_right=window_size_right,
             swap_AB=self.SdP_swapAB,
+            compress_factor=self.compress_factor,
         )
         TileSchedulerCls = partial(TileScheduler.create, tile_sched_params)
 

--- a/flash_attn/cute/flash_fwd.py
+++ b/flash_attn/cute/flash_fwd.py
@@ -56,6 +56,7 @@ class FlashAttentionForwardBase:
         mask_mod: Optional[cutlass.Constexpr] = None,
         has_aux_tensors: bool = False,
         q_subtile_factor: int | None = None,
+        compress_factor: cutlass.Constexpr[int] = 1,
     ):
         """Initializes the configuration for a flash attention kernel.
 
@@ -98,6 +99,7 @@ class FlashAttentionForwardBase:
         self.Q_in_regs = Q_in_regs
         self.score_mod = score_mod
         self.mask_mod = mask_mod
+        self.compress_factor = compress_factor
         self.qk_acc_dtype = Float32
         self.vec_size: cutlass.Constexpr = getattr(
             score_mod, "__vec_size__", 1 if cutlass.const_expr(has_aux_tensors) else 2

--- a/flash_attn/cute/flash_fwd_sm100.py
+++ b/flash_attn/cute/flash_fwd_sm100.py
@@ -114,6 +114,7 @@ class FlashAttentionForwardSm100:
         is_varlen_q: bool = False,
         use_2cta_instrs: bool = False,
         use_clc_scheduler: bool = False,
+        compress_factor: cutlass.Constexpr[int] = 1,
     ):
         self.use_tma_KV = not paged_kv_non_tma
         # self.dtype = dtype
@@ -165,6 +166,7 @@ class FlashAttentionForwardSm100:
         )
         self.score_mod = score_mod
         self.mask_mod = mask_mod
+        self.compress_factor = compress_factor
         self.vec_size: cutlass.Constexpr = getattr(
             score_mod, "__vec_size__", 1 if cutlass.const_expr(has_aux_tensors) else 2
         )
@@ -996,6 +998,7 @@ class FlashAttentionForwardSm100:
             window_size_left,
             window_size_right,
             qhead_per_kvhead_packgqa=self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
+            compress_factor=self.compress_factor,
         )
         SeqlenInfoCls = partial(
             SeqlenInfoQK.create,
@@ -1015,6 +1018,7 @@ class FlashAttentionForwardSm100:
             window_size_left=window_size_left,
             window_size_right=window_size_right,
             qhead_per_kvhead_packgqa=self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
+            compress_factor=self.compress_factor,
         )
         # Cluster wait before tensor memory alloc
         pipeline_init_wait(cluster_shape_mn=cta_layout_vmnk)

--- a/flash_attn/cute/flash_fwd_sm90.py
+++ b/flash_attn/cute/flash_fwd_sm90.py
@@ -542,6 +542,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
             window_size_left,
             window_size_right,
             qhead_per_kvhead_packgqa=self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
+            compress_factor=self.compress_factor,
         )
         SeqlenInfoCls = partial(
             SeqlenInfoQK.create,
@@ -562,6 +563,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
             window_size_left=window_size_left,
             window_size_right=window_size_right,
             qhead_per_kvhead_packgqa=self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
+            compress_factor=self.compress_factor,
         )
         TileSchedulerCls = partial(TileScheduler.create, tile_sched_params)
 

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -325,6 +325,7 @@ def _flash_attn_fwd(
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
     aux_tensors: Optional[list[torch.Tensor]] = None,
+    compress_factor: int = 1,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """Forward pass for FlashAttention.
 
@@ -636,6 +637,7 @@ def _flash_attn_fwd(
         intra_wg_overlap,
         requested_use_clc_scheduler,
         fa_logging.get_fa_log_level(),
+        compress_factor,
     )
     if compile_key not in _flash_attn_fwd.compile_cache:
         (
@@ -743,6 +745,7 @@ def _flash_attn_fwd(
                 q_subtile_factor=q_subtile_factor,
                 use_2cta_instrs=use_2cta_instrs,
                 use_clc_scheduler=requested_use_clc_scheduler,
+                compress_factor=compress_factor,
             )
         elif arch // 10 == 12:
             # SM120 (Blackwell GeForce / DGX Spark): uses SM80 MMA with SM120 SMEM capacity
@@ -1006,6 +1009,7 @@ def _flash_attn_bwd(
     aux_tensors: Optional[list[torch.Tensor]] = None,
     block_sparse_tensors: Optional[BlockSparseTensorsTorch] = None,
     dlse: Optional[torch.Tensor] = None,
+    compress_factor: int = 1,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     arch = _get_device_arch()
     assert arch // 10 in [9, 10, 11, 12], "Unsupported compute capability. Supported: 9.x, 10.x, 11.x, 12.x"
@@ -1384,6 +1388,7 @@ def _flash_attn_bwd(
             get_broadcast_dims(k),
             get_broadcast_dims(v),
             get_broadcast_dims(dout),
+            compress_factor,
         )
     if compile_key not in _flash_attn_bwd.compile_cache:
         q_tensor, k_tensor, v_tensor, do_tensor, dq_tensor, dk_tensor, dv_tensor = [
@@ -1473,6 +1478,7 @@ def _flash_attn_bwd(
                 mask_mod=mask_mod,
                 has_aux_tensors=aux_tensors is not None,
                 subtile_factor=subtile_factor,
+                compress_factor=compress_factor,
             )
 
         # Block sparse tensors for backward use Q-direction indexing (transposed from forward).

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -719,6 +719,7 @@ def _flash_attn_fwd(
                 has_aux_tensors=aux_tensors is not None,
                 q_subtile_factor=q_subtile_factor,
                 paged_kv_non_tma=page_size not in [None, tile_n],
+                compress_factor=compress_factor,
             )
         elif arch // 10 in [10, 11]:
             fa_fwd = FlashAttentionForwardSm100(
@@ -1355,6 +1356,7 @@ def _flash_attn_bwd(
             get_broadcast_dims(k),
             get_broadcast_dims(v),
             get_broadcast_dims(dout),
+            compress_factor,
         )
     else:
         compile_key = (
@@ -1460,6 +1462,7 @@ def _flash_attn_bwd(
                 has_aux_tensors=aux_tensors is not None,
                 subtile_factor=subtile_factor,
                 dQ_single_wg=dQ_single_wg,
+                compress_factor=compress_factor,
             )
         else:
             fa_bwd_obj = FlashAttentionBackwardSm100(

--- a/flash_attn/cute/mask.py
+++ b/flash_attn/cute/mask.py
@@ -108,6 +108,7 @@ class AttentionMask:
     window_size_right: Optional[Int32] = None
     qhead_per_kvhead_packgqa: cutlass.Constexpr[int] = 1  # only pass in if we're doing PackGQA
     swap_AB: cutlass.Constexpr[bool] = False
+    compress_factor: cutlass.Constexpr[int] = 1
 
     @property
     def seqlen_q(self) -> Int32:
@@ -242,6 +243,8 @@ class AttentionMask:
                     ) // self.qhead_per_kvhead_packgqa
                 causal_row_offset = (
                     1 + self.seqlen_k - n_block * self.tile_n - self.seqlen_q - thr_col_offset
+                    if const_expr(self.compress_factor == 1)
+                    else 1 - n_block * self.tile_n - thr_col_offset
                 )
                 if const_expr(mask_causal):
                     r2p = const_expr(not self.swap_AB)  # R2P trick, see apply_mask_sm100
@@ -253,6 +256,8 @@ class AttentionMask:
                             row_idx = utils.shuffle_sync(
                                 mma_m_idx, r % threads_per_row, width=threads_per_row
                             )
+                        if const_expr(self.compress_factor > 1):
+                            row_idx = row_idx // self.compress_factor
                         col_limit_right = row_idx + causal_row_offset
                         if const_expr(mask_seqlen):
                             col_limit_right = cutlass.min(col_limit_right, seqlenk_col_limit)
@@ -464,10 +469,16 @@ class AttentionMask:
                     acc_S[i] = -Float32.inf if mask_row >= self.seqlen_q else acc_S[i]
 
         else:  # Causal or local
-            causal_row_offset = self.seqlen_k - n_block * self.tile_n - self.seqlen_q
+            causal_row_offset = (
+                self.seqlen_k - n_block * self.tile_n - self.seqlen_q
+                if const_expr(self.compress_factor == 1)
+                else -n_block * self.tile_n
+            )
             row_idx = tScS_t2r[0][0] + m_block * self.tile_m
             if const_expr(self.qhead_per_kvhead_packgqa != 1):
                 row_idx = row_idx // self.qhead_per_kvhead_packgqa
+            if const_expr(self.compress_factor > 1):
+                row_idx = row_idx // self.compress_factor
             if const_expr(mask_causal):
                 col_limit_right = row_idx + causal_row_offset + 1
                 if const_expr(mask_seqlen):
@@ -645,7 +656,17 @@ class AttentionMask:
         else:  # Causal or local
             thr_row_offset = tScS_t2r[0][ROW]
             seqlenq_row_limit = self.seqlen_q - m_block * self.tile_m - thr_row_offset
-            causal_offset = seqlenq_row_limit - seqlenk_col_limit
+            if const_expr(self.compress_factor > 1):
+                # Compressed causal: q_idx >= kv_idx * compress_factor
+                # row_limit = kv_col * cf - q_row
+                causal_offset = (
+                    seqlenq_row_limit
+                    - self.compress_factor * seqlenk_col_limit
+                    + self.compress_factor * self.seqlen_k
+                    - self.seqlen_q
+                )
+            else:
+                causal_offset = seqlenq_row_limit - seqlenk_col_limit
             if const_expr(mask_causal):
                 # tidx = cute.arch.thread_idx()[0] % 256
                 # if tidx < 32:


### PR DESCRIPTION
 Add a `compress_factor: int = 1` parameter to `_flash_attn_fwd` and
 `_flash_attn_bwd` that adjusts the causal mask relationship from
 `kv_idx <= q_idx` to `kv_idx <= q_idx // compress_factor`.

 This enables native causal masking for compressed KV sequences where
 each KV token represents `compress_factor` original tokens (e.g., in
 sparse attention). Without this, users must supply a custom `mask_mod`
 function, which is slower because it prevents blocks from being
 classified as "full" — all blocks become "mask" blocks requiring
 per-element evaluation.
    
seqlen_q | cf | compress_factor | mask_mod | speedup
-- | -- | -- | -- | --
2048 | 2 | 0.070 ms | 0.094 ms | 1.35x
4096 | 4 | 0.091 ms | 0.118 ms | 1.29x
8192 | 2 | 0.298 ms | 0.370 ms | 1.24x
16384 | 4 | 0.510 ms | 0.616 ms | 1.21x
