### PR TITLE
Add page table support for MLA SM100 forward kernel

### DIFF
--- a/flash_attn/cute/flash_fwd_mla_sm100.py
+++ b/flash_attn/cute/flash_fwd_mla_sm100.py
@@ -370,9 +370,6 @@ class FlashAttentionMLAForwardSm100:
         # Always keep stream as the last parameter (EnvStream: obtained implicitly via TVM FFI).
         stream: cuda.CUstream = None,
     ):
-        # ==== asserts for unimplemented features ====
-        assert mPageTable is None, "page table tbd for MLA"
-
         # ==== dtype info ====
         self.dtype_Q = mQ.element_type
         self.dtype_K = mK.element_type
@@ -609,8 +606,10 @@ class FlashAttentionMLAForwardSm100:
             num_batch=cute.size(mQ.shape[3])
             if const_expr(mCuSeqlensQ is None)
             else cute.size(mCuSeqlensQ.shape[0] - 1),
-            num_splits=1,  # todo: split_kv
-            seqlen_k=cute.size(mK.shape[0]),  # todo: page table
+            num_splits=1, # todo: split_kv
+            seqlen_k=cute.size(mK.shape[0])
+            if const_expr(mPageTable is None)
+            else cute.size(mK.shape[0]) * cute.size(mPageTable.shape[1]),
             headdim=self.hdim,
             headdim_v=self.hdimv,
             total_q=cute.size(mQ.shape[0])
@@ -709,6 +708,7 @@ class FlashAttentionMLAForwardSm100:
             topk_length_dynamic,
             tile_sched_params,
             SharedStorage,
+            mPageTable,
         ).launch(
             grid=grid_dim,
             block=(
@@ -766,6 +766,7 @@ class FlashAttentionMLAForwardSm100:
         topk_length_dynamic: Optional[Int32],
         tile_sched_params: ParamsBase,
         SharedStorage: cutlass.Constexpr[Callable],
+        mPageTable: Optional[cute.Tensor] = None,
     ):
         warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
         cta_layout_vmnk = cute.tiled_divide(
@@ -935,7 +936,9 @@ class FlashAttentionMLAForwardSm100:
         SeqlenInfoCls = partial(
             SeqlenInfoQK.create,
             seqlen_q_static=mQ.shape[0] if const_expr(not self.pack_gqa) else mQ.shape[0][1],
-            seqlen_k_static=mK.shape[0],
+            seqlen_k_static=mK.shape[0]
+            if const_expr(mPageTable is None)
+            else mK.shape[0] * mPageTable.shape[1],
             tile_m=self.cta_tile_m,
             tile_n=self.tile_n,
             mCuSeqlensQ=mCuSeqlensQ,
@@ -1097,6 +1100,7 @@ class FlashAttentionMLAForwardSm100:
                 block_info,
                 SeqlenInfoCls,
                 tile_scheduler=tile_scheduler,
+                mPageTable=mPageTable,
             )
 
         if warp_idx == self.mma_warp_id:
@@ -1645,6 +1649,7 @@ class FlashAttentionMLAForwardSm100:
         block_info: BlockInfo,
         SeqlenInfoCls: Callable,
         tile_scheduler: TileSchedulerProtocol,
+        mPageTable: Optional[cute.Tensor] = None,
     ):
         # ==== Load warp ====
         # Description: loads tiles of Q, Qv, K, V, V0, V1 from gmem to smem using TMA
@@ -1757,48 +1762,80 @@ class FlashAttentionMLAForwardSm100:
             )
 
             if const_expr(self.use_tma_KV):
-                # (seqlen_k, hdim) or (seqlen_k, hdimv//2)
-                mK_cur = seqlen.offset_batch_K(mK, batch_idx, dim=3)[None, None, head_idx_kv]
-                mVs_cur = [
-                    seqlen.offset_batch_K(mVs[split], batch_idx, dim=3)[None, None, head_idx_kv]
-                    for split in range(self.num_hdimv_splits)
-                ]
-                # (hdimv//2, seqlen_k)
-                if const_expr(not seqlen.has_cu_seqlens_k):
-                    mVts_cur = [
-                        mVts[split][None, None, head_idx_kv, batch_idx]
+                if const_expr(mPageTable is None):
+                    # Non-paged: select batch, tile over seqlen_k
+                    # (seqlen_k, hdim) or (seqlen_k, hdimv//2)
+                    mK_cur = seqlen.offset_batch_K(mK, batch_idx, dim=3)[None, None, head_idx_kv]
+                    mVs_cur = [
+                        seqlen.offset_batch_K(mVs[split], batch_idx, dim=3)[None, None, head_idx_kv]
                         for split in range(self.num_hdimv_splits)
                     ]
-                else:
-                    mVts_cur = [
-                        cute.domain_offset(
-                            (0, seqlen.offset_k), mVts[split][None, None, head_idx_kv]
-                        )
-                        for split in range(self.num_hdimv_splits)
-                    ]
-                # (tile_n, hdim or hdimv//2, num_n_blocks)
-                gK = cute.local_tile(
-                    mK_cur,
-                    (self.mma_tiler_QK[1], self.mma_tiler_QK[2]),
-                    (None, 0),
-                )
-                gVs = [
-                    cute.local_tile(
-                        mVs_cur[split],
-                        (self.mma_tiler_QviVi[1], self.mma_tiler_QviVi[2]),
+                    # (hdimv//2, seqlen_k)
+                    if const_expr(not seqlen.has_cu_seqlens_k):
+                        mVts_cur = [
+                            mVts[split][None, None, head_idx_kv, batch_idx]
+                            for split in range(self.num_hdimv_splits)
+                        ]
+                    else:
+                        mVts_cur = [
+                            cute.domain_offset((0, seqlen.offset_k), mVts[split][None, None, head_idx_kv])
+                            for split in range(self.num_hdimv_splits)
+                        ]
+                    # (tile_n, hdim or hdimv//2, num_n_blocks)
+                    gK = cute.local_tile(
+                        mK_cur,
+                        (self.mma_tiler_QK[1], self.mma_tiler_QK[2]),
                         (None, 0),
                     )
-                    for split in range(self.num_hdimv_splits)
-                ]
-                # (hdim or hdimv//2, tile_n, num_n_blocks)
-                gVts = [
-                    cute.local_tile(
-                        mVts_cur[split],
-                        (self.mma_tiler_PVti[1], self.mma_tiler_PVti[2]),
-                        (0, None),
+                    gVs = [
+                        cute.local_tile(
+                            mVs_cur[split],
+                            (self.mma_tiler_QviVi[1], self.mma_tiler_QviVi[2]),
+                            (None, 0),
+                        ) for split in range(self.num_hdimv_splits)
+                    ]
+                    # (hdim or hdimv//2, tile_n, num_n_blocks)
+                    gVts = [
+                        cute.local_tile(
+                            mVts_cur[split],
+                            (self.mma_tiler_PVti[1], self.mma_tiler_PVti[2]),
+                            (0, None),
+                        ) for split in range(self.num_hdimv_splits)
+                    ]
+                else:
+                    # Paged KV: keep pages dim, index by page_idx at load time
+                    # (page_size, hdim, num_pages) or (page_size, hdimv//2, num_pages)
+                    mK_cur = mK[None, None, head_idx_kv, None]
+                    mVs_cur = [
+                        mVs[split][None, None, head_idx_kv, None]
+                        for split in range(self.num_hdimv_splits)
+                    ]
+                    # (hdimv//2, page_size, num_pages)
+                    mVts_cur = [
+                        mVts[split][None, None, head_idx_kv, None]
+                        for split in range(self.num_hdimv_splits)
+                    ]
+                    # (tile_n, hdim or hdimv//2, 1, num_pages)
+                    gK = cute.local_tile(
+                        mK_cur,
+                        (self.mma_tiler_QK[1], self.mma_tiler_QK[2]),
+                        (None, 0, None),
                     )
-                    for split in range(self.num_hdimv_splits)
-                ]
+                    gVs = [
+                        cute.local_tile(
+                            mVs_cur[split],
+                            (self.mma_tiler_QviVi[1], self.mma_tiler_QviVi[2]),
+                            (None, 0, None),
+                        ) for split in range(self.num_hdimv_splits)
+                    ]
+                    # (hdim or hdimv//2, tile_n, 1, num_pages)
+                    gVts = [
+                        cute.local_tile(
+                            mVts_cur[split],
+                            (self.mma_tiler_PVti[1], self.mma_tiler_PVti[2]),
+                            (0, None, None),
+                        ) for split in range(self.num_hdimv_splits)
+                    ]
                 tSgK = thr_mma_QK.partition_B(gK)
                 tSgVs = [
                     thr_mma_QviVi.partition_B(gVs[split]) for split in range(self.num_hdimv_splits)
@@ -1855,11 +1892,16 @@ class FlashAttentionMLAForwardSm100:
             if const_expr(self.use_tma_KV):
                 # ==== Prologue ====
                 n_block_first = n_block_max - 1
+                page_idx = (
+                    mPageTable[batch_idx, n_block_first]
+                    if const_expr(mPageTable is not None)
+                    else None
+                )
                 # copy K gmem -> smem
-                producer_state_K = load_K(producer_state_K, n_block=n_block_first)
+                producer_state_K = load_K(producer_state_K, n_block=n_block_first, page_idx=page_idx)
                 # copy Vi gmem -> smem
-                producer_state_V0 = load_V(producer_state_V0, n_block=n_block_first, split=0)
-                producer_state_V1 = load_V(producer_state_V1, n_block=n_block_first, split=1)
+                producer_state_V0 = load_V(producer_state_V0, n_block=n_block_first, split=0, page_idx=page_idx)
+                producer_state_V1 = load_V(producer_state_V1, n_block=n_block_first, split=1, page_idx=page_idx)
 
                 if const_expr(self.use_tma_O and self.overlap_sO_sV):
                     cute.arch.mbarrier_wait(sO_empty_mbar_ptr, phase=producer_phase_O)
@@ -1869,28 +1911,48 @@ class FlashAttentionMLAForwardSm100:
                 for n_block_group in cutlass.range(num_n_block_groups - 1, unroll=1):
                     for stage in cutlass.range_constexpr(self.num_stages_S):
                         n_block = n_block_max - 1 - n_block_group * self.num_stages_S - stage
+                        page_idx_next = (
+                            mPageTable[batch_idx, n_block - 1]
+                            if const_expr(mPageTable is not None)
+                            else None
+                        )
+                        page_idx_cur = (
+                            mPageTable[batch_idx, n_block]
+                            if const_expr(mPageTable is not None)
+                            else None
+                        )
                         # copy K gmem -> smem
-                        producer_state_K = load_K(producer_state_K, n_block=n_block - 1)
+                        producer_state_K = load_K(producer_state_K, n_block=n_block-1, page_idx=page_idx_next)
                         # copy Vi gmem -> smem
-                        producer_state_V0 = load_V(producer_state_V0, n_block=n_block - 1, split=0)
-                        producer_state_V1 = load_V(producer_state_V1, n_block=n_block - 1, split=1)
+                        producer_state_V0 = load_V(producer_state_V0, n_block=n_block-1, split=0, page_idx=page_idx_next)
+                        producer_state_V1 = load_V(producer_state_V1, n_block=n_block-1, split=1, page_idx=page_idx_next)
                         # copy Vti gmem -> smem
-                        producer_state_V0 = load_Vt(producer_state_V0, n_block=n_block, split=0)
-                        producer_state_V1 = load_Vt(producer_state_V1, n_block=n_block, split=1)
+                        producer_state_V0 = load_Vt(producer_state_V0, n_block=n_block, split=0, page_idx=page_idx_cur)
+                        producer_state_V1 = load_Vt(producer_state_V1, n_block=n_block, split=1, page_idx=page_idx_cur)
 
                 # ==== Epilogue ====
                 num_final_n_blocks = self.num_stages_S if even_n_blocks else self.num_stages_S - 1
                 for stage in cutlass.range(num_final_n_blocks, unroll_full=True):
                     n_block = num_final_n_blocks - 1 - stage
                     if n_block > 0:
+                        page_idx_next = (
+                            mPageTable[batch_idx, n_block - 1]
+                            if const_expr(mPageTable is not None)
+                            else None
+                        )
                         # copy K gmem -> smem
-                        producer_state_K = load_K(producer_state_K, n_block=n_block - 1)
+                        producer_state_K = load_K(producer_state_K, n_block=n_block-1, page_idx=page_idx_next)
                         # copy Vi gmem -> smem
-                        producer_state_V0 = load_V(producer_state_V0, n_block=n_block - 1, split=0)
-                        producer_state_V1 = load_V(producer_state_V1, n_block=n_block - 1, split=1)
+                        producer_state_V0 = load_V(producer_state_V0, n_block=n_block-1, split=0, page_idx=page_idx_next)
+                        producer_state_V1 = load_V(producer_state_V1, n_block=n_block-1, split=1, page_idx=page_idx_next)
+                    page_idx_cur = (
+                        mPageTable[batch_idx, n_block]
+                        if const_expr(mPageTable is not None)
+                        else None
+                    )
                     # copy Vti gmem -> smem
-                    producer_state_V0 = load_Vt(producer_state_V0, n_block=n_block, split=0)
-                    producer_state_V1 = load_Vt(producer_state_V1, n_block=n_block, split=1)
+                    producer_state_V0 = load_Vt(producer_state_V0, n_block=n_block, split=0, page_idx=page_idx_cur)
+                    producer_state_V1 = load_Vt(producer_state_V1, n_block=n_block, split=1, page_idx=page_idx_cur)
 
             # Advance to next tile
             work_tile = tile_scheduler.advance_to_next_work()
@@ -1913,6 +1975,7 @@ class FlashAttentionMLAForwardSm100:
         producer_state: pipeline.PipelineState,
         n_block: Optional[Int32] = None,
         split: Optional[Int32] = None,
+        page_idx: Optional[Int32] = None,
     ):
         stage = producer_state.index
         if const_expr(split is not None):
@@ -1921,7 +1984,10 @@ class FlashAttentionMLAForwardSm100:
             tXsX = tXsX[split]
             load_pipeline = load_pipeline[split]
         if const_expr(n_block is not None):
-            tXgX = tXgX[(None, n_block)]
+            if const_expr(page_idx is not None):
+                tXgX = tXgX[(None, 0, page_idx)]
+            else:
+                tXgX = tXgX[(None, n_block)]
         tXsX = tXsX[(None, stage)]
 
         load_pipeline.producer_acquire(producer_state)

--- a/flash_attn/cute/flash_fwd_mla_sm100.py
+++ b/flash_attn/cute/flash_fwd_mla_sm100.py
@@ -609,7 +609,7 @@ class FlashAttentionMLAForwardSm100:
             num_batch=cute.size(mQ.shape[3])
             if const_expr(mCuSeqlensQ is None)
             else cute.size(mCuSeqlensQ.shape[0] - 1),
-            num_splits=1, # todo: split_kv
+            num_splits=1,  # todo: split_kv
             seqlen_k=cute.size(mK.shape[0])
             if const_expr(mPageTable is None)
             else cute.size(mK.shape[0]) * cute.size(mPageTable.shape[1]),
@@ -1470,32 +1470,70 @@ class FlashAttentionMLAForwardSm100:
                     mVt0_cur = mVt0[None, None, head_idx_kv, batch_idx]
                     mVt1_cur = mVt1[None, None, head_idx_kv, batch_idx]
                 else:
-                    mVt0_cur = cute.domain_offset((0, seqlen.offset_k), mVt0[None, None, head_idx_kv])
-                    mVt1_cur = cute.domain_offset((0, seqlen.offset_k), mVt1[None, None, head_idx_kv])
+                    mVt0_cur = cute.domain_offset(
+                        (0, seqlen.offset_k), mVt0[None, None, head_idx_kv]
+                    )
+                    mVt1_cur = cute.domain_offset(
+                        (0, seqlen.offset_k), mVt1[None, None, head_idx_kv]
+                    )
                 # (hdimv//4, seqlen_k)
                 hdimv_split_per_cta = self.hdimv // self.num_hdimv_splits // self.cta_group_size
-                mVt0_cur = cute.tiled_divide(mVt0_cur, (hdimv_split_per_cta, ))[None, cta_rank_in_cluster, None]
-                mVt1_cur = cute.tiled_divide(mVt1_cur, (hdimv_split_per_cta, ))[None, cta_rank_in_cluster, None]
+                mVt0_cur = cute.tiled_divide(mVt0_cur, (hdimv_split_per_cta,))[
+                    None, cta_rank_in_cluster, None
+                ]
+                mVt1_cur = cute.tiled_divide(mVt1_cur, (hdimv_split_per_cta,))[
+                    None, cta_rank_in_cluster, None
+                ]
 
-                load_K = partial(self.cpasync_gather_load_KV,
+                load_K = partial(
+                    self.cpasync_gather_load_KV,
                     cpasync_gather_kv_manager,
-                    pipeline_K, pipeline_K_cpasync, sK, False, "K", mK_cur,
+                    pipeline_K,
+                    pipeline_K_cpasync,
+                    sK,
+                    False,
+                    "K",
+                    mK_cur,
                 )
-                load_V0 = partial(self.cpasync_gather_load_KV,
+                load_V0 = partial(
+                    self.cpasync_gather_load_KV,
                     cpasync_gather_kv_manager,
-                    pipeline_V0, pipeline_V0_cpasync, sV0, False, "V", mV0_cur,
+                    pipeline_V0,
+                    pipeline_V0_cpasync,
+                    sV0,
+                    False,
+                    "V",
+                    mV0_cur,
                 )
-                load_V1 = partial(self.cpasync_gather_load_KV,
+                load_V1 = partial(
+                    self.cpasync_gather_load_KV,
                     cpasync_gather_kv_manager,
-                    pipeline_V1, pipeline_V1_cpasync, sV1, False, "V", mV1_cur,
+                    pipeline_V1,
+                    pipeline_V1_cpasync,
+                    sV1,
+                    False,
+                    "V",
+                    mV1_cur,
                 )
-                load_Vt0 = partial(self.cpasync_gather_load_KV,
+                load_Vt0 = partial(
+                    self.cpasync_gather_load_KV,
                     cpasync_gather_kv_manager,
-                    pipeline_V0, pipeline_V0_cpasync, sVt0, True, "V", mVt0_cur,
+                    pipeline_V0,
+                    pipeline_V0_cpasync,
+                    sVt0,
+                    True,
+                    "V",
+                    mVt0_cur,
                 )
-                load_Vt1 = partial(self.cpasync_gather_load_KV,
+                load_Vt1 = partial(
+                    self.cpasync_gather_load_KV,
                     cpasync_gather_kv_manager,
-                    pipeline_V1, pipeline_V1_cpasync, sVt1, True, "V", mVt1_cur,
+                    pipeline_V1,
+                    pipeline_V1_cpasync,
+                    sVt1,
+                    True,
+                    "V",
+                    mVt1_cur,
                 )
 
                 # gather KV path processes n_blocks in increasing order
@@ -1517,7 +1555,7 @@ class FlashAttentionMLAForwardSm100:
                     producer_phase_O ^= 1
 
                 # ==== Mainloop ====
-                for n_block_group in cutlass.range(num_n_block_groups-1, unroll=1):
+                for n_block_group in cutlass.range(num_n_block_groups - 1, unroll=1):
                     for stage in cutlass.range_constexpr(self.num_stages_S):
                         n_block = n_block_group * self.num_stages_S + stage
                         # K, V0, V1
@@ -1536,7 +1574,7 @@ class FlashAttentionMLAForwardSm100:
 
                 # ==== Epilogue ====
                 for stage in cutlass.range_constexpr(self.num_stages_S):
-                    n_block = (num_n_block_groups-1) * self.num_stages_S + stage
+                    n_block = (num_n_block_groups - 1) * self.num_stages_S + stage
                     if const_expr(stage == 0):
                         # K, V0, V1
                         cpasync_gather_kv_manager.load_index_topk(n_block + 1, transpose=False)
@@ -1584,39 +1622,109 @@ class FlashAttentionMLAForwardSm100:
 
                 # PagedKVManager for K (hdim=64): uses "K" mode only
                 paged_kv_K = PagedKVManager.create(
-                    mPageTable, mK, mK,
-                    page_size_divmod, batch_idx, head_idx_kv, tidx,
-                    seqlen.seqlen_k, 0,
-                    self.tile_n, self.hdim, self.hdim,
-                    self.num_cpasync_load_threads, mK.element_type, arch=100,
+                    mPageTable,
+                    mK,
+                    mK,
+                    page_size_divmod,
+                    batch_idx,
+                    head_idx_kv,
+                    tidx,
+                    seqlen.seqlen_k,
+                    0,
+                    self.tile_n,
+                    self.hdim,
+                    self.hdim,
+                    self.num_cpasync_load_threads,
+                    mK.element_type,
+                    arch=100,
                 )
                 # PagedKVManager for V0/Vt0: "K" mode → V0 (non-transposed), "V" mode → Vt0 (transposed)
                 paged_kv_V0 = PagedKVManager.create(
-                    mPageTable, mV0, mVt0_cta,
-                    page_size_divmod, batch_idx, head_idx_kv, tidx,
-                    seqlen.seqlen_k, 0,
-                    self.tile_n, hdimv_split, hdimv_split_per_cta,
-                    self.num_cpasync_load_threads, mV0.element_type, arch=100,
+                    mPageTable,
+                    mV0,
+                    mVt0_cta,
+                    page_size_divmod,
+                    batch_idx,
+                    head_idx_kv,
+                    tidx,
+                    seqlen.seqlen_k,
+                    0,
+                    self.tile_n,
+                    hdimv_split,
+                    hdimv_split_per_cta,
+                    self.num_cpasync_load_threads,
+                    mV0.element_type,
+                    arch=100,
                 )
                 # PagedKVManager for V1/Vt1: "K" mode → V1, "V" mode → Vt1
                 paged_kv_V1 = PagedKVManager.create(
-                    mPageTable, mV1, mVt1_cta,
-                    page_size_divmod, batch_idx, head_idx_kv, tidx,
-                    seqlen.seqlen_k, 0,
-                    self.tile_n, hdimv_split, hdimv_split_per_cta,
-                    self.num_cpasync_load_threads, mV1.element_type, arch=100,
+                    mPageTable,
+                    mV1,
+                    mVt1_cta,
+                    page_size_divmod,
+                    batch_idx,
+                    head_idx_kv,
+                    tidx,
+                    seqlen.seqlen_k,
+                    0,
+                    self.tile_n,
+                    hdimv_split,
+                    hdimv_split_per_cta,
+                    self.num_cpasync_load_threads,
+                    mV1.element_type,
+                    arch=100,
                 )
 
-                load_K = partial(self.cpasync_paged_load_KV,
-                    paged_kv_K, pipeline_K, pipeline_K_cpasync, sK, False, "K", cta_rank_in_cluster)
-                load_V0 = partial(self.cpasync_paged_load_KV,
-                    paged_kv_V0, pipeline_V0, pipeline_V0_cpasync, sV0, False, "K", cta_rank_in_cluster)
-                load_V1 = partial(self.cpasync_paged_load_KV,
-                    paged_kv_V1, pipeline_V1, pipeline_V1_cpasync, sV1, False, "K", cta_rank_in_cluster)
-                load_Vt0 = partial(self.cpasync_paged_load_KV,
-                    paged_kv_V0, pipeline_V0, pipeline_V0_cpasync, sVt0, True, "V", cta_rank_in_cluster)
-                load_Vt1 = partial(self.cpasync_paged_load_KV,
-                    paged_kv_V1, pipeline_V1, pipeline_V1_cpasync, sVt1, True, "V", cta_rank_in_cluster)
+                load_K = partial(
+                    self.cpasync_paged_load_KV,
+                    paged_kv_K,
+                    pipeline_K,
+                    pipeline_K_cpasync,
+                    sK,
+                    False,
+                    "K",
+                    cta_rank_in_cluster,
+                )
+                load_V0 = partial(
+                    self.cpasync_paged_load_KV,
+                    paged_kv_V0,
+                    pipeline_V0,
+                    pipeline_V0_cpasync,
+                    sV0,
+                    False,
+                    "K",
+                    cta_rank_in_cluster,
+                )
+                load_V1 = partial(
+                    self.cpasync_paged_load_KV,
+                    paged_kv_V1,
+                    pipeline_V1,
+                    pipeline_V1_cpasync,
+                    sV1,
+                    False,
+                    "K",
+                    cta_rank_in_cluster,
+                )
+                load_Vt0 = partial(
+                    self.cpasync_paged_load_KV,
+                    paged_kv_V0,
+                    pipeline_V0,
+                    pipeline_V0_cpasync,
+                    sVt0,
+                    True,
+                    "V",
+                    cta_rank_in_cluster,
+                )
+                load_Vt1 = partial(
+                    self.cpasync_paged_load_KV,
+                    paged_kv_V1,
+                    pipeline_V1,
+                    pipeline_V1_cpasync,
+                    sVt1,
+                    True,
+                    "V",
+                    cta_rank_in_cluster,
+                )
 
                 # Paged path must follow the same descending n_block order as the
                 # MLA TMA path (`n_block_max - 1` down to `n_block_min`). The MMA
@@ -1730,7 +1838,11 @@ class FlashAttentionMLAForwardSm100:
         tPrXPtr = paged_kv_manager.compute_X_ptr(K_or_V)
 
         # Reshape smem to flat 2D using composition (matches CpasyncGatherKVManager.load_X)
-        head_dim = paged_kv_manager.head_dim_v_padded if const_expr(K_or_V == "V") else paged_kv_manager.head_dim_padded
+        head_dim = (
+            paged_kv_manager.head_dim_v_padded
+            if const_expr(K_or_V == "V")
+            else paged_kv_manager.head_dim_padded
+        )
         cta_tile_n = self.tile_n if const_expr(transpose) else self.tile_n // self.cta_group_size
         order = (1, 0) if const_expr(transpose) else (0, 1)
 
@@ -1744,12 +1856,13 @@ class FlashAttentionMLAForwardSm100:
         tXc0X = paged_kv_manager.gmem_thr_copy_KV.get_slice(0).partition_S(cX)
 
         seqlenk_row_limit = (
-            paged_kv_manager.seqlen_k - n_block * self.tile_n - tXcX[0][0]
-            if n_block >= 0 else 0
+            paged_kv_manager.seqlen_k - n_block * self.tile_n - tXcX[0][0] if n_block >= 0 else 0
         )
 
         if const_expr(not transpose):
-            offset = cta_rank_in_cluster * (paged_kv_manager.gmem_threads_per_row // self.cta_group_size)
+            offset = cta_rank_in_cluster * (
+                paged_kv_manager.gmem_threads_per_row // self.cta_group_size
+            )
         else:
             offset = 0
 
@@ -1764,8 +1877,10 @@ class FlashAttentionMLAForwardSm100:
                 width=paged_kv_manager.gmem_threads_per_row,
             )
             x_gmem_ptr = cute.make_ptr(
-                paged_kv_manager.mK_paged.element_type, x_ptr_i64,
-                cute.AddressSpace.gmem, assumed_align=16,
+                paged_kv_manager.mK_paged.element_type,
+                x_ptr_i64,
+                cute.AddressSpace.gmem,
+                assumed_align=16,
             )
             mX_cur = cute.make_tensor(x_gmem_ptr, cute.make_layout((head_dim,)))
             mX_cur_copy = cute.tiled_divide(mX_cur, (paged_kv_manager.async_copy_elems,))
@@ -1957,7 +2072,9 @@ class FlashAttentionMLAForwardSm100:
                         ]
                     else:
                         mVts_cur = [
-                            cute.domain_offset((0, seqlen.offset_k), mVts[split][None, None, head_idx_kv])
+                            cute.domain_offset(
+                                (0, seqlen.offset_k), mVts[split][None, None, head_idx_kv]
+                            )
                             for split in range(self.num_hdimv_splits)
                         ]
                     # (tile_n, hdim or hdimv//2, num_n_blocks)
@@ -1971,7 +2088,8 @@ class FlashAttentionMLAForwardSm100:
                             mVs_cur[split],
                             (self.mma_tiler_QviVi[1], self.mma_tiler_QviVi[2]),
                             (None, 0),
-                        ) for split in range(self.num_hdimv_splits)
+                        )
+                        for split in range(self.num_hdimv_splits)
                     ]
                     # (hdim or hdimv//2, tile_n, num_n_blocks)
                     gVts = [
@@ -1979,7 +2097,8 @@ class FlashAttentionMLAForwardSm100:
                             mVts_cur[split],
                             (self.mma_tiler_PVti[1], self.mma_tiler_PVti[2]),
                             (0, None),
-                        ) for split in range(self.num_hdimv_splits)
+                        )
+                        for split in range(self.num_hdimv_splits)
                     ]
                 else:
                     # Paged KV: keep pages dim, index by page_idx at load time
@@ -2005,7 +2124,8 @@ class FlashAttentionMLAForwardSm100:
                             mVs_cur[split],
                             (self.mma_tiler_QviVi[1], self.mma_tiler_QviVi[2]),
                             (None, 0, None),
-                        ) for split in range(self.num_hdimv_splits)
+                        )
+                        for split in range(self.num_hdimv_splits)
                     ]
                     # (hdim or hdimv//2, tile_n, 1, num_pages)
                     gVts = [
@@ -2013,7 +2133,8 @@ class FlashAttentionMLAForwardSm100:
                             mVts_cur[split],
                             (self.mma_tiler_PVti[1], self.mma_tiler_PVti[2]),
                             (0, None, None),
-                        ) for split in range(self.num_hdimv_splits)
+                        )
+                        for split in range(self.num_hdimv_splits)
                     ]
                 tSgK = thr_mma_QK.partition_B(gK)
                 tSgVs = [
@@ -2077,10 +2198,16 @@ class FlashAttentionMLAForwardSm100:
                     else None
                 )
                 # copy K gmem -> smem
