### PR TITLE
Draft: native FA4 bring-up for SM100 larger attention head dims

### DIFF
--- a/flash_attn/cute/flash_fwd_sm100.py
+++ b/flash_attn/cute/flash_fwd_sm100.py
@@ -9,6 +9,7 @@
 # Unsupported features that will be added later:
 # - page size != 128
 # - more hdim (192, 256)
+# - native full-width V tiles > 256 (the interface chunks V/O slices into <=256)
 # Based on the cutlass example and cute-dsl example:
 # https://github.com/NVIDIA/cutlass/tree/main/examples/77_blackwell_fmha
 # https://github.com/NVIDIA/cutlass/blob/main/examples/python/CuTeDSL/blackwell/fmha.py
@@ -130,6 +131,8 @@ class FlashAttentionForwardSm100:
         self.n_block_size = n_block_size
         self.q_stage = q_stage
         assert self.q_stage in [1, 2]
+        if self.head_dim_v_padded >= 256:
+            self.q_stage = 1
         self.use_2cta_instrs = use_2cta_instrs
         # If split_P_arrive, the softmax warps write some columns of P first, signal to the MMA warp
         # to being the P @ V MMA, then write the rest of P and signal again. This allows some overlap

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -105,15 +105,17 @@ def _validate_head_dims(head_dim: int, head_dim_v: int, compute_capability: int,
     is_standard_range = 8 <= head_dim <= 128 and 8 <= head_dim_v <= 128
 
     is_sm90_range = 8 <= head_dim <= 256 and 8 <= head_dim_v <= 256
+    is_sm100_chunked_v_range = 8 <= head_dim <= 512 and 8 <= head_dim_v <= 256
     if compute_capability == 9:
         assert is_sm90_range and head_dim % alignment == 0 and head_dim_v % alignment == 0, (
             f"(head_dim, head_dim_v)=({head_dim}, {head_dim_v}) is not supported on SM90. "
             f"head_dim and head_dim_v must be between 8 and 256 and divisible by {alignment}."
         )
     elif compute_capability in [10, 11]:
-        assert (is_standard_range or is_deepseek_shape) and head_dim % alignment == 0 and head_dim_v % alignment == 0, (
+        assert (is_standard_range or is_deepseek_shape or is_sm100_chunked_v_range) and head_dim % alignment == 0 and head_dim_v % alignment == 0, (
             f"(head_dim, head_dim_v)=({head_dim}, {head_dim_v}) is not supported on SM100/SM110. "
-            f"head_dim and head_dim_v must be between 8 and 128 and divisible by {alignment}, or (192, 128) for DeepSeek."
+            f"head_dim and head_dim_v must be between 8 and 128 and divisible by {alignment}, "
+            f"or (192, 128) for DeepSeek, or head_dim<=512 with native V chunking and head_dim_v<=256."
         )
 
 
@@ -502,6 +504,12 @@ def _flash_attn_fwd(
         q_stage = 2 if seqlen_q_packgqa > tile_m else 1
     else:
         q_stage = 1
+    if arch // 10 in [10, 11]:
+        head_dim_v_padded = int(math.ceil(head_dim_v / 16) * 16)
+        max_tmem_cols = 512
+        predicted_tmem_total = 2 * tile_n + q_stage * head_dim_v_padded
+        if predicted_tmem_total > max_tmem_cols:
+            q_stage = 1
 
     m_block_size_effective = q_stage * tile_m
     seqlen_k_loaded = max_seqlen_k if not local else max(0, min(max_seqlen_k, (window_size_right or max_seqlen_k) + (window_size_left or max_seqlen_k) + 1 + tile_m))
@@ -1773,6 +1781,37 @@ def flash_attn_func(
     block_size: Optional[Tuple[int, int]] = None,
     return_lse: bool = False,
 ):
+    arch = _get_device_arch()
+    if arch // 10 in [10, 11] and v.shape[-1] > 256:
+        out_chunks = []
+        lse = None
+        for start in range(0, v.shape[-1], 256):
+            end = min(start + 256, v.shape[-1])
+            out_i, lse_i = FlashAttnFunc.apply(
+                q,
+                k,
+                v[..., start:end],
+                softmax_scale,
+                causal,
+                window_size,
+                learnable_sink,
+                softcap,
+                num_splits,
+                pack_gqa,
+                deterministic,
+                mask_mod,
+                full_block_cnt,
+                full_block_idx,
+                mask_block_cnt,
+                mask_block_idx,
+                block_size,
+                return_lse and lse is None,
+            )
+            out_chunks.append(out_i)
+            if lse is None:
+                lse = lse_i
+        out = torch.cat(out_chunks, dim=-1)
+        return (out, lse) if return_lse else out
     return FlashAttnFunc.apply(
         q,
         k,
@@ -1818,6 +1857,40 @@ def flash_attn_varlen_func(
     aux_tensors: Optional[list] = None,
     return_lse: bool = False,
 ):
+    arch = _get_device_arch()
+    if arch // 10 in [10, 11] and v.shape[-1] > 256:
+        out_chunks = []
+        lse = None
+        for start in range(0, v.shape[-1], 256):
+            end = min(start + 256, v.shape[-1])
+            out_i, lse_i = FlashAttnVarlenFunc.apply(
+                q,
+                k,
+                v[..., start:end],
+                cu_seqlens_q,
+                cu_seqlens_k,
+                seqused_q,
+                seqused_k,
+                max_seqlen_q,
+                max_seqlen_k,
+                page_table,
+                softmax_scale,
+                causal,
+                window_size,
+                learnable_sink,
+                softcap,
+                num_splits,
+                pack_gqa,
+                deterministic,
+                score_mod,
+                aux_tensors,
+                return_lse and lse is None,
+            )
+            out_chunks.append(out_i)
+            if lse is None:
+                lse = lse_i
+        out = torch.cat(out_chunks, dim=-1)
+        return (out, lse) if return_lse else out
     return FlashAttnVarlenFunc.apply(
         q,
         k,

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -10,6 +10,7 @@ import pytest
 import torch
 
 from einops import rearrange, repeat
+import flash_attn.cute.interface as cute_interface
 
 try:
     from flash_attn.layers.rotary import apply_rotary_emb
@@ -1702,3 +1703,74 @@ def test_flash_attn_invalid_head_dim(head_dim):
 
     with pytest.raises(AssertionError, match=re.escape(f"(head_dim, head_dim_v)=({head_dim}, {head_dim}) is not supported on SM")):
         flash_attn_func(q, k, v)
+
+
+def test_validate_head_dims_sm100_native_v_chunking():
+    cute_interface._validate_head_dims(512, 256, 10, 8)
+    with pytest.raises(
+        AssertionError,
+        match=re.escape("(head_dim, head_dim_v)=(512, 512) is not supported on SM100/SM110."),
+    ):
+        cute_interface._validate_head_dims(512, 512, 10, 8)
+
+
+def test_flash_attn_func_sm100_chunks_v(monkeypatch):
+    calls = []
+
+    def fake_apply(q, k, v, *args):
+        chunk_idx = len(calls)
+        calls.append(v.shape[-1])
+        out = torch.full((*q.shape[:-1], v.shape[-1]), chunk_idx + 1, dtype=q.dtype)
+        lse = torch.full(q.shape[:-1], chunk_idx + 11, dtype=torch.float32)
+        return out, lse
+
+    monkeypatch.setattr(cute_interface, "_get_device_arch", lambda: 100)
+    monkeypatch.setattr(cute_interface.FlashAttnFunc, "apply", staticmethod(fake_apply))
+
+    q = torch.zeros(2, 8, 4, 512, dtype=torch.float32)
+    k = torch.zeros(2, 8, 4, 512, dtype=torch.float32)
+    v = torch.zeros(2, 8, 4, 512, dtype=torch.float32)
+
+    out, lse = cute_interface.flash_attn_func(q, k, v, return_lse=True)
+
+    assert calls == [256, 256]
+    assert out.shape == v.shape
+    assert torch.equal(out[..., :256], torch.ones_like(out[..., :256]))
+    assert torch.equal(out[..., 256:], torch.full_like(out[..., 256:], 2))
+    assert torch.equal(lse, torch.full(q.shape[:-1], 11, dtype=torch.float32))
+
+
+def test_flash_attn_varlen_func_sm100_chunks_v(monkeypatch):
+    calls = []
+
+    def fake_apply(q, k, v, *args):
+        chunk_idx = len(calls)
+        calls.append(v.shape[-1])
+        out = torch.full((q.shape[0], q.shape[1], v.shape[-1]), chunk_idx + 1, dtype=q.dtype)
+        lse = torch.full((q.shape[0], q.shape[1]), chunk_idx + 21, dtype=torch.float32)
+        return out, lse
+
+    monkeypatch.setattr(cute_interface, "_get_device_arch", lambda: 100)
+    monkeypatch.setattr(cute_interface.FlashAttnVarlenFunc, "apply", staticmethod(fake_apply))
+
+    q = torch.zeros(16, 4, 512, dtype=torch.float32)
+    k = torch.zeros(16, 4, 512, dtype=torch.float32)
+    v = torch.zeros(16, 4, 512, dtype=torch.float32)
+    cu_seqlens = torch.tensor([0, 8, 16], dtype=torch.int32)
+
+    out, lse = cute_interface.flash_attn_varlen_func(
+        q,
+        k,
+        v,
+        cu_seqlens_q=cu_seqlens,
+        cu_seqlens_k=cu_seqlens,
+        max_seqlen_q=8,
+        max_seqlen_k=8,
+        return_lse=True,
+    )
+
+    assert calls == [256, 256]
+    assert out.shape == v.shape
+    assert torch.equal(out[..., :256], torch.ones_like(out[..., :256]))
+    assert torch.equal(out[..., 256:], torch.full_like(out[..., 256:], 2))
+    assert torch.equal(lse, torch.full((q.shape[0], q.shape[1]), 21, dtype=torch.float32))


### PR DESCRIPTION
## Summary
This draft supersedes the earlier FA3-framed exploratory PR and keeps the ongoing SM100 larger-head work tracked under the correct FA4-native direction.

## Current State
- this branch still contains exploratory prior work from the initial larger-head investigation
- direct B200 probing showed the early V/O-only chunking idea is not sufficient for dense `512`-dim attention
- current dense `512` support is still not ready to merge

## What We Know
- Gemma 4 full-attention is dense `q/k/v = 512`
- forward/native support for this path still needs real FA4-native implementation work
- backward/native support still needs correct dense `512` support before training is safe
- this effort should be tracked as FA4/SM100 native bring-up, not FA3

## Why This Draft Exists
- keep the discussion attached to the real upstream repo
- make the backend direction explicit going forward
- avoid implying the earlier exploratory branch is merge-ready

## Status
Keep this PR draft.

Do not merge until dense native `512` support is correct on B200 for both forward and backward.