### PR TITLE
Add forward and backward support for FA4 hdim=256 on SM100

### DIFF
--- a/flash_attn/cute/flash_bwd_sm100.py
+++ b/flash_attn/cute/flash_bwd_sm100.py
@@ -65,6 +65,7 @@ class FlashAttentionBackwardSm100:
         mask_mod: cutlass.Constexpr | None = None,
         has_aux_tensors: cutlass.Constexpr = False,
         subtile_factor: cutlass.Constexpr[int] = 1,
+        is_split_d: bool = False,
     ):
         # padding head_dim to a multiple of 16 as k_block_size
         hdim_multiple_of = 16
@@ -75,11 +76,22 @@ class FlashAttentionBackwardSm100:
         self.check_hdim_oob = head_dim != self.tile_hdim
         self.check_hdim_v_oob = head_dim_v != self.tile_hdimv
 
+        self.is_split_d = is_split_d
+        if self.is_split_d:
+            assert self.tile_hdim == 256 and self.tile_hdimv == 256
+            self.half_hdim = self.tile_hdim // 2
+            self.half_hdimv = self.tile_hdimv // 2
+            use_2cta_instrs = False
+            cluster_size = 1
+            self.dK_as_reduce = True
+        else:
+            self.dK_as_reduce = False
+
         self.tile_m = tile_m
         self.tile_n = tile_n
 