-                producer_state_K = load_K(producer_state_K, n_block=n_block_first, page_idx=page_idx)
+                producer_state_K = load_K(
+                    producer_state_K, n_block=n_block_first, page_idx=page_idx
+                )
                 # copy Vi gmem -> smem
-                producer_state_V0 = load_V(producer_state_V0, n_block=n_block_first, split=0, page_idx=page_idx)
-                producer_state_V1 = load_V(producer_state_V1, n_block=n_block_first, split=1, page_idx=page_idx)
+                producer_state_V0 = load_V(
+                    producer_state_V0, n_block=n_block_first, split=0, page_idx=page_idx
+                )
+                producer_state_V1 = load_V(
+                    producer_state_V1, n_block=n_block_first, split=1, page_idx=page_idx
+                )
 
                 if const_expr(self.use_tma_O and self.overlap_sO_sV):
                     cute.arch.mbarrier_wait(sO_empty_mbar_ptr, phase=producer_phase_O)
@@ -2101,13 +2228,23 @@ class FlashAttentionMLAForwardSm100:
                             else None
                         )
                         # copy K gmem -> smem
-                        producer_state_K = load_K(producer_state_K, n_block=n_block-1, page_idx=page_idx_next)
+                        producer_state_K = load_K(
+                            producer_state_K, n_block=n_block - 1, page_idx=page_idx_next
+                        )
                         # copy Vi gmem -> smem
-                        producer_state_V0 = load_V(producer_state_V0, n_block=n_block-1, split=0, page_idx=page_idx_next)
-                        producer_state_V1 = load_V(producer_state_V1, n_block=n_block-1, split=1, page_idx=page_idx_next)
+                        producer_state_V0 = load_V(
+                            producer_state_V0, n_block=n_block - 1, split=0, page_idx=page_idx_next
+                        )
+                        producer_state_V1 = load_V(
+                            producer_state_V1, n_block=n_block - 1, split=1, page_idx=page_idx_next
+                        )
                         # copy Vti gmem -> smem
-                        producer_state_V0 = load_Vt(producer_state_V0, n_block=n_block, split=0, page_idx=page_idx_cur)
-                        producer_state_V1 = load_Vt(producer_state_V1, n_block=n_block, split=1, page_idx=page_idx_cur)
+                        producer_state_V0 = load_Vt(
+                            producer_state_V0, n_block=n_block, split=0, page_idx=page_idx_cur
+                        )
+                        producer_state_V1 = load_Vt(
+                            producer_state_V1, n_block=n_block, split=1, page_idx=page_idx_cur
+                        )
 
                 # ==== Epilogue ====
                 num_final_n_blocks = self.num_stages_S if even_n_blocks else self.num_stages_S - 1
@@ -2120,18 +2257,28 @@ class FlashAttentionMLAForwardSm100:
                             else None
                         )
                         # copy K gmem -> smem
-                        producer_state_K = load_K(producer_state_K, n_block=n_block-1, page_idx=page_idx_next)
+                        producer_state_K = load_K(
+                            producer_state_K, n_block=n_block - 1, page_idx=page_idx_next
+                        )
                         # copy Vi gmem -> smem
-                        producer_state_V0 = load_V(producer_state_V0, n_block=n_block-1, split=0, page_idx=page_idx_next)
-                        producer_state_V1 = load_V(producer_state_V1, n_block=n_block-1, split=1, page_idx=page_idx_next)
+                        producer_state_V0 = load_V(
+                            producer_state_V0, n_block=n_block - 1, split=0, page_idx=page_idx_next
+                        )
+                        producer_state_V1 = load_V(
+                            producer_state_V1, n_block=n_block - 1, split=1, page_idx=page_idx_next
+                        )
                     page_idx_cur = (
                         mPageTable[batch_idx, n_block]
                         if const_expr(mPageTable is not None)
                         else None
                     )
                     # copy Vti gmem -> smem
-                    producer_state_V0 = load_Vt(producer_state_V0, n_block=n_block, split=0, page_idx=page_idx_cur)
-                    producer_state_V1 = load_Vt(producer_state_V1, n_block=n_block, split=1, page_idx=page_idx_cur)
+                    producer_state_V0 = load_Vt(
+                        producer_state_V0, n_block=n_block, split=0, page_idx=page_idx_cur
+                    )
+                    producer_state_V1 = load_Vt(
+                        producer_state_V1, n_block=n_block, split=1, page_idx=page_idx_cur
+                    )
 
             # Advance to next tile
             work_tile = tile_scheduler.advance_to_next_work()

--- a/flash_attn/cute/flash_fwd_mla_sm100.py
+++ b/flash_attn/cute/flash_fwd_mla_sm100.py
@@ -1738,15 +1738,21 @@ class FlashAttentionMLAForwardSm100:
                 #   prologue(K,V0,V1) + mainloop×(N-1)(K,V0,V1,Vt0,Vt1) + epilogue(Vt0,Vt1)
                 n_block_first = n_block_max - 1
                 n_block = n_block_first
+                # Clamp to 0 when num_n_blocks == 0 (empty tile) so that
+                # load_page_table never receives a negative n_block.  paged_kv.py's
+                # validity check (0 <= row_idx < seqlen_k) then marks every entry
+                # invalid, falling back to page 0; the consumer's mask_seqlen=True
+                # zeroes the result.
+                safe_n_block_first = n_block_first if num_n_blocks > 0 else 0
 
                 # ==== Prologue ====
                 # load_page_table must be called directly in loop body, not inside
                 # cpasync_paged_load_KV, to avoid MLIR SSA region crossing errors.
-                paged_kv_K.load_page_table(n_block_first)
+                paged_kv_K.load_page_table(safe_n_block_first)
                 producer_state_K = load_K(n_block_first, producer_state_K)
-                paged_kv_V0.load_page_table(n_block_first)
+                paged_kv_V0.load_page_table(safe_n_block_first)
                 producer_state_V0 = load_V0(n_block_first, producer_state_V0)
-                paged_kv_V1.load_page_table(n_block_first)
+                paged_kv_V1.load_page_table(safe_n_block_first)
                 producer_state_V1 = load_V1(n_block_first, producer_state_V1)
 
                 if const_expr(self.use_tma_O and self.overlap_sO_sV):
@@ -2192,8 +2198,13 @@ class FlashAttentionMLAForwardSm100:
             if const_expr(self.use_tma_KV):
                 # ==== Prologue ====
                 n_block_first = n_block_max - 1
+                # Clamp to 0 when num_n_blocks == 0 (empty tile) to avoid a
+                # negative index into the page table.  The consumer's first
+                # iteration carries mask_seqlen=True which zeroes the output,
+                # so the garbage data loaded from page 0 is never used.
+                safe_n_block_first = n_block_first if num_n_blocks > 0 else 0
                 page_idx = (
-                    mPageTable[batch_idx, n_block_first]
+                    mPageTable[batch_idx, safe_n_block_first]
                     if const_expr(mPageTable is not None)
                     else None
                 )

--- a/flash_attn/cute/flash_fwd_mla_sm100.py
+++ b/flash_attn/cute/flash_fwd_mla_sm100.py
@@ -11,6 +11,7 @@ import cuda.bindings.driver as cuda
 import cutlass
 import cutlass.cute as cute
 from cutlass import Float32, Int64, Int32, Uint32, Boolean, const_expr
+from cutlass.cute import FastDivmodDivisor
 import cutlass.pipeline as pipeline
 from cutlass.cute.nvgpu import cpasync, tcgen05
 from cutlass.cute.runtime import from_dlpack
@@ -20,6 +21,8 @@ from cutlass.utils import ClcDynamicPersistentTileScheduler
 from quack import copy_utils
 
 from flash_attn.cute.pack_gqa import pack_gqa_layout, make_packgqa_tiled_tma_atom
+from flash_attn.cute.paged_kv import PagedKVManager
+from flash_attn.cute import utils
 from flash_attn.cute.seqlen_info import SeqlenInfoQK
 from flash_attn.cute.block_info import BlockInfo
 from flash_attn.cute.mask import AttentionMask
@@ -1056,6 +1059,7 @@ class FlashAttentionMLAForwardSm100:
                     block_info,
                     SeqlenInfoCls,
                     tile_scheduler=tile_scheduler,
+                    mPageTable=mPageTable,
                 )
 
         if warp_idx == self.load_warp_id:
@@ -1334,6 +1338,7 @@ class FlashAttentionMLAForwardSm100:
         pipeline_cpasync.consumer_wait(consumer_state)
         with cute.arch.elect_one():
             pipeline_mma.producer_commit(producer_state)
+        pipeline_cpasync.consumer_release(consumer_state)
         consumer_state.advance()
         producer_state.advance()
         return consumer_state, producer_state
@@ -1365,14 +1370,14 @@ class FlashAttentionMLAForwardSm100:
         block_info: BlockInfo,
         SeqlenInfoCls: Callable,
         tile_scheduler: TileSchedulerProtocol,
+        mPageTable: Optional[cute.Tensor] = None,
     ):
         # ==== cpasync load warpgroup ====
         # Description: loads tiles of K, V, V0, V1 from gmem to smem using cpasync
         # produces: K, V, V0, V1, bitmask
         # consumes: -
 
