### PR TITLE
fix: add [cu13] extra to dev install instructions for CUDA 13 / B200 systems

### DIFF
--- a/flash_attn/cute/README.md
+++ b/flash_attn/cute/README.md
@@ -27,6 +27,7 @@ out = flash_attn_func(q, k, v, causal=True)
 ```sh
 git clone https://github.com/Dao-AILab/flash-attention.git
 cd flash-attention
-pip install -e "flash_attn/cute[dev]"
+pip install -e "flash_attn/cute[dev]"       # CUDA 12.x
+pip install -e "flash_attn/cute[dev,cu13]"  # CUDA 13.x (e.g. B200)
 pytest tests/cute/
 ```


### PR DESCRIPTION
## Problem

The development install command in `flash_attn/cute/README.md` was:

```bash
pip install -e "flash_attn/cute[dev]"
````

On CUDA 13.x systems (e.g., B200), this fails silently: the installation completes successfully, but the `cutlass` Python module is not available. As a result, all tests fail during collection with:

```
ModuleNotFoundError: No module named 'cutlass'
```

---

## Root Cause

The `nvidia-cutlass-dsl` package provides CUDA-version-specific binaries via extras.
For CUDA 13.x, the `[cu13]` extra is required:

```bash
nvidia-cutlass-dsl[cu13]
```

Without this extra, only a base stub package is installed, which does not include the `cutlass` module for CUDA 13.x.

---

## Why This Matters

B200 (Blackwell SM100) is the primary target hardware for FA4 and uses CUDA 13.x.
This means any developer working on FA4 with B200 will immediately encounter this issue after following the README.

While the README correctly documents the `[cu13]` extra for the PyPI install path, it is missing from the development setup instructions.

---

## Fix

Update the development install instructions to include both variants:

```bash
pip install -e "flash_attn/cute[dev]"        # CUDA 12.x
pip install -e "flash_attn/cute[dev,cu13]"   # CUDA 13.x (e.g., B200)
```
