### PR TITLE
[FA4] Add missing fence.proxy.async SM90 backward

### DIFF
--- a/flash_attn/cute/flash_bwd_sm90.py
+++ b/flash_attn/cute/flash_bwd_sm90.py
@@ -1592,6 +1592,9 @@ class FlashAttentionBackwardSm90:
                 mma_dsq_fn(tCrA=tdKrdS, B_idx=smem_idx_Q, zero_init=not dKV_accumulate, wg_wait=1)
             pipeline_dO.consumer_release(consumer_state_dO_cur)
             warpgroup.wait_group(0)
+            # Fence generic-proxy reads of sLSE before releasing the pipeline_Q
+            # stage back to TMA for overwriting.
+            cute.arch.fence_view_async_shared()
             pipeline_Q.consumer_release(consumer_state_Q)
 
         consumer_state_Q.advance()


### PR DESCRIPTION
The CUDA memory model requires a fence.proxy.async.shared::cta when shared memory transitions from generic-proxy access back to async-proxy access. In the SM90 backward kernel, sLSE is co-loaded with Q into the same pipeline stage via TMA (async proxy), and then read by threads via generic ld.shared. Before releasing the pipeline stage (consumer_release) — which allows TMA to overwrite it with the next tile — the kernel must fence to signal that the generic proxy is done with the memory.

In the is_dQ_wg=True path, an unrelated fence_view_async_shared() for the dQaccum store incidentally covered sLSE. In the is_dQ_wg=False path (used when dQ_single_wg=True), no such fence existed, leaving a window where TMA could begin overwriting the pipeline stage while generic-proxy reads of sLSE were still formally in flight.

Add fence_view_async_shared() before pipeline_Q.consumer_release in the is_dQ_wg=False path.