-        # TODO: use cpasync for non-topk paged attn
-        assert sBitmask is not None, "cpasync load meant to be used with topk gather"
+        # cpasync load is used for both topk gather and paged KV with page_size != tile_n
         cta_rank_in_cluster = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster())
         tidx = cute.arch.thread_idx()[0] % self.num_cpasync_load_threads
         warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx()) % (
@@ -1391,7 +1396,7 @@ class FlashAttentionMLAForwardSm100:
         producer_state_V1 = pipeline.make_pipeline_state(
             pipeline.PipelineUserType.Producer, stages=self.num_stages_Vi
         )
-        if const_expr(not self.disable_bitmask):
+        if const_expr(self.is_topk_gather and not self.disable_bitmask):
             producer_state_bitmask = pipeline.make_pipeline_state(
                 pipeline.PipelineUserType.Producer,
                 stages=self.num_stages_bitmask,
@@ -1420,164 +1425,246 @@ class FlashAttentionMLAForwardSm100:
             num_n_blocks = n_block_max - n_block_min
             num_n_block_groups = cute.ceil_div(num_n_blocks, self.num_stages_S)
 
-            # cluster_m_block == m_idx under MQA 128 assumption
-            m_idx = cluster_m_block
-            if const_expr(not seqlen.has_cu_seqlens_q):
-                mIndexTopk_cur = mIndexTopk[None, m_idx, batch_idx]
-            else:
-                offset_q = seqlen.offset_q
-                mIndexTopk_cur = mIndexTopk[None, m_idx + offset_q]
+            if const_expr(self.is_topk_gather):
+                # ==== Topk gather path ====
+                # cluster_m_block == m_idx under MQA 128 assumption
+                m_idx = cluster_m_block
+                if const_expr(not seqlen.has_cu_seqlens_q):
+                    mIndexTopk_cur = mIndexTopk[None, m_idx, batch_idx]
+                else:
+                    offset_q = seqlen.offset_q
+                    mIndexTopk_cur = mIndexTopk[None, m_idx + offset_q]
 
-            if const_expr(self.is_causal):
-                seqlen_k_limit = m_idx + 1 + seqlen.seqlen_k - seqlen.seqlen_q
-            else:
-                seqlen_k_limit = seqlen.seqlen_k
-            cpasync_gather_kv_manager = CpasyncGatherKVManager.create(
-                mIndexTopk_cur,
-                sBitmask,
-                cta_rank_in_cluster,
-                tidx,
-                warp_idx,
-                self.topk_length,
-                seqlen_k_limit,
-                self.tile_n,
-                self.hdim,
-                self.hdimv,
-                self.num_hdimv_splits,
-                self.num_cpasync_load_threads,
-                mK.element_type,
-                self.cta_group_size,
-                pipeline_bitmask,
-                self.num_stages_bitmask,
-                self.cpasync_barrier,
-                self.disable_bitmask,
-            )
-
-            # (seqlen_k, hdim) or (seqlen_k, hdimv//2)
-            mK_cur = seqlen.offset_batch_K(mK, batch_idx, dim=3)[None, None, head_idx_kv]
-            mV0_cur = seqlen.offset_batch_K(mV0, batch_idx, dim=3)[None, None, head_idx_kv]
-            mV1_cur = seqlen.offset_batch_K(mV1, batch_idx, dim=3)[None, None, head_idx_kv]
-            # (hdimv//2, seqlen_k)
-            if const_expr(not seqlen.has_cu_seqlens_k):
-                mVt0_cur = mVt0[None, None, head_idx_kv, batch_idx]
-                mVt1_cur = mVt1[None, None, head_idx_kv, batch_idx]
-            else:
-                mVt0_cur = cute.domain_offset((0, seqlen.offset_k), mVt0[None, None, head_idx_kv])
-                mVt1_cur = cute.domain_offset((0, seqlen.offset_k), mVt1[None, None, head_idx_kv])
-            # (hdimv//4, seqlen_k)
-            hdimv_split_per_cta = self.hdimv // self.num_hdimv_splits // self.cta_group_size
-            mVt0_cur = cute.tiled_divide(mVt0_cur, (hdimv_split_per_cta,))[
-                None, cta_rank_in_cluster, None
-            ]
-            mVt1_cur = cute.tiled_divide(mVt1_cur, (hdimv_split_per_cta,))[
-                None, cta_rank_in_cluster, None
-            ]
-
-            load_K = partial(
-                self.cpasync_gather_load_KV,
-                cpasync_gather_kv_manager,
-                pipeline_K,
-                pipeline_K_cpasync,
-                sK,
-                False,
-                "K",
-                mK_cur,
-            )
-            load_V0 = partial(
-                self.cpasync_gather_load_KV,
-                cpasync_gather_kv_manager,
-                pipeline_V0,
-                pipeline_V0_cpasync,
-                sV0,
-                False,
-                "V",
-                mV0_cur,
-            )
-            load_V1 = partial(
-                self.cpasync_gather_load_KV,
-                cpasync_gather_kv_manager,
-                pipeline_V1,
-                pipeline_V1_cpasync,
-                sV1,
-                False,
-                "V",
-                mV1_cur,
-            )
-            load_Vt0 = partial(
-                self.cpasync_gather_load_KV,
-                cpasync_gather_kv_manager,
-                pipeline_V0,
-                pipeline_V0_cpasync,
-                sVt0,
-                True,
-                "V",
-                mVt0_cur,
-            )
-            load_Vt1 = partial(
-                self.cpasync_gather_load_KV,
-                cpasync_gather_kv_manager,
-                pipeline_V1,
-                pipeline_V1_cpasync,
-                sVt1,
-                True,
-                "V",
-                mVt1_cur,
-            )
-
-            # gather KV path processes n_blocks in increasing order
-            n_block = 0
-
-            # ==== Prologue ====
-            # K, V0, V1
-            cpasync_gather_kv_manager.load_index_topk(n_block, transpose=False)
-            producer_state_K = load_K(producer_state_K)
-            producer_state_V0 = load_V0(producer_state_V0)
-            producer_state_V1 = load_V1(producer_state_V1)
-            if const_expr(not self.disable_bitmask):
-                producer_state_bitmask = cpasync_gather_kv_manager.compute_bitmask(
-                    producer_state_bitmask
+                if const_expr(self.is_causal):
+                    seqlen_k_limit = m_idx + 1 + seqlen.seqlen_k - seqlen.seqlen_q
+                else:
+                    seqlen_k_limit = seqlen.seqlen_k
+                cpasync_gather_kv_manager = CpasyncGatherKVManager.create(
+                    mIndexTopk_cur,
+                    sBitmask,
+                    cta_rank_in_cluster,
+                    tidx,
+                    warp_idx,
+                    self.topk_length,
+                    seqlen_k_limit,
+                    self.tile_n,
+                    self.hdim,
+                    self.hdimv,
+                    self.num_hdimv_splits,
+                    self.num_cpasync_load_threads,
+                    mK.element_type,
+                    self.cta_group_size,
+                    pipeline_bitmask,
+                    self.num_stages_bitmask,
+                    self.cpasync_barrier,
+                    self.disable_bitmask,
                 )
 
-            if const_expr(self.use_tma_O and self.overlap_sO_sV):
-                cute.arch.mbarrier_wait(sO_empty_mbar_ptr, phase=producer_phase_O)
-                producer_phase_O ^= 1
+                # (seqlen_k, hdim) or (seqlen_k, hdimv//2)
+                mK_cur = seqlen.offset_batch_K(mK, batch_idx, dim=3)[None, None, head_idx_kv]
+                mV0_cur = seqlen.offset_batch_K(mV0, batch_idx, dim=3)[None, None, head_idx_kv]
+                mV1_cur = seqlen.offset_batch_K(mV1, batch_idx, dim=3)[None, None, head_idx_kv]
+                # (hdimv//2, seqlen_k)
+                if const_expr(not seqlen.has_cu_seqlens_k):
+                    mVt0_cur = mVt0[None, None, head_idx_kv, batch_idx]
+                    mVt1_cur = mVt1[None, None, head_idx_kv, batch_idx]
+                else:
+                    mVt0_cur = cute.domain_offset((0, seqlen.offset_k), mVt0[None, None, head_idx_kv])
+                    mVt1_cur = cute.domain_offset((0, seqlen.offset_k), mVt1[None, None, head_idx_kv])
+                # (hdimv//4, seqlen_k)
+                hdimv_split_per_cta = self.hdimv // self.num_hdimv_splits // self.cta_group_size
+                mVt0_cur = cute.tiled_divide(mVt0_cur, (hdimv_split_per_cta, ))[None, cta_rank_in_cluster, None]
+                mVt1_cur = cute.tiled_divide(mVt1_cur, (hdimv_split_per_cta, ))[None, cta_rank_in_cluster, None]
 
-            # ==== Mainloop ====
-            for n_block_group in cutlass.range(num_n_block_groups - 1, unroll=1):
+                load_K = partial(self.cpasync_gather_load_KV,
+                    cpasync_gather_kv_manager,
+                    pipeline_K, pipeline_K_cpasync, sK, False, "K", mK_cur,
+                )
+                load_V0 = partial(self.cpasync_gather_load_KV,
+                    cpasync_gather_kv_manager,
+                    pipeline_V0, pipeline_V0_cpasync, sV0, False, "V", mV0_cur,
+                )
+                load_V1 = partial(self.cpasync_gather_load_KV,
+                    cpasync_gather_kv_manager,
+                    pipeline_V1, pipeline_V1_cpasync, sV1, False, "V", mV1_cur,
+                )
+                load_Vt0 = partial(self.cpasync_gather_load_KV,
+                    cpasync_gather_kv_manager,
+                    pipeline_V0, pipeline_V0_cpasync, sVt0, True, "V", mVt0_cur,
+                )
+                load_Vt1 = partial(self.cpasync_gather_load_KV,
+                    cpasync_gather_kv_manager,
+                    pipeline_V1, pipeline_V1_cpasync, sVt1, True, "V", mVt1_cur,
+                )
+
+                # gather KV path processes n_blocks in increasing order
+                n_block = 0
+
+                # ==== Prologue ====
+                # K, V0, V1
+                cpasync_gather_kv_manager.load_index_topk(n_block, transpose=False)
+                producer_state_K = load_K(producer_state_K)
+                producer_state_V0 = load_V0(producer_state_V0)
+                producer_state_V1 = load_V1(producer_state_V1)
+                if const_expr(not self.disable_bitmask):
+                    producer_state_bitmask = cpasync_gather_kv_manager.compute_bitmask(
+                        producer_state_bitmask
+                    )
+
+                if const_expr(self.use_tma_O and self.overlap_sO_sV):
+                    cute.arch.mbarrier_wait(sO_empty_mbar_ptr, phase=producer_phase_O)
+                    producer_phase_O ^= 1
+
+                # ==== Mainloop ====
+                for n_block_group in cutlass.range(num_n_block_groups-1, unroll=1):
+                    for stage in cutlass.range_constexpr(self.num_stages_S):
+                        n_block = n_block_group * self.num_stages_S + stage
+                        # K, V0, V1
+                        cpasync_gather_kv_manager.load_index_topk(n_block + 1, transpose=False)
+                        producer_state_K = load_K(producer_state_K)
+                        producer_state_V0 = load_V0(producer_state_V0)
+                        producer_state_V1 = load_V1(producer_state_V1)
+                        if const_expr(not self.disable_bitmask):
+                            producer_state_bitmask = cpasync_gather_kv_manager.compute_bitmask(
+                                producer_state_bitmask
+                            )
+                        # Vt0, Vt1
+                        cpasync_gather_kv_manager.load_index_topk(n_block, transpose=True)
+                        producer_state_V0 = load_Vt0(producer_state_V0)
+                        producer_state_V1 = load_Vt1(producer_state_V1)
+
+                # ==== Epilogue ====
                 for stage in cutlass.range_constexpr(self.num_stages_S):
-                    n_block = n_block_group * self.num_stages_S + stage
-                    # K, V0, V1
-                    cpasync_gather_kv_manager.load_index_topk(n_block + 1, transpose=False)
-                    producer_state_K = load_K(producer_state_K)
-                    producer_state_V0 = load_V0(producer_state_V0)
-                    producer_state_V1 = load_V1(producer_state_V1)
-                    if const_expr(not self.disable_bitmask):
-                        producer_state_bitmask = cpasync_gather_kv_manager.compute_bitmask(
-                            producer_state_bitmask
-                        )
+                    n_block = (num_n_block_groups-1) * self.num_stages_S + stage
+                    if const_expr(stage == 0):
+                        # K, V0, V1
+                        cpasync_gather_kv_manager.load_index_topk(n_block + 1, transpose=False)
+                        producer_state_K = load_K(producer_state_K)
+                        producer_state_V0 = load_V0(producer_state_V0)
+                        producer_state_V1 = load_V1(producer_state_V1)
+                        if const_expr(not self.disable_bitmask):
+                            producer_state_bitmask = cpasync_gather_kv_manager.compute_bitmask(
+                                producer_state_bitmask
+                            )
+
                     # Vt0, Vt1
                     cpasync_gather_kv_manager.load_index_topk(n_block, transpose=True)
                     producer_state_V0 = load_Vt0(producer_state_V0)
                     producer_state_V1 = load_Vt1(producer_state_V1)
 
-            # ==== Epilogue ====
-            for stage in cutlass.range_constexpr(self.num_stages_S):
-                n_block = (num_n_block_groups - 1) * self.num_stages_S + stage
-                if const_expr(stage == 0):
-                    # K, V0, V1
-                    cpasync_gather_kv_manager.load_index_topk(n_block + 1, transpose=False)
-                    producer_state_K = load_K(producer_state_K)
-                    producer_state_V0 = load_V0(producer_state_V0)
-                    producer_state_V1 = load_V1(producer_state_V1)
-                    if const_expr(not self.disable_bitmask):
-                        producer_state_bitmask = cpasync_gather_kv_manager.compute_bitmask(
-                            producer_state_bitmask
-                        )
+            else:
+                # ==== Paged KV cp.async path (page_size != tile_n) ====
+                page_size_divmod = FastDivmodDivisor(cute.size(mK.shape[0]))
+                hdimv_split = self.hdimv // self.num_hdimv_splits
+                hdimv_split_per_cta = hdimv_split // self.cta_group_size
 
-                # Vt0, Vt1
-                cpasync_gather_kv_manager.load_index_topk(n_block, transpose=True)
-                producer_state_V0 = load_Vt0(producer_state_V0)
-                producer_state_V1 = load_Vt1(producer_state_V1)
+                # CTA-split Vt: (dv/2, page_size, h_k, num_pages) -> (dv/4, page_size, h_k, num_pages)
+                # Use domain_offset + make_tensor to get a flat-shaped tensor for PagedKVManager
+                mVt0_off = cute.domain_offset(
+                    (cta_rank_in_cluster * hdimv_split_per_cta, 0, 0, 0), mVt0
+                )
+                mVt0_cta = cute.make_tensor(
+                    mVt0_off.iterator,
+                    cute.make_layout(
+                        (hdimv_split_per_cta, mVt0.shape[1], mVt0.shape[2], mVt0.shape[3]),
+                        stride=mVt0.layout.stride,
+                    ),
+                )
+                mVt1_off = cute.domain_offset(
+                    (cta_rank_in_cluster * hdimv_split_per_cta, 0, 0, 0), mVt1
+                )
+                mVt1_cta = cute.make_tensor(
+                    mVt1_off.iterator,
+                    cute.make_layout(
+                        (hdimv_split_per_cta, mVt1.shape[1], mVt1.shape[2], mVt1.shape[3]),
+                        stride=mVt1.layout.stride,
+                    ),
+                )
+
+                # PagedKVManager for K (hdim=64): uses "K" mode only
+                paged_kv_K = PagedKVManager.create(
+                    mPageTable, mK, mK,
+                    page_size_divmod, batch_idx, head_idx_kv, tidx,
+                    seqlen.seqlen_k, 0,
+                    self.tile_n, self.hdim, self.hdim,
+                    self.num_cpasync_load_threads, mK.element_type, arch=100,
+                )
+                # PagedKVManager for V0/Vt0: "K" mode → V0 (non-transposed), "V" mode → Vt0 (transposed)
+                paged_kv_V0 = PagedKVManager.create(
+                    mPageTable, mV0, mVt0_cta,
+                    page_size_divmod, batch_idx, head_idx_kv, tidx,
+                    seqlen.seqlen_k, 0,
+                    self.tile_n, hdimv_split, hdimv_split_per_cta,
+                    self.num_cpasync_load_threads, mV0.element_type, arch=100,
+                )
+                # PagedKVManager for V1/Vt1: "K" mode → V1, "V" mode → Vt1
+                paged_kv_V1 = PagedKVManager.create(
+                    mPageTable, mV1, mVt1_cta,
+                    page_size_divmod, batch_idx, head_idx_kv, tidx,
+                    seqlen.seqlen_k, 0,
+                    self.tile_n, hdimv_split, hdimv_split_per_cta,
+                    self.num_cpasync_load_threads, mV1.element_type, arch=100,
+                )
+
+                load_K = partial(self.cpasync_paged_load_KV,
+                    paged_kv_K, pipeline_K, pipeline_K_cpasync, sK, False, "K", cta_rank_in_cluster)
+                load_V0 = partial(self.cpasync_paged_load_KV,
+                    paged_kv_V0, pipeline_V0, pipeline_V0_cpasync, sV0, False, "K", cta_rank_in_cluster)
+                load_V1 = partial(self.cpasync_paged_load_KV,
+                    paged_kv_V1, pipeline_V1, pipeline_V1_cpasync, sV1, False, "K", cta_rank_in_cluster)
+                load_Vt0 = partial(self.cpasync_paged_load_KV,
+                    paged_kv_V0, pipeline_V0, pipeline_V0_cpasync, sVt0, True, "V", cta_rank_in_cluster)
+                load_Vt1 = partial(self.cpasync_paged_load_KV,
+                    paged_kv_V1, pipeline_V1, pipeline_V1_cpasync, sVt1, True, "V", cta_rank_in_cluster)
+
+                # Paged path must follow the same descending n_block order as the
+                # MLA TMA path (`n_block_max - 1` down to `n_block_min`). The MMA
+                # mainloop consumes KV tiles in that order, so ascending order
+                # produces multi-block numerical mismatches even when commit counts
+                # are otherwise correct.
+                #
+                # Pipeline commit counts must still match the relay exactly:
+                #   K = N, V0 = 2N, V1 = 2N  (N = num_n_blocks)
+                # This loop structure mirrors the relay's:
+                #   prologue(K,V0,V1) + mainloop×(N-1)(K,V0,V1,Vt0,Vt1) + epilogue(Vt0,Vt1)
+                n_block_first = n_block_max - 1
+                n_block = n_block_first
+
+                # ==== Prologue ====
+                # load_page_table must be called directly in loop body, not inside
+                # cpasync_paged_load_KV, to avoid MLIR SSA region crossing errors.
+                paged_kv_K.load_page_table(n_block_first)
+                producer_state_K = load_K(n_block_first, producer_state_K)
+                paged_kv_V0.load_page_table(n_block_first)
+                producer_state_V0 = load_V0(n_block_first, producer_state_V0)
+                paged_kv_V1.load_page_table(n_block_first)
+                producer_state_V1 = load_V1(n_block_first, producer_state_V1)
+
+                if const_expr(self.use_tma_O and self.overlap_sO_sV):
+                    cute.arch.mbarrier_wait(sO_empty_mbar_ptr, phase=producer_phase_O)
+                    producer_phase_O ^= 1
+
+                # ==== Mainloop ====
+                for n_idx in cutlass.range(num_n_blocks - 1, unroll=2):
+                    n_block = n_block_first - n_idx
+                    # K, V0, V1 for next block in descending order
+                    paged_kv_K.load_page_table(n_block - 1)
+                    producer_state_K = load_K(n_block - 1, producer_state_K)
+                    paged_kv_V0.load_page_table(n_block - 1)
+                    producer_state_V0 = load_V0(n_block - 1, producer_state_V0)
+                    paged_kv_V1.load_page_table(n_block - 1)
+                    producer_state_V1 = load_V1(n_block - 1, producer_state_V1)
+                    # Vt0, Vt1 for current block
+                    paged_kv_V0.load_page_table(n_block)
+                    producer_state_V0 = load_Vt0(n_block, producer_state_V0)
+                    paged_kv_V1.load_page_table(n_block)
+                    producer_state_V1 = load_Vt1(n_block, producer_state_V1)
+
+                # ==== Epilogue ====
+                paged_kv_V0.load_page_table(n_block_min)
+                producer_state_V0 = load_Vt0(n_block_min, producer_state_V0)
+                paged_kv_V1.load_page_table(n_block_min)
+                producer_state_V1 = load_Vt1(n_block_min, producer_state_V1)
 
             # Advance to next tile
             work_tile = tile_scheduler.advance_to_next_work()
@@ -1585,7 +1672,7 @@ class FlashAttentionMLAForwardSm100:
         pipeline_K_cpasync.producer_tail(producer_state_K)
         pipeline_V0_cpasync.producer_tail(producer_state_V0)
         pipeline_V1_cpasync.producer_tail(producer_state_V1)
-        if const_expr(not self.disable_bitmask):
+        if const_expr(self.is_topk_gather and not self.disable_bitmask):
             pipeline_bitmask.producer_tail(producer_state_bitmask)
 
     @cute.jit
@@ -1603,6 +1690,97 @@ class FlashAttentionMLAForwardSm100:
         stage, phase = producer_state.index, producer_state.phase
         pipeline_mma.producer_acquire(producer_state)
         cpasync_gather_kv_manager.load_X(mX, sX[None, None, None, stage], transpose, K_or_V)
+        cute.arch.cp_async_commit_group()
+        pipeline_cpasync.sync_object_full.arrive_cp_async_mbarrier(stage)
+        producer_state.advance()
+        return producer_state
+
+    @cute.jit
+    def cpasync_paged_load_KV(
+        self,
+        paged_kv_manager: PagedKVManager,
+        pipeline_mma: pipeline.PipelineAsyncUmma,
+        pipeline_cpasync: pipeline.PipelineAsync,
+        sX: cute.Tensor,
+        transpose: bool,
+        K_or_V: str,
+        cta_rank_in_cluster: Int32,
+        n_block: Int32,
+        producer_state: pipeline.PipelineState,
+    ):
+        """Load one tile of K or V from paged gmem to smem using cp.async.
+
+        Uses PagedKVManager for page table lookups and pointer computation,
+        with smem reshaping via cute.composition (same approach as CpasyncGatherKVManager).
+
+        For non-transposed tensors (K, V0, V1): K_or_V="K", transpose=False
+        For transposed tensors (Vt0, Vt1):      K_or_V="V", transpose=True
+        """
+        stage = producer_state.index
+        pipeline_mma.producer_acquire(producer_state)
+
+        # NOTE: load_page_table() must be called by the caller BEFORE this method.
+        # Calling it here (through a @cute.jit boundary) causes MLIR SSA verification
+        # errors because the rmem tensor writes inside load_page_table's dynamic
+        # cutlass.range loop cross region boundaries. This matches the SM90/SM100
+        # pattern where load_page_table is called directly in the loop body.
+
+        # Compute row pointers from cached page table entries
+        tPrXPtr = paged_kv_manager.compute_X_ptr(K_or_V)
+
+        # Reshape smem to flat 2D using composition (matches CpasyncGatherKVManager.load_X)
+        head_dim = paged_kv_manager.head_dim_v_padded if const_expr(K_or_V == "V") else paged_kv_manager.head_dim_padded
+        cta_tile_n = self.tile_n if const_expr(transpose) else self.tile_n // self.cta_group_size
+        order = (1, 0) if const_expr(transpose) else (0, 1)
+
+        sX_stage = sX[None, None, None, stage]
+        sX_nd_layout = cute.make_ordered_layout((cta_tile_n, head_dim), order=order)
+        sX_nd = cute.composition(sX_stage, sX_nd_layout)
+
+        cX = cute.make_identity_tensor((cta_tile_n, head_dim))
+        tXsX = paged_kv_manager.gmem_thr_copy_KV.partition_D(sX_nd)
+        tXcX = paged_kv_manager.gmem_thr_copy_KV.partition_S(cX)
+        tXc0X = paged_kv_manager.gmem_thr_copy_KV.get_slice(0).partition_S(cX)
+
+        seqlenk_row_limit = (
+            paged_kv_manager.seqlen_k - n_block * self.tile_n - tXcX[0][0]
+            if n_block >= 0 else 0
+        )
+
+        if const_expr(not transpose):
+            offset = cta_rank_in_cluster * (paged_kv_manager.gmem_threads_per_row // self.cta_group_size)
+        else:
+            offset = 0
+
+        for m in cutlass.range_constexpr(cute.size(tXsX, mode=[1])):
+            row_valid = tXc0X[0, m, 0][0] < seqlenk_row_limit
+            should_load = cute.make_fragment_like(tXsX[(0, None), m, 0], cute.Boolean)
+            should_load.fill(row_valid)
+
+            x_ptr_i64 = utils.shuffle_sync(
+                tPrXPtr[m // paged_kv_manager.gmem_threads_per_row],
+                (m + offset) % paged_kv_manager.gmem_threads_per_row,
+                width=paged_kv_manager.gmem_threads_per_row,
+            )
+            x_gmem_ptr = cute.make_ptr(
+                paged_kv_manager.mK_paged.element_type, x_ptr_i64,
+                cute.AddressSpace.gmem, assumed_align=16,
+            )
+            mX_cur = cute.make_tensor(x_gmem_ptr, cute.make_layout((head_dim,)))
+            mX_cur_copy = cute.tiled_divide(mX_cur, (paged_kv_manager.async_copy_elems,))
+
+            for k in cutlass.range_constexpr(cute.size(tXsX, mode=[2])):
+                ki = tXcX[0, 0, k][1] // paged_kv_manager.async_copy_elems
+                mX_cur_copy_ki = mX_cur_copy[None, ki]
+                tXsX_k = tXsX[None, m, k]
+                mX_cur_copy_ki = cute.make_tensor(mX_cur_copy_ki.iterator, tXsX_k.layout)
+                cute.copy(
+                    paged_kv_manager.gmem_tiled_copy_KV,
+                    mX_cur_copy_ki,
+                    tXsX_k,
+                    pred=should_load,
+                )
+
         cute.arch.cp_async_commit_group()
         pipeline_cpasync.sync_object_full.arrive_cp_async_mbarrier(stage)
         producer_state.advance()

--- a/flash_attn/cute/flash_fwd_mla_sm100.py
+++ b/flash_attn/cute/flash_fwd_mla_sm100.py
@@ -370,9 +370,6 @@ class FlashAttentionMLAForwardSm100:
         # Always keep stream as the last parameter (EnvStream: obtained implicitly via TVM FFI).
         stream: cuda.CUstream = None,
     ):
-        # ==== asserts for unimplemented features ====
-        assert mPageTable is None, "page table tbd for MLA"
-
         # ==== dtype info ====
         self.dtype_Q = mQ.element_type
         self.dtype_K = mK.element_type
@@ -609,8 +606,10 @@ class FlashAttentionMLAForwardSm100:
             num_batch=cute.size(mQ.shape[3])
             if const_expr(mCuSeqlensQ is None)
             else cute.size(mCuSeqlensQ.shape[0] - 1),
-            num_splits=1,  # todo: split_kv
-            seqlen_k=cute.size(mK.shape[0]),  # todo: page table
+            num_splits=1, # todo: split_kv
+            seqlen_k=cute.size(mK.shape[0])
+            if const_expr(mPageTable is None)
+            else cute.size(mK.shape[0]) * cute.size(mPageTable.shape[1]),
             headdim=self.hdim,
             headdim_v=self.hdimv,
             total_q=cute.size(mQ.shape[0])
@@ -709,6 +708,7 @@ class FlashAttentionMLAForwardSm100:
             topk_length_dynamic,
             tile_sched_params,
             SharedStorage,
+            mPageTable,
         ).launch(
             grid=grid_dim,
             block=(
@@ -767,6 +767,7 @@ class FlashAttentionMLAForwardSm100:
         topk_length_dynamic: Optional[Int32],
         tile_sched_params: ParamsBase,
         SharedStorage: cutlass.Constexpr[Callable],
+        mPageTable: Optional[cute.Tensor] = None,
     ):
         warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
         cta_layout_vmnk = cute.tiled_divide(
@@ -936,7 +937,9 @@ class FlashAttentionMLAForwardSm100:
         SeqlenInfoCls = partial(
             SeqlenInfoQK.create,
             seqlen_q_static=mQ.shape[0] if const_expr(not self.pack_gqa) else mQ.shape[0][1],
-            seqlen_k_static=mK.shape[0],
+            seqlen_k_static=mK.shape[0]
+            if const_expr(mPageTable is None)
+            else mK.shape[0] * mPageTable.shape[1],
             tile_m=self.cta_tile_m,
             tile_n=self.tile_n,
             mCuSeqlensQ=mCuSeqlensQ,
@@ -1098,6 +1101,7 @@ class FlashAttentionMLAForwardSm100:
                 block_info,
                 SeqlenInfoCls,
                 tile_scheduler=tile_scheduler,
+                mPageTable=mPageTable,
             )
 
         if warp_idx == self.mma_warp_id:
@@ -1646,6 +1650,7 @@ class FlashAttentionMLAForwardSm100:
         block_info: BlockInfo,
         SeqlenInfoCls: Callable,
         tile_scheduler: TileSchedulerProtocol,
+        mPageTable: Optional[cute.Tensor] = None,
     ):
         # ==== Load warp ====
         # Description: loads tiles of Q, Qv, K, V, V0, V1 from gmem to smem using TMA
@@ -1758,48 +1763,80 @@ class FlashAttentionMLAForwardSm100:
             )
 
             if const_expr(self.use_tma_KV):
-                # (seqlen_k, hdim) or (seqlen_k, hdimv//2)
-                mK_cur = seqlen.offset_batch_K(mK, batch_idx, dim=3)[None, None, head_idx_kv]
-                mVs_cur = [
-                    seqlen.offset_batch_K(mVs[split], batch_idx, dim=3)[None, None, head_idx_kv]
-                    for split in range(self.num_hdimv_splits)
-                ]
-                # (hdimv//2, seqlen_k)
-                if const_expr(not seqlen.has_cu_seqlens_k):
-                    mVts_cur = [
-                        mVts[split][None, None, head_idx_kv, batch_idx]
+                if const_expr(mPageTable is None):
+                    # Non-paged: select batch, tile over seqlen_k
+                    # (seqlen_k, hdim) or (seqlen_k, hdimv//2)
+                    mK_cur = seqlen.offset_batch_K(mK, batch_idx, dim=3)[None, None, head_idx_kv]
+                    mVs_cur = [
+                        seqlen.offset_batch_K(mVs[split], batch_idx, dim=3)[None, None, head_idx_kv]
                         for split in range(self.num_hdimv_splits)
                     ]
-                else:
-                    mVts_cur = [
-                        cute.domain_offset(
-                            (0, seqlen.offset_k), mVts[split][None, None, head_idx_kv]
-                        )
-                        for split in range(self.num_hdimv_splits)
-                    ]
-                # (tile_n, hdim or hdimv//2, num_n_blocks)
-                gK = cute.local_tile(
-                    mK_cur,
-                    (self.mma_tiler_QK[1], self.mma_tiler_QK[2]),
-                    (None, 0),
-                )
-                gVs = [
-                    cute.local_tile(
-                        mVs_cur[split],
-                        (self.mma_tiler_QviVi[1], self.mma_tiler_QviVi[2]),
+                    # (hdimv//2, seqlen_k)
+                    if const_expr(not seqlen.has_cu_seqlens_k):
+                        mVts_cur = [
+                            mVts[split][None, None, head_idx_kv, batch_idx]
+                            for split in range(self.num_hdimv_splits)
+                        ]
+                    else:
+                        mVts_cur = [
+                            cute.domain_offset((0, seqlen.offset_k), mVts[split][None, None, head_idx_kv])
+                            for split in range(self.num_hdimv_splits)
+                        ]
+                    # (tile_n, hdim or hdimv//2, num_n_blocks)
+                    gK = cute.local_tile(
+                        mK_cur,
+                        (self.mma_tiler_QK[1], self.mma_tiler_QK[2]),
                         (None, 0),
                     )
-                    for split in range(self.num_hdimv_splits)
-                ]
-                # (hdim or hdimv//2, tile_n, num_n_blocks)
-                gVts = [
-                    cute.local_tile(
-                        mVts_cur[split],
-                        (self.mma_tiler_PVti[1], self.mma_tiler_PVti[2]),
-                        (0, None),
+                    gVs = [
+                        cute.local_tile(
+                            mVs_cur[split],
+                            (self.mma_tiler_QviVi[1], self.mma_tiler_QviVi[2]),
+                            (None, 0),
+                        ) for split in range(self.num_hdimv_splits)
+                    ]
+                    # (hdim or hdimv//2, tile_n, num_n_blocks)
+                    gVts = [
+                        cute.local_tile(
+                            mVts_cur[split],
+                            (self.mma_tiler_PVti[1], self.mma_tiler_PVti[2]),
+                            (0, None),
+                        ) for split in range(self.num_hdimv_splits)
+                    ]
+                else:
+                    # Paged KV: keep pages dim, index by page_idx at load time
+                    # (page_size, hdim, num_pages) or (page_size, hdimv//2, num_pages)
+                    mK_cur = mK[None, None, head_idx_kv, None]
+                    mVs_cur = [
+                        mVs[split][None, None, head_idx_kv, None]
+                        for split in range(self.num_hdimv_splits)
+                    ]
+                    # (hdimv//2, page_size, num_pages)
+                    mVts_cur = [
+                        mVts[split][None, None, head_idx_kv, None]
+                        for split in range(self.num_hdimv_splits)
+                    ]
+                    # (tile_n, hdim or hdimv//2, 1, num_pages)
+                    gK = cute.local_tile(
+                        mK_cur,
+                        (self.mma_tiler_QK[1], self.mma_tiler_QK[2]),
+                        (None, 0, None),
                     )
-                    for split in range(self.num_hdimv_splits)
-                ]
+                    gVs = [
+                        cute.local_tile(
+                            mVs_cur[split],
+                            (self.mma_tiler_QviVi[1], self.mma_tiler_QviVi[2]),
+                            (None, 0, None),
+                        ) for split in range(self.num_hdimv_splits)
+                    ]
+                    # (hdim or hdimv//2, tile_n, 1, num_pages)
+                    gVts = [
+                        cute.local_tile(
+                            mVts_cur[split],
+                            (self.mma_tiler_PVti[1], self.mma_tiler_PVti[2]),
+                            (0, None, None),
+                        ) for split in range(self.num_hdimv_splits)
+                    ]
                 tSgK = thr_mma_QK.partition_B(gK)
                 tSgVs = [
                     thr_mma_QviVi.partition_B(gVs[split]) for split in range(self.num_hdimv_splits)
@@ -1856,11 +1893,16 @@ class FlashAttentionMLAForwardSm100:
             if const_expr(self.use_tma_KV):
                 # ==== Prologue ====
                 n_block_first = n_block_max - 1
+                page_idx = (
+                    mPageTable[batch_idx, n_block_first]
+                    if const_expr(mPageTable is not None)
+                    else None
+                )
                 # copy K gmem -> smem
-                producer_state_K = load_K(producer_state_K, n_block=n_block_first)
+                producer_state_K = load_K(producer_state_K, n_block=n_block_first, page_idx=page_idx)
                 # copy Vi gmem -> smem
-                producer_state_V0 = load_V(producer_state_V0, n_block=n_block_first, split=0)
-                producer_state_V1 = load_V(producer_state_V1, n_block=n_block_first, split=1)
+                producer_state_V0 = load_V(producer_state_V0, n_block=n_block_first, split=0, page_idx=page_idx)
+                producer_state_V1 = load_V(producer_state_V1, n_block=n_block_first, split=1, page_idx=page_idx)
 
                 if const_expr(self.use_tma_O and self.overlap_sO_sV):
                     cute.arch.mbarrier_wait(sO_empty_mbar_ptr, phase=producer_phase_O)
@@ -1870,28 +1912,48 @@ class FlashAttentionMLAForwardSm100:
                 for n_block_group in cutlass.range(num_n_block_groups - 1, unroll=1):
                     for stage in cutlass.range_constexpr(self.num_stages_S):
                         n_block = n_block_max - 1 - n_block_group * self.num_stages_S - stage
+                        page_idx_next = (
+                            mPageTable[batch_idx, n_block - 1]
+                            if const_expr(mPageTable is not None)
+                            else None
+                        )
+                        page_idx_cur = (
+                            mPageTable[batch_idx, n_block]
+                            if const_expr(mPageTable is not None)
+                            else None
+                        )
                         # copy K gmem -> smem
-                        producer_state_K = load_K(producer_state_K, n_block=n_block - 1)
+                        producer_state_K = load_K(producer_state_K, n_block=n_block-1, page_idx=page_idx_next)
                         # copy Vi gmem -> smem
-                        producer_state_V0 = load_V(producer_state_V0, n_block=n_block - 1, split=0)
-                        producer_state_V1 = load_V(producer_state_V1, n_block=n_block - 1, split=1)
+                        producer_state_V0 = load_V(producer_state_V0, n_block=n_block-1, split=0, page_idx=page_idx_next)
+                        producer_state_V1 = load_V(producer_state_V1, n_block=n_block-1, split=1, page_idx=page_idx_next)
                         # copy Vti gmem -> smem
-                        producer_state_V0 = load_Vt(producer_state_V0, n_block=n_block, split=0)
-                        producer_state_V1 = load_Vt(producer_state_V1, n_block=n_block, split=1)
+                        producer_state_V0 = load_Vt(producer_state_V0, n_block=n_block, split=0, page_idx=page_idx_cur)
+                        producer_state_V1 = load_Vt(producer_state_V1, n_block=n_block, split=1, page_idx=page_idx_cur)
 
                 # ==== Epilogue ====
                 num_final_n_blocks = self.num_stages_S if even_n_blocks else self.num_stages_S - 1
                 for stage in cutlass.range(num_final_n_blocks, unroll_full=True):
                     n_block = num_final_n_blocks - 1 - stage
                     if n_block > 0:
+                        page_idx_next = (
+                            mPageTable[batch_idx, n_block - 1]
+                            if const_expr(mPageTable is not None)
+                            else None
+                        )
                         # copy K gmem -> smem
-                        producer_state_K = load_K(producer_state_K, n_block=n_block - 1)
+                        producer_state_K = load_K(producer_state_K, n_block=n_block-1, page_idx=page_idx_next)
                         # copy Vi gmem -> smem
-                        producer_state_V0 = load_V(producer_state_V0, n_block=n_block - 1, split=0)
-                        producer_state_V1 = load_V(producer_state_V1, n_block=n_block - 1, split=1)
+                        producer_state_V0 = load_V(producer_state_V0, n_block=n_block-1, split=0, page_idx=page_idx_next)
+                        producer_state_V1 = load_V(producer_state_V1, n_block=n_block-1, split=1, page_idx=page_idx_next)
+                    page_idx_cur = (
+                        mPageTable[batch_idx, n_block]
+                        if const_expr(mPageTable is not None)
+                        else None
+                    )
                     # copy Vti gmem -> smem
-                    producer_state_V0 = load_Vt(producer_state_V0, n_block=n_block, split=0)
-                    producer_state_V1 = load_Vt(producer_state_V1, n_block=n_block, split=1)
+                    producer_state_V0 = load_Vt(producer_state_V0, n_block=n_block, split=0, page_idx=page_idx_cur)
+                    producer_state_V1 = load_Vt(producer_state_V1, n_block=n_block, split=1, page_idx=page_idx_cur)
 
             # Advance to next tile
             work_tile = tile_scheduler.advance_to_next_work()
@@ -1914,6 +1976,7 @@ class FlashAttentionMLAForwardSm100:
         producer_state: pipeline.PipelineState,
         n_block: Optional[Int32] = None,
         split: Optional[Int32] = None,
+        page_idx: Optional[Int32] = None,
     ):
         stage = producer_state.index
         if const_expr(split is not None):
@@ -1922,7 +1985,10 @@ class FlashAttentionMLAForwardSm100:
             tXsX = tXsX[split]
             load_pipeline = load_pipeline[split]
         if const_expr(n_block is not None):
-            tXgX = tXgX[(None, n_block)]
+            if const_expr(page_idx is not None):
+                tXgX = tXgX[(None, 0, page_idx)]
+            else:
+                tXgX = tXgX[(None, n_block)]
         tXsX = tXsX[(None, stage)]
 
         load_pipeline.producer_acquire(producer_state)

--- a/flash_attn/cute/flash_fwd_mla_sm100.py
+++ b/flash_attn/cute/flash_fwd_mla_sm100.py
@@ -609,7 +609,7 @@ class FlashAttentionMLAForwardSm100:
             num_batch=cute.size(mQ.shape[3])
             if const_expr(mCuSeqlensQ is None)
             else cute.size(mCuSeqlensQ.shape[0] - 1),
-            num_splits=1, # todo: split_kv
+            num_splits=1,  # todo: split_kv
             seqlen_k=cute.size(mK.shape[0])
             if const_expr(mPageTable is None)
             else cute.size(mK.shape[0]) * cute.size(mPageTable.shape[1]),
@@ -1469,32 +1469,70 @@ class FlashAttentionMLAForwardSm100:
                     mVt0_cur = mVt0[None, None, head_idx_kv, batch_idx]
                     mVt1_cur = mVt1[None, None, head_idx_kv, batch_idx]
                 else:
-                    mVt0_cur = cute.domain_offset((0, seqlen.offset_k), mVt0[None, None, head_idx_kv])
-                    mVt1_cur = cute.domain_offset((0, seqlen.offset_k), mVt1[None, None, head_idx_kv])
+                    mVt0_cur = cute.domain_offset(
+                        (0, seqlen.offset_k), mVt0[None, None, head_idx_kv]
+                    )
+                    mVt1_cur = cute.domain_offset(
+                        (0, seqlen.offset_k), mVt1[None, None, head_idx_kv]
+                    )
                 # (hdimv//4, seqlen_k)
                 hdimv_split_per_cta = self.hdimv // self.num_hdimv_splits // self.cta_group_size
-                mVt0_cur = cute.tiled_divide(mVt0_cur, (hdimv_split_per_cta, ))[None, cta_rank_in_cluster, None]
-                mVt1_cur = cute.tiled_divide(mVt1_cur, (hdimv_split_per_cta, ))[None, cta_rank_in_cluster, None]
+                mVt0_cur = cute.tiled_divide(mVt0_cur, (hdimv_split_per_cta,))[
+                    None, cta_rank_in_cluster, None
+                ]
+                mVt1_cur = cute.tiled_divide(mVt1_cur, (hdimv_split_per_cta,))[
+                    None, cta_rank_in_cluster, None
+                ]
 
-                load_K = partial(self.cpasync_gather_load_KV,
+                load_K = partial(
+                    self.cpasync_gather_load_KV,
                     cpasync_gather_kv_manager,
-                    pipeline_K, pipeline_K_cpasync, sK, False, "K", mK_cur,
+                    pipeline_K,
+                    pipeline_K_cpasync,
+                    sK,
+                    False,
+                    "K",
+                    mK_cur,
                 )
-                load_V0 = partial(self.cpasync_gather_load_KV,
+                load_V0 = partial(
+                    self.cpasync_gather_load_KV,
                     cpasync_gather_kv_manager,
-                    pipeline_V0, pipeline_V0_cpasync, sV0, False, "V", mV0_cur,
+                    pipeline_V0,
+                    pipeline_V0_cpasync,
+                    sV0,
+                    False,
+                    "V",
+                    mV0_cur,
                 )
-                load_V1 = partial(self.cpasync_gather_load_KV,
+                load_V1 = partial(
+                    self.cpasync_gather_load_KV,
                     cpasync_gather_kv_manager,
-                    pipeline_V1, pipeline_V1_cpasync, sV1, False, "V", mV1_cur,
+                    pipeline_V1,
+                    pipeline_V1_cpasync,
+                    sV1,
+                    False,
+                    "V",
+                    mV1_cur,
                 )
-                load_Vt0 = partial(self.cpasync_gather_load_KV,
+                load_Vt0 = partial(
+                    self.cpasync_gather_load_KV,
                     cpasync_gather_kv_manager,
-                    pipeline_V0, pipeline_V0_cpasync, sVt0, True, "V", mVt0_cur,
+                    pipeline_V0,
+                    pipeline_V0_cpasync,
+                    sVt0,
+                    True,
+                    "V",
+                    mVt0_cur,
                 )
-                load_Vt1 = partial(self.cpasync_gather_load_KV,
+                load_Vt1 = partial(
+                    self.cpasync_gather_load_KV,
                     cpasync_gather_kv_manager,
-                    pipeline_V1, pipeline_V1_cpasync, sVt1, True, "V", mVt1_cur,
+                    pipeline_V1,
+                    pipeline_V1_cpasync,
+                    sVt1,
+                    True,
+                    "V",
+                    mVt1_cur,
                 )
 
                 # gather KV path processes n_blocks in increasing order
@@ -1516,7 +1554,7 @@ class FlashAttentionMLAForwardSm100:
                     producer_phase_O ^= 1
 
                 # ==== Mainloop ====
-                for n_block_group in cutlass.range(num_n_block_groups-1, unroll=1):
+                for n_block_group in cutlass.range(num_n_block_groups - 1, unroll=1):
                     for stage in cutlass.range_constexpr(self.num_stages_S):
                         n_block = n_block_group * self.num_stages_S + stage
                         # K, V0, V1
@@ -1535,7 +1573,7 @@ class FlashAttentionMLAForwardSm100:
 
                 # ==== Epilogue ====
                 for stage in cutlass.range_constexpr(self.num_stages_S):
-                    n_block = (num_n_block_groups-1) * self.num_stages_S + stage
+                    n_block = (num_n_block_groups - 1) * self.num_stages_S + stage
                     if const_expr(stage == 0):
                         # K, V0, V1
                         cpasync_gather_kv_manager.load_index_topk(n_block + 1, transpose=False)
@@ -1583,39 +1621,109 @@ class FlashAttentionMLAForwardSm100:
 
                 # PagedKVManager for K (hdim=64): uses "K" mode only
                 paged_kv_K = PagedKVManager.create(
-                    mPageTable, mK, mK,
-                    page_size_divmod, batch_idx, head_idx_kv, tidx,
-                    seqlen.seqlen_k, 0,
-                    self.tile_n, self.hdim, self.hdim,
-                    self.num_cpasync_load_threads, mK.element_type, arch=100,
+                    mPageTable,
+                    mK,
+                    mK,
+                    page_size_divmod,
+                    batch_idx,
+                    head_idx_kv,
+                    tidx,
+                    seqlen.seqlen_k,
+                    0,
+                    self.tile_n,
+                    self.hdim,
+                    self.hdim,
+                    self.num_cpasync_load_threads,
+                    mK.element_type,
+                    arch=100,
                 )
                 # PagedKVManager for V0/Vt0: "K" mode → V0 (non-transposed), "V" mode → Vt0 (transposed)
                 paged_kv_V0 = PagedKVManager.create(
-                    mPageTable, mV0, mVt0_cta,
-                    page_size_divmod, batch_idx, head_idx_kv, tidx,
-                    seqlen.seqlen_k, 0,
-                    self.tile_n, hdimv_split, hdimv_split_per_cta,
-                    self.num_cpasync_load_threads, mV0.element_type, arch=100,
+                    mPageTable,
+                    mV0,
+                    mVt0_cta,
+                    page_size_divmod,
+                    batch_idx,
+                    head_idx_kv,
+                    tidx,
+                    seqlen.seqlen_k,
+                    0,
+                    self.tile_n,
+                    hdimv_split,
+                    hdimv_split_per_cta,
+                    self.num_cpasync_load_threads,
+                    mV0.element_type,
+                    arch=100,
                 )
                 # PagedKVManager for V1/Vt1: "K" mode → V1, "V" mode → Vt1
                 paged_kv_V1 = PagedKVManager.create(
-                    mPageTable, mV1, mVt1_cta,
-                    page_size_divmod, batch_idx, head_idx_kv, tidx,
-                    seqlen.seqlen_k, 0,
-                    self.tile_n, hdimv_split, hdimv_split_per_cta,
-                    self.num_cpasync_load_threads, mV1.element_type, arch=100,
+                    mPageTable,
+                    mV1,
+                    mVt1_cta,
+                    page_size_divmod,
+                    batch_idx,
+                    head_idx_kv,
+                    tidx,
+                    seqlen.seqlen_k,
+                    0,
+                    self.tile_n,
+                    hdimv_split,
+                    hdimv_split_per_cta,
+                    self.num_cpasync_load_threads,
+                    mV1.element_type,
+                    arch=100,
                 )
 
-                load_K = partial(self.cpasync_paged_load_KV,
-                    paged_kv_K, pipeline_K, pipeline_K_cpasync, sK, False, "K", cta_rank_in_cluster)
-                load_V0 = partial(self.cpasync_paged_load_KV,
-                    paged_kv_V0, pipeline_V0, pipeline_V0_cpasync, sV0, False, "K", cta_rank_in_cluster)
-                load_V1 = partial(self.cpasync_paged_load_KV,
-                    paged_kv_V1, pipeline_V1, pipeline_V1_cpasync, sV1, False, "K", cta_rank_in_cluster)
-                load_Vt0 = partial(self.cpasync_paged_load_KV,
-                    paged_kv_V0, pipeline_V0, pipeline_V0_cpasync, sVt0, True, "V", cta_rank_in_cluster)
-                load_Vt1 = partial(self.cpasync_paged_load_KV,
-                    paged_kv_V1, pipeline_V1, pipeline_V1_cpasync, sVt1, True, "V", cta_rank_in_cluster)
+                load_K = partial(
+                    self.cpasync_paged_load_KV,
+                    paged_kv_K,
+                    pipeline_K,
+                    pipeline_K_cpasync,
+                    sK,
+                    False,
+                    "K",
+                    cta_rank_in_cluster,
+                )
+                load_V0 = partial(
+                    self.cpasync_paged_load_KV,
+                    paged_kv_V0,
+                    pipeline_V0,
+                    pipeline_V0_cpasync,
+                    sV0,
+                    False,
+                    "K",
+                    cta_rank_in_cluster,
+                )
+                load_V1 = partial(
+                    self.cpasync_paged_load_KV,
+                    paged_kv_V1,
+                    pipeline_V1,
+                    pipeline_V1_cpasync,
+                    sV1,
+                    False,
+                    "K",
+                    cta_rank_in_cluster,
+                )
+                load_Vt0 = partial(
+                    self.cpasync_paged_load_KV,
+                    paged_kv_V0,
+                    pipeline_V0,
+                    pipeline_V0_cpasync,
+                    sVt0,
+                    True,
+                    "V",
+                    cta_rank_in_cluster,
+                )
+                load_Vt1 = partial(
+                    self.cpasync_paged_load_KV,
+                    paged_kv_V1,
+                    pipeline_V1,
+                    pipeline_V1_cpasync,
+                    sVt1,
+                    True,
+                    "V",
+                    cta_rank_in_cluster,
+                )
 
                 # Paged path must follow the same descending n_block order as the
                 # MLA TMA path (`n_block_max - 1` down to `n_block_min`). The MMA
@@ -1729,7 +1837,11 @@ class FlashAttentionMLAForwardSm100:
         tPrXPtr = paged_kv_manager.compute_X_ptr(K_or_V)
 
         # Reshape smem to flat 2D using composition (matches CpasyncGatherKVManager.load_X)
-        head_dim = paged_kv_manager.head_dim_v_padded if const_expr(K_or_V == "V") else paged_kv_manager.head_dim_padded
+        head_dim = (
+            paged_kv_manager.head_dim_v_padded
+            if const_expr(K_or_V == "V")
+            else paged_kv_manager.head_dim_padded
+        )
         cta_tile_n = self.tile_n if const_expr(transpose) else self.tile_n // self.cta_group_size
         order = (1, 0) if const_expr(transpose) else (0, 1)
 
@@ -1743,12 +1855,13 @@ class FlashAttentionMLAForwardSm100:
         tXc0X = paged_kv_manager.gmem_thr_copy_KV.get_slice(0).partition_S(cX)
 
         seqlenk_row_limit = (
-            paged_kv_manager.seqlen_k - n_block * self.tile_n - tXcX[0][0]
-            if n_block >= 0 else 0
+            paged_kv_manager.seqlen_k - n_block * self.tile_n - tXcX[0][0] if n_block >= 0 else 0
         )
 
         if const_expr(not transpose):
-            offset = cta_rank_in_cluster * (paged_kv_manager.gmem_threads_per_row // self.cta_group_size)
+            offset = cta_rank_in_cluster * (
+                paged_kv_manager.gmem_threads_per_row // self.cta_group_size
+            )
         else:
             offset = 0
 
@@ -1763,8 +1876,10 @@ class FlashAttentionMLAForwardSm100:
                 width=paged_kv_manager.gmem_threads_per_row,
             )
             x_gmem_ptr = cute.make_ptr(
-                paged_kv_manager.mK_paged.element_type, x_ptr_i64,
-                cute.AddressSpace.gmem, assumed_align=16,
+                paged_kv_manager.mK_paged.element_type,
+                x_ptr_i64,
+                cute.AddressSpace.gmem,
+                assumed_align=16,
             )
             mX_cur = cute.make_tensor(x_gmem_ptr, cute.make_layout((head_dim,)))
             mX_cur_copy = cute.tiled_divide(mX_cur, (paged_kv_manager.async_copy_elems,))
@@ -1956,7 +2071,9 @@ class FlashAttentionMLAForwardSm100:
                         ]
                     else:
                         mVts_cur = [
-                            cute.domain_offset((0, seqlen.offset_k), mVts[split][None, None, head_idx_kv])
+                            cute.domain_offset(
+                                (0, seqlen.offset_k), mVts[split][None, None, head_idx_kv]
+                            )
                             for split in range(self.num_hdimv_splits)
                         ]
                     # (tile_n, hdim or hdimv//2, num_n_blocks)
@@ -1970,7 +2087,8 @@ class FlashAttentionMLAForwardSm100:
                             mVs_cur[split],
                             (self.mma_tiler_QviVi[1], self.mma_tiler_QviVi[2]),
                             (None, 0),
-                        ) for split in range(self.num_hdimv_splits)
+                        )
+                        for split in range(self.num_hdimv_splits)
                     ]
                     # (hdim or hdimv//2, tile_n, num_n_blocks)
                     gVts = [
@@ -1978,7 +2096,8 @@ class FlashAttentionMLAForwardSm100:
                             mVts_cur[split],
                             (self.mma_tiler_PVti[1], self.mma_tiler_PVti[2]),
                             (0, None),
-                        ) for split in range(self.num_hdimv_splits)
+                        )
+                        for split in range(self.num_hdimv_splits)
                     ]
                 else:
                     # Paged KV: keep pages dim, index by page_idx at load time
@@ -2004,7 +2123,8 @@ class FlashAttentionMLAForwardSm100:
                             mVs_cur[split],
                             (self.mma_tiler_QviVi[1], self.mma_tiler_QviVi[2]),
                             (None, 0, None),
-                        ) for split in range(self.num_hdimv_splits)
+                        )
+                        for split in range(self.num_hdimv_splits)
                     ]
                     # (hdim or hdimv//2, tile_n, 1, num_pages)
                     gVts = [
@@ -2012,7 +2132,8 @@ class FlashAttentionMLAForwardSm100:
                             mVts_cur[split],
                             (self.mma_tiler_PVti[1], self.mma_tiler_PVti[2]),
                             (0, None, None),
-                        ) for split in range(self.num_hdimv_splits)
+                        )
+                        for split in range(self.num_hdimv_splits)
                     ]
                 tSgK = thr_mma_QK.partition_B(gK)
                 tSgVs = [
@@ -2076,10 +2197,16 @@ class FlashAttentionMLAForwardSm100:
                     else None
                 )
                 # copy K gmem -> smem
