### PR TITLE
Expose --pack-gqa and --num-splits in benchmark_attn.py

### DIFF
--- a/benchmarks/benchmark_attn.py
+++ b/benchmarks/benchmark_attn.py
@@ -323,6 +323,13 @@ def parse_args():
                         help='kv sparsity length for MLA (hdim=64, hdim_v=512 only). '
                              'When set, passes random kv indices (without repeats) to FA4 and uses gather-kv as '
                              'the effective KV length for flops/bandwidth accounting.')
+    parser.add_argument('--num-splits', type=int, default=0,
+                        help='Override kernel num_splits heuristic. 0 = auto (default). '
+                             '>1 forces SplitKV with that many splits.')
+    parser.add_argument('--pack-gqa', type=str.lower, choices=['auto', 'true', 'false'], default='auto',
+                        help='Override kernel pack_gqa heuristic. auto = kernel default (default). '
+                             'true/false force pack_gqa on or off. Note: for non-MLA GQA with '
+                             'num_splits>1, interface.py may still force pack_gqa off pending a fix.')
     parser.add_argument('--warmup', type=int, default=5,
                         help='Warmup iterations (default: 5)')
     parser.add_argument('--rep', type=int, default=10,
@@ -406,10 +413,10 @@ def main():
         has_qv = headdim == 64 and headdim_v == 512
         sinks = None
 
-        num_splits = 0
+        num_splits = args.num_splits
         window_size = (None, None)
         window_size_fa = (-1, -1)
-        pack_gqa = None
+        pack_gqa = None if args.pack_gqa == 'auto' else (args.pack_gqa == 'true')
 
         for seqlen, seqlen_q in zip(seqlen_list, seqlen_q_list):
             batch_size = args.batch_size if args.batch_size is not None else max(1, args.total_seqlen // seqlen)


### PR DESCRIPTION
                                                            
  ## Summary                                                                                                                   
  - Add `--num-splits INT` and `--pack-gqa {auto,true,false}` flags to `benchmarks/benchmark_attn.py`
  - Both override kernel heuristics that were previously hardcoded (`num_splits = 0`, `pack_gqa = None`)                       
  - Default behavior unchanged (both default to kernel auto)                                                                   
                                                                                                                               
  ## Motivation                                                                                                                
                                                                                                                               
  These flags are already accepted by the kernel but were only settable by editing the benchmark source. Exposing them enables CLI-driven A/B comparisons without touching the script.
                                                                                                                               
  Concrete example — MLA decode bs=32 seqlen_kv=65536 num_splits=2 on B200:                                                    
  
  | `--pack-gqa` | Time | Note |                                                                                               
  |---|---:|---|                                            
  | `auto`  | 0.75 ms | kernel picks True |                                                                                    
  | `true`  | 0.75 ms | forced on |
  | `false` | 49.37 ms | **66× slowdown** |                                                                                    
                                                            
  The gap confirms `pack_gqa` is load-bearing for long-context MLA decode parallelism; this PR makes that measurable from the CLI.                                                      
                                                                                                                               
  ## Caveat                                                                                                                    
  
  For non-MLA GQA with `num_splits > 1`, `interface.py` still force-disables `pack_gqa` pending a separate fix. `--pack-gqa  true` is silently overridden in that path. For MLA (`qv is not None`), the flag is honored. No new code path is exposed -  this PR only makes existing kernel options reachable from the CLI.                                                           
                                                            
  ## Test plan                                                                                                                 
  - [x] `--help` shows both flags with correct choices
  - [x] `--pack-gqa auto|true|false` all execute without error                                                                 
  - [x] MLA decode smoke: auto=0.75ms, true=0.75ms, false=49.37ms (66× gap as expected)                                        
  - [x] `pre-commit run --all-files` passes                                                                                    
  - [x] Default invocation unchanged (no flag → identical behavior to before) 