### PR TITLE
Add [STATIC] tile trace for CLC-off work distribution

### DIFF
--- a/flash_attn/cute/tile_scheduler.py
+++ b/flash_attn/cute/tile_scheduler.py
@@ -21,6 +21,8 @@ from quack.cute_dsl_utils import ParamsBase
 
 import flash_attn.cute.utils as utils
 from flash_attn.cute.fast_math import clz
+from flash_attn.cute.fa_logging import fa_printf
+from flash_attn.cute.utils import smid
 
 
 class SchedulingMode(IntEnum):
@@ -575,6 +577,18 @@ class SingleTileLPTScheduler:
         if const_expr(params.lpt):
             block = params.num_block - 1 - block
         is_valid = self._tile_idx < params.total_blocks
+        if is_valid and cute.arch.thread_idx()[0] == 0:
+            fa_printf(
+                3,
+                "[STATIC] query sm={} cta={} (m_blk={},h={},b={},s={}) valid={}\n",
+                smid(),
+                cute.arch.block_idx()[0],
+                Int32(block),
+                Int32(head_idx),
+                Int32(batch_idx),
+                Int32(self._split_idx),
+                is_valid,
+            )
         return WorkTileInfo(
             (Int32(block), Int32(head_idx), Int32(batch_idx), Int32(self._split_idx)), is_valid
         )


### PR DESCRIPTION
## Summary
- Adds a `[STATIC] query sm=... cta=... (m_blk=...,h=...,b=...,s=...) valid=...` trace line to `SingleTileLPTScheduler.get_current_work()` on the non-CLC path
- Matches the existing `[CLC] query ...` format so `parse_clc_log.py` can produce work-distribution histograms for both CLC-on and CLC-off modes
- Guarded by `FA_LOG_LEVEL=3` and `is_valid` — zero cost when logging is off, no invalid/exhausted tile spam
- Remove invalid/exhausted tile as for non-persistent each tile will have an "invalid" tail.
<img width="1674" height="1618" alt="image" src="https://github.com/user-attachments/assets/691951aa-2a17-479c-a281-860ee6392658" />

## Usage
```bash
# CLC off trace
FA_LOG_LEVEL=3 FA_CLC=0 python your_script.py > static_trace.log 2>&1

# Convert [STATIC] -> [CLC] for the existing parser
sed 's/\[STATIC\]/[CLC]/g' static_trace.log > converted.log
python AI/parse_clc_log.py converted.log --html -o static_histogram.html
```

## Test plan
- [x] Verified trace output on B200 for `mqa_causal_q16384_k1024_h96` (16:1, d=96)
- [x] Confirmed 2048 valid tile lines (128 Q-blocks × 16 heads), no invalid tile spam
- [x] `parse_clc_log.py --html` generates correct histogram after `[STATIC]` → `[CLC]` conversion

cc @drisspg