-                producer_state_K = load_K(producer_state_K, n_block=n_block_first, page_idx=page_idx)
+                producer_state_K = load_K(
+                    producer_state_K, n_block=n_block_first, page_idx=page_idx
+                )
                 # copy Vi gmem -> smem
-                producer_state_V0 = load_V(producer_state_V0, n_block=n_block_first, split=0, page_idx=page_idx)
-                producer_state_V1 = load_V(producer_state_V1, n_block=n_block_first, split=1, page_idx=page_idx)
+                producer_state_V0 = load_V(
+                    producer_state_V0, n_block=n_block_first, split=0, page_idx=page_idx
+                )
+                producer_state_V1 = load_V(
+                    producer_state_V1, n_block=n_block_first, split=1, page_idx=page_idx
+                )
 
                 if const_expr(self.use_tma_O and self.overlap_sO_sV):
                     cute.arch.mbarrier_wait(sO_empty_mbar_ptr, phase=producer_phase_O)
@@ -2100,13 +2227,23 @@ class FlashAttentionMLAForwardSm100:
                             else None
                         )
                         # copy K gmem -> smem
-                        producer_state_K = load_K(producer_state_K, n_block=n_block-1, page_idx=page_idx_next)
+                        producer_state_K = load_K(
+                            producer_state_K, n_block=n_block - 1, page_idx=page_idx_next
+                        )
                         # copy Vi gmem -> smem