-        assert self.tile_hdim <= 128 or (self.tile_hdim == 192 and self.tile_hdimv == 128)
-        assert self.tile_hdimv <= 128
+        assert self.tile_hdim <= 128 or (self.tile_hdim == 192 and self.tile_hdimv == 128) or self.is_split_d
+        assert self.tile_hdimv <= 128 or self.is_split_d
 
         self.use_2cta_instrs = bool(
             use_2cta_instrs
@@ -93,18 +105,24 @@ class FlashAttentionBackwardSm100:
         assert self.tile_hdim != 192 or self.use_2cta_instrs, "Must use 2CTA for hdim 192"
 
         # CTA tiler
-        self.cta_tiler = (tile_n, tile_m, self.tile_hdim)
+        if self.is_split_d:
+            hdim_for_mma = self.half_hdim
+            hdimv_for_mma = self.half_hdimv
+        else:
+            hdim_for_mma = self.tile_hdim
+            hdimv_for_mma = self.tile_hdimv
+        self.cta_tiler = (tile_n, tile_m, hdim_for_mma)
         # S = K @ Q.T
-        self.mma_tiler_kq = (self.cta_group_size * tile_n, tile_m, self.tile_hdim)
+        self.mma_tiler_kq = (self.cta_group_size * tile_n, tile_m, hdim_for_mma)
         # dP = V @ dO.T
-        self.mma_tiler_vdo = (self.cta_group_size * tile_n, tile_m, self.tile_hdimv)
+        self.mma_tiler_vdo = (self.cta_group_size * tile_n, tile_m, hdimv_for_mma)
         # dV = P.T @ dO
-        self.mma_tiler_pdo = (self.cta_group_size * tile_n, self.tile_hdimv, tile_m)
+        self.mma_tiler_pdo = (self.cta_group_size * tile_n, hdimv_for_mma, tile_m)
         # dK = dS.T @ Q
-        self.mma_tiler_dsq = (self.cta_group_size * tile_n, self.tile_hdim, tile_m)
+        self.mma_tiler_dsq = (self.cta_group_size * tile_n, hdim_for_mma, tile_m)
         # dQ = dS @ K
         # 2-CTA: reduction dim is cluster-wide (tile_n * cta_group_size).
-        self.mma_tiler_dsk = (tile_m, self.tile_hdim, tile_n * self.cta_group_size)
+        self.mma_tiler_dsk = (tile_m, hdim_for_mma, tile_n * self.cta_group_size)
 
         self.acc_dtype = Float32
 
@@ -178,7 +196,18 @@ class FlashAttentionBackwardSm100:
         # self.tmem_total = self.tmem_S_offset + self.tile_n
         # assert self.tmem_total <= self.tmem_alloc_cols
 
-        if self.use_2cta_instrs and self.tile_hdim == 192 and self.tile_hdimv == 128:
+        if self.is_split_d:
+            # Split-D TMEM layout (512 cols, 100% utilization):
+            # S/P [0, 128) | dV_low [128, 256) | dV_high [256, 384) | dP/dS [384, 512)
+            # dK_partial and dQ_partial time-share with S/P at [0, 128)
+            self.tmem_S_offset = 0
+            self.tmem_P_offset = 0
+            self.tmem_dV_offset = self.tile_n               # 128
+            self.tmem_dP_offset = self.tmem_dV_offset + self.tile_hdimv  # 384
+            self.tmem_dS_offset = self.tmem_dP_offset
+            self.tmem_dK_offset = 0                          # time-shares with S/P
+            self.tmem_dQ_offset = 0                          # time-shares with S/P
+        elif self.use_2cta_instrs and self.tile_hdim == 192 and self.tile_hdimv == 128:
             assert self.tile_m == 128
             assert self.tile_n == 128
             self.tmem_dV_offset = 0
@@ -234,8 +263,14 @@ class FlashAttentionBackwardSm100:
         self.buffer_align_bytes = 1024
 
     def _setup_attributes(self):
-        self.Q_stage = 1 if self.use_2cta_instrs else 2
-        self.dO_stage = 1
+        if self.is_split_d:
+            self.Q_stage = 1
+            self.dO_stage = 1
+            self.K_smem_stages = 2
+        else:
+            self.Q_stage = 1 if self.use_2cta_instrs else 2
+            self.dO_stage = 1
+            self.K_smem_stages = 1
         self.single_stage = 1
         # LSE_stage = Q_stage and dPsum_stage = dO_stage
         self.sdKVaccum_stage = 2
@@ -254,12 +289,13 @@ class FlashAttentionBackwardSm100:
                 self.dQ_reduce_ncol = 32
                 self.sdQaccum_stage = 64 // self.dQ_reduce_ncol
                 self.dQ_reduce_ncol_t2r = self.dQ_reduce_ncol
-        assert (self.tile_hdim // self.cta_group_size) % self.dQ_reduce_ncol == 0
-        self.dQaccum_reduce_stage = self.tile_hdim // self.dQ_reduce_ncol
-        self.dQaccum_reduce_stage_t2r = self.tile_hdim // self.dQ_reduce_ncol_t2r
+        hdim_for_reduce = self.half_hdim if self.is_split_d else self.tile_hdim
+        assert (hdim_for_reduce // self.cta_group_size) % self.dQ_reduce_ncol == 0
+        self.dQaccum_reduce_stage = hdim_for_reduce // self.dQ_reduce_ncol
+        self.dQaccum_reduce_stage_t2r = hdim_for_reduce // self.dQ_reduce_ncol_t2r
         self.cluster_reduce_dQ = False and cute.size(self.cluster_shape_mn) > 1
         # number of tma reduce adds for dKacc and dVacc epilogue (must divide hdim_per_wg)
-        self.dK_reduce_ncol = math.gcd(32, self.tile_hdim // 2)
+        self.dK_reduce_ncol = math.gcd(32, hdim_for_reduce // 2)
         # CTA group for MMA operations
         self.cta_group = tcgen05.CtaGroup.TWO if self.use_2cta_instrs else tcgen05.CtaGroup.ONE
 
@@ -323,9 +359,12 @@ class FlashAttentionBackwardSm100:
             self.tiled_mma_S,
             self.mma_tiler_kq,
             self.k_dtype,
-            1,
+            self.K_smem_stages,
         )
-        self.sK_layout = cute.slice_(sK_layout, (None, None, None, 0))
+        if self.is_split_d:
+            self.sK_layout = sK_layout
+        else:
+            self.sK_layout = cute.slice_(sK_layout, (None, None, None, 0))
         self.sQ_layout = sm100_utils_basic.make_smem_layout_b(
             self.tiled_mma_S,
             self.mma_tiler_kq,
@@ -393,9 +432,12 @@ class FlashAttentionBackwardSm100:
             self.tiled_mma_dQ,
             self.mma_tiler_dsk,
             self.k_dtype,
-            1,
+            self.K_smem_stages,
         )
-        self.sKt_layout = cute.slice_(sKt_layout, (None, None, None, 0))
+        if self.is_split_d:
+            self.sKt_layout = sKt_layout
+        else:
+            self.sKt_layout = cute.slice_(sKt_layout, (None, None, None, 0))
         self.sdS_xchg_layout = cute.make_layout(shape=(self.tile_n, self.tile_m // 2))
 
         self.sdQaccum_layout = cute.make_layout(
@@ -408,19 +450,21 @@ class FlashAttentionBackwardSm100:
             shape=(self.tile_m, self.dO_stage),
             stride=(1, cute.round_up(self.tile_m, 64)),
         )
+        hdim_epi = self.half_hdim if self.is_split_d else self.tile_hdim
+        hdimv_epi = self.half_hdimv if self.is_split_d else self.tile_hdimv
         self.sdK_epi_tile = (
             self.tile_n,
-            math.gcd(128 // (self.dk_dtype.width // 8), self.tile_hdim // 2),  # 64 or 32
+            math.gcd(128 // (self.dk_dtype.width // 8), hdim_epi // 2),  # 64 or 32
         )  # subtiles mma_tiler_dsq[:2] = mma_tiler_pdo[:2]
         self.sdV_epi_tile = (
             self.tile_n,
-            math.gcd(128 // (self.dk_dtype.width // 8), self.tile_hdimv // 2),  # 64 or 32
+            math.gcd(128 // (self.dk_dtype.width // 8), hdimv_epi // 2),  # 64 or 32
         )  # subtiles mma_tiler_dsq[:2] = mma_tiler_pdo[:2]
         # headdim_64 gets 1 stage
-        self.num_epi_stages = max(1, (self.tile_hdim // 2) // self.sdK_epi_tile[1])
-        self.num_epi_stages_v = max(1, (self.tile_hdimv // 2) // self.sdV_epi_tile[1])
-        self.sdK_flat_epi_tile = self.tile_n * (self.tile_hdim // 2) // self.num_epi_stages
-        self.sdV_flat_epi_tile = self.tile_n * (self.tile_hdimv // 2) // self.num_epi_stages_v
+        self.num_epi_stages = max(1, (hdim_epi // 2) // self.sdK_epi_tile[1])
+        self.num_epi_stages_v = max(1, (hdimv_epi // 2) // self.sdV_epi_tile[1])
+        self.sdK_flat_epi_tile = self.tile_n * (hdim_epi // 2) // self.num_epi_stages
+        self.sdV_flat_epi_tile = self.tile_n * (hdimv_epi // 2) // self.num_epi_stages_v
         if const_expr(not self.dKV_postprocess):
             self.sdK_layout = sm100_utils_basic.make_smem_layout_epi(
                 self.dk_dtype,
@@ -482,8 +526,9 @@ class FlashAttentionBackwardSm100:
         self.is_varlen_k = mCuSeqlensK is not None or mSeqUsedK is not None
         self.is_varlen_q = mCuSeqlensQ is not None or mSeqUsedQ is not None
         self.use_tma_store = not (self.qhead_per_kvhead == 1 and mCuSeqlensK is not None)
-        # self.use_tma_store = not self.qhead_per_kvhead == 1
-        self.dKV_postprocess = self.qhead_per_kvhead > 1
+        if const_expr(self.is_split_d):
+            self.use_tma_store = True
+        self.dKV_postprocess = self.qhead_per_kvhead > 1 or self.is_split_d
 
         if const_expr(self.dKV_postprocess):
             assert self.dk_dtype.width == 32, "Must accumulate dK in float precision for GQA"
@@ -1367,6 +1412,12 @@ class FlashAttentionBackwardSm100:
         dvacc_shape = thr_mma_dV.partition_shape_C(self.mma_tiler_pdo[:2])
         tdVtdV = thr_mma_dV.make_fragment_C(dvacc_shape)
         tdVtdV = cute.make_tensor(tmem_ptr + self.tmem_dV_offset, tdVtdV.layout)
+        if const_expr(self.is_split_d):
+            tdVtdV_high = cute.make_tensor(
+                tmem_ptr + self.tmem_dV_offset + self.half_hdimv, tdVtdV.layout
+            )
+        else:
+            tdVtdV_high = tdVtdV
         tP = cute.make_tensor(
             cute.recast_ptr(tmem_ptr + self.tmem_P_offset, dtype=self.do_dtype), tP_layout.outer
         )
@@ -1518,6 +1569,7 @@ class FlashAttentionBackwardSm100:
                 tStS,
                 tdPtdP,
                 tdVtdV,
+                tdVtdV_high,
                 tdKtdK,
                 tdQtdQ,
                 dS_cluster_full_mbar_ptr,
@@ -1588,9 +1640,10 @@ class FlashAttentionBackwardSm100:
                 tiled_copy_r2s_dKV,
                 mdK_semaphore,
                 mdV_semaphore,
-                aux_tensors,
-                fastdiv_mods,
-                blocksparse_tensors,
+                tdVtdV_high=tdVtdV_high if const_expr(self.is_split_d) else None,
+                aux_tensors=aux_tensors,
+                fastdiv_mods=fastdiv_mods,
+                blocksparse_tensors=blocksparse_tensors,
             )
             tmem_alloc_barrier.arrive()
 
@@ -1612,6 +1665,7 @@ class FlashAttentionBackwardSm100:
                 TileSchedulerCls,
                 mdQ_semaphore,
                 blocksparse_tensors,
+                mdK=mdK if const_expr(self.is_split_d) else None,
             )
             tmem_alloc_barrier.arrive()
 
@@ -1796,12 +1850,16 @@ class FlashAttentionBackwardSm100:
             tdPgdO = thr_mma_dV.partition_B(gdO)
 
             a_cta_layout = cute.make_layout(cute.slice_(cluster_layout_vmnk, (0, 0, None, 0)).shape)
+            if const_expr(self.is_split_d):
+                sK_stage0 = sK[None, None, None, 0]
+            else:
+                sK_stage0 = sK
             load_K, _, _ = copy_utils.tma_get_copy_fn(
                 tma_atom_K,
                 block_in_cluster_coord_vmnk[2],
                 a_cta_layout,
                 tSgK,
-                sK,
+                sK_stage0,
                 single_stage=True,
             )
 
@@ -2056,6 +2114,238 @@ class FlashAttentionBackwardSm100:
                             pipeline_dO.producer_commit(producer_state_O_Ot)
                             producer_state_O_Ot.advance()
 
+                    elif const_expr(self.is_split_d):
+                        # ====================================================
+                        # Split-D load path: per M-block schedule
+                        # K: loaded once (K_low→sK[0], K_high→sK[1])
+                        # Per M-block: Q_low, Q_high, V_low+dO_low, V_high+dO_high,
+                        #              dO_low(reload), Q_low(reload)
+                        # ====================================================
+                        sK_low = sK[None, None, None, 0]
+                        sK_high = sK[None, None, None, 1]
+                        # K_low / K_high GMEM tiles
+                        gK_low = cute.local_tile(
+                            mK_cur, cute.select(self.mma_tiler_kq, mode=[0, 2]),
+                            (n_block_cta_group, 0),
+                        )
+                        gK_high = cute.local_tile(
+                            mK_cur, cute.select(self.mma_tiler_kq, mode=[0, 2]),
+                            (n_block_cta_group, 1),
+                        )
+                        tSgK_low = thr_mma_S.partition_A(gK_low)
+                        tSgK_high = thr_mma_S.partition_A(gK_high)
+                        load_K_low, _, _ = copy_utils.tma_get_copy_fn(
+                            tma_atom_K, block_in_cluster_coord_vmnk[2], a_cta_layout,
+                            tSgK_low, sK_low, single_stage=True,
+                        )
+                        load_K_high, _, _ = copy_utils.tma_get_copy_fn(
+                            tma_atom_K, block_in_cluster_coord_vmnk[2], a_cta_layout,
+                            tSgK_high, sK_high, single_stage=True,
+                        )
+                        # Q_low / Q_high GMEM tiles
+                        gQ_low = cute.local_tile(
+                            mQ_cur, cute.select(self.mma_tiler_kq, mode=[1, 2]), (None, 0)
+                        )
+                        gQ_high = cute.local_tile(
+                            mQ_cur, cute.select(self.mma_tiler_kq, mode=[1, 2]), (None, 1)
+                        )
+                        tSgQ_low = thr_mma_S.partition_B(gQ_low)
+                        tSgQ_high = thr_mma_S.partition_B(gQ_high)
+                        load_Q_low_raw, _, _ = copy_utils.tma_get_copy_fn(
+                            tma_atom_Q, block_in_cluster_coord_vmnk[1], b_cta_layout,
+                            tSgQ_low, sQ, mcast_mask=q_do_mcast_mask,
+                        )
+                        load_Q_high_raw, _, _ = copy_utils.tma_get_copy_fn(
+                            tma_atom_Q, block_in_cluster_coord_vmnk[1], b_cta_layout,
+                            tSgQ_high, sQ, mcast_mask=q_do_mcast_mask,
+                        )
+                        load_Q_low = copy_utils.tma_producer_copy_fn(load_Q_low_raw, pipeline_Q)
+                        load_Q_high = copy_utils.tma_producer_copy_fn(load_Q_high_raw, pipeline_Q)
+                        # V_low / V_high GMEM tiles
+                        gV_low = cute.local_tile(
+                            mV_cur, cute.select(self.mma_tiler_vdo, mode=[0, 2]),
+                            (n_block_cta_group, 0),
+                        )
+                        gV_high = cute.local_tile(
+                            mV_cur, cute.select(self.mma_tiler_vdo, mode=[0, 2]),
+                            (n_block_cta_group, 1),
+                        )
+                        tdPgV_low = thr_mma_dP.partition_A(gV_low)
+                        tdPgV_high = thr_mma_dP.partition_A(gV_high)
+                        load_V_low, _, _ = copy_utils.tma_get_copy_fn(
+                            tma_atom_V, 0, cute.make_layout(1),
+                            tdPgV_low, sV, single_stage=True,
+                        )
+                        load_V_high, _, _ = copy_utils.tma_get_copy_fn(
+                            tma_atom_V, 0, cute.make_layout(1),
+                            tdPgV_high, sV, single_stage=True,
+                        )
+                        # dO_low / dO_high GMEM tiles (for dV = P^T @ dO)
+                        gdO_low = cute.local_tile(
+                            mdO_cur, cute.select(self.mma_tiler_pdo, mode=[1, 2]), (0, None)
+                        )
+                        gdO_high = cute.local_tile(
+                            mdO_cur, cute.select(self.mma_tiler_pdo, mode=[1, 2]), (1, None)
+                        )
+                        tdVgdO_low = thr_mma_dV.partition_B(gdO_low)
+                        tdVgdO_high = thr_mma_dV.partition_B(gdO_high)
+                        load_dO_low_raw, _, _ = copy_utils.tma_get_copy_fn(
+                            tma_atom_dO, block_in_cluster_coord_vmnk[1], b_cta_layout,
+                            tdVgdO_low, sdO, mcast_mask=q_do_mcast_mask,
+                        )
+                        load_dO_high_raw, _, _ = copy_utils.tma_get_copy_fn(
+                            tma_atom_dO, block_in_cluster_coord_vmnk[1], b_cta_layout,
+                            tdVgdO_high, sdO, mcast_mask=q_do_mcast_mask,
+                        )
+                        load_dO_low = copy_utils.tma_producer_copy_fn(load_dO_low_raw, pipeline_dO)
+                        load_dO_high = copy_utils.tma_producer_copy_fn(load_dO_high_raw, pipeline_dO)
+
+                        #### Split-D Prologue (first M-block) ####
+                        # 1) K_low + Q_low → pipeline_Q
+                        pipeline_Q.producer_acquire(
+                            producer_state_Q_LSE, extra_tx_count=self.tma_copy_bytes["K"]
+                        )
+                        load_K_low(
+                            tma_bar_ptr=pipeline_Q.producer_get_barrier(producer_state_Q_LSE)
+                        )
+                        load_Q_low(first_m_block, producer_state=producer_state_Q_LSE)
+                        pipeline_Q.producer_commit(producer_state_Q_LSE)
+                        # LSE
+                        pipeline_LSE.producer_acquire(producer_state_Q_LSE)
+                        with cute.arch.elect_one():
+                            copy_stats(
+                                gLSE[None, first_m_block],
+                                sLSE[None, producer_state_Q_LSE.index],
+                                mbar_ptr=pipeline_LSE.producer_get_barrier(producer_state_Q_LSE),
+                            )
+                        producer_state_Q_LSE.advance()
+
+                        # 2) K_high + Q_high → pipeline_Q
+                        pipeline_Q.producer_acquire(
+                            producer_state_Q_LSE, extra_tx_count=self.tma_copy_bytes["K"]
+                        )
+                        load_K_high(
+                            tma_bar_ptr=pipeline_Q.producer_get_barrier(producer_state_Q_LSE)
+                        )
+                        load_Q_high(first_m_block, producer_state=producer_state_Q_LSE)
+                        pipeline_Q.producer_commit(producer_state_Q_LSE)
+                        producer_state_Q_LSE.advance()
+
+                        # 3) V_low + dO_low → pipeline_dO
+                        pipeline_dO.producer_acquire(
+                            producer_state_dO_dPsum,
+                            extra_tx_count=self.tma_copy_bytes["V"],
+                        )
+                        load_V_low(
+                            tma_bar_ptr=pipeline_dO.producer_get_barrier(producer_state_dO_dPsum)
+                        )
+                        load_dO_low(first_m_block, producer_state=producer_state_dO_dPsum)
+                        pipeline_dO.producer_commit(producer_state_dO_dPsum)
+                        # dPsum
+                        pipeline_dPsum.producer_acquire(producer_state_dO_dPsum)
+                        with cute.arch.elect_one():
+                            copy_stats(
+                                gdPsum[None, first_m_block],
+                                sdPsum[None, producer_state_dO_dPsum.index],
+                                mbar_ptr=pipeline_dPsum.producer_get_barrier(
+                                    producer_state_dO_dPsum
+                                ),
+                            )
+                        producer_state_dO_dPsum.advance()
+
+                        # 4) V_high + dO_high → pipeline_dO
+                        pipeline_dO.producer_acquire(
+                            producer_state_dO_dPsum,
+                            extra_tx_count=self.tma_copy_bytes["V"],
+                        )
+                        load_V_high(
+                            tma_bar_ptr=pipeline_dO.producer_get_barrier(producer_state_dO_dPsum)
+                        )
+                        load_dO_high(first_m_block, producer_state=producer_state_dO_dPsum)
+                        pipeline_dO.producer_commit(producer_state_dO_dPsum)
+                        producer_state_dO_dPsum.advance()
+
+                        # 5) dO_low reload (for dV_low)
+                        pipeline_dO.producer_acquire(producer_state_dO_dPsum)
+                        load_dO_low(first_m_block, producer_state=producer_state_dO_dPsum)
+                        pipeline_dO.producer_commit(producer_state_dO_dPsum)
+                        producer_state_dO_dPsum.advance()
+
+                        # 6) Q_low reload (for dK_low + dQ_low)
+                        pipeline_Q.producer_acquire(producer_state_Q_LSE)
+                        load_Q_low(first_m_block, producer_state=producer_state_Q_LSE)
+                        pipeline_Q.producer_commit(producer_state_Q_LSE)
+                        producer_state_Q_LSE.advance()
+
+                        #### Split-D Main Loop ####
+                        for m_block in cutlass.range(m_block_min + 1, m_block_max, unroll=1):
+                            # 1) Q_low
+                            pipeline_Q.producer_acquire(producer_state_Q_LSE)
+                            load_Q_low(m_block, producer_state=producer_state_Q_LSE)
+                            pipeline_Q.producer_commit(producer_state_Q_LSE)
+                            # LSE
+                            pipeline_LSE.producer_acquire(producer_state_Q_LSE)
+                            with cute.arch.elect_one():
+                                copy_stats(
+                                    gLSE[None, m_block],
+                                    sLSE[None, producer_state_Q_LSE.index],
+                                    mbar_ptr=pipeline_LSE.producer_get_barrier(
+                                        producer_state_Q_LSE
+                                    ),
+                                )
+                            producer_state_Q_LSE.advance()
+                            # 2) Q_high
+                            pipeline_Q.producer_acquire(producer_state_Q_LSE)
+                            load_Q_high(m_block, producer_state=producer_state_Q_LSE)
+                            pipeline_Q.producer_commit(producer_state_Q_LSE)
+                            producer_state_Q_LSE.advance()
+                            # 3) V_low + dO_low
+                            pipeline_dO.producer_acquire(
+                                producer_state_dO_dPsum,
+                                extra_tx_count=self.tma_copy_bytes["V"],
+                            )
+                            load_V_low(
+                                tma_bar_ptr=pipeline_dO.producer_get_barrier(
+                                    producer_state_dO_dPsum
+                                )
+                            )
+                            load_dO_low(m_block, producer_state=producer_state_dO_dPsum)
+                            pipeline_dO.producer_commit(producer_state_dO_dPsum)
+                            # dPsum
+                            pipeline_dPsum.producer_acquire(producer_state_dO_dPsum)
+                            with cute.arch.elect_one():
+                                copy_stats(
+                                    gdPsum[None, m_block],
+                                    sdPsum[None, producer_state_dO_dPsum.index],
+                                    mbar_ptr=pipeline_dPsum.producer_get_barrier(
+                                        producer_state_dO_dPsum
+                                    ),
+                                )
+                            producer_state_dO_dPsum.advance()
+                            # 4) V_high + dO_high
+                            pipeline_dO.producer_acquire(
+                                producer_state_dO_dPsum,
+                                extra_tx_count=self.tma_copy_bytes["V"],
+                            )
+                            load_V_high(
+                                tma_bar_ptr=pipeline_dO.producer_get_barrier(
+                                    producer_state_dO_dPsum
+                                )
+                            )
+                            load_dO_high(m_block, producer_state=producer_state_dO_dPsum)
+                            pipeline_dO.producer_commit(producer_state_dO_dPsum)
+                            producer_state_dO_dPsum.advance()
+                            # 5) dO_low reload (for dV_low)
+                            pipeline_dO.producer_acquire(producer_state_dO_dPsum)
+                            load_dO_low(m_block, producer_state=producer_state_dO_dPsum)
+                            pipeline_dO.producer_commit(producer_state_dO_dPsum)
+                            producer_state_dO_dPsum.advance()
+                            # 6) Q_low reload (for dK_low + dQ_low)
+                            pipeline_Q.producer_acquire(producer_state_Q_LSE)
+                            load_Q_low(m_block, producer_state=producer_state_Q_LSE)
+                            pipeline_Q.producer_commit(producer_state_Q_LSE)
+                            producer_state_Q_LSE.advance()
+
                     else:
                         #### Prologue ####
                         if const_expr(should_load_Q):
@@ -2214,6 +2504,7 @@ class FlashAttentionBackwardSm100:
         tStS: cute.Tensor,
         tdPtdP: cute.Tensor,
         tdVtdV: cute.Tensor,
+        tdVtdV_high: cute.Tensor,
         tdKtdK: cute.Tensor,
         tdQtdQ: cute.Tensor,
         dS_cluster_full_mbar_ptr: cute.Pointer,
@@ -2294,6 +2585,18 @@ class FlashAttentionBackwardSm100:
             tA_addr=self.tmem_P_offset,
             cta_group=self.cta_group_size,
         )
+        if const_expr(self.is_split_d):
+            mma_pdo_high_fn = partial(
+                gemm_ptx_w_idx,
+                tiled_mma_dV,
+                tdVtdV_high,
+                tdVrP,
+                tdVrdO,
+                sA=None,
+                sB=sdO,
+                tA_addr=self.tmem_P_offset,
+                cta_group=self.cta_group_size,
+            )
         num_unroll_groups = 2 if const_expr(self.use_2cta_instrs) else 1
         mma_dsk_fn = partial(
             gemm_w_idx,
@@ -2575,6 +2878,127 @@ class FlashAttentionBackwardSm100:
                     producer_phase_dQ ^= 1
 
                     producer_phase_acc ^= 1
+            elif const_expr(self.is_split_d):
+                if is_leader_cta and process_tile:
+                    # ==========================================================
+                    # Split-D MMA: 10 sub-GEMMs per M-block
+                    # TMEM [0,128) is time-shared by S/P and dK/dQ.
+                    # pipeline_dQ empty/full must be paired for each of the 4
+                    # reduce outputs (dK_high, dK_low, dQ_low, dQ_high) so the
+                    # reduce warp reads TMEM before the next write overwrites it.
+                    # ==========================================================
+                    accumulate_dK = False
+                    producer_phase_dQ = Int32(1)
+
+                    main_loop_iters = m_block_max - m_block_min
+
+                    for iter_idx in cutlass.range(main_loop_iters, unroll=1):
+                        # --- Phase 1: S^T (contraction split) ---
+                        # 1a) S_low = K_low @ Q_low^T (zero_init)
+                        handle_Q = pipeline_Q_consumer.wait_and_advance()
+                        pipeline_S_P.sync_object_empty.wait(0, producer_phase_acc)
+                        pipeline_dQ.sync_object_empty.wait(0, producer_phase_dQ)
+                        mma_qk_fn(A_idx=0, B_idx=handle_Q.index, zero_init=True)
+                        handle_Q.release()
+
+                        # 1b) S_high = K_high @ Q_high^T (accumulate)
+                        handle_Q = pipeline_Q_consumer.wait_and_advance()
+                        mma_qk_fn(A_idx=1, B_idx=handle_Q.index, zero_init=False)
+                        pipeline_S_P.sync_object_full.arrive(
+                            0, pipeline_S_P.producer_mask, cta_group
+                        )
+
+                        # --- Phase 2: dP^T (contraction split) ---
+                        # 2a) dP_low = V_low @ dO_low^T (zero_init)
+                        pipeline_dO.consumer_wait(consumer_state_dO)
+                        pipeline_dP.sync_object_empty.wait(0, producer_phase_acc)
+                        mma_dov_fn(B_idx=consumer_state_dO.index, zero_init=True)
+                        pipeline_dO.consumer_release(consumer_state_dO)
+                        consumer_state_dO.advance()
+
+                        # 2b) dP_high = V_high @ dO_high^T (accumulate)
+                        pipeline_dO.consumer_wait(consumer_state_dO)
+                        mma_dov_fn(B_idx=consumer_state_dO.index, zero_init=False)
+                        pipeline_dP.sync_object_full.arrive(
+                            0, pipeline_dP.producer_mask, cta_group
+                        )
+
+                        producer_phase_acc ^= 1
+
+                        # --- Phase 3: dV (output split) ---
+                        # Wait for P ready from compute warps
+                        pipeline_S_P.sync_object_empty.wait(0, producer_phase_acc)
+
+                        # 3a) dV_high += P^T @ dO_high (dO_high still in sdO)
+                        mma_pdo_high_fn(
+                            B_idx=consumer_state_dO.index,
+                            zero_init=(iter_idx == 0),
+                        )
+                        pipeline_dO.consumer_release(consumer_state_dO)
+                        consumer_state_dO.advance()
+
+                        # 3b) dV_low += P^T @ dO_low (reloaded)
+                        pipeline_dO.consumer_wait(consumer_state_dO)
+                        mma_pdo_fn(
+                            B_idx=consumer_state_dO.index,
+                            zero_init=(iter_idx == 0),
+                        )
+                        pipeline_dO.consumer_release(consumer_state_dO)
+                        consumer_state_dO.advance()
+
+                        # --- Phase 4: dK (output split → reduce) ---
+                        # Wait for dS from compute warps
+                        pipeline_dS.consumer_wait(consumer_state_dS)
+
+                        # 4a) dK_high = dS^T @ Q_high (Q_high still from step 1b)
+                        mma_dsq_fn(B_idx=handle_Q.index, zero_init=True)
+                        pipeline_dQ.sync_object_full.arrive(
+                            0, pipeline_dQ.producer_mask, cta_group
+                        )
+                        producer_phase_dQ ^= 1
+                        handle_Q.release()
+
+                        # 4b) dK_low = dS^T @ Q_low (reloaded)
+                        handle_Q = pipeline_Q_consumer.wait_and_advance()
+                        pipeline_dQ.sync_object_empty.wait(0, producer_phase_dQ)
+                        mma_dsq_fn(B_idx=handle_Q.index, zero_init=True)
+                        pipeline_dQ.sync_object_full.arrive(
+                            0, pipeline_dQ.producer_mask, cta_group
+                        )
+                        producer_phase_dQ ^= 1
+
+                        # --- Phase 5: dQ (output split → reduce) ---
+                        # 5a) dQ_low = dS @ K_low
+                        pipeline_dQ.sync_object_empty.wait(0, producer_phase_dQ)
+                        mma_dsk_fn(B_idx=0)
+                        pipeline_dQ.sync_object_full.arrive(
+                            0, pipeline_dQ.producer_mask, cta_group
+                        )
+                        producer_phase_dQ ^= 1
+
+                        # 5b) dQ_high = dS @ K_high
+                        pipeline_dQ.sync_object_empty.wait(0, producer_phase_dQ)
+                        mma_dsk_fn(B_idx=1)
+                        pipeline_dQ.sync_object_full.arrive(
+                            0, pipeline_dQ.producer_mask, cta_group
+                        )
+                        producer_phase_dQ ^= 1
+
+                        handle_Q.release()
+                        pipeline_dS.consumer_release(consumer_state_dS)
+                        consumer_state_dS.advance()
+
+                    # Signal dV_low ready (stage 0) and dV_high ready (stage 1)
+                    pipeline_dKV.sync_object_empty.wait(0, producer_phase_dKV)
+                    pipeline_dKV.sync_object_full.arrive(
+                        0, pipeline_dKV.producer_mask, cta_group
+                    )
+                    pipeline_dKV.sync_object_empty.wait(1, producer_phase_dKV)
+                    pipeline_dKV.sync_object_full.arrive(
+                        1, pipeline_dKV.producer_mask, cta_group
+                    )
+                    producer_phase_dKV ^= 1
+
             else:
                 if is_leader_cta and process_tile:
                     accumulate_dK = False
@@ -2849,6 +3273,7 @@ class FlashAttentionBackwardSm100:
         tiled_copy_r2s_dKV: Optional[cute.TiledCopy],
         mdK_semaphore: Optional[cute.Tensor],
         mdV_semaphore: Optional[cute.Tensor],
+        tdVtdV_high: Optional[cute.Tensor] = None,
         aux_tensors: Optional[list] = None,
         fastdiv_mods=(None, None),
         blocksparse_tensors: Optional[BlockSparseTensors] = None,
@@ -3234,8 +3659,7 @@ class FlashAttentionBackwardSm100:
                 if const_expr(not self.use_smem_dS_for_mma_dK):
                     cute.arch.fence_view_async_tmem_store()
 
-                if const_expr(self.use_2cta_instrs):
-                    # use pipeline_dP to signal tmem store of dS
+                if const_expr(self.use_2cta_instrs or self.is_split_d):
                     with cute.arch.elect_one():
                         pipeline_dP.consumer_release(consumer_state_S_P_dP)
                 consumer_state_S_P_dP.advance()
@@ -3313,46 +3737,89 @@ class FlashAttentionBackwardSm100:
                     )
                 else:
                     thr_copy_r2s_dKV = tiled_copy_r2s_dKV.get_slice(dp_idx)
-                    #### STORE dV
-                    consumer_state_dKV = self.epilogue_dK_or_dV_tma(
-                        dp_idx,
-                        batch_idx,
-                        head_idx,
-                        n_block,
-                        seqlen,
-                        thr_mma_dV,
-                        tdVtdV,
-                        mdV_tma_tensor,
-                        sdV,
-                        tma_atom_dV,
-                        thr_copy_r2s_dKV,
-                        pipeline_dKV,
-                        consumer_state_dKV,
-                        None,  # Don't scale
-                        int(NamedBarrierBwdSm100.EpilogueWG1),  # barrier_id
-                        mdV_semaphore,
-                        "V",
-                    )
-                    #### STORE dK
-                    consumer_state_dKV = self.epilogue_dK_or_dV_tma(
-                        dp_idx,
-                        batch_idx,
-                        head_idx,
-                        n_block,
-                        seqlen,
-                        thr_mma_dK,
-                        tdKtdK,
-                        mdK_tma_tensor,
-                        sdK,
-                        tma_atom_dK,
-                        thr_copy_r2s_dKV,
-                        pipeline_dKV,
-                        consumer_state_dKV,
-                        softmax_scale if const_expr(not self.dKV_postprocess) else None,
-                        int(NamedBarrierBwdSm100.EpilogueWG1),  # barrier_id
-                        mdK_semaphore,
-                        "K",
-                    )
+                    if const_expr(self.is_split_d):
+                        #### STORE dV_low
+                        consumer_state_dKV = self.epilogue_dK_or_dV_tma(
+                            dp_idx,
+                            batch_idx,
+                            head_idx,
+                            n_block,
+                            seqlen,
+                            thr_mma_dV,
+                            tdVtdV,
+                            mdV_tma_tensor,
+                            sdV,
+                            tma_atom_dV,
+                            thr_copy_r2s_dKV,
+                            pipeline_dKV,
+                            consumer_state_dKV,
+                            None,  # Don't scale
+                            int(NamedBarrierBwdSm100.EpilogueWG1),  # barrier_id
+                            mdV_semaphore,
+                            "V",
+                        )
+                        #### STORE dV_high (stage 1 of pipeline_dKV)
+                        consumer_state_dKV = self.epilogue_dK_or_dV_tma(
+                            dp_idx,
+                            batch_idx,
+                            head_idx,
+                            n_block,
+                            seqlen,
+                            thr_mma_dV,
+                            tdVtdV_high,
+                            mdV_tma_tensor,
+                            sdV,
+                            tma_atom_dV,
+                            thr_copy_r2s_dKV,
+                            pipeline_dKV,
+                            consumer_state_dKV,
+                            None,  # Don't scale
+                            int(NamedBarrierBwdSm100.EpilogueWG1),  # barrier_id
+                            mdV_semaphore,
+                            "V",
+                            is_high_half=True,
+                        )
+                    else:
+                        #### STORE dV
+                        consumer_state_dKV = self.epilogue_dK_or_dV_tma(
+                            dp_idx,
+                            batch_idx,
+                            head_idx,
+                            n_block,
+                            seqlen,
+                            thr_mma_dV,
+                            tdVtdV,
+                            mdV_tma_tensor,
+                            sdV,
+                            tma_atom_dV,
+                            thr_copy_r2s_dKV,
+                            pipeline_dKV,
+                            consumer_state_dKV,
+                            None,  # Don't scale
+                            int(NamedBarrierBwdSm100.EpilogueWG1),  # barrier_id
+                            mdV_semaphore,
+                            "V",
+                        )
+                        #### STORE dK
+                        consumer_state_dKV = self.epilogue_dK_or_dV_tma(
+                            dp_idx,
+                            batch_idx,
+                            head_idx,
+                            n_block,
+                            seqlen,
+                            thr_mma_dK,
+                            tdKtdK,
+                            mdK_tma_tensor,
+                            sdK,
+                            tma_atom_dK,
+                            thr_copy_r2s_dKV,
+                            pipeline_dKV,
+                            consumer_state_dKV,
+                            softmax_scale if const_expr(not self.dKV_postprocess) else None,
+                            int(NamedBarrierBwdSm100.EpilogueWG1),  # barrier_id
+                            mdK_semaphore,
+                            "K",
+                        )
             # Zero dK/dV for empty tiles (local attention or block sparsity)
             # When total_m_block_cnt == 0 for block sparsity, no Q tiles contribute to this KV tile
             if const_expr(not self.dKV_postprocess):
@@ -3427,6 +3894,7 @@ class FlashAttentionBackwardSm100:
         TileSchedulerCls: Callable,
         mdQ_semaphore: Optional[cute.Tensor],
         blocksparse_tensors: Optional[BlockSparseTensors] = None,
+        mdK: Optional[cute.Tensor] = None,
     ):
         num_reduce_threads = cute.arch.WARP_SIZE * len(self.reduce_warp_ids)
         tidx = cute.arch.thread_idx()[0] % num_reduce_threads
@@ -3472,17 +3940,79 @@ class FlashAttentionBackwardSm100:
             n_block_cta_group = n_block // self.cta_group_size  # for 2cta
             seqlen = SeqlenInfoCls(batch_idx)
             m_block_min, m_block_max = block_info.get_m_block_min_max(seqlen, n_block_cta_group)
-            if const_expr(not seqlen.has_cu_seqlens_q):
-                mdQaccum_cur = mdQaccum[None, head_idx, batch_idx]
-            else:
-                mdQaccum_cur = cute.domain_offset(
-                    (seqlen.padded_offset_q * self.tile_hdim,), mdQaccum[None, head_idx]
+
+            if const_expr(self.is_split_d):
+                # Split-D: tile dQ and dK accum as two contiguous halves (low, high)
+                # Buffer layout: [all_low_half, all_high_half], each seqlen*half_hdim
+                half_hdim = self.half_hdim
+                if const_expr(not seqlen.has_cu_seqlens_q):
+                    mdQaccum_low_cur = mdQaccum[None, head_idx, batch_idx]
+                    dQ_half_offset = cute.size(mdQaccum_low_cur) // 2
+                    mdQaccum_high_cur = cute.domain_offset(
+                        (dQ_half_offset,), mdQaccum_low_cur
+                    )
+                else:
+                    mdQaccum_base = mdQaccum[None, head_idx]
+                    dQ_total_half = cute.size(mdQaccum_base) // 2
+                    mdQaccum_low_cur = cute.domain_offset(
+                        (seqlen.padded_offset_q * half_hdim,), mdQaccum_base
+                    )
+                    mdQaccum_high_cur = cute.domain_offset(
+                        (dQ_total_half + seqlen.padded_offset_q * half_hdim,), mdQaccum_base
+                    )
+                gdQaccum_low_ = cute.local_tile(
+                    mdQaccum_low_cur, (self.tile_m * half_hdim,), (None,)
                 )
-            gdQaccum_ = cute.local_tile(mdQaccum_cur, (self.tile_m * self.tile_hdim,), (None,))
-            # (M * K / STAGE, STAGE, _)
-            gdQaccum = cute.flat_divide(
-                gdQaccum_, (self.tile_m * self.tile_hdim // self.dQaccum_reduce_stage,)
-            )
+                gdQaccum_low = cute.flat_divide(
+                    gdQaccum_low_, (self.tile_m * self.dQ_reduce_ncol,)
+                )
+                gdQaccum_high_ = cute.local_tile(
+                    mdQaccum_high_cur, (self.tile_m * half_hdim,), (None,)
+                )
+                gdQaccum_high = cute.flat_divide(
+                    gdQaccum_high_, (self.tile_m * self.dQ_reduce_ncol,)
+                )
+                # dK accum tiling
+                head_idx_kv = head_idx // self.qhead_per_kvhead
+                if const_expr(not seqlen.has_cu_seqlens_k):
+                    mdKaccum_low_cur = mdK[None, head_idx_kv, batch_idx]
+                    dK_half_offset = cute.size(mdKaccum_low_cur) // 2
+                    mdKaccum_high_cur = cute.domain_offset(
+                        (dK_half_offset,), mdKaccum_low_cur
+                    )
+                else:
+                    mdKaccum_base = mdK[None, head_idx_kv]
+                    dK_total_half = cute.size(mdKaccum_base) // 2
+                    mdKaccum_low_cur = cute.domain_offset(
+                        (seqlen.padded_offset_k * half_hdim,), mdKaccum_base
+                    )
+                    mdKaccum_high_cur = cute.domain_offset(
+                        (dK_total_half + seqlen.padded_offset_k * half_hdim,), mdKaccum_base
+                    )
+                gdKaccum_low_ = cute.local_tile(
+                    mdKaccum_low_cur, (self.tile_n * half_hdim,), (None,)
+                )
+                gdKaccum_low = cute.flat_divide(
+                    gdKaccum_low_, (self.tile_n * self.dK_reduce_ncol,)
+                )
+                gdKaccum_high_ = cute.local_tile(
+                    mdKaccum_high_cur, (self.tile_n * half_hdim,), (None,)
+                )
+                gdKaccum_high = cute.flat_divide(
+                    gdKaccum_high_, (self.tile_n * self.dK_reduce_ncol,)
+                )
+            else:
+                if const_expr(not seqlen.has_cu_seqlens_q):
+                    mdQaccum_cur = mdQaccum[None, head_idx, batch_idx]
+                else:
+                    mdQaccum_cur = cute.domain_offset(
+                        (seqlen.padded_offset_q * self.tile_hdim,), mdQaccum[None, head_idx]
+                    )
+                gdQaccum_ = cute.local_tile(mdQaccum_cur, (self.tile_m * self.tile_hdim,), (None,))
+                # (M * K / STAGE, STAGE, _)
+                gdQaccum = cute.flat_divide(
+                    gdQaccum_, (self.tile_m * self.tile_hdim // self.dQaccum_reduce_stage,)
+                )
 
             if const_expr(self.deterministic):
                 mdQ_semaphore_cur = mdQ_semaphore[None, None, head_idx, batch_idx]
@@ -3514,6 +4044,11 @@ class FlashAttentionBackwardSm100:
                 )
                 loop_count = m_block_max - m_block_min
 
+            if const_expr(self.is_split_d):
+                hdim_for_reduce_shape = self.half_hdim
+            else:
+                hdim_for_reduce_shape = self.tile_hdim
+
             # dQacc_reduce mainloop
             # Block sparsity: iterate over sparse m_block count and derive actual m_block
             # from Q_IDX/FULL_Q_IDX tensors. Dense: iterate m_block_min..m_block_max directly.
@@ -3532,98 +4067,198 @@ class FlashAttentionBackwardSm100:
                         m_block = cutlass.min(m_block, m_block_max - 1)
                 else:
                     m_block = m_block_min + iter_idx
-                pipeline_dQ.consumer_wait(dQ_consumer_state)
-                # TMEM -> RMEM
-                tdQrdQ_t2r = cute.make_fragment(tdQrdQ_t2r_shape, Float32)
-                cute.copy(thr_copy_t2r, tdQtdQ_t2r, tdQrdQ_t2r)
-                cute.arch.fence_view_async_tmem_load()
-                cute.arch.sync_warp()
-                with cute.arch.elect_one():
-                    pipeline_dQ.consumer_release(dQ_consumer_state)
-                dQ_consumer_state.advance()
 
-                gdQaccum_cur = gdQaccum[None, None, m_block]
+                if const_expr(self.is_split_d):
+                    # Split-D: 4 reduces per M-block
+                    # Order: dK_high(0), dK_low(1), dQ_low(2), dQ_high(3)
+                    gdKaccum_high_n = gdKaccum_high[None, None, n_block_cta_group]
+                    gdKaccum_low_n = gdKaccum_low[None, None, n_block_cta_group]
+                    gdQaccum_low_m = gdQaccum_low[None, None, m_block]
+                    gdQaccum_high_m = gdQaccum_high[None, None, m_block]
 
-                tdQrdQ_shape = (
-                    self.dQ_reduce_ncol,
-                    self.tile_hdim // self.cta_group_size // self.dQ_reduce_ncol,
-                )
-                tdQrdQ = cute.make_tensor(tdQrdQ_t2r.iterator, tdQrdQ_shape)
+                    for reduce_idx in cutlass.range_constexpr(4):
+                        pipeline_dQ.consumer_wait(dQ_consumer_state)
+                        tdQrdQ_t2r = cute.make_fragment(tdQrdQ_t2r_shape, Float32)
+                        cute.copy(thr_copy_t2r, tdQtdQ_t2r, tdQrdQ_t2r)
+                        cute.arch.fence_view_async_tmem_load()
+                        cute.arch.sync_warp()
+                        with cute.arch.elect_one():
+                            pipeline_dQ.consumer_release(dQ_consumer_state)
+                        dQ_consumer_state.advance()
 
-                for stage in cutlass.range_constexpr(cute.size(tdQrdQ, mode=[1])):
-                    smem_idx = dQ_tma_store_producer_state.index
-                    tdQsdQ_r2s = tdQsdQ[None, None, smem_idx]
-                    tdQrdQ_r2s = cute.make_tensor(tdQrdQ[None, stage].iterator, tdQsdQ_r2s.shape)
-                    cute.copy(thr_copy_dQaccum_r2s, tdQrdQ_r2s, tdQsdQ_r2s)
-                    # Fence and barrier to make sure shared memory store is visible to TMA store
-                    cute.arch.fence_view_async_shared()
-                    # semaphore acquire
-                    if const_expr(self.deterministic and stage == 0):
-                        if const_expr(self.spt):
-                            _, n_block_max_for_m_block = block_info.get_n_block_min_max(
-                                seqlen, m_block
-                            )
-                            lock_value = n_block_max_for_m_block - 1 - n_block_cta_group
+                        if const_expr(reduce_idx == 0):
+                            gdAccum_cur = gdKaccum_high_n
+                            cur_tma_bytes = self.tma_copy_bytes["dKacc"]
+                        elif const_expr(reduce_idx == 1):
+                            gdAccum_cur = gdKaccum_low_n
+                            cur_tma_bytes = self.tma_copy_bytes["dKacc"]
+                        elif const_expr(reduce_idx == 2):
+                            gdAccum_cur = gdQaccum_low_m
+                            cur_tma_bytes = self.tma_copy_bytes["dQ"]
                         else:
-                            lock_value = n_block_cta_group
-                        barrier.wait_eq(
-                            mdQ_semaphore_cur[(m_block, None)].iterator,
+                            gdAccum_cur = gdQaccum_high_m
+                            cur_tma_bytes = self.tma_copy_bytes["dQ"]
+
+                        tdQrdQ_shape = (
+                            self.dQ_reduce_ncol,
+                            hdim_for_reduce_shape // self.cta_group_size // self.dQ_reduce_ncol,
+                        )
+                        tdQrdQ = cute.make_tensor(tdQrdQ_t2r.iterator, tdQrdQ_shape)
+
+                        for stage in cutlass.range_constexpr(cute.size(tdQrdQ, mode=[1])):
+                            smem_idx = dQ_tma_store_producer_state.index
+                            tdQsdQ_r2s = tdQsdQ[None, None, smem_idx]
+                            tdQrdQ_r2s = cute.make_tensor(
+                                tdQrdQ[None, stage].iterator, tdQsdQ_r2s.shape
+                            )
+                            cute.copy(thr_copy_dQaccum_r2s, tdQrdQ_r2s, tdQsdQ_r2s)
+                            cute.arch.fence_view_async_shared()
+                            # Deterministic semaphore acquire: first dQ half (reduce_idx==2), stage 0
+                            if const_expr(self.deterministic and reduce_idx == 2 and stage == 0):
+                                if const_expr(self.spt):
+                                    _, n_block_max_for_m_block = block_info.get_n_block_min_max(
+                                        seqlen, m_block
+                                    )
+                                    lock_value = n_block_max_for_m_block - 1 - n_block_cta_group
+                                else:
+                                    lock_value = n_block_cta_group
+                                barrier.wait_eq(
+                                    mdQ_semaphore_cur[(m_block, None)].iterator,
+                                    tidx,
+                                    cta_rank_in_cluster,
+                                    lock_value,
+                                )
+                            self.reduce_sync_barrier.arrive_and_wait()
+                            if is_tma_warp:
+                                with cute.arch.elect_one():
+                                    copy_utils.cpasync_reduce_bulk_add_f32(
+                                        sdQaccum[None, smem_idx].iterator,
+                                        gdAccum_cur[None, stage + stage_offset].iterator,
+                                        cur_tma_bytes // 1,
+                                    )
+                                cute.arch.cp_async_bulk_commit_group()
+                                cute.arch.cp_async_bulk_wait_group(
+                                    self.sdQaccum_stage - 1, read=read_flag
+                                )
+                            self.reduce_sync_barrier.arrive_and_wait()
+                            dQ_tma_store_producer_state.advance()
+                            # Deterministic semaphore release for prior m_block
+                            if const_expr(
+                                self.deterministic
+                                and reduce_idx == 2
+                                and stage == 0
+                                and delay_semaphore_release
+                            ):
+                                if m_block > m_block_min:
+                                    barrier.arrive_inc(
+                                        mdQ_semaphore_cur[(m_block - 1, None)].iterator,
+                                        tidx,
+                                        cta_rank_in_cluster,
+                                        1,
+                                    )
+
+                    # Deterministic semaphore release (non-delayed, Split-D)
+                    if const_expr(self.deterministic and not delay_semaphore_release):
+                        if is_tma_warp:
+                            cute.arch.cp_async_bulk_wait_group(0, read=read_flag)
+                        self.reduce_sync_barrier.arrive_and_wait()
+                        barrier.arrive_inc(
+                            mdQ_semaphore_cur[m_block, None].iterator,
                             tidx,
                             cta_rank_in_cluster,
-                            lock_value,
+                            1,
                         )
-                    self.reduce_sync_barrier.arrive_and_wait()
-                    # Copy from shared memory to global memory
-                    if is_tma_warp:
-                        with cute.arch.elect_one():
-                            copy_utils.cpasync_reduce_bulk_add_f32(
-                                sdQaccum[None, smem_idx].iterator,
-                                gdQaccum_cur[None, stage + stage_offset].iterator,
-                                self.tma_copy_bytes["dQ"] // 1,
-                            )
-                        cute.arch.cp_async_bulk_commit_group()
-                        cute.arch.cp_async_bulk_wait_group(self.sdQaccum_stage - 1, read=read_flag)
-                    self.reduce_sync_barrier.arrive_and_wait()
-                    dQ_tma_store_producer_state.advance()
-                    # Directly add to gmem, much slower
-                    # tdQgdQ = thr_copy_dQaccum_r2s.partition_D(gdQaccum[None, stage, m_block])
-                    # assert cute.size(tdQrdQ_r2s) == cute.size(tdQgdQ)
-                    # for i in cutlass.range(cute.size(tdQrdQ_r2s) // 4, unroll_full=True):
-                    #     copy_utils.atomic_add_fp32x4(
-                    #         tdQrdQ_r2s[4 * i],
-                    #         tdQrdQ_r2s[4 * i + 1],
-                    #         tdQrdQ_r2s[4 * i + 2],
-                    #         tdQrdQ_r2s[4 * i + 3],
-                    #         utils.elem_pointer(tdQgdQ, 4 * i),
-                    #     )
-                    # semaphore release for prior m_block
-                    if const_expr(self.deterministic and stage == 0 and delay_semaphore_release):
-                        if m_block > m_block_min:
-                            barrier.arrive_inc(
-                                mdQ_semaphore_cur[(m_block - 1, None)].iterator,
+
+                else:
+                    # Non-Split-D: single reduce per M-block
+                    pipeline_dQ.consumer_wait(dQ_consumer_state)
+                    # TMEM -> RMEM
+                    tdQrdQ_t2r = cute.make_fragment(tdQrdQ_t2r_shape, Float32)
+                    cute.copy(thr_copy_t2r, tdQtdQ_t2r, tdQrdQ_t2r)
+                    cute.arch.fence_view_async_tmem_load()
+                    cute.arch.sync_warp()
+                    with cute.arch.elect_one():
+                        pipeline_dQ.consumer_release(dQ_consumer_state)
+                    dQ_consumer_state.advance()
+
+                    gdQaccum_cur = gdQaccum[None, None, m_block]
+
+                    tdQrdQ_shape = (
+                        self.dQ_reduce_ncol,
+                        hdim_for_reduce_shape // self.cta_group_size // self.dQ_reduce_ncol,
+                    )
+                    tdQrdQ = cute.make_tensor(tdQrdQ_t2r.iterator, tdQrdQ_shape)
+
+                    for stage in cutlass.range_constexpr(cute.size(tdQrdQ, mode=[1])):
+                        smem_idx = dQ_tma_store_producer_state.index
+                        tdQsdQ_r2s = tdQsdQ[None, None, smem_idx]
+                        tdQrdQ_r2s = cute.make_tensor(
+                            tdQrdQ[None, stage].iterator, tdQsdQ_r2s.shape
+                        )
+                        cute.copy(thr_copy_dQaccum_r2s, tdQrdQ_r2s, tdQsdQ_r2s)
+                        # Fence and barrier to make sure shared memory store is visible to TMA store
+                        cute.arch.fence_view_async_shared()
+                        # semaphore acquire
+                        if const_expr(self.deterministic and stage == 0):
+                            if const_expr(self.spt):
+                                _, n_block_max_for_m_block = block_info.get_n_block_min_max(
+                                    seqlen, m_block
+                                )
+                                lock_value = n_block_max_for_m_block - 1 - n_block_cta_group
+                            else:
+                                lock_value = n_block_cta_group
+                            barrier.wait_eq(
+                                mdQ_semaphore_cur[(m_block, None)].iterator,
                                 tidx,
                                 cta_rank_in_cluster,
-                                1,
+                                lock_value,
                             )
-
-                if const_expr(self.tile_hdim == 192):
-                    if const_expr(self.sdQaccum_stage > 1):
-                        if is_tma_warp:
-                            cute.arch.cp_async_bulk_wait_group(0, read=read_flag)
                         self.reduce_sync_barrier.arrive_and_wait()
-                    with cute.arch.elect_one():
-                        cute.arch.mbarrier_arrive(dQaccum_empty_mbar_ptr)
-
-                # semaphore release
-                # NOTE: arrive_inc calls red_release which issues membar
-                if const_expr(self.deterministic and not delay_semaphore_release):
-                    if const_expr(self.sdQaccum_stage > 1 and not self.tile_hdim == 192):
+                        # Copy from shared memory to global memory
                         if is_tma_warp:
-                            cute.arch.cp_async_bulk_wait_group(0, read=read_flag)
+                            with cute.arch.elect_one():
+                                copy_utils.cpasync_reduce_bulk_add_f32(
+                                    sdQaccum[None, smem_idx].iterator,
+                                    gdQaccum_cur[None, stage + stage_offset].iterator,
+                                    self.tma_copy_bytes["dQ"] // 1,
+                                )
+                            cute.arch.cp_async_bulk_commit_group()
+                            cute.arch.cp_async_bulk_wait_group(
+                                self.sdQaccum_stage - 1, read=read_flag
+                            )
                         self.reduce_sync_barrier.arrive_and_wait()
-                    barrier.arrive_inc(
-                        mdQ_semaphore_cur[m_block, None].iterator, tidx, cta_rank_in_cluster, 1
-                    )
+                        dQ_tma_store_producer_state.advance()
+                        # semaphore release for prior m_block
+                        if const_expr(self.deterministic and stage == 0 and delay_semaphore_release):
+                            if m_block > m_block_min:
+                                barrier.arrive_inc(
+                                    mdQ_semaphore_cur[(m_block - 1, None)].iterator,
+                                    tidx,
+                                    cta_rank_in_cluster,
+                                    1,
+                                )
+
+                    if const_expr(self.tile_hdim == 192):
+                        if const_expr(self.sdQaccum_stage > 1):
+                            if is_tma_warp:
+                                cute.arch.cp_async_bulk_wait_group(0, read=read_flag)
+                            self.reduce_sync_barrier.arrive_and_wait()
+                        with cute.arch.elect_one():
+                            cute.arch.mbarrier_arrive(dQaccum_empty_mbar_ptr)
+
+                    # semaphore release
+                    # NOTE: arrive_inc calls red_release which issues membar
+                    if const_expr(self.deterministic and not delay_semaphore_release):
+                        if const_expr(self.sdQaccum_stage > 1 and not self.tile_hdim == 192):
+                            if is_tma_warp:
+                                cute.arch.cp_async_bulk_wait_group(0, read=read_flag)
+                            self.reduce_sync_barrier.arrive_and_wait()
+                        barrier.arrive_inc(
+                            mdQ_semaphore_cur[m_block, None].iterator,
+                            tidx,
+                            cta_rank_in_cluster,
+                            1,
+                        )
 
             if process_tile:
                 if is_tma_warp:
@@ -3810,9 +4445,13 @@ class FlashAttentionBackwardSm100:
         barrier_id: Int32,
         mdKV_semaphore: Optional[cute.Tensor],
         K_or_V: cutlass.Constexpr[str],
+        is_high_half: cutlass.Constexpr[bool] = False,
     ) -> cutlass.pipeline.PipelineState:
         assert K_or_V in ("K", "V")
-        tile_hdim = self.tile_hdim if const_expr(K_or_V == "K") else self.tile_hdimv
+        if const_expr(self.is_split_d):
+            tile_hdim = self.half_hdim if const_expr(K_or_V == "K") else self.half_hdimv
+        else:
+            tile_hdim = self.tile_hdim if const_expr(K_or_V == "K") else self.tile_hdimv
         dtype = self.dk_dtype if const_expr(K_or_V == "K") else self.dv_dtype
         epi_tile = self.sdK_epi_tile if const_expr(K_or_V == "K") else self.sdV_epi_tile
         flat_epi_tile = (
@@ -3852,15 +4491,19 @@ class FlashAttentionBackwardSm100:
                 mdKV_cur = cute.domain_offset(
                     (seqlen.padded_offset_k * tile_hdim,), mdKV[None, head_idx_kv]
                 )
+            if const_expr(is_high_half):
+                dKV_half_offset = cute.size(mdKV_cur) // 2
+                mdKV_cur = cute.domain_offset((dKV_half_offset,), mdKV_cur)
             gdKV_p = cute.local_tile(
                 mdKV_cur, (self.tile_n * tile_hdim,), (n_block,)
             )  # (tile_n * hdim)
             gdKV = cute.logical_divide(gdKV_p, (self.tile_n * tile_hdim // num_wg,))[
                 ((None, wg_idx),)
             ]  # (tile_n * hdim / 2)
+            postprocess_epi_tile = self.tile_n * self.dK_reduce_ncol
             gdKV_epi = cute.flat_divide(
-                gdKV, (flat_epi_tile,)
-            )  # (tile_n * hdim / 2 / epi_stage, epi_stage)
+                gdKV, (postprocess_epi_tile,)
+            )  # (tile_n * dK_reduce_ncol, epi_stages)
 
         deterministic_KV = self.deterministic and self.qhead_per_kvhead > 1
         if const_expr(deterministic_KV):
@@ -3882,9 +4525,7 @@ class FlashAttentionBackwardSm100:
             else:
                 assert num_epi_stages == self.num_epi_stages_v, "Epi stage calculation is wrong (V)"
         else:
-            num_epi_stages = (
-                self.num_epi_stages if const_expr(K_or_V == "K") else self.num_epi_stages_v
-            )
+            num_epi_stages = (tile_hdim // num_wg) // self.dK_reduce_ncol
 
         tmem_load_atom = cute.make_copy_atom(
             tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(self.dK_reduce_ncol)), Float32
@@ -3894,8 +4535,9 @@ class FlashAttentionBackwardSm100:
 
         pipeline_dKV.consumer_wait(consumer_state_dKV)
 
-        # semaphore acquire
-        if const_expr(deterministic_KV):
+        # semaphore acquire — for Split-D, only on the first half (low) since both
+        # halves share one semaphore slot per Q-head ordering
+        if const_expr(deterministic_KV and not is_high_half):
             barrier.wait_eq(
                 mdKV_semaphore_cur.iterator, tidx, wg_idx, head_idx % self.qhead_per_kvhead
             )
@@ -3952,7 +4594,7 @@ class FlashAttentionBackwardSm100:
                             gdKV_epi[None, epi_stage].iterator,
                             self.tma_copy_bytes["dKacc"],
                         )
-                if const_expr(epi_stage < num_epi_stages - 1):
+                if const_expr(epi_stage < num_epi_stages - 1 or self.is_split_d):
                     cute.arch.cp_async_bulk_commit_group()
                     cute.arch.cp_async_bulk_wait_group(0, read=read_flag)
                 cute.arch.barrier_arrive(
@@ -3965,9 +4607,9 @@ class FlashAttentionBackwardSm100:
                 barrier_id=barrier_id + wg_idx, number_of_threads=128 + cute.arch.WARP_SIZE
             )
 
-        # semaphore release
-        # NOTE: arrive_inc calls red_release which issues membar
-        if const_expr(deterministic_KV):
+        # semaphore release — for Split-D, only on the last half (high) so the
+        # semaphore increments exactly once per Q-head, matching non-split-d behavior
+        if const_expr(deterministic_KV and (is_high_half or not self.is_split_d)):
             if leader_warp:
                 cute.arch.cp_async_bulk_commit_group()
                 cute.arch.cp_async_bulk_wait_group(0, read=read_flag)

--- a/flash_attn/cute/flash_fwd_sm100.py
+++ b/flash_attn/cute/flash_fwd_sm100.py
@@ -114,6 +114,7 @@ class FlashAttentionForwardSm100:
         is_varlen_q: bool = False,
         use_2cta_instrs: bool = False,
         use_clc_scheduler: bool = False,
+        is_split_d: bool = False,
     ):
         self.use_tma_KV = not paged_kv_non_tma
         # self.dtype = dtype
@@ -126,6 +127,19 @@ class FlashAttentionForwardSm100:
         self.same_hdim_kv_padded = self.head_dim_padded == self.head_dim_v_padded
         self.check_hdim_oob = head_dim != self.head_dim_padded
         self.check_hdim_v_oob = head_dim_v != self.head_dim_v_padded
+
+        self.is_split_d = is_split_d
+        if self.is_split_d:
+            assert self.head_dim_padded == 256 and self.head_dim_v_padded == 256
+            self.half_head_dim = self.head_dim_padded // 2
+            self.half_head_dim_v = self.head_dim_v_padded // 2
+            q_stage = 1
+            use_2cta_instrs = False
+            is_persistent = False
+            pack_gqa = False
+            assert not paged_kv_non_tma, "Paged KV not supported with Split-D"
+            assert not is_split_kv, "SplitKV not supported with Split-D"
+
         self.m_block_size = m_block_size
         self.n_block_size = n_block_size
         self.q_stage = q_stage
@@ -143,11 +157,16 @@ class FlashAttentionForwardSm100:
 
         self.cta_group_size = 2 if self.use_2cta_instrs else 1
         # cta_tiler M includes only 1 CTA, the scheduler will take into account the cluster shape
-        self.cta_tiler = (self.q_stage * m_block_size, n_block_size, self.head_dim_padded)
-        # With 2CTA, the MMA tiler M covers both CTAs, so it's cta_group_size * m_block_size.
-        # Each CTA owns m_block_size rows; the 2CTA MMA instruction spans both.
-        self.mma_tiler_qk = (self.cta_group_size * m_block_size, n_block_size, self.head_dim_padded)
-        self.mma_tiler_pv = (self.cta_group_size * m_block_size, self.head_dim_v_padded, n_block_size)
+        if self.is_split_d:
+            self.cta_tiler = (self.q_stage * m_block_size, n_block_size, self.half_head_dim)
+            self.mma_tiler_qk = (m_block_size, n_block_size, self.half_head_dim)
+            self.mma_tiler_pv = (m_block_size, self.half_head_dim_v, n_block_size)
+        else:
+            self.cta_tiler = (self.q_stage * m_block_size, n_block_size, self.head_dim_padded)
+            # With 2CTA, the MMA tiler M covers both CTAs, so it's cta_group_size * m_block_size.
+            # Each CTA owns m_block_size rows; the 2CTA MMA instruction spans both.
+            self.mma_tiler_qk = (self.cta_group_size * m_block_size, n_block_size, self.head_dim_padded)
+            self.mma_tiler_pv = (self.cta_group_size * m_block_size, self.head_dim_v_padded, n_block_size)
         self.qk_acc_dtype = Float32
         self.pv_acc_dtype = Float32
         self.cluster_shape_mn = (2, 1) if self.use_2cta_instrs else (1, 1)
@@ -178,7 +197,8 @@ class FlashAttentionForwardSm100:
         self.s0_s1_barrier = False
         self.overlap_sO_sQ = (
             (self.head_dim_padded == 192 and self.head_dim_v_padded >= 64) or
-            (self.head_dim_v_padded >= 128 and self.is_split_kv)
+            (self.head_dim_v_padded >= 128 and self.is_split_kv) or
+            self.is_split_d
         )
         if self.overlap_sO_sQ:
             self.is_persistent = False
@@ -255,17 +275,30 @@ class FlashAttentionForwardSm100:
 
         self.clc_scheduler_warp_id = self.empty_warp_ids[0] if self.use_clc_scheduler else None
 
-        self.tmem_s_offset = [0, self.n_block_size]  # e.g., 0, 128
-        self.tmem_o_offset = [
-            self.tmem_s_offset[-1] + self.n_block_size + i * self.head_dim_v_padded
-            for i in range(self.q_stage)
-        ]  # e.g., 256, 384
-        self.tmem_total = self.tmem_o_offset[-1] + self.head_dim_v_padded
-        assert self.tmem_total <= self.tmem_alloc_cols
-        self.tmem_s_to_p_offset = self.n_block_size // 2
-        self.tmem_p_offset = [
-            self.tmem_s_offset[i] + self.tmem_s_to_p_offset for i in range(2)
-        ]  # 0, 128
+        if self.is_split_d:
+            # Split-D TMEM layout: S0[0,128) + S1/P[128,256) + O_low[256,384) + O_high[384,512)
+            self.tmem_s_offset = [0, self.n_block_size]  # [0, 128]
+            self.tmem_o_low_offset = 2 * self.n_block_size  # 256
+            self.tmem_o_high_offset = 2 * self.n_block_size + self.half_head_dim_v  # 384
+            self.tmem_o_offset = [self.tmem_o_low_offset]  # q_stage=1, only one entry
+            self.tmem_total = self.tmem_o_high_offset + self.half_head_dim_v  # 512
+            assert self.tmem_total <= self.tmem_alloc_cols
+            self.tmem_s_to_p_offset = self.n_block_size // 2
+            self.tmem_p_offset = [
+                self.tmem_s_offset[i] + self.tmem_s_to_p_offset for i in range(2)
+            ]
+        else:
+            self.tmem_s_offset = [0, self.n_block_size]  # e.g., 0, 128
+            self.tmem_o_offset = [
+                self.tmem_s_offset[-1] + self.n_block_size + i * self.head_dim_v_padded
+                for i in range(self.q_stage)
+            ]  # e.g., 256, 384
+            self.tmem_total = self.tmem_o_offset[-1] + self.head_dim_v_padded
+            assert self.tmem_total <= self.tmem_alloc_cols
+            self.tmem_s_to_p_offset = self.n_block_size // 2
+            self.tmem_p_offset = [
+                self.tmem_s_offset[i] + self.tmem_s_to_p_offset for i in range(2)
+            ]  # 0, 128
 
         # vec buffer for row_max & row_sum
         self.tmem_vec_offset = self.tmem_s_offset
@@ -303,35 +336,42 @@ class FlashAttentionForwardSm100:
         - Configures pipeline stages for softmax, correction, and epilogue operations
         """
 
-        smem_size_q = self.q_stage * self.m_block_size * self.head_dim_padded * self.q_dtype.width // 8
-        smem_size_o = self.q_stage * self.m_block_size * self.head_dim_v_padded * self.o_dtype.width // 8
-        smem_size_q_o = smem_size_q + smem_size_o if not self.overlap_sO_sQ else max(smem_size_q, smem_size_o)
-        smem_size_k_per_stage = self.n_block_size * self.head_dim_padded * self.k_dtype.width // 8
-        smem_size_v_per_stage = self.n_block_size * self.head_dim_v_padded * self.v_dtype.width // 8
-        smem_size_kv_per_stage = max(smem_size_k_per_stage, smem_size_v_per_stage) // self.cta_group_size
-        kv_stage = (224 * 1024 - smem_size_q_o) // smem_size_kv_per_stage
-        if self.head_dim_padded == 192 and self.head_dim_v_padded == 128 and kv_stage == 2:
-            # For hdim 192,128, we can fit 3 stages if we use uneven_kv_smem
-             kv_stage = 3
-        self.kv_stage = kv_stage
-        # print("kv_stage", self.kv_stage)
-        self.s_stage = 2
-        assert self.s_stage >= self.q_stage
-        # For hdim 192,128 1CTA, we don't have enough smem to store all 3 stages of KV:
-        # 128 x 192 x 2 bytes x 3 stages = 144KB, and we need 96KB for Q.
-        # Instead we store smem as [smem_large, smem_small, smem_large], where smem_large is
-        # 128 x 192 and smem_small is 128 x 128. We set the stride between the stages to be
-        # 128 * 160, so that indexing the 0th and 2nd stages will get the right address,
-        # but for the 1st stage we need to add or subtract (depending on phase) 128 x 64.
-        self.uneven_kv_smem = (
-            self.head_dim_padded == 192 and self.head_dim_v_padded == 128 and self.kv_stage == 3
-        )
-        self.uneven_kv_smem_offset = (
-            self.n_block_size * (self.head_dim_padded - self.head_dim_v_padded) // 2
-            if self.uneven_kv_smem
-            else 0
-        )
-        assert self.uneven_kv_smem_offset % 1024 == 0
+        if self.is_split_d:
+            # Split-D: sQ has 2 physical stages (Q_low, Q_high) but q_stage=1
+            # sO has full head_dim_v_padded=256
+            self.q_smem_stages = 2
+            smem_size_q = self.q_smem_stages * self.m_block_size * self.half_head_dim * self.q_dtype.width // 8
+            smem_size_o = self.m_block_size * self.head_dim_v_padded * self.o_dtype.width // 8
+            smem_size_q_o = max(smem_size_q, smem_size_o)  # overlap_sO_sQ=True
+            smem_size_kv_per_stage = self.n_block_size * self.half_head_dim * self.k_dtype.width // 8
+            kv_stage = (224 * 1024 - smem_size_q_o) // smem_size_kv_per_stage
+            self.kv_stage = kv_stage
+            self.s_stage = 2
+            self.uneven_kv_smem = False
+            self.uneven_kv_smem_offset = 0
+        else:
+            self.q_smem_stages = self.q_stage
+            smem_size_q = self.q_stage * self.m_block_size * self.head_dim_padded * self.q_dtype.width // 8
+            smem_size_o = self.q_stage * self.m_block_size * self.head_dim_v_padded * self.o_dtype.width // 8
+            smem_size_q_o = smem_size_q + smem_size_o if not self.overlap_sO_sQ else max(smem_size_q, smem_size_o)
+            smem_size_k_per_stage = self.n_block_size * self.head_dim_padded * self.k_dtype.width // 8
+            smem_size_v_per_stage = self.n_block_size * self.head_dim_v_padded * self.v_dtype.width // 8
+            smem_size_kv_per_stage = max(smem_size_k_per_stage, smem_size_v_per_stage) // self.cta_group_size
+            kv_stage = (224 * 1024 - smem_size_q_o) // smem_size_kv_per_stage
+            if self.head_dim_padded == 192 and self.head_dim_v_padded == 128 and kv_stage == 2:
+                kv_stage = 3
+            self.kv_stage = kv_stage
+            self.s_stage = 2
+            assert self.s_stage >= self.q_stage
+            self.uneven_kv_smem = (
+                self.head_dim_padded == 192 and self.head_dim_v_padded == 128 and self.kv_stage == 3
+            )
+            self.uneven_kv_smem_offset = (
+                self.n_block_size * (self.head_dim_padded - self.head_dim_v_padded) // 2
+                if self.uneven_kv_smem
+                else 0
+            )
+            assert self.uneven_kv_smem_offset % 1024 == 0
 
     @cute.jit
     def __call__(
@@ -457,7 +497,7 @@ class FlashAttentionForwardSm100:
         self.epi_tile = (self.m_block_size, self.head_dim_v_padded)
 
         sQ_layout = sm100_utils_basic.make_smem_layout_a(
-            tiled_mma_qk, self.mma_tiler_qk, self.q_dtype, self.q_stage
+            tiled_mma_qk, self.mma_tiler_qk, self.q_dtype, self.q_smem_stages
         )
         sK_layout = sm100_utils_basic.make_smem_layout_b(
             tiled_mma_qk, self.mma_tiler_qk, self.k_dtype, self.kv_stage
@@ -516,6 +556,9 @@ class FlashAttentionForwardSm100:
         }
         for name in ("Q", "K", "V"):
             self.tma_copy_bytes[name] *= self.cta_group_size
+        if const_expr(self.is_split_d):
+            # Split-D: Q load covers both Q_low and Q_high (2 halves on same barrier)
+            self.tma_copy_bytes["Q"] *= 2
 
         # TMA load for Q
         tma_load_op = cpasync.CopyBulkTensorTileG2SOp(cta_group)
@@ -973,8 +1016,17 @@ class FlashAttentionForwardSm100:
         # request 512 columns of tmem, so we know that it starts at 0.
         tStS = thr_mma_qk.make_fragment_C(cute.append(qk_acc_shape, self.s_stage))
         pv_acc_shape = thr_mma_pv.partition_shape_C(self.mma_tiler_pv[:2])
-        tOtO = thr_mma_pv.make_fragment_C(cute.append(pv_acc_shape, self.q_stage))
-        tOtO = cute.make_tensor(tOtO.iterator + self.tmem_o_offset[0], tOtO.layout)
+        if const_expr(self.is_split_d):
+            # Split-D: O_low and O_high each use half_head_dim_v cols in TMEM
+            # For MMA gemm_Pi_low/gemm_Pi_high: TMEM offsets baked into GEMM partials
+            # For correction/epilogue: use half-width tOtO_low and tOtO_high
+            tOtO_half = thr_mma_pv.make_fragment_C(cute.append(pv_acc_shape, 1))
+            tOtO_low = cute.make_tensor(tOtO_half.iterator + self.tmem_o_low_offset, tOtO_half.layout)
+            tOtO_high = cute.make_tensor(tOtO_half.iterator + self.tmem_o_high_offset, tOtO_half.layout)
+            tOtO = tOtO_low
+        else:
+            tOtO = thr_mma_pv.make_fragment_C(cute.append(pv_acc_shape, self.q_stage))
+            tOtO = cute.make_tensor(tOtO.iterator + self.tmem_o_offset[0], tOtO.layout)
         tP = cute.make_tensor(tStS.iterator, tP_layout.outer)
         tOrP = thr_mma_pv.make_fragment_A(tP)[None, None, None, 0]
         # Need to multiply by width ratio bc tP is in v_dtype but tmem offsets are in FP32
@@ -1300,8 +1352,18 @@ class FlashAttentionForwardSm100:
                 else:
                     mK_cur = cute.domain_offset((seqlen.offset_k, 0), mK[None, None, head_idx_kv])
                     mV_cur = cute.domain_offset((0, seqlen.offset_k), mV[None, None, head_idx_kv])
-                gK = cute.local_tile(mK_cur, cute.select(self.mma_tiler_qk, mode=[1, 2]), (None, 0))
-                gV = cute.local_tile(mV_cur, cute.select(self.mma_tiler_pv, mode=[1, 2]), (0, None))
+                if const_expr(self.is_split_d):
+                    kv_tile = cute.select(self.mma_tiler_qk, mode=[1, 2])  # (n_block_size, half_head_dim)
+                    pv_tile = cute.select(self.mma_tiler_pv, mode=[1, 2])  # (half_head_dim_v, n_block_size)
+                    gK_low = cute.local_tile(mK_cur, kv_tile, (None, 0))
+                    gK_high = cute.local_tile(mK_cur, kv_tile, (None, 1))
+                    gV_low = cute.local_tile(mV_cur, pv_tile, (0, None))
+                    gV_high = cute.local_tile(mV_cur, pv_tile, (1, None))
+                    gK = gK_low  # placeholder for existing code paths
+                    gV = gV_low
+                else:
+                    gK = cute.local_tile(mK_cur, cute.select(self.mma_tiler_qk, mode=[1, 2]), (None, 0))
+                    gV = cute.local_tile(mV_cur, cute.select(self.mma_tiler_pv, mode=[1, 2]), (0, None))
             else:
                 # Need to keep batch coord None since we'll index into it with page idx
                 mK_cur, mV_cur = [t[None, None, head_idx_kv, None] for t in (mK, mV)]
@@ -1313,7 +1375,23 @@ class FlashAttentionForwardSm100:
                 )
             tSgK = thr_mma_qk.partition_B(gK)
             tOgV = thr_mma_pv.partition_B(gV)
-            if const_expr(self.use_tma_Q):
+            if const_expr(self.is_split_d):
+                tSgK_high = thr_mma_qk.partition_B(gK_high)
+                tOgV_high = thr_mma_pv.partition_B(gV_high)
+            if const_expr(self.is_split_d):
+                q_tile_splitd = (self.mma_tiler_qk[0], self.half_head_dim)
+                gQ_low = cute.local_tile(mQ_cur, q_tile_splitd, (None, 0))
+                gQ_high = cute.local_tile(mQ_cur, q_tile_splitd, (None, 1))
+                tSgQ_low = thr_mma_qk.partition_A(gQ_low)
+                tSgQ_high = thr_mma_qk.partition_A(gQ_high)
+                load_Q_low_fn, _, _ = copy_utils.tma_get_copy_fn(
+                    tma_atom_Q, 0, cute.make_layout(1), tSgQ_low, sQ
+                )
+                load_Q_high_fn, _, _ = copy_utils.tma_get_copy_fn(
+                    tma_atom_Q, 0, cute.make_layout(1), tSgQ_high, sQ
+                )
+                load_Q = partial(self.load_Q_split_d, load_Q_low_fn, load_Q_high_fn, pipeline_q=pipeline_q, phase=q_producer_phase)
+            elif const_expr(self.use_tma_Q):
                 tiler_gQ = ((self.mma_tiler_qk[0] * self.q_stage), self.head_dim_padded)
                 gQ = cute.local_tile(mQ_cur, tiler_gQ, (m_block, 0))  # (128 * 2, 128)
                 gQ = layout_utils.select(
@@ -1353,8 +1431,20 @@ class FlashAttentionForwardSm100:
                     cute.group_modes(sV, 0, 3),
                     cute.group_modes(tOgV, 0, 3),
                 )
+                if const_expr(self.is_split_d):
+                    _, tKgK_high = cpasync.tma_partition(
+                        tma_atom_K, 0, cute.make_layout(1),
+                        cute.group_modes(sK, 0, 3),
+                        cute.group_modes(tSgK_high, 0, 3),
+                    )
+                    _, tVgV_high = cpasync.tma_partition(
+                        tma_atom_V, 0, cute.make_layout(1),
+                        cute.group_modes(sV, 0, 3),
+                        cute.group_modes(tOgV_high, 0, 3),
+                    )
                 paged_kv_manager = None
             else:
+                assert not self.is_split_d, "Paged KV not supported with Split-D"
                 page_size = mK.shape[0]
                 paged_kv_manager = PagedKVManager.create(
                     mPageTable,
@@ -1395,6 +1485,27 @@ class FlashAttentionForwardSm100:
                 pipeline_kv=pipeline_kv,
                 K_or_V="V",
             )
+            if const_expr(self.is_split_d):
+                load_K_high = partial(
+                    self.load_KV,
+                    tma_atom_K,
+                    tKgK_high,
+                    tKsK,
+                    None,
+                    sK,
+                    pipeline_kv=pipeline_kv,
+                    K_or_V="K",
+                )
+                load_V_high = partial(
+                    self.load_KV,
+                    tma_atom_V,
+                    tVgV_high,
+                    tVsV,
+                    None,
+                    sV,
+                    pipeline_kv=pipeline_kv,
+                    K_or_V="V",
+                )
 
             if const_expr(not self.use_block_sparsity):
                 n_block_min, n_block_max = block_info.get_n_block_min_max(
@@ -1409,34 +1520,61 @@ class FlashAttentionForwardSm100:
                     )
                     if const_expr(not self.use_tma_KV):
                         paged_kv_manager.load_page_table(n_block_first)
-                    if issue_kv_for_this_warp:
-                        load_K(block=n_block_max - 1, producer_state=kv_producer_state, page_idx=page_idx)  # K0
-                    # load_K(block=n_block_max - 1, producer_state=kv_producer_state, page_idx=page_idx, extra_tx_count=self.tma_copy_bytes["Q"])  # K0
-                    if issue_q_for_this_warp:
-                        load_Q(block=0, stage=0)
-                    if issue_kv_for_this_warp:
-                        kv_producer_state.advance()
-                    if const_expr(self.q_stage == 2) and issue_q_for_this_warp:
-                        load_Q(block=1, stage=1)
-                    q_producer_phase ^= 1
-                    if issue_kv_for_this_warp:
-                        load_V(block=n_block_max - 1, producer_state=kv_producer_state, page_idx=page_idx)  # V0
-                        kv_producer_state.advance()
-                    for i in cutlass.range(n_block_max - 1 - n_block_min, unroll=1):
-                        n_block = n_block_max - 2 - i
-                        page_idx = (
-                            mPageTable[batch_idx, n_block]
-                            if const_expr(mPageTable is not None and self.use_tma_KV)
-                            else None
-                        )
-                        if const_expr(not self.use_tma_KV):
-                            paged_kv_manager.load_page_table(n_block)
-                    # if cute.arch.thread_idx()[0] % 32 == 0: cute.printf("n_block = {}, page_idx = {}", n_block, page_idx)
+                    if const_expr(self.is_split_d):
+                        # Split-D: load K_low, K_high, Q(split), V_low, V_high per N-block
                         if issue_kv_for_this_warp:
-                            load_K(block=n_block, producer_state=kv_producer_state, page_idx=page_idx)  # Ki
+                            load_K(block=n_block_max - 1, producer_state=kv_producer_state, page_idx=page_idx)
                             kv_producer_state.advance()
-                            load_V(block=n_block, producer_state=kv_producer_state, page_idx=page_idx)  # Vi
+                            load_K_high(block=n_block_max - 1, producer_state=kv_producer_state, page_idx=page_idx)
                             kv_producer_state.advance()
+                        if issue_q_for_this_warp:
+                            load_Q(block=m_block)
+                        q_producer_phase ^= 1
+                        if issue_kv_for_this_warp:
+                            load_V(block=n_block_max - 1, producer_state=kv_producer_state, page_idx=page_idx)
+                            kv_producer_state.advance()
+                            load_V_high(block=n_block_max - 1, producer_state=kv_producer_state, page_idx=page_idx)
+                            kv_producer_state.advance()
+                        for i in cutlass.range(n_block_max - 1 - n_block_min, unroll=1):
+                            n_block = n_block_max - 2 - i
+                            if issue_kv_for_this_warp:
+                                load_K(block=n_block, producer_state=kv_producer_state, page_idx=None)
+                                kv_producer_state.advance()
+                                load_K_high(block=n_block, producer_state=kv_producer_state, page_idx=None)
+                                kv_producer_state.advance()
+                                load_V(block=n_block, producer_state=kv_producer_state, page_idx=None)
+                                kv_producer_state.advance()
+                                load_V_high(block=n_block, producer_state=kv_producer_state, page_idx=None)
+                                kv_producer_state.advance()
+                    else:
+                        if issue_kv_for_this_warp:
+                            load_K(block=n_block_max - 1, producer_state=kv_producer_state, page_idx=page_idx)  # K0
+                        # load_K(block=n_block_max - 1, producer_state=kv_producer_state, page_idx=page_idx, extra_tx_count=self.tma_copy_bytes["Q"])  # K0
+                        if issue_q_for_this_warp:
+                            load_Q(block=0, stage=0)
+                        if issue_kv_for_this_warp:
+                            kv_producer_state.advance()
+                        if const_expr(self.q_stage == 2) and issue_q_for_this_warp:
+                            load_Q(block=1, stage=1)
+                        q_producer_phase ^= 1
+                        if issue_kv_for_this_warp:
+                            load_V(block=n_block_max - 1, producer_state=kv_producer_state, page_idx=page_idx)  # V0
+                            kv_producer_state.advance()
+                        for i in cutlass.range(n_block_max - 1 - n_block_min, unroll=1):
+                            n_block = n_block_max - 2 - i
+                            page_idx = (
+                                mPageTable[batch_idx, n_block]
+                                if const_expr(mPageTable is not None and self.use_tma_KV)
+                                else None
+                            )
+                            if const_expr(not self.use_tma_KV):
+                                paged_kv_manager.load_page_table(n_block)
+                        # if cute.arch.thread_idx()[0] % 32 == 0: cute.printf("n_block = {}, page_idx = {}", n_block, page_idx)
+                            if issue_kv_for_this_warp:
+                                load_K(block=n_block, producer_state=kv_producer_state, page_idx=page_idx)  # Ki
+                                kv_producer_state.advance()
+                                load_V(block=n_block, producer_state=kv_producer_state, page_idx=page_idx)  # Vi
+                                kv_producer_state.advance()
 
             else:
                 kv_producer_state, q_producer_phase = produce_block_sparse_loads_sm100(
@@ -1501,73 +1639,89 @@ class FlashAttentionForwardSm100:
         q_smem_base = sm100_desc.smem_desc_base_from_tensor(sQ, sm100_desc.Major.K)
         k_smem_base = sm100_desc.smem_desc_base_from_tensor(sK, sm100_desc.Major.K)
         v_smem_base = sm100_desc.smem_desc_base_from_tensor(sV, sm100_desc.Major.MN)
-        q_smem_start = [sm100_desc.make_smem_desc_start_addr(sQ[None, None, None, stage].iterator) for stage in range(self.q_stage)]
-
-        sm100_utils.declare_ptx_smem_desc(q_smem_start[self.q_stage - 1], q_smem_base, tSrQ[None, None, None, 0].layout, var_name_prefix="fa_fwd_q_smem_desc")
+        if const_expr(self.is_split_d):
+            q_smem_start = [sm100_desc.make_smem_desc_start_addr(sQ[None, None, None, stage].iterator) for stage in range(self.q_smem_stages)]
+            sm100_utils.declare_ptx_smem_desc(q_smem_start[1], q_smem_base, tSrQ[None, None, None, 0].layout, var_name_prefix="fa_fwd_q_smem_desc")
+        else:
+            q_smem_start = [sm100_desc.make_smem_desc_start_addr(sQ[None, None, None, stage].iterator) for stage in range(self.q_stage)]
+            sm100_utils.declare_ptx_smem_desc(q_smem_start[self.q_stage - 1], q_smem_base, tSrQ[None, None, None, 0].layout, var_name_prefix="fa_fwd_q_smem_desc")
         sm100_utils.declare_ptx_idesc(qk_mma_op, var_name="fa_fwd_qk_mma_idesc")
         sm100_utils.declare_ptx_idesc(pv_mma_op, var_name="fa_fwd_pv_mma_idesc")
 
         sQ_stage_stride = (sQ.layout.stride[-1] * sQ.element_type.width // 8) >> 4
-        if const_expr(self.q_stage == 1):
+        if const_expr(self.q_stage == 1 and not self.is_split_d):
             sQ_stage_stride = 0
-        gemm_Si = [
-            partial(
-                # sm100_utils.gemm_ptx_precomputed,
-                # self.tmem_s_offset[stage],
-                # smem_desc_start_a=q_smem_start[stage],
-                # idesc=qk_mma_idesc,
-                # smem_desc_base_a=q_smem_base,
-                # smem_desc_base_b=k_smem_base,
-                # tCrA_layout=tSrQ[None, None, None, 0].layout,
+
+        if const_expr(self.is_split_d):
+            gemm_Si_low = partial(
                 sm100_utils.gemm_ptx_precomputed_varname,
-                self.tmem_s_offset[stage],
-                # idesc=qk_mma_idesc,
+                self.tmem_s_offset[0],
                 smem_desc_base_b=k_smem_base,
                 tCrB_layout=tSrK[None, None, None, 0].layout,
-                smem_var_name_prefix=f"fa_fwd_q_smem_desc",
-                idesc_var_name=f"fa_fwd_qk_mma_idesc",
-                smem_offset=-sQ_stage_stride if stage == 0 else sQ_stage_stride,
+                smem_var_name_prefix="fa_fwd_q_smem_desc",
+                idesc_var_name="fa_fwd_qk_mma_idesc",
+                smem_offset=-sQ_stage_stride,
                 zero_init=True,
                 cta_group=self.cta_group_size,
             )
-            for stage in range(self.q_stage)
-        ]
-        # gemm_Si = [
-        #     partial(
-        #         sm100_utils.gemm,
-        #         tiled_mma_qk,
-        #         tStS[None, None, None, stage],
-        #         tCrA=tSrQ[None, None, None, stage],
-        #         zero_init=True,
-        #     )
-        #     for stage in range(self.q_stage)
-        # ]
-        gemm_Pi = [
-            partial(
-                # sm100_utils.gemm_ptx_precomputed,
-                sm100_utils.gemm_ptx_partial,
-                pv_mma_op,
-                self.tmem_o_offset[stage],
-                tOrP[None, None, None, stage],
-                sA=None,
-                split_arrive=self.split_P_arrive if self.split_P_arrive > 0 else None,
-                # smem_desc_start_a=tOrP[None, None, None, stage].iterator.toint(),
-                # smem_desc_start_a=self.tmem_p_offset[stage],
-                # idesc=pv_mma_idesc,
-                # smem_desc_base_a=None,
-                # smem_desc_base_b=v_smem_base,
-                # tCrA_layout=tOrP[None, None, None, 0].layout,
-                # tCrB_layout=tOrV[None, None, None, 0].layout
+            gemm_Si_high = partial(
+                sm100_utils.gemm_ptx_precomputed_varname,
+                self.tmem_s_offset[0],
+                smem_desc_base_b=k_smem_base,
+                tCrB_layout=tSrK[None, None, None, 0].layout,
+                smem_var_name_prefix="fa_fwd_q_smem_desc",
+                idesc_var_name="fa_fwd_qk_mma_idesc",
+                smem_offset=sQ_stage_stride,
+                zero_init=False,
                 cta_group=self.cta_group_size,
             )
-            for stage in range(self.q_stage)
-        ]
-        # gemm_Pi = [
-        #     partial(
-        #         sm100_utils.gemm, tOtO[None, None, None, stage], tCrA=tOrP[None, None, None, stage]
-        #     )
-        #     for stage in range(self.q_stage)
-        # ]
+            gemm_Si = [gemm_Si_low]
+            gemm_Pi_low = partial(
+                sm100_utils.gemm_ptx_partial,
+                pv_mma_op,
+                self.tmem_o_low_offset,
+                tOrP[None, None, None, 0],
+                sA=None,
+                split_arrive=self.split_P_arrive if self.split_P_arrive > 0 else None,
+                cta_group=self.cta_group_size,
+            )
+            gemm_Pi_high = partial(
+                sm100_utils.gemm_ptx_partial,
+                pv_mma_op,
+                self.tmem_o_high_offset,
+                tOrP[None, None, None, 0],
+                sA=None,
+                split_arrive=None,
+                cta_group=self.cta_group_size,
+            )
+            gemm_Pi = [gemm_Pi_low]
+        else:
+            gemm_Si = [
+                partial(
+                    sm100_utils.gemm_ptx_precomputed_varname,
+                    self.tmem_s_offset[stage],
+                    smem_desc_base_b=k_smem_base,
+                    tCrB_layout=tSrK[None, None, None, 0].layout,
+                    smem_var_name_prefix=f"fa_fwd_q_smem_desc",
+                    idesc_var_name=f"fa_fwd_qk_mma_idesc",
+                    smem_offset=-sQ_stage_stride if stage == 0 else sQ_stage_stride,
+                    zero_init=True,
+                    cta_group=self.cta_group_size,
+                )
+                for stage in range(self.q_stage)
+            ]
+            gemm_Pi = [
+                partial(
+                    sm100_utils.gemm_ptx_partial,
+                    pv_mma_op,
+                    self.tmem_o_offset[stage],
+                    tOrP[None, None, None, stage],
+                    sA=None,
+                    split_arrive=self.split_P_arrive if self.split_P_arrive > 0 else None,
+                    cta_group=self.cta_group_size,
+                )
+                for stage in range(self.q_stage)
+            ]
 
         mma_q_consumer_phase = Int32(0)
         mma_kv_consumer_state = pipeline.make_pipeline_state(
@@ -1602,6 +1756,101 @@ class FlashAttentionForwardSm100:
                     process_tile = n_block_min < n_block_max
 
             if process_tile and is_leader_cta:
+              if const_expr(self.is_split_d):
+                # ── Split-D MMA: 4 KV stages per N-block ──
+                # Prologue: QK_low + QK_high for first N-block
+                pipeline_q.consumer_wait_w_index_phase(0, mma_q_consumer_phase)
+                # K_low
+                pipeline_kv.consumer_wait(mma_kv_consumer_state)
+                sK_cur = sK[None, None, None, mma_kv_consumer_state.index]
+                gemm_Si_low(smem_desc_start_b=sm100_desc.make_smem_desc_start_addr(sK_cur.iterator))
+                pipeline_kv.consumer_release(mma_kv_consumer_state)
+                mma_kv_consumer_state.advance()
+                # K_high
+                pipeline_kv.consumer_wait(mma_kv_consumer_state)
+                sK_cur = sK[None, None, None, mma_kv_consumer_state.index]
+                gemm_Si_high(smem_desc_start_b=sm100_desc.make_smem_desc_start_addr(sK_cur.iterator))
+                pipeline_kv.consumer_release(mma_kv_consumer_state)
+                mma_kv_consumer_state.advance()
+                pipeline_s_p_o.producer_commit_w_index(0)
+                mma_q_consumer_phase ^= 1
+
+                block_loop_count = block_iter_count - 1
+                O_should_accumulate = False
+                Vi_index = Int32(0)
+                for i in cutlass.range(block_loop_count, unroll=1):
+                    # PV_low
+                    pipeline_kv.consumer_wait(mma_kv_consumer_state)
+                    Vi_index = mma_kv_consumer_state.index
+                    pipeline_s_p_o.producer_acquire_w_index_phase(0, P_full_O_rescaled_phase)
+                    gemm_Pi_low(
+                        tCrB=tOrV[None, None, None, Vi_index],
+                        sB=sV[None, None, None, Vi_index],
+                        zero_init=not O_should_accumulate,
+                        mbar_ptr=pipeline_p_lastsplit.sync_object_full.get_barrier(0) if self.split_P_arrive > 0 else None,
+                        mbar_phase=P_full_O_rescaled_phase,
+                    )
+                    pipeline_kv.consumer_release(mma_kv_consumer_state)
+                    mma_kv_consumer_state.advance()
+                    # PV_high
+                    pipeline_kv.consumer_wait(mma_kv_consumer_state)
+                    Vi_index = mma_kv_consumer_state.index
+                    gemm_Pi_high(
+                        tCrB=tOrV[None, None, None, Vi_index],
+                        sB=sV[None, None, None, Vi_index],
+                        zero_init=not O_should_accumulate,
+                        mbar_ptr=None,
+                        mbar_phase=P_full_O_rescaled_phase,
+                    )
+                    pipeline_kv.consumer_release(mma_kv_consumer_state)
+                    mma_kv_consumer_state.advance()
+                    # QK_low
+                    pipeline_kv.consumer_wait(mma_kv_consumer_state)
+                    sK_cur = sK[None, None, None, mma_kv_consumer_state.index]
+                    gemm_Si_low(smem_desc_start_b=sm100_desc.make_smem_desc_start_addr(sK_cur.iterator))
+                    pipeline_kv.consumer_release(mma_kv_consumer_state)
+                    mma_kv_consumer_state.advance()
+                    # QK_high
+                    pipeline_kv.consumer_wait(mma_kv_consumer_state)
+                    sK_cur = sK[None, None, None, mma_kv_consumer_state.index]
+                    gemm_Si_high(smem_desc_start_b=sm100_desc.make_smem_desc_start_addr(sK_cur.iterator))
+                    pipeline_kv.consumer_release(mma_kv_consumer_state)
+                    mma_kv_consumer_state.advance()
+                    pipeline_s_p_o.producer_commit_w_index(0)
+                    P_full_O_rescaled_phase ^= 1
+                    O_should_accumulate = True
+
+                # Release Q
+                pipeline_q.consumer_release_w_index(0)
+
+                # Epilogue: last PV_low + PV_high
+                pipeline_kv.consumer_wait(mma_kv_consumer_state)
+                Vi_index = mma_kv_consumer_state.index
+                pipeline_s_p_o.producer_acquire_w_index_phase(0, P_full_O_rescaled_phase)
+                gemm_Pi_low(
+                    tCrB=tOrV[None, None, None, Vi_index],
+                    sB=sV[None, None, None, Vi_index],
+                    zero_init=not O_should_accumulate,
+                    mbar_ptr=pipeline_p_lastsplit.sync_object_full.get_barrier(0) if self.split_P_arrive > 0 else None,
+                    mbar_phase=P_full_O_rescaled_phase,
+                )
+                pipeline_kv.consumer_release(mma_kv_consumer_state)
+                mma_kv_consumer_state.advance()
+
+                pipeline_kv.consumer_wait(mma_kv_consumer_state)
+                Vi_index = mma_kv_consumer_state.index
+                gemm_Pi_high(
+                    tCrB=tOrV[None, None, None, Vi_index],
+                    sB=sV[None, None, None, Vi_index],
+                    zero_init=not O_should_accumulate,
+                    mbar_ptr=None,
+                    mbar_phase=P_full_O_rescaled_phase,
+                )
+                pipeline_o_acc.producer_commit_w_index(0)
+                P_full_O_rescaled_phase ^= 1
+                pipeline_kv.consumer_release(mma_kv_consumer_state)
+                mma_kv_consumer_state.advance()
+              else:
                 for stage in cutlass.range_constexpr(self.q_stage):
                     # GEMM_QK00 (Q0 * K0 -> S0) or GEMM_QK01 (Q1 * K0 -> S1)
                     # 1. wait for Q0 / Q1
@@ -1611,93 +1860,58 @@ class FlashAttentionForwardSm100:
                         pipeline_kv.consumer_wait(mma_kv_consumer_state)
                     Ki_index, Ki_phase = mma_kv_consumer_state.index, mma_kv_consumer_state.phase
                     tSrKi = tSrK[None, None, None, Ki_index]
-                    # We don't need to acquire empty S0 / S1.
-                    # For the first iteration, we don't need to wait as we're guaranteed S0 / S1
-                    # are empty. For subsequent iterations, the wait happened at the end
-                    # of the while loop.
-                    # 3. gemm
-                    # sm100_utils.gemm(tiled_mma_qk, tStS[None, None, None, stage], tSrQ[None, None, None, stage], tSrKi, zero_init=True)
                     sK_cur = sK[None, None, None, Ki_index]
                     if const_expr(self.uneven_kv_smem):
                         sK_cur = self.offset_kv_smem(sK_cur, Ki_index, Ki_phase)
-                    # gemm_Si[stage](tCrB=tSrKi, sB=sK_cur)
                     gemm_Si[stage](
                         smem_desc_start_b=sm100_desc.make_smem_desc_start_addr(sK_cur.iterator)
                     )
-                    # gemm_Si[stage](tCrB=tSrKi)
                     # 4. release S0 / S1
                     pipeline_s_p_o.producer_commit_w_index(stage)
                 mma_q_consumer_phase ^= 1
                 # 5. release K0
                 pipeline_kv.consumer_release(mma_kv_consumer_state)
                 mma_kv_consumer_state.advance()
-                # End of GEMM (Q1 * K0 -> S1)
-                # Note: Q0 & Q1 are still needed in the seqlen_kv loop
-                # so we need to release them after the seqlen_kv loop
 
                 # O hasn't been accumulated yet, its first MMA calculation doesn't need to accumulate
                 block_loop_count = block_iter_count - 1
                 O_should_accumulate = False
+                Vi_index = Int32(0)
                 for i in cutlass.range(block_loop_count, unroll=1):
-                    # GEMM_PV00 (P0 * V0 -> O0_partial), O0 needs to be accumulated in the seqlen_kv loop
+                    # GEMM_PV00 (P0 * V0 -> O0_partial)
                     # 1. wait for V0
                     pipeline_kv.consumer_wait(mma_kv_consumer_state)
                     mma_kv_release_state = mma_kv_consumer_state.clone()
                     Vi_index, Vi_phase = mma_kv_consumer_state.index, mma_kv_consumer_state.phase
                     tOrVi = tOrV[None, None, None, Vi_index]
                     for stage in cutlass.range_constexpr(self.q_stage):
-                        # 2. acquire corrected O0/O1_partial and P0 / P1
-                        # For the first iteration in this work tile, waiting for O0/O1_partial
-                        # means that the correction warps has finished reading tO during
-                        # the last iteration of the previous work tile.
                         pipeline_s_p_o.producer_acquire_w_index_phase(stage, P_full_O_rescaled_phase)
-                        # 3. gemm
-                        # sm100_utils.gemm(tiled_mma_pv, tOtO0, tOrP0, tOrVi, zero_init=True)
-                        # gemm_Pi[stage](tCrB=tOrVi, sB=sV[None, None, None, Vi_index], zero_init=not O_should_accumulate)
                         sV_cur = sV[None, None, None, Vi_index]
                         if const_expr(self.uneven_kv_smem):
                             sV_cur = self.offset_kv_smem(sV_cur, Vi_index, Vi_phase)
                         gemm_Pi[stage](
                             tCrB=tOrVi,
                             sB=sV_cur,
-                            # smem_desc_start_b=sm100_desc.make_smem_desc_start_addr(sV_cur.iterator),
                             zero_init=not O_should_accumulate,
                             mbar_ptr=pipeline_p_lastsplit.sync_object_full.get_barrier(stage) if self.split_P_arrive > 0 else None,
                             mbar_phase=P_full_O_rescaled_phase,
                         )
-                        # Don't need to signal O_full to the correction warps since the
-                        # correction warps wait for the softmax warps anyway. By the time the softmax
-                        # warps finished, S_i for the next iteration must have been done, so O_i-1
-                        # must have been done as well.
-                        # pipeline_o_acc.producer_commit_w_index(stage)
-                        # 4. release V(i-1)
                         if const_expr(stage == self.q_stage - 1):
                             pipeline_kv.consumer_release(mma_kv_release_state)
                             mma_kv_release_state.advance()
-                        # End of GEMM_PV00 (P0 * V0 -> O0_partial)
 
                         # GEMM_QK0i (Q0 * Ki -> S0)
-                        # 1. wait for Ki
                         if const_expr(stage == 0):
                             mma_kv_consumer_state.advance()
                             pipeline_kv.consumer_wait(mma_kv_consumer_state)
                         Ki_index, Ki_phase = mma_kv_consumer_state.index, mma_kv_consumer_state.phase
-                        # 2. gemm
-                        # Don't need to wait for the softmax warp to have finished reading the previous
-                        # Si, since this gemm is scheduled after the PV gemm, which guaranteed that Si
-                        # has been read and Pi has been written.
-                        # sm100_utils.gemm(tiled_mma_qk, tStS[None, None, None, stage], tSrQ[None, None, None, stage], tSrK[None, None, None, Ki_index], zero_init=True)
                         sK_cur = sK[None, None, None, Ki_index]
                         if const_expr(self.uneven_kv_smem):
                             sK_cur = self.offset_kv_smem(sK_cur, Ki_index, Ki_phase)
-                        # gemm_Si[stage](tCrB=tSrK[None, None, None, Ki_index], sB=sK_cur)
                         gemm_Si[stage](
                             smem_desc_start_b=sm100_desc.make_smem_desc_start_addr(sK_cur.iterator)
                         )
-                        # gemm_Si[stage](tCrB=tSrK[None, None, None, Ki_index])
-                        # 3. release S0 / S1
                         pipeline_s_p_o.producer_commit_w_index(stage)
-                        # End of GEMM_QK0i (Q0 * Ki -> S0)
                     # 4. release Ki
                     pipeline_kv.consumer_release(mma_kv_consumer_state)
                     mma_kv_consumer_state.advance()
@@ -1709,40 +1923,26 @@ class FlashAttentionForwardSm100:
                 for stage in cutlass.range(self.q_stage):
                     pipeline_q.consumer_release_w_index(stage)
 
-                # GEMM_PV00 (P0 * V0 -> O0_partial), O0 needs to be accumulated in the seqlen_kv loop
-                # 1. wait for V0
+                # Last PV GEMM
                 pipeline_kv.consumer_wait(mma_kv_consumer_state)
                 Vi_index, Vi_phase = mma_kv_consumer_state.index, mma_kv_consumer_state.phase
                 tOrVi = tOrV[None, None, None, Vi_index]
                 for stage in cutlass.range_constexpr(self.q_stage):
-                    # 2. acquire corrected Oi_partial and Pi
                     pipeline_s_p_o.producer_acquire_w_index_phase(stage, P_full_O_rescaled_phase)
-                    # 3. gemm
-                    # sm100_utils.gemm(tiled_mma_pv, tOtO0, tOrP0, tOrVi, zero_init=True)
-                    # gemm_Pi[stage](tCrB=tOrVi, sB=sV[None, None, None, Vi_index], zero_init=not O_should_accumulate)
                     sV_cur = sV[None, None, None, Vi_index]
                     if const_expr(self.uneven_kv_smem):
                         sV_cur = self.offset_kv_smem(sV_cur, Vi_index, Vi_phase)
                     gemm_Pi[stage](
                         tCrB=tOrVi,
                         sB=sV_cur,
-                        # smem_desc_start_b=sm100_desc.make_smem_desc_start_addr(sV_cur.iterator),
                         zero_init=not O_should_accumulate,
                         mbar_ptr=pipeline_p_lastsplit.sync_object_full.get_barrier(stage) if self.split_P_arrive > 0 else None,
                         mbar_phase=P_full_O_rescaled_phase,
                     )
-                    # 4. release accumulated O0_partial
-                    # We do need O_full here since for the last tile, by the time the softmax warp
-                    # has signaled to the correction warps, the softmax warp has just finished
-                    # computing the row sum of the current tile. It does not guarantee that the 1st
-                    # tile of the next work tile has been computed yet.
                     pipeline_o_acc.producer_commit_w_index(stage)
-                    # End of GEMM_PV00 (P0 * V0 -> O0_partial)
                 P_full_O_rescaled_phase ^= 1
-                # 5. release Vi_end
                 pipeline_kv.consumer_release(mma_kv_consumer_state)
                 mma_kv_consumer_state.advance()
-                # End of GEMM_PV1(i_end) (P1 * Vi_end -> O1)
 
             # Advance to next tile
             work_tile = tile_scheduler.advance_to_next_work()
@@ -2635,10 +2835,19 @@ class FlashAttentionForwardSm100:
         tOtO_t2r = thr_tmem_load.partition_S(tOtO_i[(None, None), None])
         tOsO_s2r = copy_utils.partition_D_position_independent(thr_tmem_load, tOsO_i[(None, None), None])
         tOcO_t2r = thr_tmem_load.partition_D(tOcO_i[(None, None), None])
+        tOrO_frg_shape = tOcO_t2r[None, 0, 0, 0].shape
+        single_tile_layout = tOtO_t2r[None, 0, 0, 0].layout
         for i in cutlass.range(self.head_dim_v_padded // corr_tile_size, unroll_full=True):
-            tOtO_t2r_i = tOtO_t2r[None, 0, 0, i]
+            if const_expr(self.is_split_d):
+                # Split-D: tOtO only covers half_head_dim_v cols, but O_low and O_high are
+                # contiguous in TMEM. Use manual iterator arithmetic to reach O_high cols.
+                tOtO_t2r_i = cute.make_tensor(
+                    tOtO_t2r.iterator + i * corr_tile_size, single_tile_layout
+                )
+            else:
+                tOtO_t2r_i = tOtO_t2r[None, 0, 0, i]
             tOsO_r2s_i = tOsO_s2r[None, 0, 0, i]
-            tOrO_frg = cute.make_fragment(tOcO_t2r[None, 0, 0, i].shape, self.pv_acc_dtype)
+            tOrO_frg = cute.make_fragment(tOrO_frg_shape, self.pv_acc_dtype)
             cute.copy(tiled_tmem_load, tOtO_t2r_i, tOrO_frg)
             for j in cutlass.range(0, cute.size(tOrO_frg), 2, unroll_full=True):
                 tOrO_frg[j], tOrO_frg[j + 1] = cute.arch.mul_packed_f32x2(
@@ -2821,6 +3030,20 @@ class FlashAttentionForwardSm100:
     ):
         pipeline_q.producer_acquire_w_index_phase(stage, phase)
         load_Q_fn(src_idx=block, dst_idx=stage, tma_bar_ptr=pipeline_q.sync_object_full.get_barrier(stage))
+
+    def load_Q_split_d(
+        self,
+        load_Q_low_fn: Callable,
+        load_Q_high_fn: Callable,
+        pipeline_q: pipeline.PipelineAsync,
+        block: Int32,
+        phase: Int32,
+    ):
+        """Load both Q_low and Q_high for Split-D on the same pipeline barrier (stage=0)."""
+        pipeline_q.producer_acquire_w_index_phase(0, phase)
+        bar_ptr = pipeline_q.sync_object_full.get_barrier(0)
+        load_Q_low_fn(src_idx=block, dst_idx=0, tma_bar_ptr=bar_ptr)
+        load_Q_high_fn(src_idx=block, dst_idx=1, tma_bar_ptr=bar_ptr)
 
     def load_Q_non_tma(
         self,

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -103,6 +103,7 @@ def _validate_head_dims(head_dim: int, head_dim_v: int, compute_capability: int,
     """Validate head dimension constraints based on compute capability."""
     is_deepseek_shape = head_dim == 192 and head_dim_v == 128
     is_standard_range = 8 <= head_dim <= 128 and 8 <= head_dim_v <= 128
+    is_d256_shape = head_dim == 256 and head_dim_v == 256
 
     is_sm90_range = 8 <= head_dim <= 256 and 8 <= head_dim_v <= 256
     if compute_capability == 9:
@@ -111,9 +112,9 @@ def _validate_head_dims(head_dim: int, head_dim_v: int, compute_capability: int,
             f"head_dim and head_dim_v must be between 8 and 256 and divisible by {alignment}."
         )
     elif compute_capability in [10, 11]:
-        assert (is_standard_range or is_deepseek_shape) and head_dim % alignment == 0 and head_dim_v % alignment == 0, (
+        assert (is_standard_range or is_deepseek_shape or is_d256_shape) and head_dim % alignment == 0 and head_dim_v % alignment == 0, (
             f"(head_dim, head_dim_v)=({head_dim}, {head_dim_v}) is not supported on SM100/SM110. "
-            f"head_dim and head_dim_v must be between 8 and 128 and divisible by {alignment}, or (192, 128) for DeepSeek."
+            f"head_dim and head_dim_v must be between 8 and 128 and divisible by {alignment}, or (192, 128) for DeepSeek, or (256, 256) for Split-D."
         )
 
 
@@ -527,6 +528,19 @@ def _flash_attn_fwd(
         out_partial = torch.empty(num_splits, *q_batch_seqlen_shape, num_head, head_dim_v, dtype=torch.float32, device=device)
         lse_partial = torch.empty(num_splits, *lse_shape, dtype=torch.float32, device=device)
 
+    is_split_d = (
+        arch // 10 in [10, 11]
+        and head_dim > 128
+        and head_dim == head_dim_v
+        and head_dim != 192
+    )
+    if is_split_d:
+        q_stage = 1
+        pack_gqa = False
+        if num_splits > 1:
+            num_splits = 1
+            is_split_kv = False
+
     use_2cta_instrs = (
         arch // 10 in [10, 11]
         and not requested_disable_2cta
@@ -635,6 +649,7 @@ def _flash_attn_fwd(
         mma_pv_is_rs,
         intra_wg_overlap,
         requested_use_clc_scheduler,
+        is_split_d,
         fa_logging.get_fa_log_level(),
     )
     if compile_key not in _flash_attn_fwd.compile_cache:
@@ -743,6 +758,7 @@ def _flash_attn_fwd(
                 q_subtile_factor=q_subtile_factor,
                 use_2cta_instrs=use_2cta_instrs,
                 use_clc_scheduler=requested_use_clc_scheduler,
+                is_split_d=is_split_d,
             )
         elif arch // 10 == 12:
             # SM120 (Blackwell GeForce / DGX Spark): uses SM80 MMA with SM120 SMEM capacity
@@ -1080,6 +1096,12 @@ def _flash_attn_bwd(
         dKV_swapAB = False
         AtomLayoutMdQ = 1
         AtomLayoutNdKV = 1
+        is_split_d_bwd = (
+            arch // 10 in [10, 11]
+            and head_dim > 128
+            and head_dim == head_dim_v
+            and head_dim != 192
+        )
         requested_disable_2cta = utils._get_disable_2cta_default()
         disable_2cta = (
             requested_disable_2cta
@@ -1087,6 +1109,7 @@ def _flash_attn_bwd(
             or score_mod_bwd is not None
             or mask_mod is not None
             or block_sparse_tensors is not None
+            or is_split_d_bwd
         )
         cluster_size = 2 if head_dim >= 128 and not disable_2cta else 1
         use_2cta_instrs = cluster_size==2
@@ -1216,7 +1239,8 @@ def _flash_attn_bwd(
         total_q_rounded_padded = (
             (total_q + cu_seqlens_q.shape[0] * m_block_size - 1) // m_block_size * m_block_size
         )
-        dq_accum = torch.empty(
+        dq_alloc = torch.zeros if is_split_d_bwd else torch.empty
+        dq_accum = dq_alloc(
             num_head, total_q_rounded_padded * head_dim_rounded, dtype=torch.float32, device=device
         )
         dpsum = torch.empty(num_head, total_q_rounded_padded, dtype=torch.float32, device=device)
@@ -1225,7 +1249,8 @@ def _flash_attn_bwd(
     # GQA (qhead_per_kvhead > 1) needs dK/dV accum+postprocess since multiple Q heads
     # accumulate into the same dK/dV. SM90 varlen_k with qhead_per_kvhead==1 now uses
     # ragged TMA tensors for direct store, so no longer needs accum+postprocess.
-    dKV_postprocess = qhead_per_kvhead > 1
+    # Split-D BWD always needs dK reduce via GMEM atomics (TMEM budget exhausted).
+    dKV_postprocess = qhead_per_kvhead > 1 or is_split_d_bwd
     if dKV_postprocess:
         head_dim_v_rounded = (head_dim_v + 32 - 1) // 32 * 32
         if cu_seqlens_k is None:
@@ -1377,6 +1402,7 @@ def _flash_attn_bwd(
             num_aux_tensors,
             use_block_sparsity,
             block_sparse_broadcast_pattern,
+            is_split_d_bwd,
             cu_seqlens_q is None,
             cu_seqlens_k is None,
             seqused_q is None,
@@ -1474,6 +1500,7 @@ def _flash_attn_bwd(
                 mask_mod=mask_mod,
                 has_aux_tensors=aux_tensors is not None,
                 subtile_factor=subtile_factor,
+                is_split_d=is_split_d_bwd,
             )
 
         # Block sparse tensors for backward use Q-direction indexing (transposed from forward).
@@ -1543,32 +1570,101 @@ def _flash_attn_bwd(
         num_threads_post_dQ = 128
         num_threads_post_dKV = 128
 
-    # Postprocess: convert dq_accum from float32 to dq in bf16/fp16
-    _bwd_postprocess_convert(
-        dq_accum, dq, softmax_scale,
-        cu_seqlens_q, seqused_q,
-        arch, dtype, head_dim, m_block_size, num_threads_post_dQ,
-        AtomLayoutMdQ, dQ_swapAB,
-        use_2cta_instrs=use_2cta_instrs, cluster_size=1,
-    )
+    if is_split_d_bwd:
+        half_hdim = head_dim // 2
+        half_hdim_v = head_dim_v // 2
 
-    if dKV_postprocess:
-        # Postprocess: convert dk_accum from float32 to dk in bf16/fp16
+        # dQ: accum layout is [low_half | high_half], each with half_hdim MMA layout
+        dq_accum_low = dq_accum[..., :dq_accum.shape[-1] // 2]
+        dq_accum_high = dq_accum[..., dq_accum.shape[-1] // 2:]
+        dq_low = dq[..., :half_hdim].contiguous()
+        dq_high = dq[..., half_hdim:].contiguous()
         _bwd_postprocess_convert(
-            dk_accum, dk, softmax_scale,
-            cu_seqlens_k, seqused_k,
-            arch, dtype, head_dim, n_block_size, num_threads_post_dKV,
-            AtomLayoutNdKV, dKV_swapAB,
-            cluster_size=cluster_size,
+            dq_accum_low, dq_low, softmax_scale,
+            cu_seqlens_q, seqused_q,
+            arch, dtype, half_hdim, m_block_size, num_threads_post_dQ,
+            AtomLayoutMdQ, dQ_swapAB,
+            use_2cta_instrs=False, cluster_size=1,
         )
-        # Postprocess: convert dv_accum from float32 to dv in bf16/fp16
         _bwd_postprocess_convert(
-            dv_accum, dv, 1.0,
-            cu_seqlens_k, seqused_k,
-            arch, dtype, head_dim_v, n_block_size, num_threads_post_dKV,
-            AtomLayoutNdKV, dKV_swapAB,
-            cluster_size=cluster_size,
+            dq_accum_high, dq_high, softmax_scale,
+            cu_seqlens_q, seqused_q,
+            arch, dtype, half_hdim, m_block_size, num_threads_post_dQ,
+            AtomLayoutMdQ, dQ_swapAB,
+            use_2cta_instrs=False, cluster_size=1,
         )
+        dq[..., :half_hdim].copy_(dq_low)
+        dq[..., half_hdim:].copy_(dq_high)
+
+        # dK/dV: same split pattern
+        dk_accum_low = dk_accum[..., :dk_accum.shape[-1] // 2]
+        dk_accum_high = dk_accum[..., dk_accum.shape[-1] // 2:]
+        dk_low = dk[..., :half_hdim].contiguous()
+        dk_high = dk[..., half_hdim:].contiguous()
+        _bwd_postprocess_convert(
+            dk_accum_low, dk_low, softmax_scale,
+            cu_seqlens_k, seqused_k,
+            arch, dtype, half_hdim, n_block_size, num_threads_post_dKV,
+            AtomLayoutNdKV, dKV_swapAB,
+            cluster_size=1,
+        )
+        _bwd_postprocess_convert(
+            dk_accum_high, dk_high, softmax_scale,
+            cu_seqlens_k, seqused_k,
+            arch, dtype, half_hdim, n_block_size, num_threads_post_dKV,
+            AtomLayoutNdKV, dKV_swapAB,
+            cluster_size=1,
+        )
+        dk[..., :half_hdim].copy_(dk_low)
+        dk[..., half_hdim:].copy_(dk_high)
+
+        dv_accum_low = dv_accum[..., :dv_accum.shape[-1] // 2]
+        dv_accum_high = dv_accum[..., dv_accum.shape[-1] // 2:]
+        dv_low = dv[..., :half_hdim_v].contiguous()
+        dv_high = dv[..., half_hdim_v:].contiguous()
+        _bwd_postprocess_convert(
+            dv_accum_low, dv_low, 1.0,
+            cu_seqlens_k, seqused_k,
+            arch, dtype, half_hdim_v, n_block_size, num_threads_post_dKV,
+            AtomLayoutNdKV, dKV_swapAB,
+            cluster_size=1,
+        )
+        _bwd_postprocess_convert(
+            dv_accum_high, dv_high, 1.0,
+            cu_seqlens_k, seqused_k,
+            arch, dtype, half_hdim_v, n_block_size, num_threads_post_dKV,
+            AtomLayoutNdKV, dKV_swapAB,
+            cluster_size=1,
+        )
+        dv[..., :half_hdim_v].copy_(dv_low)
+        dv[..., half_hdim_v:].copy_(dv_high)
+    else:
+        # Postprocess: convert dq_accum from float32 to dq in bf16/fp16
+        _bwd_postprocess_convert(
+            dq_accum, dq, softmax_scale,
+            cu_seqlens_q, seqused_q,
+            arch, dtype, head_dim, m_block_size, num_threads_post_dQ,
+            AtomLayoutMdQ, dQ_swapAB,
+            use_2cta_instrs=use_2cta_instrs, cluster_size=1,
+        )
+
+        if dKV_postprocess:
+            # Postprocess: convert dk_accum from float32 to dk in bf16/fp16
+            _bwd_postprocess_convert(
+                dk_accum, dk, softmax_scale,
+                cu_seqlens_k, seqused_k,
+                arch, dtype, head_dim, n_block_size, num_threads_post_dKV,
+                AtomLayoutNdKV, dKV_swapAB,
+                cluster_size=cluster_size,
+            )
+            # Postprocess: convert dv_accum from float32 to dv in bf16/fp16
+            _bwd_postprocess_convert(
+                dv_accum, dv, 1.0,
+                cu_seqlens_k, seqused_k,
+                arch, dtype, head_dim_v, n_block_size, num_threads_post_dKV,
+                AtomLayoutNdKV, dKV_swapAB,
+                cluster_size=cluster_size,
+            )
 
     return dq, dk, dv
 

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -253,7 +253,7 @@ def test_flash_attn_output(
             # SplitKV not supported on SM90 - skip this iteration
             if IS_SM90 and num_splits > 1:
                 continue
-            if IS_SM100 and (d >= 192 and dv >= 192):  # hdim 192 and 256 not support on SM100
+            if IS_SM100 and d >= 192 and dv >= 192 and d != 256:
                 continue
             out, lse = flash_attn_func(
                 q,
@@ -292,7 +292,7 @@ def test_flash_attn_output(
             and not dv > 256
             and not attention_chunk != 0
             and softcap == 0.0
-            and ((dv == d and d <= 128) or (d == 192 and dv == 128))
+            and ((dv == d and (d <= 128 or d == 256)) or (d == 192 and dv == 128))
             and learnable_sink is None
             # and False
             and not ((causal or local) and seqlen_k < seqlen_q)
@@ -403,7 +403,7 @@ def test_flash_attn_output(
 # @pytest.mark.parametrize('d', [32, 40, 64, 80, 96, 128])
 # @pytest.mark.parametrize("d", [64, 96, 128])
 # @pytest.mark.parametrize("d", [128, 192])
-@pytest.mark.parametrize("d", [64, 128, 192])
+@pytest.mark.parametrize("d", [64, 128, 192, 256])
 @pytest.mark.parametrize(
     "seqlen_q,seqlen_k",
     [
@@ -741,7 +741,7 @@ def test_flash_attn_varlen_output(
             and not has_qv
             and not dv > 256
             and not attention_chunk != 0
-            and ((dv == d and d <= 128) or (d == 192 and dv == 128))
+            and ((dv == d and (d <= 128 or d == 256)) or (d == 192 and dv == 128))
             and not has_learnable_sink
             # and False
         ):

--- a/tests/cute/test_flash_attn_fast.py
+++ b/tests/cute/test_flash_attn_fast.py
@@ -35,7 +35,7 @@ IS_SM90 = torch.cuda.get_device_capability()[0] == 9
 @pytest.mark.parametrize("mha_type", ["mha", "gqa", "mqa"])
 @pytest.mark.parametrize("num_splits", [1, 3])
 @pytest.mark.parametrize("causal", [False, True])
-@pytest.mark.parametrize("d", [64, 128])
+@pytest.mark.parametrize("d", [64, 128, 256])
 @pytest.mark.parametrize(
     "seqlen_q,seqlen_k",
     [
@@ -49,11 +49,13 @@ IS_SM90 = torch.cuda.get_device_capability()[0] == 9
 def test_flash_attn_output(seqlen_q, seqlen_k, d, causal, num_splits, mha_type, dtype):
     if IS_SM90 and num_splits > 1:
         pytest.skip("SM90 fwd doens't support num_splits > 1")
+    if d >= 192 and num_splits > 1:
+        pytest.skip("SplitKV not supported for hdim >= 192")
     device = "cuda"
     torch.random.manual_seed(0)
     random.seed(0)
     torch.cuda.empty_cache()
-    batch_size = 4
+    batch_size = 2 if d == 256 else 4
     nheads = 6
     nheads_kv = nheads if mha_type == "mha" else (3 if mha_type == "gqa" else 1)
 
@@ -81,7 +83,7 @@ def test_flash_attn_output(seqlen_q, seqlen_k, d, causal, num_splits, mha_type, 
     # Backward (only for non-split, matching d)
     can_bwd = (
         num_splits == 1
-        and d <= 128
+        and d <= 256
         and not (causal and seqlen_k < seqlen_q)
     )
     if IS_SM90 and d == 64 and not causal:
@@ -110,7 +112,7 @@ def test_flash_attn_output(seqlen_q, seqlen_k, d, causal, num_splits, mha_type, 
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 @pytest.mark.parametrize("mha_type", ["mha", "gqa", "mqa"])
 @pytest.mark.parametrize("causal", [False, True])
-@pytest.mark.parametrize("d", [64, 128])
+@pytest.mark.parametrize("d", [64, 128, 256])
 @pytest.mark.parametrize("seqlen", [128, 256, 1024])
 @maybe_fake_tensor_mode(USE_FAKE_TENSOR)
 def test_flash_attn_varlen_output(seqlen, d, causal, mha_type, dtype):
@@ -119,7 +121,7 @@ def test_flash_attn_varlen_output(seqlen, d, causal, mha_type, dtype):
     seed = seqlen + d + int(causal) * 2
     torch.random.manual_seed(seed)
     random.seed(seed)
-    batch_size = 9
+    batch_size = 3 if d == 256 else 9
     nheads = 6
     nheads_kv = nheads if mha_type == "mha" else (3 if mha_type == "gqa" else 1)
 
@@ -152,7 +154,7 @@ def test_flash_attn_varlen_output(seqlen, d, causal, mha_type, dtype):
     assert (out_reshaped - out_ref).abs().max().item() <= 2 * (out_pt - out_ref).abs().max().item() + fwd_atol
 
     # Backward
-    can_bwd = d <= 128
+    can_bwd = d <= 256
     if not can_bwd:
         return
 
@@ -179,7 +181,7 @@ def test_flash_attn_varlen_output(seqlen, d, causal, mha_type, dtype):
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 @pytest.mark.parametrize("mha_type", ["mha", "gqa", "mqa"])
 @pytest.mark.parametrize("causal", [False, True])
-@pytest.mark.parametrize("d", [64, 128])
+@pytest.mark.parametrize("d", [64, 128, 256])
 @pytest.mark.parametrize("seqlen", [128, 256])
 @pytest.mark.parametrize(
     "unpad_q,unpad_kv",
@@ -192,7 +194,7 @@ def test_flash_attn_varlen_unpad_output(seqlen, d, causal, mha_type, unpad_q, un
     seed = seqlen + d + int(causal) * 2 + int(unpad_q) * 7 + int(unpad_kv) * 13
     torch.random.manual_seed(seed)
     random.seed(seed)
-    batch_size = 9
+    batch_size = 3 if d == 256 else 9
     nheads = 6
     nheads_kv = nheads if mha_type == "mha" else (3 if mha_type == "gqa" else 1)
 
@@ -265,7 +267,7 @@ def test_flash_attn_varlen_unpad_output(seqlen, d, causal, mha_type, unpad_q, un
     assert (out_masked - out_ref_masked).abs().max().item() <= 2 * (out_pt_masked - out_ref_masked).abs().max().item() + fwd_atol
 
     # Backward (original test skips all SM90 varlen backward)
-    can_bwd = d <= 128 and not IS_SM90
+    can_bwd = d <= 256 and not IS_SM90
     if not can_bwd:
         return
 
@@ -301,7 +303,7 @@ def attention_combine_ref(out_partial, lse_partial):
 
 
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
-@pytest.mark.parametrize("d", [64, 128])
+@pytest.mark.parametrize("d", [64, 128, 256])
 @pytest.mark.parametrize("seqlen", [32, 256])
 @pytest.mark.parametrize("num_splits", [2, 5, 17])
 @maybe_fake_tensor_mode(USE_FAKE_TENSOR)

--- a/tests/cute/test_flash_attn_race_condition.py
+++ b/tests/cute/test_flash_attn_race_condition.py
@@ -51,7 +51,7 @@ INCREASED_TRIALS = False
 # @pytest.mark.parametrize("causal", [True])
 # @pytest.mark.parametrize("d", [64, 128])
 # @pytest.mark.parametrize("d", [128, 192])
-@pytest.mark.parametrize("d", [64, 128, 192])
+@pytest.mark.parametrize("d", [64, 128, 192, 256])
 @pytest.mark.parametrize(
     "seqlen_q,seqlen_k",
     [
@@ -96,6 +96,8 @@ def test_flash_attn_output(
         dv_vals = [d]
     # attention_chunk_vals = [torch.randint(1, seqlen_k * 2, (1,)).item(), 0]
     attention_chunk_vals = [0]
+    if d == 256:
+        batch_size = max(1, batch_size // 3)
     for dv, attention_chunk in itertools.product(dv_vals, attention_chunk_vals):
         q_ref = torch.randn(
             batch_size, seqlen_q, nheads, d, device=device, dtype=dtype_ref
@@ -247,7 +249,7 @@ def test_flash_attn_output(
             and not dv > 256
             and not attention_chunk != 0
             and softcap == 0.0
-            and ((dv == d and d <= 128) or (d == 192 and dv == 128))
+            and ((dv == d and d <= 128) or (d == 192 and dv == 128) or (d == 256 and dv == 256))
             and learnable_sink is None
             # and False
         ):
@@ -370,7 +372,7 @@ def test_flash_attn_output(
 # @pytest.mark.parametrize('d', [56, 80])
 # @pytest.mark.parametrize('d', [32, 40, 64, 80, 96, 128])
 # @pytest.mark.parametrize("d", [64, 96, 128])
-@pytest.mark.parametrize("d", [64, 128, 192])
+@pytest.mark.parametrize("d", [64, 128, 192, 256])
 # @pytest.mark.parametrize("d", [192])
 @pytest.mark.parametrize(
     "seqlen_q,seqlen_k",
@@ -423,6 +425,8 @@ def test_flash_attn_varlen_output(
     # set seed
     torch.random.manual_seed(seqlen_q + seqlen_k + d + int(causal) * 2 + int(local))
     batch_size = 49 if seqlen_q <= 1024 else 7
+    if d == 256:
+        batch_size = max(1, batch_size // 3)
     nheads = 6
     # nheads = 1
     nheads_kv = nheads if mha_type == "mha" else (3 if mha_type == "gqa" else 1)
@@ -651,7 +655,7 @@ def test_flash_attn_varlen_output(
             and not has_qv
             and not dv > 256
             and not attention_chunk != 0
-            and ((dv == d and d <= 128) or (d == 192 and dv == 128))
+            and ((dv == d and d <= 128) or (d == 192 and dv == 128) or (d == 256 and dv == 256))
             and not has_learnable_sink
             and not is_sm90
             # and False

--- a/tests/cute/test_flash_attn_varlen.py
+++ b/tests/cute/test_flash_attn_varlen.py
@@ -7,7 +7,7 @@ from flash_attn.cute import flash_attn_varlen_func
 
 @pytest.mark.parametrize("B", [1, 7, 20])
 @pytest.mark.parametrize("H", [1, 4, 6])
-@pytest.mark.parametrize("D", [64, 128])
+@pytest.mark.parametrize("D", [64, 128, 256])
 @pytest.mark.parametrize("min_seq_len", [1, 32, 128])
 @pytest.mark.parametrize("max_seq_len", [8, 64, 2048])
 @pytest.mark.parametrize("causal", [True, False])


### PR DESCRIPTION
## Summary

This PR enables `head_dim=256` forward and backward attention kernels on SM100 (Blackwell) via the **Split-D** technique. SM100's TMEM is limited to 512 FP32 columns, which is insufficient to hold all accumulators for `d=256` in a single GEMM pass. Split-D decomposes each 256-dim GEMM into two 128-dim sub-GEMMs, keeping each sub-GEMM fully compatible with the existing `d=128` datapath while achieving 100% TMEM utilization.

All Split-D logic is guarded by a compile-time `is_split_d` flag derived from `head_dim > 128 && head_dim == head_dim_v && head_dim != 192`, ensuring **zero impact** on existing `d=64/128/192` paths.

## Motivation

- Many emerging model architectures (e.g., large vision transformers, certain LLM variants) use `head_dim=256`.
- SM100 TMEM has exactly 512 FP32 columns. For `d=256`, output accumulators alone (e.g., `O_low(256) + O_high(256)` in FWD, `dV(256) + dK(256)` in BWD) exhaust the budget, leaving no room for intermediate accumulators (S, P, dP, dS).
- Split-D resolves this by splitting the head dimension: **contraction-dimension split** for QK/S GEMMs (S remains `[M, N]` — softmax and masks are unaffected), and **output-dimension split** for PV/O GEMMs.

## Technical Approach

### FWD Kernel: 2 GEMMs → 4 sub-GEMMs per N-block

**TMEM layout (512 cols, 100% utilization):**
```
|--- S0 ---|--- S1/P ---|--- O_low ---|--- O_high ---|
  [0, 128)   [128, 256)    [256, 384)    [384, 512)
```

**MMA main loop (per N-block):**
1. `S  = Q_low @ K_low^T` (zero_init)
2. `S += Q_high @ K_high^T` (accumulate) → softmax
3. `O_low  += P @ V_low`
4. `O_high += P @ V_high`

**Key techniques:**
- PTX SMEM descriptor pre-set to Q_high address; `gemm_Si_low` uses negative offset (`-sQ_stage_stride`) to access Q_low, avoiding descriptor updates in the main loop.
- 5 KV pipeline stages (each 128×128×2B = 32 KB): 4 consumed per N-block (K_low, K_high, V_low, V_high), 1 for prefetch overlap.
- `overlap_sO_sQ = True`: sQ (2 physical stages for Q_low/Q_high) and sO share SMEM.
- O_low and O_high are physically contiguous in TMEM [256, 512); correction/epilogue traverses all 256 columns via manual iterator arithmetic (`tOtO_t2r.iterator + i * corr_tile_size`).

### BWD Kernel: 5 GEMMs → 10 sub-GEMMs per M-block

**Core design decision:** dK moved from TMEM persistent accumulation to GMEM atomic reduce (`dK_as_reduce = True`), freeing TMEM for S/P/dP/dS intermediates. dV remains persistent in TMEM.

**TMEM layout (512 cols, 100% utilization):**
```
|--- S/P ---|--- dV_low ---|--- dV_high ---|--- dP/dS ---|
  [0, 128)    [128, 256)     [256, 384)      [384, 512)
```
TMEM [0, 128) is time-division multiplexed between S/P, dK_partial, and dQ_partial.

**10 sub-GEMM schedule (per M-block):**
| Phase | Sub-GEMMs | Notes |
|-------|-----------|-------|
| S^T (contraction split) | K_low @ Q_low^T + K_high @ Q_high^T | → softmax/mask |
| dP^T (contraction split) | V_low @ dO_low^T + V_high @ dO_high^T | → dS = P*(dP-D) |
| dV (output split, TMEM persistent) | P^T @ dO_high, P^T @ dO_low | accumulate across M-blocks |
| dK (output split → GMEM reduce) | dS^T @ Q_high, dS^T @ Q_low | fire to reduce warp |
| dQ (output split → GMEM reduce) | dS @ K_low, dS @ K_high | fire to reduce warp |

**Key techniques:**
- `producer_phase_dQ` variable with XOR toggling ensures correct pipeline synchronization for TMEM [0, 128) time-division multiplexing between MMA and reduce warps.
- Q and dO each loaded 3 times per M-block (load + reload) due to single-stage buffer reuse across sub-GEMMs.
- K persisted in 2 SMEM stages (K_low + K_high) throughout the entire M-block loop.
- dV epilogue splits into two 128-col passes with explicit SMEM async commit+wait between passes to prevent race conditions.
- Deterministic dV semaphore: acquire only on dV_low, release only on dV_high (one logical increment per slot).

### Interface Changes

- `_validate_head_dims`: Accept `(256, 256)` on SM100/SM110.
- FWD: Compute `is_split_d`, enforce `q_stage=1`, `pack_gqa=False`, `num_splits=1`.
- BWD: Compute `is_split_d_bwd`, enforce `cluster_size=1`, `use_2cta_instrs=False`, `dKV_postprocess=True`.
- BWD postprocess: Split dQ/dK/dV accumulators into low/high halves, call `_bwd_postprocess_convert(head_dim=128)` on each half, copy results back.
- Varlen: `dq_accum` allocated with `torch.zeros` (instead of `torch.empty`) to ensure the high-half region is properly initialized for Split-D's `[low|high]` layout.

## Constraints (d=256)

| Feature | Status | Reason |
|---------|--------|--------|
| 2CTA instructions | Disabled | TMEM > 512 columns |
| Persistent kernel | Disabled | `overlap_sO_sQ` incompatible |
| SplitKV | Disabled | `head_dim_v >= 192` assertion |
| Paged KV | Disabled | Non-TMA path not adapted |
| pack_gqa | Disabled | `load_Q_non_tma` not adapted |
| Block Sparsity | Not yet adapted | Load path not adapted |
| score_mod / mask_mod | Not yet validated | Theoretically compatible (S/P dimensions unchanged) |

## Files Changed

| File | Lines | Description |
|------|-------|-------------|
| `flash_attn/cute/flash_fwd_sm100.py` | +440/−145 | Split-D FWD: TMEM layout, MMA tilers, 4 sub-GEMM loop, Q split-load, correction epilogue |
| `flash_attn/cute/flash_bwd_sm100.py` | +779/−213 | Split-D BWD: TMEM layout, 10 sub-GEMM loop, 4x reduce/M-block, dV 2-pass epilogue, pipeline sync |
| `flash_attn/cute/interface.py` | +107/−31 | Head dim validation, `is_split_d` flags, constraints, accum allocation, split-half postprocess |
| `tests/cute/test_flash_attn.py` | +4/−4 | Add d=256 to parametrization, enable BWD for d=256 |
| `tests/cute/test_flash_attn_fast.py` | +15/−7 | Add d=256, adjust batch sizes, enable BWD for d=256 |
| `tests/cute/test_flash_attn_race_condition.py` | +8/−4 | Add d=256, adjust batch sizes, enable BWD deterministic tests |
| `tests/cute/test_flash_attn_varlen.py` | +1/−1 | Enable d=256 varlen tests |

**Total: 7 files, +1363/−396 lines.**

## Test Results

### Full Regression (all head dims)

| Test | Result |
|------|--------|
| `test_flash_attn.py` | **1506 passed**, 177 skipped |
| `test_flash_attn_fast.py` | **336 passed**, 24 skipped |
| `test_flash_attn_varlen.py` | d=256 added and passing |
| `test_flash_attn_combine.py` | **2394 passed** (combine kernel natively supports d=256) |
| `test_flash_attn_race_condition.py` | **89 passed**, 36 skipped, 8 failed (see known issues) |

### Regression Verification

- **d=64 / d=128**: All FWD and BWD tests pass — existing paths unaffected.

## Known Issues

### MQA dK bitwise non-determinism (8 test failures in race_condition)

Split-D BWD's dK uses per-M-block `cpasync_reduce_bulk_add_f32` atomic accumulation to GMEM. For MQA (`qhead_per_kvhead=6`), multiple Q heads atomically add to the same K head address. FP32 atomic addition is not associative, so operation ordering affects the result at the bit level (max diff ≈ 0.002). This affects **only MQA dK bitwise determinism**; MHA/GQA determinism is correct, and numerical accuracy is within tolerance.

### Varlen GQA + bf16 dK precision boundary

Split-D's dK GMEM atomic reduce path introduces extra FP32 round-off compared to the TMEM persistent accumulation used for d≤128. For GQA with bf16, this can marginally increase numerical error at extreme sequence lengths.
