### PR TITLE
[FA3][Hopper] Make the split heuristic sequence-aware for low-tile decode

### DIFF
--- a/hopper/heuristics.h
+++ b/hopper/heuristics.h
@@ -36,8 +36,18 @@ inline int num_splits_heuristic(int total_mblocks, int num_SMs, int num_n_blocks
             return 1;
         }
     }
-    // If num_n_blocks is too small, use 1 split. For example, we never split for hdim = 128 and seqlen_k = 512.
-    if (num_n_blocks <= 4) { return 1; }
+    // Guard 1: L_K <= 384 (nblk <= 3) - leave shorter contexts unchanged
+    if (num_n_blocks <= 3) { return 1; }
+
+    // Guard 2: nblk = 4 boundary bucket with enough tiles
+    // total_mblocks is the aggregate work-tile count; for decode (L_Q = 1),
+    // this reduces to batch_size * num_heads_kv.
+    if (num_n_blocks <= 4 && total_mblocks >= 4) { return 1; }
+
+    // Low-tile boundary case: demonstrate the idea with one small override
+    if (num_n_blocks == 4 && total_mblocks < 4) { return 3; }
+
+    // For longer contexts, existing efficiency loop runs (unchanged)
     max_splits = std::min({max_splits, num_SMs, num_n_blocks});
     float max_efficiency = 0.f;
     std::vector<float> efficiency;


### PR DESCRIPTION
# [FA3][Hopper] Make the split heuristic sequence-aware for low-tile decode

## Summary

This patch updates the Hopper FA3 split heuristic in `hopper/heuristics.h` so we do not unconditionally force `num_splits = 1` for every `num_n_blocks <= 4` case.

Today the heuristic does this:

```cpp
if (num_n_blocks <= 4) {
    return 1;
}
```

That works well for saturated workloads, but it is too aggressive for low-head-count decode regimes such as MQA and small-GQA on H100. In those cases, the kernel can launch too few CTAs to keep the GPU busy.

This patch narrows that early return to preserve the existing behavior for shorter contexts and already-saturated boundary cases, while adding a small override for the starved `num_n_blocks == 4` case:

```cpp
// Guard 1: L_K <= 384 (nblk <= 3) - leave shorter contexts unchanged
if (num_n_blocks <= 3) { return 1; }

// Guard 2: nblk = 4 boundary bucket with enough tiles
// total_mblocks is the aggregate work-tile count; for decode (L_Q = 1),
// this reduces to batch_size * num_heads_kv.
if (num_n_blocks <= 4 && total_mblocks >= 4) { return 1; }

// Low-tile boundary case: demonstrate the idea with one small override
if (num_n_blocks == 4 && total_mblocks < 4) { return 3; }

// For longer contexts, existing efficiency loop runs (unchanged)
```

## Why

In decode-like workloads with `L_Q = 1`, the available parallel work can be very small when `H_KV` is small. A representative target shape is:

- `batch = 1`
- `L_Q = 1`
- `L_K = 512`
- `H_KV in {1, 2}`
- `D = 128`

On H100, the current `num_n_blocks <= 4 -> return 1` shortcut can leave the device badly underfilled in this regime. The issue is that the guard only looks at sequence blocks and ignores how little total work is available.

This patch keeps the current behavior where it already makes sense:

- `num_n_blocks <= 3` (roughly `L_K <= 384`)
- `num_n_blocks == 4` with enough tiles already available (`total_mblocks >= 4`)
- longer contexts, which still use the existing efficiency loop

The only new behavior is the low-tile boundary case:

- `num_n_blocks == 4 && total_mblocks < 4` -> `return 3`

## Why `3` splits

I swept larger split counts for the target boundary case and found that once splitting is enabled, latency drops sharply and then enters a broad low-latency plateau. `3` is the smallest split count that reliably gets into that regime on the tested Hopper stack, so this patch uses the most conservative override that still fixes the underutilization.

The goal here is not to broadly retune FA3. It is to remove one premature shortcut in the regime where it is clearly harmful.

## Results

Representative H100 BF16 kernel measurements for the metadata-enabled decode path (`batch = 1`, `L_Q = 1`, `D = 128`):

| `L_K` | `H_KV` | Baseline | Patched | Speedup |
|---|---:|---:|---:|---:|
| 512 | 1 | 13.72 us | 11.37 us | 1.21x |
| 512 | 2 | 13.52 us | 10.93 us | 1.24x |
| 512 | 8 | 13.56 us | 13.56 us | 1.00x |

I also ran a broader 160-configuration sweep over:

- `Batch in {1, 2, 4, 8}`
- `L_K in {128, 256, 384, 512, 1024, 2048, 4096, 8192}`
- `H_KV in {1, 2, 4, 8, 32}`

In that sweep, I did not observe regressions. The wins appeared only in the intended low-tile `L_K = 512`, `H_KV in {1, 2}` boundary regime; shorter, longer, and already-saturated cases stayed unchanged.

## Scope

- Hopper / FA3 path only (`hopper/heuristics.h`)
- scheduling-only change
- no attention math changes
- intentionally conservative and limited to a narrow boundary case

## Testing

- correctness checks passed
- A/B kernel benchmarks on H100
- broader safety / regression sweep over 160 configurations

## Reproduction

I have included both an informative preprint and a standalone reproduction repo with the patch, benchmark harnesses, and reviewer artifacts:

- Repro repo: <https://github.com/mllopartbsc/fa3-heuristic-fix>
- Preprint: <https://arxiv.org/abs/2604.00028>