-                        producer_state_V0 = load_V(producer_state_V0, n_block=n_block-1, split=0, page_idx=page_idx_next)
-                        producer_state_V1 = load_V(producer_state_V1, n_block=n_block-1, split=1, page_idx=page_idx_next)
+                        producer_state_V0 = load_V(
+                            producer_state_V0, n_block=n_block - 1, split=0, page_idx=page_idx_next
+                        )
+                        producer_state_V1 = load_V(
+                            producer_state_V1, n_block=n_block - 1, split=1, page_idx=page_idx_next
+                        )
                         # copy Vti gmem -> smem
-                        producer_state_V0 = load_Vt(producer_state_V0, n_block=n_block, split=0, page_idx=page_idx_cur)
-                        producer_state_V1 = load_Vt(producer_state_V1, n_block=n_block, split=1, page_idx=page_idx_cur)
+                        producer_state_V0 = load_Vt(
+                            producer_state_V0, n_block=n_block, split=0, page_idx=page_idx_cur
+                        )
+                        producer_state_V1 = load_Vt(
+                            producer_state_V1, n_block=n_block, split=1, page_idx=page_idx_cur
+                        )
 
                 # ==== Epilogue ====
                 num_final_n_blocks = self.num_stages_S if even_n_blocks else self.num_stages_S - 1
@@ -2119,18 +2256,28 @@ class FlashAttentionMLAForwardSm100:
                             else None
                         )
                         # copy K gmem -> smem
-                        producer_state_K = load_K(producer_state_K, n_block=n_block-1, page_idx=page_idx_next)
+                        producer_state_K = load_K(
+                            producer_state_K, n_block=n_block - 1, page_idx=page_idx_next
+                        )
                         # copy Vi gmem -> smem
