### PR TITLE
Fix FlashAttention-3 installation verification script

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,8 @@ export PYTHONPATH=$PWD
 pytest -q -s test_flash_attn.py
 ```
 Once the package is installed, you can import it as follows:
-```python
-import flash_attn_interface
-flash_attn_interface.flash_attn_func()
+```bash
+python3 -c "import flash_attn_interface; print(dir(flash_attn_interface))" | grep flash_attn_3
 ```
 
 ## FlashAttention-4 (CuTeDSL)

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ pytest -q -s test_flash_attn.py
 ```
 Once the package is installed, you can import it as follows:
 ```bash
-python3 -c "import flash_attn_interface; print(dir(flash_attn_interface))" | grep flash_attn_3
+python -c "import flash_attn_interface; print(dir(flash_attn_interface))" 2>/dev/null | grep -q flash_attn_3 && echo "✓ flash_attn_3 installed" || echo "✗ flash_attn_3 not installed"
 ```
 
 ## FlashAttention-4 (CuTeDSL)


### PR DESCRIPTION
# Description

The proposed check after FlashAttention-3 installation does not work
```python 
import flash_attn_interface
flash_attn_interface.flash_attn_func()
```

```bash
>>> import flash_attn_interface
>>> flash_attn_interface.flash_attn_func()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: flash_attn_func() missing 3 required positional arguments: 'q', 'k', and 'v'
```