### PR TITLE
[FA3,SM90,Fwd] Enable symmetric head dim 512 forward

### DIFF
--- a/hopper/flash_api.cpp
+++ b/hopper/flash_api.cpp
@@ -291,6 +291,14 @@ void run_mha_fwd_constexpr(Flash_fwd_params &params, cudaStream_t stream) {
             #ifndef FLASHATTENTION_DISABLE_HDIM256
             if (params.d <= 256) { return run_mha_fwd_<Arch, cutlass::bfloat16_t, 256, 256, Split, PagedKVNonTMA, Has_softcap, PackGQA>(params, stream); }
             #endif
+            #ifndef FLASHATTENTION_DISABLE_HDIM512
+            if (params.d <= 512) {
+                if constexpr (Arch == 90 && !PagedKVNonTMA) {
+                    return run_mha_fwd_<90, cutlass::bfloat16_t, 512, 512, Split, false, Has_softcap, PackGQA>(params, stream);
+                }
+                STD_TORCH_CHECK(!PagedKVNonTMA, "FlashAttention forward with head_dim 512 does not support PagedKV non-TMA. Use pagedkv_tma=True or non-paged KV.");
+            }
+            #endif
         } else {
             #ifndef FLASHATTENTION_DISABLE_FP16
             #ifndef FLASHATTENTION_DISABLE_HDIM64
@@ -327,6 +335,14 @@ void run_mha_fwd_constexpr(Flash_fwd_params &params, cudaStream_t stream) {
             #endif
             #ifndef FLASHATTENTION_DISABLE_HDIM256
             if (params.d <= 256) { return run_mha_fwd_<Arch, cutlass::half_t, 256, 256, Split, PagedKVNonTMA, Has_softcap, PackGQA>(params, stream); }
+            #endif
+            #ifndef FLASHATTENTION_DISABLE_HDIM512
+            if (params.d <= 512) {
+                if constexpr (Arch == 90 && !PagedKVNonTMA) {
+                    return run_mha_fwd_<90, cutlass::half_t, 512, 512, Split, false, Has_softcap, PackGQA>(params, stream);
+                }
+                STD_TORCH_CHECK(!PagedKVNonTMA, "FlashAttention forward with head_dim 512 does not support PagedKV non-TMA. Use pagedkv_tma=True or non-paged KV.");
+            }
             #endif
             #else
             TORCH_CHECK(false, "This flash attention build does not support FP16.");
@@ -471,6 +487,9 @@ inline int get_num_splits(Flash_fwd_params const& params) {
 }
 
 inline int get_max_headdim() {
+    #ifndef FLASHATTENTION_DISABLE_HDIM512
+    return 512;
+    #endif
     #ifndef FLASHATTENTION_DISABLE_HDIM256
     return 256;
     #endif
@@ -505,7 +524,10 @@ inline int round_up_headdim(int head_size) {
     #ifndef FLASHATTENTION_DISABLE_HDIM256
     if (head_size <= 256) { return 256; }
     #endif
-    return 256;
+    #ifndef FLASHATTENTION_DISABLE_HDIM512
+    if (head_size <= 512) { return 512; }
+    #endif
+    return 512;
 }
 
 inline int round_up_headdimv(int head_size) {

--- a/hopper/flash_api_stable.cpp
+++ b/hopper/flash_api_stable.cpp
@@ -356,6 +356,14 @@ void run_mha_fwd_constexpr(Flash_fwd_params &params, cudaStream_t stream) {
             #ifndef FLASHATTENTION_DISABLE_HDIM256
             if (params.d <= 256) { return run_mha_fwd_<Arch, cutlass::bfloat16_t, 256, 256, Split, PagedKVNonTMA, Has_softcap, PackGQA>(params, stream); }
             #endif
+            #ifndef FLASHATTENTION_DISABLE_HDIM512
+            if (params.d <= 512) {
+                if constexpr (Arch == 90 && !PagedKVNonTMA) {
+                    return run_mha_fwd_<90, cutlass::bfloat16_t, 512, 512, Split, false, Has_softcap, PackGQA>(params, stream);
+                }
+                STD_TORCH_CHECK(!PagedKVNonTMA, "FlashAttention forward with head_dim 512 does not support PagedKV non-TMA. Use pagedkv_tma=True or non-paged KV.");
+            }
+            #endif
         } else {
             #ifndef FLASHATTENTION_DISABLE_FP16
             #ifndef FLASHATTENTION_DISABLE_HDIM64
@@ -392,6 +400,14 @@ void run_mha_fwd_constexpr(Flash_fwd_params &params, cudaStream_t stream) {
             #endif
             #ifndef FLASHATTENTION_DISABLE_HDIM256
             if (params.d <= 256) { return run_mha_fwd_<Arch, cutlass::half_t, 256, 256, Split, PagedKVNonTMA, Has_softcap, PackGQA>(params, stream); }
+            #endif
+            #ifndef FLASHATTENTION_DISABLE_HDIM512
+            if (params.d <= 512) {
+                if constexpr (Arch == 90 && !PagedKVNonTMA) {
+                    return run_mha_fwd_<90, cutlass::half_t, 512, 512, Split, false, Has_softcap, PackGQA>(params, stream);
+                }
+                STD_TORCH_CHECK(!PagedKVNonTMA, "FlashAttention forward with head_dim 512 does not support PagedKV non-TMA. Use pagedkv_tma=True or non-paged KV.");
+            }
             #endif
             #else
             STD_TORCH_CHECK(false, "This flash attention build does not support FP16.");
@@ -536,6 +552,9 @@ inline int get_num_splits(Flash_fwd_params const& params) {
 }
 
 inline int get_max_headdim() {
+    #ifndef FLASHATTENTION_DISABLE_HDIM512
+    return 512;
+    #endif
     #ifndef FLASHATTENTION_DISABLE_HDIM256
     return 256;
     #endif
@@ -570,7 +589,10 @@ inline int round_up_headdim(int head_size) {
     #ifndef FLASHATTENTION_DISABLE_HDIM256
     if (head_size <= 256) { return 256; }
     #endif
-    return 256;
+    #ifndef FLASHATTENTION_DISABLE_HDIM512
+    if (head_size <= 512) { return 512; }
+    #endif
+    return 512;
 }
 
 inline int round_up_headdimv(int head_size) {

--- a/hopper/flash_attn_interface.py
+++ b/hopper/flash_attn_interface.py
@@ -53,7 +53,10 @@ def round_up_headdim(head_size: int) -> int:
     if not CONFIG["build_flags"]["FLASHATTENTION_DISABLE_HDIM256"]:
         if head_size <= 256:
             return 256
-    return 256
+    if not CONFIG["build_flags"].get("FLASHATTENTION_DISABLE_HDIM512", True):
+        if head_size <= 512:
+            return 512
+    return 512
 
 
 @torch.library.custom_op("flash_attn_3::_flash_attn_forward", mutates_args=(), device_types="cuda")

--- a/hopper/flash_fwd_kernel_sm90.h
+++ b/hopper/flash_fwd_kernel_sm90.h
@@ -223,6 +223,7 @@ public:
         if constexpr (Use_TMA_KV) {
             pipeline_params_k.transaction_bytes = CollectiveMainloop::TmaTransactionBytesK;
             pipeline_params_k.is_leader = warp_group_thread_idx == 0;
+            // For LargeHeadDimV: only WG0 (mma) consumes K for QK^T. WG1 (mma_pv) never touches pipeline_k.
             pipeline_params_k.num_consumers = !LargeHeadDimV ? NumMmaThreads : cutlass::NumThreadsPerWarpGroup;
         } else {
             pipeline_params_k.consumer_arv_count = !LargeHeadDimV ? NumMmaThreads : cutlass::NumThreadsPerWarpGroup;
@@ -233,9 +234,15 @@ public:
         PipelineParamsVt pipeline_params_vt = pipeline_params_k;
         if constexpr (Use_TMA_KV && !SameHeadDim) {
             pipeline_params_vt.transaction_bytes = CollectiveMainloop::TmaTransactionBytesV;
-            if constexpr (LargeHeadDimV) { pipeline_params_vt.num_consumers = NumMmaThreads; }
-        } else {
-            if constexpr (LargeHeadDimV) { pipeline_params_vt.consumer_arv_count = NumMmaThreads; }
+        }
+        // For LargeHeadDimV: both WG0 (mma) and WG1 (mma_pv) consume V, so need NumMmaThreads consumers.
+        // This applies regardless of SameHeadDim — pipeline_v is separate from pipeline_k.
+        if constexpr (LargeHeadDimV) {
+            if constexpr (Use_TMA_KV) {
+                pipeline_params_vt.num_consumers = NumMmaThreads;
+            } else {
+                pipeline_params_vt.consumer_arv_count = NumMmaThreads;
+            }
         }
 
         MainloopPipelineK pipeline_k = [&] {

--- a/hopper/generate_kernels.py
+++ b/hopper/generate_kernels.py
@@ -29,7 +29,7 @@ DTYPE_MAP_BWD = {
 }
 
 SM = [80, 90]  # Sm kernels support up to
-HEAD_DIMENSIONS = [64, 96, 128, 192, 256]
+HEAD_DIMENSIONS = [64, 96, 128, 192, 256, 512]
 PAGEDKV = [False, True]
 SPLIT = [False, True]
 SOFTCAP = [False, True]
@@ -134,6 +134,15 @@ def get_all_kernels() -> List[Kernel]:
          # so we should just pass in packgqa=False to avoid the `_packgqa` in the filename.
         if packgqa and (sm < 90 or (sm >= 90 and (paged_kv or split))):
             continue
+        # Symmetric d=512: SM90 only, BF16/FP16 only (no FP8, no SM80)
+        if head_dim > 256 and (sm < 90 or dtype == "e4m3"):
+            continue
+        # Symmetric d=512 + PagedKV non-TMA: register budget insufficient
+        # (384 threads = 256 MMA + 128 producer, 170 reg/thread max, not enough for d=512 WGMMA)
+        # PagedKV TMA path (pagedkv_tma=True) is unaffected and works normally.
+        # This only skips generating the non-TMA paged kernel instantiations.
+        if head_dim > 256 and paged_kv:
+            continue
         if sm >= 90 or dtype in DTYPE_MAP_FWD_SM8x:
             yield Kernel(sm=sm, dtype=dtype, head_dim=head_dim, head_dim_v=head_dim, split=split, paged_kv=paged_kv, softcap=softcap, packgqa=packgqa, direction="fwd")
         if sm == 90 and head_dim == 192:
@@ -142,6 +151,8 @@ def get_all_kernels() -> List[Kernel]:
             yield Kernel(sm=sm, dtype=dtype, head_dim=head_dim, head_dim_v=256, split=split, paged_kv=paged_kv, softcap=softcap, packgqa=packgqa, direction="fwd")
             yield Kernel(sm=sm, dtype=dtype, head_dim=head_dim, head_dim_v=512, split=split, paged_kv=paged_kv, softcap=softcap, packgqa=packgqa, direction="fwd")
     for dtype, head_dim, softcap, sm in itertools.product(DTYPE_MAP_BWD.keys(), HEAD_DIMENSIONS, SOFTCAP, SM):
+        if head_dim > 256:  # No backward for d>256
+            continue
         yield Kernel(sm=sm, dtype=dtype, head_dim=head_dim, head_dim_v=head_dim, split=False, paged_kv=False, softcap=softcap, packgqa=False, direction="bwd")
 
 

--- a/hopper/instantiations/flash_fwd_hdim512_bf16_packgqa_sm90.cu
+++ b/hopper/instantiations/flash_fwd_hdim512_bf16_packgqa_sm90.cu
@@ -2,9 +2,8 @@
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"
 
-#include "flash_fwd_hdim64_bf16_sm90.cu"
-#include "flash_fwd_hdim96_bf16_sm90.cu"
-#include "flash_fwd_hdim128_bf16_sm90.cu"
-#include "flash_fwd_hdim192_bf16_sm90.cu"
-#include "flash_fwd_hdim256_bf16_sm90.cu"
-#include "flash_fwd_hdim512_bf16_sm90.cu"
+#include "flash_fwd_launch_template.h"
+
+#ifndef FLASHATTENTION_DISABLE_HDIM512
+template void run_mha_fwd_<90, cutlass::bfloat16_t, 512, 512, false, false, false, true>(Flash_fwd_params &params, cudaStream_t stream);
+#endif

--- a/hopper/instantiations/flash_fwd_hdim512_bf16_paged_sm90.cu
+++ b/hopper/instantiations/flash_fwd_hdim512_bf16_paged_sm90.cu
@@ -2,9 +2,8 @@
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"
 
-#include "flash_fwd_hdim64_bf16_sm90.cu"
-#include "flash_fwd_hdim96_bf16_sm90.cu"
-#include "flash_fwd_hdim128_bf16_sm90.cu"
-#include "flash_fwd_hdim192_bf16_sm90.cu"
-#include "flash_fwd_hdim256_bf16_sm90.cu"
-#include "flash_fwd_hdim512_bf16_sm90.cu"
+#include "flash_fwd_launch_template.h"
+
+#ifndef FLASHATTENTION_DISABLE_HDIM512
+template void run_mha_fwd_<90, cutlass::bfloat16_t, 512, 512, false, true, false, true>(Flash_fwd_params &params, cudaStream_t stream);
+#endif

--- a/hopper/instantiations/flash_fwd_hdim512_bf16_paged_softcap_sm90.cu
+++ b/hopper/instantiations/flash_fwd_hdim512_bf16_paged_softcap_sm90.cu
@@ -2,9 +2,8 @@
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"
 
-#include "flash_fwd_hdim64_bf16_sm90.cu"
-#include "flash_fwd_hdim96_bf16_sm90.cu"
-#include "flash_fwd_hdim128_bf16_sm90.cu"
-#include "flash_fwd_hdim192_bf16_sm90.cu"
-#include "flash_fwd_hdim256_bf16_sm90.cu"
-#include "flash_fwd_hdim512_bf16_sm90.cu"
+#include "flash_fwd_launch_template.h"
+
+#ifndef FLASHATTENTION_DISABLE_HDIM512
+template void run_mha_fwd_<90, cutlass::bfloat16_t, 512, 512, false, true, true, true>(Flash_fwd_params &params, cudaStream_t stream);
+#endif

--- a/hopper/instantiations/flash_fwd_hdim512_bf16_paged_split_sm90.cu
+++ b/hopper/instantiations/flash_fwd_hdim512_bf16_paged_split_sm90.cu
@@ -2,9 +2,8 @@
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"
 
-#include "flash_fwd_hdim64_bf16_sm90.cu"
-#include "flash_fwd_hdim96_bf16_sm90.cu"
-#include "flash_fwd_hdim128_bf16_sm90.cu"
-#include "flash_fwd_hdim192_bf16_sm90.cu"
-#include "flash_fwd_hdim256_bf16_sm90.cu"
-#include "flash_fwd_hdim512_bf16_sm90.cu"
+#include "flash_fwd_launch_template.h"
+
+#ifndef FLASHATTENTION_DISABLE_HDIM512
+template void run_mha_fwd_<90, cutlass::bfloat16_t, 512, 512, true, true, false, true>(Flash_fwd_params &params, cudaStream_t stream);
+#endif

--- a/hopper/instantiations/flash_fwd_hdim512_bf16_paged_split_softcap_sm90.cu
+++ b/hopper/instantiations/flash_fwd_hdim512_bf16_paged_split_softcap_sm90.cu
@@ -2,9 +2,8 @@
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"
 
-#include "flash_fwd_hdim64_bf16_sm90.cu"
-#include "flash_fwd_hdim96_bf16_sm90.cu"
-#include "flash_fwd_hdim128_bf16_sm90.cu"
-#include "flash_fwd_hdim192_bf16_sm90.cu"
-#include "flash_fwd_hdim256_bf16_sm90.cu"
-#include "flash_fwd_hdim512_bf16_sm90.cu"
+#include "flash_fwd_launch_template.h"
+
+#ifndef FLASHATTENTION_DISABLE_HDIM512
+template void run_mha_fwd_<90, cutlass::bfloat16_t, 512, 512, true, true, true, true>(Flash_fwd_params &params, cudaStream_t stream);
+#endif

--- a/hopper/instantiations/flash_fwd_hdim512_bf16_sm90.cu
+++ b/hopper/instantiations/flash_fwd_hdim512_bf16_sm90.cu
@@ -2,9 +2,8 @@
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"
 
-#include "flash_fwd_hdim64_bf16_sm90.cu"
-#include "flash_fwd_hdim96_bf16_sm90.cu"
-#include "flash_fwd_hdim128_bf16_sm90.cu"
-#include "flash_fwd_hdim192_bf16_sm90.cu"
-#include "flash_fwd_hdim256_bf16_sm90.cu"
-#include "flash_fwd_hdim512_bf16_sm90.cu"
+#include "flash_fwd_launch_template.h"
+
+#ifndef FLASHATTENTION_DISABLE_HDIM512
+template void run_mha_fwd_<90, cutlass::bfloat16_t, 512, 512, false, false, false, false>(Flash_fwd_params &params, cudaStream_t stream);
+#endif

--- a/hopper/instantiations/flash_fwd_hdim512_bf16_softcap_packgqa_sm90.cu
+++ b/hopper/instantiations/flash_fwd_hdim512_bf16_softcap_packgqa_sm90.cu
@@ -2,9 +2,8 @@
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"
 
-#include "flash_fwd_hdim64_bf16_sm90.cu"
-#include "flash_fwd_hdim96_bf16_sm90.cu"
-#include "flash_fwd_hdim128_bf16_sm90.cu"
-#include "flash_fwd_hdim192_bf16_sm90.cu"
-#include "flash_fwd_hdim256_bf16_sm90.cu"
-#include "flash_fwd_hdim512_bf16_sm90.cu"
+#include "flash_fwd_launch_template.h"
+
+#ifndef FLASHATTENTION_DISABLE_HDIM512
+template void run_mha_fwd_<90, cutlass::bfloat16_t, 512, 512, false, false, true, true>(Flash_fwd_params &params, cudaStream_t stream);
+#endif

--- a/hopper/instantiations/flash_fwd_hdim512_bf16_softcap_sm90.cu
+++ b/hopper/instantiations/flash_fwd_hdim512_bf16_softcap_sm90.cu
@@ -2,9 +2,8 @@
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"
 
-#include "flash_fwd_hdim64_bf16_sm90.cu"
-#include "flash_fwd_hdim96_bf16_sm90.cu"
-#include "flash_fwd_hdim128_bf16_sm90.cu"
-#include "flash_fwd_hdim192_bf16_sm90.cu"
-#include "flash_fwd_hdim256_bf16_sm90.cu"
-#include "flash_fwd_hdim512_bf16_sm90.cu"
+#include "flash_fwd_launch_template.h"
+
+#ifndef FLASHATTENTION_DISABLE_HDIM512
+template void run_mha_fwd_<90, cutlass::bfloat16_t, 512, 512, false, false, true, false>(Flash_fwd_params &params, cudaStream_t stream);
+#endif

--- a/hopper/instantiations/flash_fwd_hdim512_bf16_split_sm90.cu
+++ b/hopper/instantiations/flash_fwd_hdim512_bf16_split_sm90.cu
@@ -2,9 +2,8 @@
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"
 
-#include "flash_fwd_hdim64_bf16_sm90.cu"
-#include "flash_fwd_hdim96_bf16_sm90.cu"
-#include "flash_fwd_hdim128_bf16_sm90.cu"
-#include "flash_fwd_hdim192_bf16_sm90.cu"
-#include "flash_fwd_hdim256_bf16_sm90.cu"
-#include "flash_fwd_hdim512_bf16_sm90.cu"
+#include "flash_fwd_launch_template.h"
+
+#ifndef FLASHATTENTION_DISABLE_HDIM512
+template void run_mha_fwd_<90, cutlass::bfloat16_t, 512, 512, true, false, false, true>(Flash_fwd_params &params, cudaStream_t stream);
+#endif

--- a/hopper/instantiations/flash_fwd_hdim512_bf16_split_softcap_sm90.cu
+++ b/hopper/instantiations/flash_fwd_hdim512_bf16_split_softcap_sm90.cu
@@ -2,9 +2,8 @@
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"
 
-#include "flash_fwd_hdim64_bf16_sm90.cu"
-#include "flash_fwd_hdim96_bf16_sm90.cu"
-#include "flash_fwd_hdim128_bf16_sm90.cu"
-#include "flash_fwd_hdim192_bf16_sm90.cu"
-#include "flash_fwd_hdim256_bf16_sm90.cu"
-#include "flash_fwd_hdim512_bf16_sm90.cu"
+#include "flash_fwd_launch_template.h"
+
+#ifndef FLASHATTENTION_DISABLE_HDIM512
+template void run_mha_fwd_<90, cutlass::bfloat16_t, 512, 512, true, false, true, true>(Flash_fwd_params &params, cudaStream_t stream);
+#endif

--- a/hopper/instantiations/flash_fwd_hdim512_fp16_packgqa_sm90.cu
+++ b/hopper/instantiations/flash_fwd_hdim512_fp16_packgqa_sm90.cu
@@ -2,9 +2,8 @@
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"
 
-#include "flash_fwd_hdim64_bf16_sm90.cu"
-#include "flash_fwd_hdim96_bf16_sm90.cu"
-#include "flash_fwd_hdim128_bf16_sm90.cu"
-#include "flash_fwd_hdim192_bf16_sm90.cu"
-#include "flash_fwd_hdim256_bf16_sm90.cu"
-#include "flash_fwd_hdim512_bf16_sm90.cu"
+#include "flash_fwd_launch_template.h"
+
+#ifndef FLASHATTENTION_DISABLE_HDIM512
+template void run_mha_fwd_<90, cutlass::half_t, 512, 512, false, false, false, true>(Flash_fwd_params &params, cudaStream_t stream);
+#endif

--- a/hopper/instantiations/flash_fwd_hdim512_fp16_paged_sm90.cu
+++ b/hopper/instantiations/flash_fwd_hdim512_fp16_paged_sm90.cu
@@ -2,9 +2,8 @@
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"
 
-#include "flash_fwd_hdim64_bf16_sm90.cu"
-#include "flash_fwd_hdim96_bf16_sm90.cu"
-#include "flash_fwd_hdim128_bf16_sm90.cu"
-#include "flash_fwd_hdim192_bf16_sm90.cu"
-#include "flash_fwd_hdim256_bf16_sm90.cu"
-#include "flash_fwd_hdim512_bf16_sm90.cu"
+#include "flash_fwd_launch_template.h"
+
+#ifndef FLASHATTENTION_DISABLE_HDIM512
+template void run_mha_fwd_<90, cutlass::half_t, 512, 512, false, true, false, true>(Flash_fwd_params &params, cudaStream_t stream);
+#endif

--- a/hopper/instantiations/flash_fwd_hdim512_fp16_paged_softcap_sm90.cu
+++ b/hopper/instantiations/flash_fwd_hdim512_fp16_paged_softcap_sm90.cu
@@ -2,9 +2,8 @@
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"
 
-#include "flash_fwd_hdim64_bf16_sm90.cu"
-#include "flash_fwd_hdim96_bf16_sm90.cu"
-#include "flash_fwd_hdim128_bf16_sm90.cu"
-#include "flash_fwd_hdim192_bf16_sm90.cu"
-#include "flash_fwd_hdim256_bf16_sm90.cu"
-#include "flash_fwd_hdim512_bf16_sm90.cu"
+#include "flash_fwd_launch_template.h"
+
+#ifndef FLASHATTENTION_DISABLE_HDIM512
+template void run_mha_fwd_<90, cutlass::half_t, 512, 512, false, true, true, true>(Flash_fwd_params &params, cudaStream_t stream);
+#endif

--- a/hopper/instantiations/flash_fwd_hdim512_fp16_paged_split_sm90.cu
+++ b/hopper/instantiations/flash_fwd_hdim512_fp16_paged_split_sm90.cu
@@ -2,9 +2,8 @@
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"
 
-#include "flash_fwd_hdim64_bf16_sm90.cu"
-#include "flash_fwd_hdim96_bf16_sm90.cu"
-#include "flash_fwd_hdim128_bf16_sm90.cu"
-#include "flash_fwd_hdim192_bf16_sm90.cu"
-#include "flash_fwd_hdim256_bf16_sm90.cu"
-#include "flash_fwd_hdim512_bf16_sm90.cu"
+#include "flash_fwd_launch_template.h"
+
+#ifndef FLASHATTENTION_DISABLE_HDIM512
+template void run_mha_fwd_<90, cutlass::half_t, 512, 512, true, true, false, true>(Flash_fwd_params &params, cudaStream_t stream);
+#endif

--- a/hopper/instantiations/flash_fwd_hdim512_fp16_paged_split_softcap_sm90.cu
+++ b/hopper/instantiations/flash_fwd_hdim512_fp16_paged_split_softcap_sm90.cu
@@ -2,9 +2,8 @@
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"
 
-#include "flash_fwd_hdim64_bf16_sm90.cu"
-#include "flash_fwd_hdim96_bf16_sm90.cu"
-#include "flash_fwd_hdim128_bf16_sm90.cu"
-#include "flash_fwd_hdim192_bf16_sm90.cu"
-#include "flash_fwd_hdim256_bf16_sm90.cu"
-#include "flash_fwd_hdim512_bf16_sm90.cu"
+#include "flash_fwd_launch_template.h"
+
+#ifndef FLASHATTENTION_DISABLE_HDIM512
+template void run_mha_fwd_<90, cutlass::half_t, 512, 512, true, true, true, true>(Flash_fwd_params &params, cudaStream_t stream);
+#endif

--- a/hopper/instantiations/flash_fwd_hdim512_fp16_sm90.cu
+++ b/hopper/instantiations/flash_fwd_hdim512_fp16_sm90.cu
@@ -2,9 +2,8 @@
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"
 
-#include "flash_fwd_hdim64_bf16_sm90.cu"
-#include "flash_fwd_hdim96_bf16_sm90.cu"
-#include "flash_fwd_hdim128_bf16_sm90.cu"
-#include "flash_fwd_hdim192_bf16_sm90.cu"
-#include "flash_fwd_hdim256_bf16_sm90.cu"
-#include "flash_fwd_hdim512_bf16_sm90.cu"
+#include "flash_fwd_launch_template.h"
+
+#ifndef FLASHATTENTION_DISABLE_HDIM512
+template void run_mha_fwd_<90, cutlass::half_t, 512, 512, false, false, false, false>(Flash_fwd_params &params, cudaStream_t stream);
+#endif

--- a/hopper/instantiations/flash_fwd_hdim512_fp16_softcap_packgqa_sm90.cu
+++ b/hopper/instantiations/flash_fwd_hdim512_fp16_softcap_packgqa_sm90.cu
@@ -2,9 +2,8 @@
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"
 
-#include "flash_fwd_hdim64_bf16_sm90.cu"
-#include "flash_fwd_hdim96_bf16_sm90.cu"
-#include "flash_fwd_hdim128_bf16_sm90.cu"
-#include "flash_fwd_hdim192_bf16_sm90.cu"
-#include "flash_fwd_hdim256_bf16_sm90.cu"
-#include "flash_fwd_hdim512_bf16_sm90.cu"
+#include "flash_fwd_launch_template.h"
+
+#ifndef FLASHATTENTION_DISABLE_HDIM512
+template void run_mha_fwd_<90, cutlass::half_t, 512, 512, false, false, true, true>(Flash_fwd_params &params, cudaStream_t stream);
+#endif

--- a/hopper/instantiations/flash_fwd_hdim512_fp16_softcap_sm90.cu
+++ b/hopper/instantiations/flash_fwd_hdim512_fp16_softcap_sm90.cu
@@ -2,9 +2,8 @@
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"
 
-#include "flash_fwd_hdim64_bf16_sm90.cu"
-#include "flash_fwd_hdim96_bf16_sm90.cu"
-#include "flash_fwd_hdim128_bf16_sm90.cu"
-#include "flash_fwd_hdim192_bf16_sm90.cu"
-#include "flash_fwd_hdim256_bf16_sm90.cu"
-#include "flash_fwd_hdim512_bf16_sm90.cu"
+#include "flash_fwd_launch_template.h"
+
+#ifndef FLASHATTENTION_DISABLE_HDIM512
+template void run_mha_fwd_<90, cutlass::half_t, 512, 512, false, false, true, false>(Flash_fwd_params &params, cudaStream_t stream);
+#endif

--- a/hopper/instantiations/flash_fwd_hdim512_fp16_split_sm90.cu
+++ b/hopper/instantiations/flash_fwd_hdim512_fp16_split_sm90.cu
@@ -2,9 +2,8 @@
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"
 
-#include "flash_fwd_hdim64_bf16_sm90.cu"
-#include "flash_fwd_hdim96_bf16_sm90.cu"
-#include "flash_fwd_hdim128_bf16_sm90.cu"
-#include "flash_fwd_hdim192_bf16_sm90.cu"
-#include "flash_fwd_hdim256_bf16_sm90.cu"
-#include "flash_fwd_hdim512_bf16_sm90.cu"
+#include "flash_fwd_launch_template.h"
+
+#ifndef FLASHATTENTION_DISABLE_HDIM512
+template void run_mha_fwd_<90, cutlass::half_t, 512, 512, true, false, false, true>(Flash_fwd_params &params, cudaStream_t stream);
+#endif

--- a/hopper/instantiations/flash_fwd_hdim512_fp16_split_softcap_sm90.cu
+++ b/hopper/instantiations/flash_fwd_hdim512_fp16_split_softcap_sm90.cu
@@ -2,9 +2,8 @@
 // Splitting the different template instantiations to different files to speed up compilation.
 // This file is auto-generated. See "generate_kernels.py"
 
-#include "flash_fwd_hdim64_bf16_sm90.cu"
-#include "flash_fwd_hdim96_bf16_sm90.cu"
-#include "flash_fwd_hdim128_bf16_sm90.cu"
-#include "flash_fwd_hdim192_bf16_sm90.cu"
-#include "flash_fwd_hdim256_bf16_sm90.cu"
-#include "flash_fwd_hdim512_bf16_sm90.cu"
+#include "flash_fwd_launch_template.h"
+
+#ifndef FLASHATTENTION_DISABLE_HDIM512
+template void run_mha_fwd_<90, cutlass::half_t, 512, 512, true, false, true, true>(Flash_fwd_params &params, cudaStream_t stream);
+#endif

--- a/hopper/instantiations/flash_fwd_hdimall_bf16_packgqa_sm90.cu
+++ b/hopper/instantiations/flash_fwd_hdimall_bf16_packgqa_sm90.cu
@@ -7,3 +7,4 @@
 #include "flash_fwd_hdim128_bf16_packgqa_sm90.cu"
 #include "flash_fwd_hdim192_bf16_packgqa_sm90.cu"
 #include "flash_fwd_hdim256_bf16_packgqa_sm90.cu"
+#include "flash_fwd_hdim512_bf16_packgqa_sm90.cu"

--- a/hopper/instantiations/flash_fwd_hdimall_bf16_paged_sm90.cu
+++ b/hopper/instantiations/flash_fwd_hdimall_bf16_paged_sm90.cu
@@ -7,3 +7,4 @@
 #include "flash_fwd_hdim128_bf16_paged_sm90.cu"
 #include "flash_fwd_hdim192_bf16_paged_sm90.cu"
 #include "flash_fwd_hdim256_bf16_paged_sm90.cu"
+#include "flash_fwd_hdim512_bf16_paged_sm90.cu"

--- a/hopper/instantiations/flash_fwd_hdimall_bf16_paged_softcap_sm90.cu
+++ b/hopper/instantiations/flash_fwd_hdimall_bf16_paged_softcap_sm90.cu
@@ -7,3 +7,4 @@
 #include "flash_fwd_hdim128_bf16_paged_softcap_sm90.cu"
 #include "flash_fwd_hdim192_bf16_paged_softcap_sm90.cu"
 #include "flash_fwd_hdim256_bf16_paged_softcap_sm90.cu"
+#include "flash_fwd_hdim512_bf16_paged_softcap_sm90.cu"

--- a/hopper/instantiations/flash_fwd_hdimall_bf16_paged_split_sm90.cu
+++ b/hopper/instantiations/flash_fwd_hdimall_bf16_paged_split_sm90.cu
@@ -7,3 +7,4 @@
 #include "flash_fwd_hdim128_bf16_paged_split_sm90.cu"
 #include "flash_fwd_hdim192_bf16_paged_split_sm90.cu"
 #include "flash_fwd_hdim256_bf16_paged_split_sm90.cu"
+#include "flash_fwd_hdim512_bf16_paged_split_sm90.cu"

--- a/hopper/instantiations/flash_fwd_hdimall_bf16_paged_split_softcap_sm90.cu
+++ b/hopper/instantiations/flash_fwd_hdimall_bf16_paged_split_softcap_sm90.cu
@@ -7,3 +7,4 @@
 #include "flash_fwd_hdim128_bf16_paged_split_softcap_sm90.cu"
 #include "flash_fwd_hdim192_bf16_paged_split_softcap_sm90.cu"
 #include "flash_fwd_hdim256_bf16_paged_split_softcap_sm90.cu"
+#include "flash_fwd_hdim512_bf16_paged_split_softcap_sm90.cu"

--- a/hopper/instantiations/flash_fwd_hdimall_bf16_softcap_packgqa_sm90.cu
+++ b/hopper/instantiations/flash_fwd_hdimall_bf16_softcap_packgqa_sm90.cu
@@ -7,3 +7,4 @@
 #include "flash_fwd_hdim128_bf16_softcap_packgqa_sm90.cu"
 #include "flash_fwd_hdim192_bf16_softcap_packgqa_sm90.cu"
 #include "flash_fwd_hdim256_bf16_softcap_packgqa_sm90.cu"
+#include "flash_fwd_hdim512_bf16_softcap_packgqa_sm90.cu"

--- a/hopper/instantiations/flash_fwd_hdimall_bf16_softcap_sm90.cu
+++ b/hopper/instantiations/flash_fwd_hdimall_bf16_softcap_sm90.cu
@@ -7,3 +7,4 @@
 #include "flash_fwd_hdim128_bf16_softcap_sm90.cu"
 #include "flash_fwd_hdim192_bf16_softcap_sm90.cu"
 #include "flash_fwd_hdim256_bf16_softcap_sm90.cu"
+#include "flash_fwd_hdim512_bf16_softcap_sm90.cu"

--- a/hopper/instantiations/flash_fwd_hdimall_bf16_split_sm90.cu
+++ b/hopper/instantiations/flash_fwd_hdimall_bf16_split_sm90.cu
@@ -7,3 +7,4 @@
 #include "flash_fwd_hdim128_bf16_split_sm90.cu"
 #include "flash_fwd_hdim192_bf16_split_sm90.cu"
 #include "flash_fwd_hdim256_bf16_split_sm90.cu"
+#include "flash_fwd_hdim512_bf16_split_sm90.cu"

--- a/hopper/instantiations/flash_fwd_hdimall_bf16_split_softcap_sm90.cu
+++ b/hopper/instantiations/flash_fwd_hdimall_bf16_split_softcap_sm90.cu
@@ -7,3 +7,4 @@
 #include "flash_fwd_hdim128_bf16_split_softcap_sm90.cu"
 #include "flash_fwd_hdim192_bf16_split_softcap_sm90.cu"
 #include "flash_fwd_hdim256_bf16_split_softcap_sm90.cu"
+#include "flash_fwd_hdim512_bf16_split_softcap_sm90.cu"

--- a/hopper/instantiations/flash_fwd_hdimall_fp16_packgqa_sm90.cu
+++ b/hopper/instantiations/flash_fwd_hdimall_fp16_packgqa_sm90.cu
@@ -7,3 +7,4 @@
 #include "flash_fwd_hdim128_fp16_packgqa_sm90.cu"
 #include "flash_fwd_hdim192_fp16_packgqa_sm90.cu"
 #include "flash_fwd_hdim256_fp16_packgqa_sm90.cu"
+#include "flash_fwd_hdim512_fp16_packgqa_sm90.cu"

--- a/hopper/instantiations/flash_fwd_hdimall_fp16_paged_sm90.cu
+++ b/hopper/instantiations/flash_fwd_hdimall_fp16_paged_sm90.cu
@@ -7,3 +7,4 @@
 #include "flash_fwd_hdim128_fp16_paged_sm90.cu"
 #include "flash_fwd_hdim192_fp16_paged_sm90.cu"
 #include "flash_fwd_hdim256_fp16_paged_sm90.cu"
+#include "flash_fwd_hdim512_fp16_paged_sm90.cu"

--- a/hopper/instantiations/flash_fwd_hdimall_fp16_paged_softcap_sm90.cu
+++ b/hopper/instantiations/flash_fwd_hdimall_fp16_paged_softcap_sm90.cu
@@ -7,3 +7,4 @@
 #include "flash_fwd_hdim128_fp16_paged_softcap_sm90.cu"
 #include "flash_fwd_hdim192_fp16_paged_softcap_sm90.cu"
 #include "flash_fwd_hdim256_fp16_paged_softcap_sm90.cu"
+#include "flash_fwd_hdim512_fp16_paged_softcap_sm90.cu"

--- a/hopper/instantiations/flash_fwd_hdimall_fp16_paged_split_sm90.cu
+++ b/hopper/instantiations/flash_fwd_hdimall_fp16_paged_split_sm90.cu
@@ -7,3 +7,4 @@
 #include "flash_fwd_hdim128_fp16_paged_split_sm90.cu"
 #include "flash_fwd_hdim192_fp16_paged_split_sm90.cu"
 #include "flash_fwd_hdim256_fp16_paged_split_sm90.cu"
+#include "flash_fwd_hdim512_fp16_paged_split_sm90.cu"

--- a/hopper/instantiations/flash_fwd_hdimall_fp16_paged_split_softcap_sm90.cu
+++ b/hopper/instantiations/flash_fwd_hdimall_fp16_paged_split_softcap_sm90.cu
@@ -7,3 +7,4 @@
 #include "flash_fwd_hdim128_fp16_paged_split_softcap_sm90.cu"
 #include "flash_fwd_hdim192_fp16_paged_split_softcap_sm90.cu"
 #include "flash_fwd_hdim256_fp16_paged_split_softcap_sm90.cu"
+#include "flash_fwd_hdim512_fp16_paged_split_softcap_sm90.cu"

--- a/hopper/instantiations/flash_fwd_hdimall_fp16_sm90.cu
+++ b/hopper/instantiations/flash_fwd_hdimall_fp16_sm90.cu
@@ -7,3 +7,4 @@
 #include "flash_fwd_hdim128_fp16_sm90.cu"
 #include "flash_fwd_hdim192_fp16_sm90.cu"
 #include "flash_fwd_hdim256_fp16_sm90.cu"
+#include "flash_fwd_hdim512_fp16_sm90.cu"

--- a/hopper/instantiations/flash_fwd_hdimall_fp16_softcap_packgqa_sm90.cu
+++ b/hopper/instantiations/flash_fwd_hdimall_fp16_softcap_packgqa_sm90.cu
@@ -7,3 +7,4 @@
 #include "flash_fwd_hdim128_fp16_softcap_packgqa_sm90.cu"
 #include "flash_fwd_hdim192_fp16_softcap_packgqa_sm90.cu"
 #include "flash_fwd_hdim256_fp16_softcap_packgqa_sm90.cu"
+#include "flash_fwd_hdim512_fp16_softcap_packgqa_sm90.cu"

--- a/hopper/instantiations/flash_fwd_hdimall_fp16_softcap_sm90.cu
+++ b/hopper/instantiations/flash_fwd_hdimall_fp16_softcap_sm90.cu
@@ -7,3 +7,4 @@
 #include "flash_fwd_hdim128_fp16_softcap_sm90.cu"
 #include "flash_fwd_hdim192_fp16_softcap_sm90.cu"
 #include "flash_fwd_hdim256_fp16_softcap_sm90.cu"
+#include "flash_fwd_hdim512_fp16_softcap_sm90.cu"

--- a/hopper/instantiations/flash_fwd_hdimall_fp16_split_sm90.cu
+++ b/hopper/instantiations/flash_fwd_hdimall_fp16_split_sm90.cu
@@ -7,3 +7,4 @@
 #include "flash_fwd_hdim128_fp16_split_sm90.cu"
 #include "flash_fwd_hdim192_fp16_split_sm90.cu"
 #include "flash_fwd_hdim256_fp16_split_sm90.cu"
+#include "flash_fwd_hdim512_fp16_split_sm90.cu"

--- a/hopper/instantiations/flash_fwd_hdimall_fp16_split_softcap_sm90.cu
+++ b/hopper/instantiations/flash_fwd_hdimall_fp16_split_softcap_sm90.cu
@@ -7,3 +7,4 @@
 #include "flash_fwd_hdim128_fp16_split_softcap_sm90.cu"
 #include "flash_fwd_hdim192_fp16_split_softcap_sm90.cu"
 #include "flash_fwd_hdim256_fp16_split_softcap_sm90.cu"
+#include "flash_fwd_hdim512_fp16_split_softcap_sm90.cu"

--- a/hopper/setup.py
+++ b/hopper/setup.py
@@ -64,6 +64,7 @@ DISABLE_HDIM96 = os.getenv("FLASH_ATTENTION_DISABLE_HDIM96", "FALSE") == "TRUE"
 DISABLE_HDIM128 = os.getenv("FLASH_ATTENTION_DISABLE_HDIM128", "FALSE") == "TRUE"
 DISABLE_HDIM192 = os.getenv("FLASH_ATTENTION_DISABLE_HDIM192", "FALSE") == "TRUE"
 DISABLE_HDIM256 = os.getenv("FLASH_ATTENTION_DISABLE_HDIM256", "FALSE") == "TRUE"
+DISABLE_HDIM512 = os.getenv("FLASH_ATTENTION_DISABLE_HDIM512", "FALSE") == "TRUE"
 DISABLE_SM8x = os.getenv("FLASH_ATTENTION_DISABLE_SM80", "FALSE") == "TRUE"
 
 ENABLE_VCOLMAJOR = os.getenv("FLASH_ATTENTION_ENABLE_VCOLMAJOR", "FALSE") == "TRUE"
@@ -516,6 +517,7 @@ if not SKIP_CUDA_BUILD:
         + (["-DFLASHATTENTION_DISABLE_HDIM128"] if DISABLE_HDIM128 else [])
         + (["-DFLASHATTENTION_DISABLE_HDIM192"] if DISABLE_HDIM192 else [])
         + (["-DFLASHATTENTION_DISABLE_HDIM256"] if DISABLE_HDIM256 else [])
+        + (["-DFLASHATTENTION_DISABLE_HDIM512"] if DISABLE_HDIM512 else [])
         + (["-DFLASHATTENTION_DISABLE_SM8x"] if DISABLE_SM8x else [])
         + (["-DFLASHATTENTION_ENABLE_VCOLMAJOR"] if ENABLE_VCOLMAJOR else [])
         + (["-DFLASHATTENTION_DISABLE_HDIMDIFF64"] if DISABLE_HDIMDIFF64 else [])
@@ -562,6 +564,12 @@ if not SKIP_CUDA_BUILD:
     if not DISABLE_HDIMDIFF64:
         sources_fwd_sm90 += [f"instantiations/flash_fwd_hdim{hdim}_{dtype}{paged}{split}{softcap}{packgqa}_sm90.cu"
                              for hdim, dtype, split, paged, softcap, packgqa in itertools.product(HEAD_DIMENSIONS_DIFF64_FWD, HALF_DTYPE_FWD_SM90, SPLIT, PAGEDKV, SOFTCAP, PACKGQA)
+                             if not (packgqa and (paged or split))]
+    if not DISABLE_HDIM512:
+        # Symmetric d=512: SM90 only, BF16/FP16 only (no FP8, no backward)
+        sources_fwd_sm90 += [f"instantiations/flash_fwd_hdim512_{dtype}{paged}{split}{softcap}{packgqa}_sm90.cu"
+                             for dtype, split, paged, softcap, packgqa in itertools.product(
+                                 HALF_DTYPE_FWD_SM90, SPLIT, PAGEDKV, SOFTCAP, PACKGQA)
                              if not (packgqa and (paged or split))]
     if not DISABLE_HDIMDIFF192:
         sources_fwd_sm90 += [f"instantiations/flash_fwd_hdim{hdim}_{dtype}{paged}{split}{softcap}{packgqa}_sm90.cu"

--- a/hopper/test_flash_attn.py
+++ b/hopper/test_flash_attn.py
@@ -43,6 +43,7 @@ DISABLE_HDIM96 = os.getenv("FLASH_ATTENTION_DISABLE_HDIM96", "FALSE") == "TRUE"
 DISABLE_HDIM128 = os.getenv("FLASH_ATTENTION_DISABLE_HDIM128", "FALSE") == "TRUE"
 DISABLE_HDIM192 = os.getenv("FLASH_ATTENTION_DISABLE_HDIM192", "FALSE") == "TRUE"
 DISABLE_HDIM256 = os.getenv("FLASH_ATTENTION_DISABLE_HDIM256", "FALSE") == "TRUE"
+DISABLE_HDIM512 = os.getenv("FLASH_ATTENTION_DISABLE_HDIM512", "FALSE") == "TRUE"
 ENABLE_OPCHECK = os.getenv("FLASH_ATTENTION_ENABLE_OPCHECK", "FALSE") == "TRUE"
 ENABLE_AUTOGRAD_CHECK = os.getenv("FLASH_ATTENTION_ENABLE_AUTOGRAD_CHECK", "FALSE") == "TRUE"
 
@@ -53,6 +54,7 @@ COMPILED_HDIMS = (
     + ([128] if not DISABLE_HDIM128 else [])
     + ([192] if not DISABLE_HDIM192 else [])
     + ([256] if not DISABLE_HDIM256 else [])
+    + ([512] if not DISABLE_HDIM512 else [])
 )
 
 def should_test_backward(args, kwargs):
@@ -171,6 +173,10 @@ def test_flash_attn_output(
         pytest.skip("V_colmajor requires seqlen_k to be a multiple of 16 and dtype to be float8_e4m3fn")
     if has_qv and (d != 64 or dtype == torch.float8_e4m3fn):
         pytest.skip("Has Qv requires hdim 64 and dtype to be float16 or bfloat16 (not float8_e4m3fn)")
+    # hdim 512: forward only, SM90 only, BF16/FP16 only (Gemma 4 31B shape: nq=32, nkv=4, d=512)
+    if d > 256:
+        if dtype == torch.float8_e4m3fn:
+            pytest.skip("hdim > 256 does not support FP8")
     device = "cuda"
     # set seed
     torch.random.manual_seed(0)
@@ -406,6 +412,8 @@ def test_flash_attn_varlen_output(
 ):
     if has_qv and (d != 64 or dtype == torch.float8_e4m3fn):
         pytest.skip("Has Qv requires hdim 64 and dtype to be float16 or bfloat16 (not float8_e4m3fn)")
+    if d > 256 and dtype == torch.float8_e4m3fn:
+        pytest.skip("hdim > 256 does not support FP8")
     device = "cuda"
     # set seed
     torch.random.manual_seed(seqlen_q + seqlen_k + d + int(causal) * 2 + int(local))

--- a/hopper/tile_size.h
+++ b/hopper/tile_size.h
@@ -35,8 +35,12 @@ constexpr std::tuple<int, int, bool, bool> tile_size_fwd_sm90(
             // 128 x 192 hits the limit of smem if MmaPV_is_RS, 128 x 144 hits the limit if !MmaPV_is_RS
         } else if (headdim <= 192) {
             return {128, paged_kv_non_TMA || is_local ? 96 : (headdim_v <= 128 ? 128 : 112), true, true};  // 128 x 112 hits the limit of smem
-        } else {
+        } else if (headdim <= 256) {
             return {128, is_local ? 64 : 80, true, true};  // 128 x 80 hits the limit of smem
+        } else {
+            // headdim > 256 (e.g., 512): LargeHeadDimV requires kBlockM <= 64, MmaPV_is_RS = false
+            // kBlockN=32 with kStages=2 gives ~197KB SMEM for d=512 BF16 (fits in 228KB)
+            return {64, 32, false, false};
         }
     } else {
         if (headdim <= 64) {


### PR DESCRIPTION
Hi, from [novita.ai](https://novita.ai)

## Summary

Enable forward attention for **symmetric head_dim=512** on SM90 (Hopper), targeting models like **Gemma 4 31B** (nq=32, nkv=4, d=512).

- **Forward only** (no backward kernels for d=512)
- **SM90 only** (Hopper H100/H200)
- **BF16 / FP16** (no FP8)
- PagedKV via TMA path supported; non-TMA paged path disabled (register pressure)
- Reuses the existing `LargeHeadDimV` two-warp-group path originally built for MLA (hdim=64, hdimv=512)
- Adds `FLASH_ATTENTION_DISABLE_HDIM512` build flag
- Adds d=512 to `test_flash_attn.py` parametrization
- Fixes a latent pipeline_v consumer count bug (see below)

## Tiling Strategy for d=512

**Tile size**: `kBlockM=64, kBlockN=32, kStages=2, MmaPV_is_RS=false`

### SMEM Budget Analysis (228KB available on SM90)

For BF16 (2 bytes/element), 2 pipeline stages:
- **Q tile**: 64 × 512 × 2B = 64KB (1 copy, not pipelined)
- **K tile**: 32 × 512 × 2B × 2 stages = 64KB
- **V tile**: 32 × 512 × 2B × 2 stages = 64KB
- **P tile**: 64 × 32 × 2B = 4KB (softmax output in SMEM for MmaPV SS)
- **O tile**: 64 × 512 × 4B ≈ scratch (accumulated in registers)
- **Pipeline barriers + misc**: ~1KB
- **Total**: ~197KB (fits in 228KB)

### Why kBlockN=32 (vs kBlockN=64 for MLA)

The MLA path (hdim=64, hdimv=512) can afford kBlockN=64 because Q/K are only 64-dim, so SMEM for Q+K is much smaller. With symmetric d=512, Q+K SMEM doubles, forcing kBlockN down to 32 to stay within the 228KB budget while keeping 2 pipeline stages for double buffering.

### WarpGroup Strategy (LargeHeadDimV path)

Two warp groups with asymmetric roles:
- **WG1**: Computes QK^T (64×32 @ 32×512 → 64×32 scores) → softmax → writes P to SMEM → computes half of P×V
- **WG0 (mma_pv)**: Only computes P×V (reads P + rescale factors from SMEM)

This avoids cross-WG softmax reduction — WG1 owns the full score row and computes softmax independently. P matrix and rescale factors are communicated via SMEM + `PFull`/`PEmpty` named barriers.

### WGMMA Configuration

- **QK MMA**: AtomLayout (1, 1, 1), tiler (64, 32) — single WG, SS mode
- **PV MMA**: AtomLayout (1, 2, 1), tiler (64, 256) — 2 WGs split headdim_v, SS mode (MmaPV_is_RS=false required by `static_assert`)

## Bug Fix: pipeline_v consumer count for SameHeadDim + LargeHeadDimV

Fixed a **latent bug in FA3's template code** (`flash_fwd_kernel_sm90.h`) where the pipeline_v consumer count was incorrectly set when `SameHeadDim=true && LargeHeadDimV=true && Use_TMA_KV=true`.

**Root cause**: The original code coupled the V consumer count update to the `!SameHeadDim` condition (since V transaction bytes only differ when head dims differ). But the consumer count for pipeline_v should always be `NumMmaThreads` (2 WGs) when `LargeHeadDimV`, regardless of whether head dims match.

**Before (broken for symmetric d=512)**:
```cpp
if constexpr (Use_TMA_KV && !SameHeadDim) {
    pipeline_params_vt.transaction_bytes = ...;
    if constexpr (LargeHeadDimV) { pipeline_params_vt.num_consumers = NumMmaThreads; }
} else {
    // When Use_TMA_KV && SameHeadDim: sets consumer_arv_count (wrong field for TMA!)
    if constexpr (LargeHeadDimV) { pipeline_params_vt.consumer_arv_count = NumMmaThreads; }
}
```

**After (correct)**:
```cpp
if constexpr (Use_TMA_KV && !SameHeadDim) {
    pipeline_params_vt.transaction_bytes = ...;
}
if constexpr (LargeHeadDimV) {
    if constexpr (Use_TMA_KV) {
        pipeline_params_vt.num_consumers = NumMmaThreads;
    } else {
        pipeline_params_vt.consumer_arv_count = NumMmaThreads;
    }
}
```

This bug was never triggered before because `LargeHeadDimV && SameHeadDim` (symmetric d>256) was never instantiated — the MLA path always has `SameHeadDim=false`.

## Benchmark Results (H200, BF16, Gemma 4 31B shape: nq=32, nkv=4, d=512)

<details>
<summary>Decode Attention (memory-bound, GB/s)</summary>

```
bs=   1  kv_len=   256  | Triton      9.4 us   227.1 GB/s  | FA3     13.2 us   161.6 GB/s
bs=   1  kv_len=  1024  | Triton     20.3 us   415.8 GB/s  | FA3     39.9 us   211.0 GB/s
bs=   1  kv_len=  4096  | Triton     68.4 us   490.7 GB/s  | FA3    150.0 us   223.9 GB/s
bs=   1  kv_len= 16384  | Triton    343.6 us   390.8 GB/s  | FA3    587.8 us   228.4 GB/s
bs=  16  kv_len=   256  | Triton     23.4 us  1456.9 GB/s  | FA3     14.4 us  2366.6 GB/s
bs=  16  kv_len=  1024  | Triton     64.9 us  2077.3 GB/s  | FA3     45.5 us  2961.1 GB/s
bs=  16  kv_len=  4096  | Triton    204.2 us  2632.2 GB/s  | FA3    166.6 us  3225.2 GB/s
bs=  16  kv_len= 16384  | Triton    749.8 us  2864.8 GB/s  | FA3    648.7 us  3311.4 GB/s
bs=  64  kv_len=   256  | Triton     81.0 us  1682.4 GB/s  | FA3     39.6 us  3443.7 GB/s
bs=  64  kv_len=  1024  | Triton    228.2 us  2361.9 GB/s  | FA3    130.8 us  4122.0 GB/s
bs=  64  kv_len=  4096  | Triton    768.8 us  2795.9 GB/s  | FA3    489.8 us  4389.1 GB/s
bs=  64  kv_len= 16384  | Triton   2936.6 us  2925.9 GB/s  | FA3   1931.5 us  4448.5 GB/s
```
FA3 achieves up to **4.4 TB/s** at large batch, **1.5-2x** faster than Triton at bs>=16.
</details>

<details>
<summary>Prefill Attention (compute-bound, TFLOPS)</summary>

```
bs=   1  seq=  1024  kv=  1024  | Triton    368.6 us   93.2 TFLOPS  | FA3     92.9 us  369.7 TFLOPS
bs=   1  seq=  2048  kv=  2048  | Triton   1326.9 us  103.6 TFLOPS  | FA3    314.7 us  436.8 TFLOPS
bs=   1  seq=  4096  kv=  4096  | Triton   5077.5 us  108.3 TFLOPS  | FA3   1148.5 us  478.7 TFLOPS
bs=   1  seq=  8192  kv=  8192  | Triton  22238.3 us   98.9 TFLOPS  | FA3   4604.4 us  477.6 TFLOPS
bs=   8  seq=  4096  kv=  4096  | Triton  44684.1 us   98.4 TFLOPS  | FA3   9464.1 us  464.7 TFLOPS
bs=  16  seq=  4096  kv=  4096  | Triton  91467.1 us   96.2 TFLOPS  | FA3  18987.5 us  463.3 TFLOPS
```
FA3 achieves **~480 TFLOPS** (causal), **~4x** faster than Triton for prefill.
</details>

<details>
<summary>KVCache Decode / Extend (inference serving)</summary>

```
KVCACHE DECODE (flash_attn_with_kvcache, seqlen_q=1):
bs=  64  kv_len=  4096  | FA3-kvcache    509.0 us  4223.0 GB/s
bs=  64  kv_len= 16384  | FA3-kvcache   1958.4 us  4387.3 GB/s

KVCACHE EXTEND (multi-turn prefill with existing cache):
bs=   4  new_seq=  512  cache=  8192  | FA3-kvcache-extend   2455.2 us  461.8 TFLOPS
bs=   8  new_seq=  512  cache=  8192  | FA3-kvcache-extend   4994.8 us  454.0 TFLOPS
```
</details>

<details>
<summary>Benchmark script (bench_gqa_headdim512.py)</summary>

📎 Full script: https://gist.github.com/foreverrookie/3f1f6b1270babc85b689a91c508b32b4

</details>

## Test plan

- [x] `test_flash_attn_output` with d=512 (BF16/FP16, causal/non-causal, MHA/GQA/MQA)
- [x] `test_flash_attn_varlen_output` with d=512
- [x] Correctness cross-validation: `flash_attn_func` vs `flash_attn_varlen_func` vs `flash_attn_with_kvcache` (in bench script)
- [x] `pytest hopper/test_flash_attn.py -k "d-512" -x` (verified on H200)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


