### PR TITLE
[Cute,Fwd,Sm90] Ceil div in paged kv manager to prevent size 0

### DIFF
--- a/flash_attn/cute/paged_kv.py
+++ b/flash_attn/cute/paged_kv.py
@@ -86,7 +86,7 @@ class PagedKVManager(ParamsBase):
         val_layout = cute.make_layout((1, async_copy_elems))
         gmem_tiled_copy_KV = cute.make_tiled_copy_tv(atom_async_copy, thr_layout, val_layout)
         gmem_thr_copy_KV = gmem_tiled_copy_KV.get_slice(thread_idx)
-        page_entry_per_thread = n_block_size // num_threads
+        page_entry_per_thread = (n_block_size + num_threads - 1) // num_threads
 
         tPrPage = cute.make_rmem_tensor((page_entry_per_thread,), Int32)
         tPrPageOffset = cute.make_rmem_tensor((page_entry_per_thread,), Int32)

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -1645,8 +1645,6 @@ def test_flash_attn_paged_deepseek(seqlen_q, page_size):
     """Regression test: paged non-TMA with DeepSeek MLA shape (d=192, dv=128).
     seqlen_q<=128 triggers q_stage=1, seqlen_q>128 triggers q_stage=2.
     """
-    if IS_SM90:
-        pytest.skip("paged KV not supported on SM90")
     device = "cuda"
     dtype = torch.bfloat16
     d, dv = 192, 128
@@ -1680,6 +1678,56 @@ def test_flash_attn_paged_deepseek(seqlen_q, page_size):
         cu_seqlens_q=cu_seqlens, cu_seqlens_k=None,
         max_seqlen_q=seqlen_q, max_seqlen_k=None,
         seqused_k=cache_seqlens, page_table=page_table, causal=True,
+    )
+
+    if is_fake_mode():
+        return
+
+    print(f"Output max diff: {(out - out_ref).abs().max().item()}")
+    print(f"Output mean diff: {(out - out_ref).abs().mean().item()}")
+    assert torch.equal(out, out_ref)
+
+
+@pytest.mark.parametrize("page_size", [64, 256])
+@pytest.mark.parametrize("seqlen_k", [128, 512])
+@maybe_fake_tensor_mode(USE_FAKE_TENSOR)
+def test_flash_attn_paged_hdim256(seqlen_k, page_size):
+    if not IS_SM90:
+        pytest.skip("Only tested on sm90")
+    device = "cuda"
+    dtype = torch.bfloat16
+    d = 256
+    nheads_q, nheads_kv = 8, 4
+    seqlen_q = 1
+
+    torch.random.manual_seed(0)
+    q = torch.randn(seqlen_q, nheads_q, d, device=device, dtype=dtype)
+    k_flat = torch.randn(seqlen_k, nheads_kv, d, device=device, dtype=dtype)
+    v_flat = torch.randn(seqlen_k, nheads_kv, d, device=device, dtype=dtype)
+    cu_seqlens_q = torch.tensor([0, seqlen_q], dtype=torch.int32, device=device)
+    cu_seqlens_k = torch.tensor([0, seqlen_k], dtype=torch.int32, device=device)
+
+    # Non-paged reference
+    out_ref, _ = flash_attn_varlen_func(
+        q, k_flat, v_flat, cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=cu_seqlens_k,
+        max_seqlen_q=seqlen_q, max_seqlen_k=seqlen_k, causal=True,
+    )
+
+    # Paged
+    num_pages = (seqlen_k + page_size - 1) // page_size
+    k_paged = torch.zeros(num_pages, page_size, nheads_kv, d, device=device, dtype=dtype)
+    v_paged = torch.zeros(num_pages, page_size, nheads_kv, d, device=device, dtype=dtype)
+    for i in range(seqlen_k):
+        k_paged[i // page_size, i % page_size] = k_flat[i]
+        v_paged[i // page_size, i % page_size] = v_flat[i]
+    page_table = torch.arange(num_pages, dtype=torch.int32, device=device).unsqueeze(0)
+    seqused_k = torch.tensor([seqlen_k], dtype=torch.int32, device=device)
+
+    out, _ = flash_attn_varlen_func(
+        q, k_paged, v_paged,
+        cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=None,
+        max_seqlen_q=seqlen_q, max_seqlen_k=None,
+        seqused_k=seqused_k, page_table=page_table, causal=True,
     )
 
     if is_fake_mode():


### PR DESCRIPTION
When running the SM90 cute-dsl fwd with kv cache with gemma 3 4B, I got `ValueError: Expected size in shape to be strictly positive, but got 0` since n_block_size is 80 (or 64 for the local layers) but num_threads = 128. Added a ceil div to prevent this and added a correctness test to the existing cute test file. Also enabled `test_flash_attn_paged_deepseek` for SM90 since paged kv is now supported on SM90.

### Tests:
Ran on H200. 

#### test_flash_attn_paged_deepseek
<img width="857" height="26" alt="image" src="https://github.com/user-attachments/assets/f9cc002a-f042-4157-9b45-70c714eb2c9c" />
#### test_flash_attn_paged_hdim256
<img width="853" height="24" alt="image" src="https://github.com/user-attachments/assets/8fdb67eb-7743-47d8-8901-9c9af25575e8" />