-                        producer_state_V0 = load_V(producer_state_V0, n_block=n_block-1, split=0, page_idx=page_idx_next)
-                        producer_state_V1 = load_V(producer_state_V1, n_block=n_block-1, split=1, page_idx=page_idx_next)
+                        producer_state_V0 = load_V(
+                            producer_state_V0, n_block=n_block - 1, split=0, page_idx=page_idx_next
+                        )
+                        producer_state_V1 = load_V(
+                            producer_state_V1, n_block=n_block - 1, split=1, page_idx=page_idx_next
+                        )
                     page_idx_cur = (
                         mPageTable[batch_idx, n_block]
                         if const_expr(mPageTable is not None)
                         else None
                     )
                     # copy Vti gmem -> smem
-                    producer_state_V0 = load_Vt(producer_state_V0, n_block=n_block, split=0, page_idx=page_idx_cur)
-                    producer_state_V1 = load_Vt(producer_state_V1, n_block=n_block, split=1, page_idx=page_idx_cur)
+                    producer_state_V0 = load_Vt(
+                        producer_state_V0, n_block=n_block, split=0, page_idx=page_idx_cur
+                    )
+                    producer_state_V1 = load_Vt(
+                        producer_state_V1, n_block=n_block, split=1, page_idx=page_idx_cur
+                    )
 
             # Advance to next tile
             work_tile = tile_scheduler.advance_to_next_work()

--- a/flash_attn/cute/flash_fwd_mla_sm100.py
+++ b/flash_attn/cute/flash_fwd_mla_sm100.py
@@ -11,6 +11,7 @@ import cuda.bindings.driver as cuda
 import cutlass
 import cutlass.cute as cute
 from cutlass import Float32, Int64, Int32, Uint32, Boolean, const_expr
+from cutlass.cute import FastDivmodDivisor
 import cutlass.pipeline as pipeline
 from cutlass.cute.nvgpu import cpasync, tcgen05
 from cutlass.cute.runtime import from_dlpack
@@ -20,6 +21,8 @@ from cutlass.utils import ClcDynamicPersistentTileScheduler
 from quack import copy_utils
 
 from flash_attn.cute.pack_gqa import pack_gqa_layout, make_packgqa_tiled_tma_atom
+from flash_attn.cute.paged_kv import PagedKVManager
+from flash_attn.cute import utils
 from flash_attn.cute.seqlen_info import SeqlenInfoQK
 from flash_attn.cute.block_info import BlockInfo
 from flash_attn.cute.mask import AttentionMask
@@ -1057,6 +1060,7 @@ class FlashAttentionMLAForwardSm100:
                     block_info,
                     SeqlenInfoCls,
                     tile_scheduler=tile_scheduler,
+                    mPageTable=mPageTable,
                 )
 
         if warp_idx == self.load_warp_id:
@@ -1335,6 +1339,7 @@ class FlashAttentionMLAForwardSm100:
         pipeline_cpasync.consumer_wait(consumer_state)
         with cute.arch.elect_one():
             pipeline_mma.producer_commit(producer_state)
+        pipeline_cpasync.consumer_release(consumer_state)
         consumer_state.advance()
         producer_state.advance()
         return consumer_state, producer_state
@@ -1366,14 +1371,14 @@ class FlashAttentionMLAForwardSm100:
         block_info: BlockInfo,
         SeqlenInfoCls: Callable,
         tile_scheduler: TileSchedulerProtocol,
+        mPageTable: Optional[cute.Tensor] = None,
     ):
         # ==== cpasync load warpgroup ====
         # Description: loads tiles of K, V, V0, V1 from gmem to smem using cpasync
         # produces: K, V, V0, V1, bitmask
         # consumes: -
 
