### PR TITLE
Disable 2CTA fwd non-causal on CUDA 12 to work around codegen regression

### DIFF
--- a/flash_attn/cute/utils.py
+++ b/flash_attn/cute/utils.py
@@ -60,10 +60,10 @@ _fa_clc_enabled: bool = os.environ.get("FA_CLC", "0") == "1"
 _fa_disable_2cta_enabled: bool = os.environ.get("FA_DISABLE_2CTA", "0") == "1"
 
 
-def _is_cuda_12_9() -> bool:
-    """Check if the CUDA toolkit version is 12.9.x.
+def _is_cuda_12() -> bool:
+    """Check if the CUDA toolkit version is 12.x.
 
-    2CTA forward non-causal has a codegen regression on CUDA 12.9 that causes
+    2CTA forward non-causal has a codegen regression on CUDA 12 that causes
     ~18% slowdown compared to 1CTA. This is fixed in CUDA 13.x.
     """
     try:
@@ -71,14 +71,14 @@ def _is_cuda_12_9() -> bool:
 
         cuda_version = torch.version.cuda
         if cuda_version is not None:
-            major, minor = cuda_version.split(".")[:2]
-            return int(major) == 12 and int(minor) == 9
+            major = cuda_version.split(".")[0]
+            return int(major) == 12
     except Exception:
         pass
     return False
 
 
-_fa_disable_2cta_cuda12_9: bool = _is_cuda_12_9()
+_fa_disable_2cta_cuda12: bool = _is_cuda_12()
 
 
 def _get_use_clc_scheduler_default() -> bool:
@@ -86,7 +86,7 @@ def _get_use_clc_scheduler_default() -> bool:
 
 
 def _get_disable_2cta_default() -> bool:
-    return _fa_disable_2cta_enabled or _fa_disable_2cta_cuda12_9
+    return _fa_disable_2cta_enabled or _fa_disable_2cta_cuda12
 
 
 def _compute_base_hash(func: Callable) -> str:

--- a/flash_attn/cute/utils.py
+++ b/flash_attn/cute/utils.py
@@ -60,12 +60,33 @@ _fa_clc_enabled: bool = os.environ.get("FA_CLC", "0") == "1"
 _fa_disable_2cta_enabled: bool = os.environ.get("FA_DISABLE_2CTA", "0") == "1"
 
 
+def _is_cuda_12_9() -> bool:
+    """Check if the CUDA toolkit version is 12.9.x.
+
+    2CTA forward non-causal has a codegen regression on CUDA 12.9 that causes
+    ~18% slowdown compared to 1CTA. This is fixed in CUDA 13.x.
+    """
+    try:
+        import torch
+
+        cuda_version = torch.version.cuda
+        if cuda_version is not None:
+            major, minor = cuda_version.split(".")[:2]
+            return int(major) == 12 and int(minor) == 9
+    except Exception:
+        pass
+    return False
+
+
+_fa_disable_2cta_cuda12_9: bool = _is_cuda_12_9()
+
+
 def _get_use_clc_scheduler_default() -> bool:
     return _fa_clc_enabled
 
 
 def _get_disable_2cta_default() -> bool:
-    return _fa_disable_2cta_enabled
+    return _fa_disable_2cta_enabled or _fa_disable_2cta_cuda12_9
 
 
 def _compute_base_hash(func: Callable) -> str:


### PR DESCRIPTION
  ## Summary                                                                                         
                                                                                                     
  - CUDA 12.9 has a codegen regression that causes ~18% slowdown for 2CTA forward non-causal         
  (hdim=128: ~1280 vs ~1542 TFLOPS)                                                                  
  - Auto-disable 2CTA when CUDA 12.9 is detected via `torch.version.cuda`                            
  - Users on CUDA 13.x are unaffected — 2CTA stays enabled and performs as expected                  
  - The manual `FA_DISABLE_2CTA=1` env var continues to work regardless of CUDA version              
                                                                                                     
  Confirmed by @Johnsonms and @jshahOSS on B200 with CUDA 12.9.                                      
                                                                                   
  ## Test plan                                                                                       
                                                                                   
  - [x] Verify on CUDA 12.9: non-causal hdim=128 should now use 1CTA (~1542 TFLOPS)
  - [x] Verify on CUDA 13.x: non-causal hdim=128 should still use 2CTA (~1597 TFLOPS)
  - [x] Verify `FA_DISABLE_2CTA=1` still works as manual override                                    
                                                                 
  ```bash                                                                                            
  python benchmarks/benchmark_attn.py \                                            
    --fwd --backend fa4 \                                                                            
    --headdim 128 --batch-size 4 --seqlen 8192 \    
    --causal both    