### PR TITLE
Fix: disable 2-CTA backward mode when block_sparse_tensors is used

### DIFF
--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -1086,6 +1086,7 @@ def _flash_attn_bwd(
             or score_mod is not None
             or score_mod_bwd is not None
             or mask_mod is not None
+            or block_sparse_tensors is not None
         )
         cluster_size = 2 if head_dim >= 128 and not disable_2cta else 1
         use_2cta_instrs = cluster_size==2


### PR DESCRIPTION
The SM100 2-CTA backward kernel does not properly handle block_sparse_tensors. When block sparsity is combined with 2-CTA mode, the kernel hits an assertion:
  'AssertionError: 2-CTA mode does not support block sparsity'

This fix adds block_sparse_tensors to the disable_2cta condition in the backward path, forcing the 1-CTA kernel when block sparsity is active. The 1-CTA backward kernel already supports block_sparse_tensors correctly.

Without this fix, any backward pass using block_sparse_tensors on SM100 (B200/GB200) with head_dim >= 128 will crash with the above assertion.