-        # TODO: use cpasync for non-topk paged attn
-        assert sBitmask is not None, "cpasync load meant to be used with topk gather"
+        # cpasync load is used for both topk gather and paged KV with page_size != tile_n
         cta_rank_in_cluster = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster())
         tidx = cute.arch.thread_idx()[0] % self.num_cpasync_load_threads
         warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx()) % (
@@ -1392,7 +1397,7 @@ class FlashAttentionMLAForwardSm100:
         producer_state_V1 = pipeline.make_pipeline_state(
             pipeline.PipelineUserType.Producer, stages=self.num_stages_Vi
         )
-        if const_expr(not self.disable_bitmask):
+        if const_expr(self.is_topk_gather and not self.disable_bitmask):
             producer_state_bitmask = pipeline.make_pipeline_state(
                 pipeline.PipelineUserType.Producer,
                 stages=self.num_stages_bitmask,
@@ -1421,164 +1426,246 @@ class FlashAttentionMLAForwardSm100:
             num_n_blocks = n_block_max - n_block_min
             num_n_block_groups = cute.ceil_div(num_n_blocks, self.num_stages_S)
 
-            # cluster_m_block == m_idx under MQA 128 assumption
-            m_idx = cluster_m_block
-            if const_expr(not seqlen.has_cu_seqlens_q):
-                mIndexTopk_cur = mIndexTopk[None, m_idx, batch_idx]
-            else:
-                offset_q = seqlen.offset_q
-                mIndexTopk_cur = mIndexTopk[None, m_idx + offset_q]
+            if const_expr(self.is_topk_gather):
+                # ==== Topk gather path ====
+                # cluster_m_block == m_idx under MQA 128 assumption
+                m_idx = cluster_m_block
+                if const_expr(not seqlen.has_cu_seqlens_q):
+                    mIndexTopk_cur = mIndexTopk[None, m_idx, batch_idx]
+                else:
+                    offset_q = seqlen.offset_q
+                    mIndexTopk_cur = mIndexTopk[None, m_idx + offset_q]
 
-            if const_expr(self.is_causal):
-                seqlen_k_limit = m_idx + 1 + seqlen.seqlen_k - seqlen.seqlen_q
-            else:
-                seqlen_k_limit = seqlen.seqlen_k
-            cpasync_gather_kv_manager = CpasyncGatherKVManager.create(
-                mIndexTopk_cur,
-                sBitmask,
-                cta_rank_in_cluster,
-                tidx,
-                warp_idx,
-                self.topk_length,
-                seqlen_k_limit,
-                self.tile_n,
-                self.hdim,
-                self.hdimv,
-                self.num_hdimv_splits,
-                self.num_cpasync_load_threads,
-                mK.element_type,
-                self.cta_group_size,
-                pipeline_bitmask,
-                self.num_stages_bitmask,
-                self.cpasync_barrier,
-                self.disable_bitmask,
-            )
-
-            # (seqlen_k, hdim) or (seqlen_k, hdimv//2)
-            mK_cur = seqlen.offset_batch_K(mK, batch_idx, dim=3)[None, None, head_idx_kv]
-            mV0_cur = seqlen.offset_batch_K(mV0, batch_idx, dim=3)[None, None, head_idx_kv]
-            mV1_cur = seqlen.offset_batch_K(mV1, batch_idx, dim=3)[None, None, head_idx_kv]
-            # (hdimv//2, seqlen_k)
-            if const_expr(not seqlen.has_cu_seqlens_k):
-                mVt0_cur = mVt0[None, None, head_idx_kv, batch_idx]
-                mVt1_cur = mVt1[None, None, head_idx_kv, batch_idx]
-            else:
-                mVt0_cur = cute.domain_offset((0, seqlen.offset_k), mVt0[None, None, head_idx_kv])
-                mVt1_cur = cute.domain_offset((0, seqlen.offset_k), mVt1[None, None, head_idx_kv])
-            # (hdimv//4, seqlen_k)
-            hdimv_split_per_cta = self.hdimv // self.num_hdimv_splits // self.cta_group_size
-            mVt0_cur = cute.tiled_divide(mVt0_cur, (hdimv_split_per_cta,))[
-                None, cta_rank_in_cluster, None
-            ]
-            mVt1_cur = cute.tiled_divide(mVt1_cur, (hdimv_split_per_cta,))[
-                None, cta_rank_in_cluster, None
-            ]
-
-            load_K = partial(
-                self.cpasync_gather_load_KV,
-                cpasync_gather_kv_manager,
-                pipeline_K,
-                pipeline_K_cpasync,
-                sK,
-                False,
-                "K",
-                mK_cur,
-            )
-            load_V0 = partial(
-                self.cpasync_gather_load_KV,
-                cpasync_gather_kv_manager,
-                pipeline_V0,
-                pipeline_V0_cpasync,
-                sV0,
-                False,
-                "V",
-                mV0_cur,
-            )
-            load_V1 = partial(
-                self.cpasync_gather_load_KV,
-                cpasync_gather_kv_manager,
-                pipeline_V1,
-                pipeline_V1_cpasync,
-                sV1,
-                False,
-                "V",
-                mV1_cur,
-            )
-            load_Vt0 = partial(
-                self.cpasync_gather_load_KV,
-                cpasync_gather_kv_manager,
-                pipeline_V0,
-                pipeline_V0_cpasync,
-                sVt0,
-                True,
-                "V",
-                mVt0_cur,
-            )
-            load_Vt1 = partial(
-                self.cpasync_gather_load_KV,
-                cpasync_gather_kv_manager,
-                pipeline_V1,
-                pipeline_V1_cpasync,
-                sVt1,
-                True,
-                "V",
-                mVt1_cur,
-            )
-
-            # gather KV path processes n_blocks in increasing order
-            n_block = 0
-
-            # ==== Prologue ====
-            # K, V0, V1
-            cpasync_gather_kv_manager.load_index_topk(n_block, transpose=False)
-            producer_state_K = load_K(producer_state_K)
-            producer_state_V0 = load_V0(producer_state_V0)
-            producer_state_V1 = load_V1(producer_state_V1)
-            if const_expr(not self.disable_bitmask):
-                producer_state_bitmask = cpasync_gather_kv_manager.compute_bitmask(
-                    producer_state_bitmask
+                if const_expr(self.is_causal):
+                    seqlen_k_limit = m_idx + 1 + seqlen.seqlen_k - seqlen.seqlen_q
+                else:
+                    seqlen_k_limit = seqlen.seqlen_k
+                cpasync_gather_kv_manager = CpasyncGatherKVManager.create(
+                    mIndexTopk_cur,
+                    sBitmask,
+                    cta_rank_in_cluster,
+                    tidx,
+                    warp_idx,
+                    self.topk_length,
+                    seqlen_k_limit,
+                    self.tile_n,
+                    self.hdim,
+                    self.hdimv,
+                    self.num_hdimv_splits,
+                    self.num_cpasync_load_threads,
+                    mK.element_type,
+                    self.cta_group_size,
+                    pipeline_bitmask,
+                    self.num_stages_bitmask,
+                    self.cpasync_barrier,
+                    self.disable_bitmask,
                 )
 
-            if const_expr(self.use_tma_O and self.overlap_sO_sV):
-                cute.arch.mbarrier_wait(sO_empty_mbar_ptr, phase=producer_phase_O)
-                producer_phase_O ^= 1
+                # (seqlen_k, hdim) or (seqlen_k, hdimv//2)
+                mK_cur = seqlen.offset_batch_K(mK, batch_idx, dim=3)[None, None, head_idx_kv]
+                mV0_cur = seqlen.offset_batch_K(mV0, batch_idx, dim=3)[None, None, head_idx_kv]
+                mV1_cur = seqlen.offset_batch_K(mV1, batch_idx, dim=3)[None, None, head_idx_kv]
+                # (hdimv//2, seqlen_k)
+                if const_expr(not seqlen.has_cu_seqlens_k):
+                    mVt0_cur = mVt0[None, None, head_idx_kv, batch_idx]
+                    mVt1_cur = mVt1[None, None, head_idx_kv, batch_idx]
+                else:
+                    mVt0_cur = cute.domain_offset((0, seqlen.offset_k), mVt0[None, None, head_idx_kv])
+                    mVt1_cur = cute.domain_offset((0, seqlen.offset_k), mVt1[None, None, head_idx_kv])
+                # (hdimv//4, seqlen_k)
+                hdimv_split_per_cta = self.hdimv // self.num_hdimv_splits // self.cta_group_size
+                mVt0_cur = cute.tiled_divide(mVt0_cur, (hdimv_split_per_cta, ))[None, cta_rank_in_cluster, None]
+                mVt1_cur = cute.tiled_divide(mVt1_cur, (hdimv_split_per_cta, ))[None, cta_rank_in_cluster, None]
 
-            # ==== Mainloop ====
-            for n_block_group in cutlass.range(num_n_block_groups - 1, unroll=1):
+                load_K = partial(self.cpasync_gather_load_KV,
+                    cpasync_gather_kv_manager,
+                    pipeline_K, pipeline_K_cpasync, sK, False, "K", mK_cur,
+                )
+                load_V0 = partial(self.cpasync_gather_load_KV,
+                    cpasync_gather_kv_manager,
+                    pipeline_V0, pipeline_V0_cpasync, sV0, False, "V", mV0_cur,
+                )
+                load_V1 = partial(self.cpasync_gather_load_KV,
+                    cpasync_gather_kv_manager,
+                    pipeline_V1, pipeline_V1_cpasync, sV1, False, "V", mV1_cur,
+                )
+                load_Vt0 = partial(self.cpasync_gather_load_KV,
+                    cpasync_gather_kv_manager,
+                    pipeline_V0, pipeline_V0_cpasync, sVt0, True, "V", mVt0_cur,
+                )
+                load_Vt1 = partial(self.cpasync_gather_load_KV,
+                    cpasync_gather_kv_manager,
+                    pipeline_V1, pipeline_V1_cpasync, sVt1, True, "V", mVt1_cur,
+                )
+
+                # gather KV path processes n_blocks in increasing order
+                n_block = 0
+
+                # ==== Prologue ====
+                # K, V0, V1
+                cpasync_gather_kv_manager.load_index_topk(n_block, transpose=False)
+                producer_state_K = load_K(producer_state_K)
+                producer_state_V0 = load_V0(producer_state_V0)
+                producer_state_V1 = load_V1(producer_state_V1)
+                if const_expr(not self.disable_bitmask):
+                    producer_state_bitmask = cpasync_gather_kv_manager.compute_bitmask(
+                        producer_state_bitmask
+                    )
+
+                if const_expr(self.use_tma_O and self.overlap_sO_sV):
+                    cute.arch.mbarrier_wait(sO_empty_mbar_ptr, phase=producer_phase_O)
+                    producer_phase_O ^= 1
+
+                # ==== Mainloop ====
+                for n_block_group in cutlass.range(num_n_block_groups-1, unroll=1):
+                    for stage in cutlass.range_constexpr(self.num_stages_S):
+                        n_block = n_block_group * self.num_stages_S + stage
+                        # K, V0, V1
+                        cpasync_gather_kv_manager.load_index_topk(n_block + 1, transpose=False)
+                        producer_state_K = load_K(producer_state_K)
+                        producer_state_V0 = load_V0(producer_state_V0)
+                        producer_state_V1 = load_V1(producer_state_V1)
+                        if const_expr(not self.disable_bitmask):
+                            producer_state_bitmask = cpasync_gather_kv_manager.compute_bitmask(
+                                producer_state_bitmask
+                            )
+                        # Vt0, Vt1
+                        cpasync_gather_kv_manager.load_index_topk(n_block, transpose=True)
+                        producer_state_V0 = load_Vt0(producer_state_V0)
+                        producer_state_V1 = load_Vt1(producer_state_V1)
+
+                # ==== Epilogue ====
                 for stage in cutlass.range_constexpr(self.num_stages_S):
-                    n_block = n_block_group * self.num_stages_S + stage
-                    # K, V0, V1
-                    cpasync_gather_kv_manager.load_index_topk(n_block + 1, transpose=False)
-                    producer_state_K = load_K(producer_state_K)
-                    producer_state_V0 = load_V0(producer_state_V0)
-                    producer_state_V1 = load_V1(producer_state_V1)
-                    if const_expr(not self.disable_bitmask):
-                        producer_state_bitmask = cpasync_gather_kv_manager.compute_bitmask(
-                            producer_state_bitmask
-                        )
+                    n_block = (num_n_block_groups-1) * self.num_stages_S + stage
+                    if const_expr(stage == 0):
+                        # K, V0, V1
+                        cpasync_gather_kv_manager.load_index_topk(n_block + 1, transpose=False)
+                        producer_state_K = load_K(producer_state_K)
+                        producer_state_V0 = load_V0(producer_state_V0)
+                        producer_state_V1 = load_V1(producer_state_V1)
+                        if const_expr(not self.disable_bitmask):
+                            producer_state_bitmask = cpasync_gather_kv_manager.compute_bitmask(
+                                producer_state_bitmask
+                            )
+
                     # Vt0, Vt1
                     cpasync_gather_kv_manager.load_index_topk(n_block, transpose=True)
                     producer_state_V0 = load_Vt0(producer_state_V0)
                     producer_state_V1 = load_Vt1(producer_state_V1)
 
-            # ==== Epilogue ====
-            for stage in cutlass.range_constexpr(self.num_stages_S):
-                n_block = (num_n_block_groups - 1) * self.num_stages_S + stage
-                if const_expr(stage == 0):
-                    # K, V0, V1
-                    cpasync_gather_kv_manager.load_index_topk(n_block + 1, transpose=False)
-                    producer_state_K = load_K(producer_state_K)
-                    producer_state_V0 = load_V0(producer_state_V0)
-                    producer_state_V1 = load_V1(producer_state_V1)
-                    if const_expr(not self.disable_bitmask):
-                        producer_state_bitmask = cpasync_gather_kv_manager.compute_bitmask(
-                            producer_state_bitmask
-                        )
+            else:
+                # ==== Paged KV cp.async path (page_size != tile_n) ====
+                page_size_divmod = FastDivmodDivisor(cute.size(mK.shape[0]))
+                hdimv_split = self.hdimv // self.num_hdimv_splits
+                hdimv_split_per_cta = hdimv_split // self.cta_group_size
 
-                # Vt0, Vt1
-                cpasync_gather_kv_manager.load_index_topk(n_block, transpose=True)
-                producer_state_V0 = load_Vt0(producer_state_V0)
-                producer_state_V1 = load_Vt1(producer_state_V1)
+                # CTA-split Vt: (dv/2, page_size, h_k, num_pages) -> (dv/4, page_size, h_k, num_pages)
+                # Use domain_offset + make_tensor to get a flat-shaped tensor for PagedKVManager
+                mVt0_off = cute.domain_offset(
+                    (cta_rank_in_cluster * hdimv_split_per_cta, 0, 0, 0), mVt0
+                )
+                mVt0_cta = cute.make_tensor(
+                    mVt0_off.iterator,
+                    cute.make_layout(
+                        (hdimv_split_per_cta, mVt0.shape[1], mVt0.shape[2], mVt0.shape[3]),
+                        stride=mVt0.layout.stride,
+                    ),
+                )
+                mVt1_off = cute.domain_offset(
+                    (cta_rank_in_cluster * hdimv_split_per_cta, 0, 0, 0), mVt1
+                )
+                mVt1_cta = cute.make_tensor(
+                    mVt1_off.iterator,
+                    cute.make_layout(
+                        (hdimv_split_per_cta, mVt1.shape[1], mVt1.shape[2], mVt1.shape[3]),
+                        stride=mVt1.layout.stride,
+                    ),
+                )
+
+                # PagedKVManager for K (hdim=64): uses "K" mode only
+                paged_kv_K = PagedKVManager.create(
+                    mPageTable, mK, mK,
+                    page_size_divmod, batch_idx, head_idx_kv, tidx,
+                    seqlen.seqlen_k, 0,
+                    self.tile_n, self.hdim, self.hdim,
+                    self.num_cpasync_load_threads, mK.element_type, arch=100,
+                )
+                # PagedKVManager for V0/Vt0: "K" mode → V0 (non-transposed), "V" mode → Vt0 (transposed)
+                paged_kv_V0 = PagedKVManager.create(
+                    mPageTable, mV0, mVt0_cta,
+                    page_size_divmod, batch_idx, head_idx_kv, tidx,
+                    seqlen.seqlen_k, 0,
+                    self.tile_n, hdimv_split, hdimv_split_per_cta,
+                    self.num_cpasync_load_threads, mV0.element_type, arch=100,
+                )
+                # PagedKVManager for V1/Vt1: "K" mode → V1, "V" mode → Vt1
+                paged_kv_V1 = PagedKVManager.create(
+                    mPageTable, mV1, mVt1_cta,
+                    page_size_divmod, batch_idx, head_idx_kv, tidx,
+                    seqlen.seqlen_k, 0,
+                    self.tile_n, hdimv_split, hdimv_split_per_cta,
+                    self.num_cpasync_load_threads, mV1.element_type, arch=100,
+                )
+
+                load_K = partial(self.cpasync_paged_load_KV,
+                    paged_kv_K, pipeline_K, pipeline_K_cpasync, sK, False, "K", cta_rank_in_cluster)
+                load_V0 = partial(self.cpasync_paged_load_KV,
+                    paged_kv_V0, pipeline_V0, pipeline_V0_cpasync, sV0, False, "K", cta_rank_in_cluster)
+                load_V1 = partial(self.cpasync_paged_load_KV,
+                    paged_kv_V1, pipeline_V1, pipeline_V1_cpasync, sV1, False, "K", cta_rank_in_cluster)
+                load_Vt0 = partial(self.cpasync_paged_load_KV,
+                    paged_kv_V0, pipeline_V0, pipeline_V0_cpasync, sVt0, True, "V", cta_rank_in_cluster)
+                load_Vt1 = partial(self.cpasync_paged_load_KV,
+                    paged_kv_V1, pipeline_V1, pipeline_V1_cpasync, sVt1, True, "V", cta_rank_in_cluster)
+
+                # Paged path must follow the same descending n_block order as the
+                # MLA TMA path (`n_block_max - 1` down to `n_block_min`). The MMA
+                # mainloop consumes KV tiles in that order, so ascending order
+                # produces multi-block numerical mismatches even when commit counts
+                # are otherwise correct.
+                #
+                # Pipeline commit counts must still match the relay exactly:
+                #   K = N, V0 = 2N, V1 = 2N  (N = num_n_blocks)
+                # This loop structure mirrors the relay's:
+                #   prologue(K,V0,V1) + mainloop×(N-1)(K,V0,V1,Vt0,Vt1) + epilogue(Vt0,Vt1)
+                n_block_first = n_block_max - 1
+                n_block = n_block_first
+
+                # ==== Prologue ====
+                # load_page_table must be called directly in loop body, not inside
+                # cpasync_paged_load_KV, to avoid MLIR SSA region crossing errors.
+                paged_kv_K.load_page_table(n_block_first)
+                producer_state_K = load_K(n_block_first, producer_state_K)
+                paged_kv_V0.load_page_table(n_block_first)
+                producer_state_V0 = load_V0(n_block_first, producer_state_V0)
+                paged_kv_V1.load_page_table(n_block_first)
+                producer_state_V1 = load_V1(n_block_first, producer_state_V1)
+
+                if const_expr(self.use_tma_O and self.overlap_sO_sV):
+                    cute.arch.mbarrier_wait(sO_empty_mbar_ptr, phase=producer_phase_O)
+                    producer_phase_O ^= 1
+
+                # ==== Mainloop ====
+                for n_idx in cutlass.range(num_n_blocks - 1, unroll=2):
+                    n_block = n_block_first - n_idx
+                    # K, V0, V1 for next block in descending order
+                    paged_kv_K.load_page_table(n_block - 1)
+                    producer_state_K = load_K(n_block - 1, producer_state_K)
+                    paged_kv_V0.load_page_table(n_block - 1)
+                    producer_state_V0 = load_V0(n_block - 1, producer_state_V0)
+                    paged_kv_V1.load_page_table(n_block - 1)
+                    producer_state_V1 = load_V1(n_block - 1, producer_state_V1)
+                    # Vt0, Vt1 for current block
+                    paged_kv_V0.load_page_table(n_block)
+                    producer_state_V0 = load_Vt0(n_block, producer_state_V0)
+                    paged_kv_V1.load_page_table(n_block)
+                    producer_state_V1 = load_Vt1(n_block, producer_state_V1)
+
+                # ==== Epilogue ====
+                paged_kv_V0.load_page_table(n_block_min)
+                producer_state_V0 = load_Vt0(n_block_min, producer_state_V0)
+                paged_kv_V1.load_page_table(n_block_min)
+                producer_state_V1 = load_Vt1(n_block_min, producer_state_V1)
 
             # Advance to next tile
             work_tile = tile_scheduler.advance_to_next_work()
@@ -1586,7 +1673,7 @@ class FlashAttentionMLAForwardSm100:
         pipeline_K_cpasync.producer_tail(producer_state_K)
         pipeline_V0_cpasync.producer_tail(producer_state_V0)
         pipeline_V1_cpasync.producer_tail(producer_state_V1)
-        if const_expr(not self.disable_bitmask):
+        if const_expr(self.is_topk_gather and not self.disable_bitmask):
             pipeline_bitmask.producer_tail(producer_state_bitmask)
 
     @cute.jit
@@ -1604,6 +1691,97 @@ class FlashAttentionMLAForwardSm100:
         stage, phase = producer_state.index, producer_state.phase
         pipeline_mma.producer_acquire(producer_state)
         cpasync_gather_kv_manager.load_X(mX, sX[None, None, None, stage], transpose, K_or_V)
+        cute.arch.cp_async_commit_group()
+        pipeline_cpasync.sync_object_full.arrive_cp_async_mbarrier(stage)
+        producer_state.advance()
+        return producer_state
+
+    @cute.jit
+    def cpasync_paged_load_KV(
+        self,
+        paged_kv_manager: PagedKVManager,
+        pipeline_mma: pipeline.PipelineAsyncUmma,
+        pipeline_cpasync: pipeline.PipelineAsync,
+        sX: cute.Tensor,
+        transpose: bool,
+        K_or_V: str,
+        cta_rank_in_cluster: Int32,
+        n_block: Int32,
+        producer_state: pipeline.PipelineState,
+    ):
+        """Load one tile of K or V from paged gmem to smem using cp.async.
+
+        Uses PagedKVManager for page table lookups and pointer computation,
+        with smem reshaping via cute.composition (same approach as CpasyncGatherKVManager).
+
+        For non-transposed tensors (K, V0, V1): K_or_V="K", transpose=False
+        For transposed tensors (Vt0, Vt1):      K_or_V="V", transpose=True
+        """
+        stage = producer_state.index
+        pipeline_mma.producer_acquire(producer_state)
+
+        # NOTE: load_page_table() must be called by the caller BEFORE this method.
+        # Calling it here (through a @cute.jit boundary) causes MLIR SSA verification
+        # errors because the rmem tensor writes inside load_page_table's dynamic
+        # cutlass.range loop cross region boundaries. This matches the SM90/SM100
+        # pattern where load_page_table is called directly in the loop body.
+
+        # Compute row pointers from cached page table entries
+        tPrXPtr = paged_kv_manager.compute_X_ptr(K_or_V)
+
+        # Reshape smem to flat 2D using composition (matches CpasyncGatherKVManager.load_X)
+        head_dim = paged_kv_manager.head_dim_v_padded if const_expr(K_or_V == "V") else paged_kv_manager.head_dim_padded
+        cta_tile_n = self.tile_n if const_expr(transpose) else self.tile_n // self.cta_group_size
+        order = (1, 0) if const_expr(transpose) else (0, 1)
+
+        sX_stage = sX[None, None, None, stage]
+        sX_nd_layout = cute.make_ordered_layout((cta_tile_n, head_dim), order=order)
+        sX_nd = cute.composition(sX_stage, sX_nd_layout)
+
+        cX = cute.make_identity_tensor((cta_tile_n, head_dim))
+        tXsX = paged_kv_manager.gmem_thr_copy_KV.partition_D(sX_nd)
+        tXcX = paged_kv_manager.gmem_thr_copy_KV.partition_S(cX)
+        tXc0X = paged_kv_manager.gmem_thr_copy_KV.get_slice(0).partition_S(cX)
+
+        seqlenk_row_limit = (
+            paged_kv_manager.seqlen_k - n_block * self.tile_n - tXcX[0][0]
+            if n_block >= 0 else 0
+        )
+
+        if const_expr(not transpose):
+            offset = cta_rank_in_cluster * (paged_kv_manager.gmem_threads_per_row // self.cta_group_size)
+        else:
+            offset = 0
+
+        for m in cutlass.range_constexpr(cute.size(tXsX, mode=[1])):
+            row_valid = tXc0X[0, m, 0][0] < seqlenk_row_limit
+            should_load = cute.make_fragment_like(tXsX[(0, None), m, 0], cute.Boolean)
+            should_load.fill(row_valid)
+
+            x_ptr_i64 = utils.shuffle_sync(
+                tPrXPtr[m // paged_kv_manager.gmem_threads_per_row],
+                (m + offset) % paged_kv_manager.gmem_threads_per_row,
+                width=paged_kv_manager.gmem_threads_per_row,
+            )
+            x_gmem_ptr = cute.make_ptr(
+                paged_kv_manager.mK_paged.element_type, x_ptr_i64,
+                cute.AddressSpace.gmem, assumed_align=16,
+            )
+            mX_cur = cute.make_tensor(x_gmem_ptr, cute.make_layout((head_dim,)))
+            mX_cur_copy = cute.tiled_divide(mX_cur, (paged_kv_manager.async_copy_elems,))
+
+            for k in cutlass.range_constexpr(cute.size(tXsX, mode=[2])):
+                ki = tXcX[0, 0, k][1] // paged_kv_manager.async_copy_elems
+                mX_cur_copy_ki = mX_cur_copy[None, ki]
+                tXsX_k = tXsX[None, m, k]
+                mX_cur_copy_ki = cute.make_tensor(mX_cur_copy_ki.iterator, tXsX_k.layout)
+                cute.copy(
+                    paged_kv_manager.gmem_tiled_copy_KV,
+                    mX_cur_copy_ki,
+                    tXsX_k,
+                    pred=should_load,
+                )
+
         cute.arch.cp_async_commit_group()
         pipeline_cpasync.sync_object_full.arrive_cp_async_mbarrier(stage)
         producer_state.advance()

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -648,12 +648,17 @@ def _flash_attn_fwd(
         assert qv.shape[-1] == head_dim_v
         assert head_dim == 64 and head_dim_v == 512, "only support MLA weight absorbed shape with qv"
         assert not local, "local not yet supported with qv"
-        assert page_table is None, "page table not yet supported with qv"
         assert q_descale is None and k_descale is None and v_descale is None, (
             "q_descale/k_descale/v_descale are not yet supported with qv"
         )
-
         assert not is_split_kv, "split kv not supported with qv"
+        if page_table is not None:
+            page_size = k.shape[1]
+            assert page_size == tile_n, (
+                f"MLA paged KV currently requires page_size ({page_size}) == tile_n ({tile_n})"
+            )
+            assert gather_kv_indices is None, "paged KV + topk sparsity not yet supported together"
+            assert seqused_k is not None, "seqused_k required for paged KV with MLA"
         assert learnable_sink is None
         assert softcap is None
         assert score_mod is None

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -654,9 +654,6 @@ def _flash_attn_fwd(
         assert not is_split_kv, "split kv not supported with qv"
         if page_table is not None:
             page_size = k.shape[1]
-            assert page_size == tile_n, (
-                f"MLA paged KV currently requires page_size ({page_size}) == tile_n ({tile_n})"
-            )
             assert gather_kv_indices is None, "paged KV + topk sparsity not yet supported together"
             assert seqused_k is not None, "seqused_k required for paged KV with MLA"
         assert learnable_sink is None
@@ -841,9 +838,10 @@ def _flash_attn_fwd(
             )
         elif arch // 10 in [10, 11]:
             if qv is not None:
+                paged_kv_cpasync = page_table is not None and page_size != 128
                 fa_fwd = FlashAttentionMLAForwardSm100(
                     is_causal=causal,
-                    use_cpasync_load_KV=sparse_kv,
+                    use_cpasync_load_KV=sparse_kv or paged_kv_cpasync,
                     topk_length=gather_kv_length,
                     is_topk_gather=sparse_kv,
                     pack_gqa=pack_gqa,

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -634,12 +634,17 @@ def _flash_attn_fwd(
         assert qv.shape[-1] == head_dim_v
         assert head_dim == 64 and head_dim_v == 512, "only support MLA weight absorbed shape with qv"
         assert not local, "local not yet supported with qv"
-        assert page_table is None, "page table not yet supported with qv"
         assert q_descale is None and k_descale is None and v_descale is None, (
             "q_descale/k_descale/v_descale are not yet supported with qv"
         )
-
         assert not is_split_kv, "split kv not supported with qv"
+        if page_table is not None:
+            page_size = k.shape[1]
+            assert page_size == tile_n, (
+                f"MLA paged KV currently requires page_size ({page_size}) == tile_n ({tile_n})"
+            )
+            assert gather_kv_indices is None, "paged KV + topk sparsity not yet supported together"
+            assert seqused_k is not None, "seqused_k required for paged KV with MLA"
         assert learnable_sink is None
         assert softcap is None
         assert score_mod is None

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -640,9 +640,6 @@ def _flash_attn_fwd(
         assert not is_split_kv, "split kv not supported with qv"
         if page_table is not None:
             page_size = k.shape[1]
-            assert page_size == tile_n, (
-                f"MLA paged KV currently requires page_size ({page_size}) == tile_n ({tile_n})"
-            )
             assert gather_kv_indices is None, "paged KV + topk sparsity not yet supported together"
             assert seqused_k is not None, "seqused_k required for paged KV with MLA"
         assert learnable_sink is None
@@ -826,9 +823,10 @@ def _flash_attn_fwd(
             )
         elif arch // 10 in [10, 11]:
             if qv is not None:
+                paged_kv_cpasync = page_table is not None and page_size != 128
                 fa_fwd = FlashAttentionMLAForwardSm100(
                     is_causal=causal,
-                    use_cpasync_load_KV=sparse_kv,
+                    use_cpasync_load_KV=sparse_kv or paged_kv_cpasync,
                     topk_length=gather_kv_length,
                     is_topk_gather=sparse_kv,
                     pack_gqa=pack_gqa,

--- a/flash_attn/cute/paged_kv.py
+++ b/flash_attn/cute/paged_kv.py
@@ -147,7 +147,7 @@ class PagedKVManager(ParamsBase):
 
             is_valid = (
                 (i + 1) * self.num_threads <= self.n_block_size or row < self.n_block_size
-            ) and row_idx < self.seqlen_k
+            ) and 0 <= row_idx < self.seqlen_k
             page = self.mPageTable[page_idx] if is_valid else 0
 
             self.tPrPage[i] = page

--- a/tests/cute/benchmark_mla_paged_kv.py
+++ b/tests/cute/benchmark_mla_paged_kv.py
@@ -1,0 +1,108 @@
+# Copyright (c) 2025, Johnsonms.
+
+# We recommend locking GPU clocks before running the benchmark to ensure consistent results.
+# This can be done using the following commands (2619 MHz is the max clock for B200):
+# sudo nvidia-smi -i 0 -pm 1
+# sudo nvidia-smi -i 0 --lock-gpu-clocks 2619,2619
+# See more here: https://github.com/triton-lang/triton/blob/d9f10ebdc5da53f73eb852fde73d8d7d80b679d1/python/triton/testing.py#L487
+
+import time
+import torch
+
+from triton.testing import do_bench
+
+from flash_attn.cute.interface import flash_attn_varlen_func
+
+
+device = "cuda"
+dtype = torch.bfloat16
+seqlen_q = 1
+nheads_q = 128
+nheads_kv = 1  # MQA-128
+headdim = 64
+headdim_v = 512
+causal = True
+
+batch_size = 128
+page_sizes = [None, 16, 64, 128]  # None = non-paged baseline
+
+torch.manual_seed(0)
+
+print(f"\nMLA paged KV, nheads_q = {nheads_q}, nheads_kv = {nheads_kv}, headdim = {headdim}, headdim_v = {headdim_v}, causal = {causal}")
+
+for seqlen in [s * 1024 for s in [1, 2, 4, 8, 16, 32, 64]]:
+    # Varlen format: (total_tokens, nheads, hdim)
+    total_q = batch_size * seqlen_q
+    total_k = batch_size * seqlen
+
+    try:
+        q = torch.randn(total_q, nheads_q, headdim, dtype=dtype, device=device)
+        k = torch.randn(total_k, nheads_kv, headdim, dtype=dtype, device=device)
+        v = torch.randn(total_k, nheads_kv, headdim_v, dtype=dtype, device=device)
+        qv = torch.randn(total_q, nheads_q, headdim_v, dtype=dtype, device=device)
+    except torch.OutOfMemoryError:
+        continue
+
+    cu_seqlens_q = torch.arange(0, total_q + seqlen_q, seqlen_q, dtype=torch.int32, device=device)
+    cu_seqlens_k = torch.arange(0, total_k + seqlen, seqlen, dtype=torch.int32, device=device)
+
+    # Mem I/O: KV read + Q/QV read + O write
+    total_seqlen = seqlen * batch_size
+    mem_io = (
+        total_seqlen * nheads_kv * (headdim + headdim_v) * 2  # K + V read
+        + q.numel() * 2 + qv.numel() * 2  # Q + QV read
+        + total_q * nheads_q * headdim_v * 2  # O write
+    )
+    # FLOPs: QK^T + PV (with qv, PV uses headdim_v)
+    flops = seqlen_q * total_seqlen * nheads_q * (headdim + headdim_v * 2) * 2
+
+    for page_size in page_sizes:
+        if page_size is None:
+            # Non-paged baseline
+            fn = lambda: flash_attn_varlen_func(
+                q, k, v, qv=qv,
+                cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=cu_seqlens_k,
+                max_seqlen_q=seqlen_q, max_seqlen_k=seqlen,
+                causal=causal,
+            )
+            label = "non-paged"
+        else:
+            # Create paged KV
+            num_pages_per_seq = (seqlen + page_size - 1) // page_size
+            total_pages = num_pages_per_seq * batch_size
+            k_paged = torch.zeros(total_pages, page_size, nheads_kv, headdim, device=device, dtype=dtype)
+            v_paged = torch.zeros(total_pages, page_size, nheads_kv, headdim_v, device=device, dtype=dtype)
+            page_table = torch.zeros(batch_size, num_pages_per_seq, dtype=torch.int32, device=device)
+            for b in range(batch_size):
+                for p in range(num_pages_per_seq):
+                    page_idx = b * num_pages_per_seq + p
+                    start = p * page_size
+                    end = min(start + page_size, seqlen)
+                    k_offset = b * seqlen
+                    if start < seqlen:
+                        k_paged[page_idx, :end - start] = k[k_offset + start:k_offset + end]
+                        v_paged[page_idx, :end - start] = v[k_offset + start:k_offset + end]
+                    page_table[b, p] = page_idx
+            seqused_k = torch.full((batch_size,), seqlen, dtype=torch.int32, device=device)
+
+            fn = lambda kp=k_paged, vp=v_paged, pt=page_table, su=seqused_k: flash_attn_varlen_func(
+                q, kp, vp, qv=qv,
+                cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=None,
+                max_seqlen_q=seqlen_q, max_seqlen_k=None,
+                seqused_k=su, page_table=pt,
+                causal=causal,
+            )
+            path = "TMA" if page_size == 128 else "cp.async"
+            label = f"paged-{page_size} ({path})"
+
+        fn()  # warmup / compile
+        time.sleep(1)  # avoid power throttling
+        t = do_bench(fn, warmup=1, rep=10)
+        print(
+            f"Seqlen = {seqlen}, {label}: {t * 1e3:.1f} us, "
+            f"{mem_io * 1e-9 / (t * 1e-3):.0f} GB/s, "
+            f"{flops * 1e-12 / (t * 1e-3):.0f} TFLOPS/s"
+        )
+
+    print(f"Arithmetic intensity: {flops / mem_io:.1f}")
+    print()

--- a/tests/cute/benchmark_mla_paged_kv.py
+++ b/tests/cute/benchmark_mla_paged_kv.py
@@ -59,7 +59,7 @@ for seqlen in [s * 1024 for s in [1, 2, 4, 8, 16, 32, 64]]:
     for page_size in page_sizes:
         if page_size is None:
             # Non-paged baseline
-            fn = lambda: flash_attn_varlen_func(
+            fn = lambda: flash_attn_varlen_func(  # noqa: E731
                 q, k, v, qv=qv,
                 cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=cu_seqlens_k,
                 max_seqlen_q=seqlen_q, max_seqlen_k=seqlen,
@@ -85,7 +85,7 @@ for seqlen in [s * 1024 for s in [1, 2, 4, 8, 16, 32, 64]]:
                     page_table[b, p] = page_idx
             seqused_k = torch.full((batch_size,), seqlen, dtype=torch.int32, device=device)
 
-            fn = lambda kp=k_paged, vp=v_paged, pt=page_table, su=seqused_k: flash_attn_varlen_func(
+            fn = lambda kp=k_paged, vp=v_paged, pt=page_table, su=seqused_k: flash_attn_varlen_func(  # noqa: E731
                 q, kp, vp, qv=qv,
                 cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=None,
                 max_seqlen_q=seqlen_q, max_seqlen_k=None,

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -2626,3 +2626,86 @@ def test_flash_attn_mla_paged(seqlen_q, seqlen_k, causal, dtype):
     print(f"Output max diff: {(out - out_ref).abs().max().item()}")
     print(f"Output mean diff: {(out - out_ref).abs().mean().item()}")
     assert torch.equal(out, out_ref)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("page_size", [16, 64])
+@pytest.mark.parametrize(
+    "seqlen_q,seqlen_k",
+    [
+        (1, 128),
+        (4, 256),
+        (64, 512),
+    ],
+)
+@maybe_fake_tensor_mode(USE_FAKE_TENSOR)
+def test_flash_attn_mla_paged_cpasync(seqlen_q, seqlen_k, page_size, causal, dtype):
+    """Test paged KV cache with MLA using cp.async path (page_size != tile_n=128)."""
+    if not IS_SM100:
+        pytest.skip("MLA paged KV only supported on SM100")
+    device = "cuda"
+    d, dv = 64, 512
+    nheads = 128
+    nheads_kv = 1  # MQA-128
+    batch_size = 2
+
+    torch.random.manual_seed(0)
+
+    # Non-paged reference tensors (varlen format)
+    q = torch.randn(batch_size * seqlen_q, nheads, d, device=device, dtype=dtype)
+    k = torch.randn(batch_size * seqlen_k, nheads_kv, d, device=device, dtype=dtype)
+    v = torch.randn(batch_size * seqlen_k, nheads_kv, dv, device=device, dtype=dtype)
+    qv = torch.randn(batch_size * seqlen_q, nheads, dv, device=device, dtype=dtype)
+
+    cu_seqlens_q = torch.tensor(
+        [i * seqlen_q for i in range(batch_size + 1)], dtype=torch.int32, device=device
+    )
+    cu_seqlens_k = torch.tensor(
+        [i * seqlen_k for i in range(batch_size + 1)], dtype=torch.int32, device=device
+    )
+
+    # Non-paged reference
+    out_ref, _ = flash_attn_varlen_func(
+        q, k, v, qv=qv,
+        cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=cu_seqlens_k,
+        max_seqlen_q=seqlen_q, max_seqlen_k=seqlen_k,
+        causal=causal,
+    )
+
+    # Create paged K/V cache
+    num_pages_per_seq = (seqlen_k + page_size - 1) // page_size
+    total_pages = num_pages_per_seq * batch_size
+    k_paged = torch.zeros(total_pages, page_size, nheads_kv, d, device=device, dtype=dtype)
+    v_paged = torch.zeros(total_pages, page_size, nheads_kv, dv, device=device, dtype=dtype)
+    page_table = torch.zeros(batch_size, num_pages_per_seq, dtype=torch.int32, device=device)
+
+    # Fill paged K/V from contiguous K/V (sequential page assignment)
+    for b in range(batch_size):
+        for p in range(num_pages_per_seq):
+            page_idx = b * num_pages_per_seq + p
+            start = p * page_size
+            end = min(start + page_size, seqlen_k)
+            k_offset = b * seqlen_k
+            if start < seqlen_k:
+                k_paged[page_idx, :end - start] = k[k_offset + start:k_offset + end]
+                v_paged[page_idx, :end - start] = v[k_offset + start:k_offset + end]
+            page_table[b, p] = page_idx
+
+    seqused_k = torch.full((batch_size,), seqlen_k, dtype=torch.int32, device=device)
+
+    # Paged output (triggers cp.async path because page_size != 128)
+    out, _ = flash_attn_varlen_func(
+        q, k_paged, v_paged, qv=qv,
+        cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=None,
+        max_seqlen_q=seqlen_q, max_seqlen_k=None,
+        seqused_k=seqused_k, page_table=page_table,
+        causal=causal,
+    )
+
+    if is_fake_mode():
+        return
+
+    print(f"Output max diff: {(out - out_ref).abs().max().item()}")
+    print(f"Output mean diff: {(out - out_ref).abs().mean().item()}")
+    assert torch.equal(out, out_ref)

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -2493,3 +2493,86 @@ def test_flash_attn_mla_paged(seqlen_q, seqlen_k, causal, dtype):
     print(f"Output max diff: {(out - out_ref).abs().max().item()}")
     print(f"Output mean diff: {(out - out_ref).abs().mean().item()}")
     assert torch.equal(out, out_ref)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("page_size", [16, 64])
+@pytest.mark.parametrize(
+    "seqlen_q,seqlen_k",
+    [
+        (1, 128),
+        (4, 256),
+        (64, 512),
+    ],
+)
+@maybe_fake_tensor_mode(USE_FAKE_TENSOR)
+def test_flash_attn_mla_paged_cpasync(seqlen_q, seqlen_k, page_size, causal, dtype):
+    """Test paged KV cache with MLA using cp.async path (page_size != tile_n=128)."""
+    if not IS_SM100:
+        pytest.skip("MLA paged KV only supported on SM100")
+    device = "cuda"
+    d, dv = 64, 512
+    nheads = 128
+    nheads_kv = 1  # MQA-128
+    batch_size = 2
+
+    torch.random.manual_seed(0)
+
+    # Non-paged reference tensors (varlen format)
+    q = torch.randn(batch_size * seqlen_q, nheads, d, device=device, dtype=dtype)
+    k = torch.randn(batch_size * seqlen_k, nheads_kv, d, device=device, dtype=dtype)
+    v = torch.randn(batch_size * seqlen_k, nheads_kv, dv, device=device, dtype=dtype)
+    qv = torch.randn(batch_size * seqlen_q, nheads, dv, device=device, dtype=dtype)
+
+    cu_seqlens_q = torch.tensor(
+        [i * seqlen_q for i in range(batch_size + 1)], dtype=torch.int32, device=device
+    )
+    cu_seqlens_k = torch.tensor(
+        [i * seqlen_k for i in range(batch_size + 1)], dtype=torch.int32, device=device
+    )
+
+    # Non-paged reference
+    out_ref, _ = flash_attn_varlen_func(
+        q, k, v, qv=qv,
+        cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=cu_seqlens_k,
+        max_seqlen_q=seqlen_q, max_seqlen_k=seqlen_k,
+        causal=causal,
+    )
+
+    # Create paged K/V cache
+    num_pages_per_seq = (seqlen_k + page_size - 1) // page_size
+    total_pages = num_pages_per_seq * batch_size
+    k_paged = torch.zeros(total_pages, page_size, nheads_kv, d, device=device, dtype=dtype)
+    v_paged = torch.zeros(total_pages, page_size, nheads_kv, dv, device=device, dtype=dtype)
+    page_table = torch.zeros(batch_size, num_pages_per_seq, dtype=torch.int32, device=device)
+
+    # Fill paged K/V from contiguous K/V (sequential page assignment)
+    for b in range(batch_size):
+        for p in range(num_pages_per_seq):
+            page_idx = b * num_pages_per_seq + p
+            start = p * page_size
+            end = min(start + page_size, seqlen_k)
+            k_offset = b * seqlen_k
+            if start < seqlen_k:
+                k_paged[page_idx, :end - start] = k[k_offset + start:k_offset + end]
+                v_paged[page_idx, :end - start] = v[k_offset + start:k_offset + end]
+            page_table[b, p] = page_idx
+
+    seqused_k = torch.full((batch_size,), seqlen_k, dtype=torch.int32, device=device)
+
+    # Paged output (triggers cp.async path because page_size != 128)
+    out, _ = flash_attn_varlen_func(
+        q, k_paged, v_paged, qv=qv,
+        cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=None,
+        max_seqlen_q=seqlen_q, max_seqlen_k=None,
+        seqused_k=seqused_k, page_table=page_table,
+        causal=causal,
+    )
+
+    if is_fake_mode():
+        return
+
+    print(f"Output max diff: {(out - out_ref).abs().max().item()}")
+    print(f"Output mean diff: {(out - out_ref).abs().mean().item()}")
+    assert torch.equal(out, out_ref)

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -2410,3 +2410,86 @@ def test_flash_attn_mla_absorbed_varlen(
                 # print(f"out vs out2 max diff: {(out_cmp - out2).abs().max().item()}, {iter=}")
                 # print(f"out vs out2 mean diff: {(out_cmp - out2).abs().mean().item()}, {iter=}")
                 assert torch.equal(out_cmp, out2), f"non-deterministic with max diff = {(out_cmp - out2).abs().max().item()} on {iter=}"
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize(
+    "seqlen_q,seqlen_k",
+    [
+        (1, 128),
+        (4, 256),
+        (64, 512),
+        (128, 1024),
+    ],
+)
+@maybe_fake_tensor_mode(USE_FAKE_TENSOR)
+def test_flash_attn_mla_paged(seqlen_q, seqlen_k, causal, dtype):
+    """Test paged KV cache with MLA absorbed shape (d=64, dv=512)."""
+    if not IS_SM100:
+        pytest.skip("MLA paged KV only supported on SM100")
+    device = "cuda"
+    d, dv = 64, 512
+    nheads = 128
+    nheads_kv = 1  # MQA-128
+    page_size = 128  # must equal tile_n
+    batch_size = 2
+
+    torch.random.manual_seed(0)
+
+    # Non-paged reference tensors (varlen format)
+    q = torch.randn(batch_size * seqlen_q, nheads, d, device=device, dtype=dtype)
+    k = torch.randn(batch_size * seqlen_k, nheads_kv, d, device=device, dtype=dtype)
+    v = torch.randn(batch_size * seqlen_k, nheads_kv, dv, device=device, dtype=dtype)
+    qv = torch.randn(batch_size * seqlen_q, nheads, dv, device=device, dtype=dtype)
+
+    cu_seqlens_q = torch.tensor(
+        [i * seqlen_q for i in range(batch_size + 1)], dtype=torch.int32, device=device
+    )
+    cu_seqlens_k = torch.tensor(
+        [i * seqlen_k for i in range(batch_size + 1)], dtype=torch.int32, device=device
+    )
+
+    # Non-paged reference
+    out_ref, _ = flash_attn_varlen_func(
+        q, k, v, qv=qv,
+        cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=cu_seqlens_k,
+        max_seqlen_q=seqlen_q, max_seqlen_k=seqlen_k,
+        causal=causal,
+    )
+
+    # Create paged K/V cache
+    num_pages_per_seq = (seqlen_k + page_size - 1) // page_size
+    total_pages = num_pages_per_seq * batch_size
+    k_paged = torch.zeros(total_pages, page_size, nheads_kv, d, device=device, dtype=dtype)
+    v_paged = torch.zeros(total_pages, page_size, nheads_kv, dv, device=device, dtype=dtype)
+    page_table = torch.zeros(batch_size, num_pages_per_seq, dtype=torch.int32, device=device)
+
+    # Fill paged K/V from contiguous K/V (sequential page assignment)
+    for b in range(batch_size):
+        for p in range(num_pages_per_seq):
+            page_idx = b * num_pages_per_seq + p
+            start = p * page_size
+            end = min(start + page_size, seqlen_k)
+            k_offset = b * seqlen_k
+            if start < seqlen_k:
+                k_paged[page_idx, :end - start] = k[k_offset + start:k_offset + end]
+                v_paged[page_idx, :end - start] = v[k_offset + start:k_offset + end]
+            page_table[b, p] = page_idx
+
+    seqused_k = torch.full((batch_size,), seqlen_k, dtype=torch.int32, device=device)
+
+    # Paged output
+    out, _ = flash_attn_varlen_func(
+        q, k_paged, v_paged, qv=qv,
+        cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=None,
+        max_seqlen_q=seqlen_q, max_seqlen_k=None,
+        seqused_k=seqused_k, page_table=page_table,
+        causal=causal,
+    )
+
+    if is_fake_mode():
+        return
+
+    print(f"Output max diff: {(out - out_ref).abs().max().item()}")
+    print(f"Output mean diff: {(out - out_ref).abs().mean().item()}")
+    assert torch.equal(out, out_ref)

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -2542,3 +2542,87 @@ def test_flash_attn_seqlen_k_zero(seqlen_q, d, causal):
     if lse is not None:
         assert torch.all(torch.isinf(lse) & (lse < 0)).item(), \
             f"Expected all -inf LSE when seqlen_k=0, got: {lse}"
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize(
+    "seqlen_q,seqlen_k",
+    [
+        (1, 128),
+        (4, 256),
+        (64, 512),
+        (128, 1024),
+    ],
+)
+@maybe_fake_tensor_mode(USE_FAKE_TENSOR)
+def test_flash_attn_mla_paged(seqlen_q, seqlen_k, causal, dtype):
+    """Test paged KV cache with MLA absorbed shape (d=64, dv=512)."""
+    if not IS_SM100:
+        pytest.skip("MLA paged KV only supported on SM100")
+    device = "cuda"
+    d, dv = 64, 512
+    nheads = 128
+    nheads_kv = 1  # MQA-128
+    page_size = 128  # must equal tile_n
+    batch_size = 2
+
+    torch.random.manual_seed(0)
+
+    # Non-paged reference tensors (varlen format)
+    q = torch.randn(batch_size * seqlen_q, nheads, d, device=device, dtype=dtype)
+    k = torch.randn(batch_size * seqlen_k, nheads_kv, d, device=device, dtype=dtype)
+    v = torch.randn(batch_size * seqlen_k, nheads_kv, dv, device=device, dtype=dtype)
+    qv = torch.randn(batch_size * seqlen_q, nheads, dv, device=device, dtype=dtype)
+
+    cu_seqlens_q = torch.tensor(
+        [i * seqlen_q for i in range(batch_size + 1)], dtype=torch.int32, device=device
+    )
+    cu_seqlens_k = torch.tensor(
+        [i * seqlen_k for i in range(batch_size + 1)], dtype=torch.int32, device=device
+    )
+
+    # Non-paged reference
+    out_ref, _ = flash_attn_varlen_func(
+        q, k, v, qv=qv,
+        cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=cu_seqlens_k,
+        max_seqlen_q=seqlen_q, max_seqlen_k=seqlen_k,
+        causal=causal,
+    )
+
+    # Create paged K/V cache
+    num_pages_per_seq = (seqlen_k + page_size - 1) // page_size
+    total_pages = num_pages_per_seq * batch_size
+    k_paged = torch.zeros(total_pages, page_size, nheads_kv, d, device=device, dtype=dtype)
+    v_paged = torch.zeros(total_pages, page_size, nheads_kv, dv, device=device, dtype=dtype)
+    page_table = torch.zeros(batch_size, num_pages_per_seq, dtype=torch.int32, device=device)
+
+    # Fill paged K/V from contiguous K/V (sequential page assignment)
+    for b in range(batch_size):
+        for p in range(num_pages_per_seq):
+            page_idx = b * num_pages_per_seq + p
+            start = p * page_size
+            end = min(start + page_size, seqlen_k)
+            k_offset = b * seqlen_k
+            if start < seqlen_k:
+                k_paged[page_idx, :end - start] = k[k_offset + start:k_offset + end]
+                v_paged[page_idx, :end - start] = v[k_offset + start:k_offset + end]
+            page_table[b, p] = page_idx
+
+    seqused_k = torch.full((batch_size,), seqlen_k, dtype=torch.int32, device=device)
+
+    # Paged output
+    out, _ = flash_attn_varlen_func(
+        q, k_paged, v_paged, qv=qv,
+        cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=None,
+        max_seqlen_q=seqlen_q, max_seqlen_k=None,
+        seqused_k=seqused_k, page_table=page_table,
+        causal=causal,
+    )
+
+    if is_fake_mode():
+        return
+
+    print(f"Output max diff: {(out - out_ref).abs().max().item()}")
+    print(f"Output mean diff: {(out - out_ref).abs().mean().item()}")
+    assert torch.equal(out, out_ref)


### PR DESCRIPTION
### Summary

Motivated from https://github.com/Dao-AILab/flash-attention/pull/2441

Enable paged KV cache for the MLA (Multi-head Latent Attention) forward kernel on SM100/Blackwell, targeting inference serving with DeepSeek-family models (vLLM/SGLang).

- **Phase 1 (TMA paged KV)**: Page table support for MLA with `page_size == tile_n` (128), using TMA bulk copies for zero-overhead paged KV access.
- **Phase 2 (cp.async paged KV)**: Extends paged KV to arbitrary `page_size` (16, 64, etc.) using cp.async loads, enabling compatibility with vLLM/SGLang page sizes.
- **Benchmark**: Adds `tests/cute/benchmark_mla_paged_kv.py` for paged vs non-paged MLA performance comparison.

### Benchmark Results (B200, batch=128, seqlen_q=1, MQA-128, bf16)

| Seqlen_k | Non-paged | Paged-128 (TMA) | Paged-64 (cp.async) | Paged-16 (cp.async) |
|----------|-----------|-----------------|---------------------|---------------------|
| 2K | 800 TFLOPS | 799 TFLOPS (-0.1%) | 616 TFLOPS (-23%) | 607 TFLOPS (-24%) |
| 4K | 1013 TFLOPS | 1020 TFLOPS (+0.7%) | 822 TFLOPS (-19%) | 811 TFLOPS (-20%) |
| 8K | 1178 TFLOPS | 1176 TFLOPS (-0.2%) | 966 TFLOPS (-18%) | 952 TFLOPS (-19%) |
| 16K | 1240 TFLOPS | 1231 TFLOPS (-0.7%) | 1006 TFLOPS (-19%) | 1019 TFLOPS (-18%) |
| 32K | 1259 TFLOPS | 1248 TFLOPS (-0.9%) | 1018 TFLOPS (-19%) | 1039 TFLOPS (-17%) |
| 64K | 1262 TFLOPS | 1252 TFLOPS (-0.8%) | 1061 TFLOPS (-16%) | 1053 TFLOPS (-17%) |

- **TMA paged (page_size=128)**: zero overhead vs non-paged
- **cp.async (page_size 16/64)**: ~16-24% overhead (expected for MLA dv=512 bandwidth)
- **Peak**: 1262 TFLOPS at seqlen=64K

### Test plan
- [x] `test_flash_attn_mla_paged` — 8 cases, TMA paged KV (page_size=128), bitwise match vs non-paged reference
- [x] `test_flash_attn_mla_paged_cpasync` — 12 cases, cp.async paged KV (page_size=16, 64), bitwise match
- [x] Benchmark on idle B200 GPU
  
PR authored by @Johnsonms @yunzhongOvO @Orion34-lanbo