### PR TITLE
[Cute,Fwd,Sm100] Fix the crash when seqlen_k=0

### DIFF
--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -450,6 +450,12 @@ def _flash_attn_fwd(
     elif lse is not None:
         _validate_tensor(lse, "lse", lse_shape, torch.float32, device)
 
+    if seqlen_k == 0:
+        out.zero_()
+        if lse is not None:
+            lse.fill_(float("-inf"))
+        return out, lse
+
     if is_fp8:
         for t, name in ((q_descale, "q_descale"), (k_descale, "k_descale"), (v_descale, "v_descale")):
             if t is not None:

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -2410,3 +2410,65 @@ def test_flash_attn_mla_absorbed_varlen(
                 # print(f"out vs out2 max diff: {(out_cmp - out2).abs().max().item()}, {iter=}")
                 # print(f"out vs out2 mean diff: {(out_cmp - out2).abs().mean().item()}, {iter=}")
                 assert torch.equal(out_cmp, out2), f"non-deterministic with max diff = {(out_cmp - out2).abs().max().item()} on {iter=}"
+
+
+# ---------------------------------------------------------------------------
+# Regression test: seqlen_k=0 must not crash (CUDA graph padding scenario)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("d", [128, 192])
+@pytest.mark.parametrize("seqlen_q", [1, 64, 128, 256])
+@maybe_fake_tensor_mode(USE_FAKE_TENSOR)
+def test_flash_attn_seqlen_k_zero(seqlen_q, d, causal):
+    """K/V with physical seqlen dim == 0 must not crash.
+
+    seqlen_k == 0 violates two downstream invariants, producing two
+    different crashes depending on the mask:
+
+      causal=False -> TMA descriptor over a 0-length K tensor goes OOB
+                      on first tile load -> PTX IllegalInstruction.
+
+      causal=True  -> SingleTileLPTScheduler's L2-swizzle heuristic in
+                      tile_scheduler.py evaluates
+                          size_l2 // (seqlen_k * (d + d_v) * elem_size)
+                      -> host SIGFPE before the kernel launches.
+
+    Varlen paths (cu_seqlens_k / seqused_k with K physical seqlen > 0)
+    are not exercised here: per-batch empty slots are already handled
+    by the kernel's fake-iteration path and do not hit either invariant.
+    """
+    if IS_SM90:
+        pytest.skip("SM90 uses a different kernel path")
+
+    device = "cuda"
+    dtype = torch.bfloat16
+    dv = 128 if d == 192 else d
+    batch_size = 4
+    nheads = 16
+    nheads_kv = 16
+
+    torch.manual_seed(0)
+
+    q = torch.randn(batch_size, seqlen_q, nheads, d, device=device, dtype=dtype)
+    # K/V have physical seqlen dim == 0 — this is what crashes on unpatched FA4.
+    # causal=False hits GPU IllegalInstruction (TMA OOB on 0-length K tensor).
+    # causal=True  hits host SIGFPE in tile_scheduler.py LPT L2-swizzle heuristic
+    #              (size_l2 // size_one_head with size_one_head = seqlen_k*... = 0).
+    k = torch.empty(batch_size, 0, nheads_kv, d, device=device, dtype=dtype)
+    v = torch.empty(batch_size, 0, nheads_kv, dv, device=device, dtype=dtype)
+
+    out, lse = flash_attn_func(q, k, v, causal=causal)
+
+    if is_fake_mode():
+        return
+
+    # No crash above already validates the fix. Below validates the contract
+    # the early-return promises: zero output, -inf LSE.
+    assert out.shape == (batch_size, seqlen_q, nheads, dv), \
+        f"Unexpected output shape: {out.shape}"
+    assert torch.all(out == 0).item(), \
+        f"Expected all-zero output when seqlen_k=0, got max={out.abs().max().item():.6f}"
+    if lse is not None:
+        assert torch.all(torch.isinf(lse) & (lse < 0)).item(), \
+            f"Expected all -inf LSE when seqlen_k=0, got: {lse}"


### PR DESCRIPTION
  ## Summary
                                                                                     
  Fix crash when K/V has `seqlen == 0` (e.g. vLLM CUDA-graph capture with an         
  all-padding batch).
                                                                                     
  Two crash sites, one root cause (`seqlen_k == 0` flows into tensor shapes):        
   
  - **`causal=False`** — `StaticPersistentTileScheduler` passes host setup;          
    kernel launches; the first TMA over `k.shape=(B, 0, H, D)` goes OOB →
    **PTX IllegalInstruction**.                                                      
  - **`causal=True`** — `SingleTileLPTScheduler.Params.create` evaluates             
    `size_l2 // size_one_head`, where                                                
    `size_one_head = seqlen_k * (d + d_v) * elem_size == 0` → **host SIGFPE**        
    before the kernel launches.                                                      
                                                                                     
  ## Fix                                                                             
                                                                                     
  Host-side early return in `_flash_attn_fwd` (`flash_attn/cute/interface.py`):      
  when `seqlen_k == 0`, write zeros to `out` and `-inf` to `lse`, then skip the
  kernel launch entirely. This is math-correct for an empty softmax and              
  mirrors FA2's handling in `csrc/flash_attn/flash_api.cpp:497-504`.                 
                                                                                     
  No kernel changes.                                                                 
                                                                                    

## Repro 
### (on main without fix)

```python
q = torch.randn(4, 1, 16, 128, device="cuda", dtype=torch.bfloat16)
k = torch.empty(4, 0, 16, 128, device="cuda", dtype=torch.bfloat16)
v = torch.empty(4, 0, 16, 128, device="cuda", dtype=torch.bfloat16)
out, lse = flash_attn_func(q, k, v, causal=False)  # cudaErrorIllegalInstruction
out, lse = flash_attn_func(q, k, v, causal=True)   # Fatal: Floating point exception
```

### After fix

```python
out, lse = flash_attn_func(q, k, v, causal=False)  # all-zeros output, -inf LSE
out, lse = flash_attn_func(q, k, v, causal=True)   # all-zeros output, -inf LSE
```

  ## Test plan                                                                       
  - [x] Repro confirmed on `main`: `cudaErrorIllegalInstruction` (causal=False),
  SIGFPE (causal=True)                                                               
  - [x] Fix verified: all-zeros output, `-inf` LSE, no crash
  - [x] `test_flash_attn_seqlen_k_zero` — 16 cases pass on B200                      
  - [x] `tests/cute/test_flash_attn.py -k test_flash_attn_output` — no regression    
  - [x] Pre-commit (ruff check + format) passes  

PR authored by @yunzhongOvO  @Johnsonms @Orion34-lanbo