### PR TITLE
[Cute,Sm120] fix Spark forward and backward regressions

### DIFF
--- a/flash_attn/cute/flash_bwd.py
+++ b/flash_attn/cute/flash_bwd.py
@@ -433,7 +433,13 @@ class FlashAttentionBackwardSm80:
         tile_sched_params = TileScheduler.to_underlying_arguments(tile_sched_args)
         grid_dim = TileScheduler.get_grid_shape(tile_sched_params)
 
-        softmax_scale_log2, softmax_scale = utils.compute_softmax_scale_log2(softmax_scale, self.score_mod)
+        softmax_scale_for_scoremod = softmax_scale
+        if cutlass.const_expr(self.score_mod is None):
+            softmax_scale_log2 = softmax_scale * math.log2(math.e)
+        else:
+            softmax_scale_log2, softmax_scale_for_scoremod = utils.compute_softmax_scale_log2(
+                softmax_scale, self.score_mod
+            )
         self.kernel(
             mQ,
             mK,
@@ -448,7 +454,7 @@ class FlashAttentionBackwardSm80:
             mCuSeqlensK,
             mSeqUsedQ,
             mSeqUsedK,
-            softmax_scale,
+            softmax_scale_for_scoremod,
             softmax_scale_log2,
             self.sQ_layout,
             self.sK_layout,

--- a/flash_attn/cute/flash_fwd_sm120.py
+++ b/flash_attn/cute/flash_fwd_sm120.py
@@ -7,6 +7,7 @@
 
 import cutlass
 import cutlass.utils as utils_basic
+from cutlass.base_dsl.arch import Arch
 
 from flash_attn.cute.flash_fwd import FlashAttentionForwardSm80
 
@@ -15,6 +16,12 @@ class FlashAttentionForwardSm120(FlashAttentionForwardSm80):
     # Keep arch = 80 to use CpAsync code paths (no TMA for output).
     # The compilation target is determined by the GPU at compile time, not this field.
     arch = 80
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # The base class records the physical GPU arch, but SM120 intentionally
+        # reuses the SM80 control-flow path and must keep the non-TMA epilogue.
+        self.arch = Arch.sm_80
 
     @staticmethod
     def can_implement(

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -1196,6 +1196,7 @@ def _flash_attn_bwd(
         causal, window_size_left, window_size_right
     )
 
+    dQ_single_wg = False
     if arch // 10 == 12:
         # SM120: uses SM80 MMA with 99 KB SMEM, 128 threads (4 warps).
         m_block_size = 64

--- a/tests/cute/test_sm120.py
+++ b/tests/cute/test_sm120.py
@@ -1,0 +1,20 @@
+import cutlass
+from cutlass.base_dsl.arch import Arch
+
+from flash_attn.cute.flash_fwd_sm120 import FlashAttentionForwardSm120
+
+
+def test_sm120_forward_uses_sm80_control_flow():
+    kernel = FlashAttentionForwardSm120(
+        cutlass.BFloat16,
+        head_dim=64,
+        head_dim_v=64,
+        qhead_per_kvhead=1,
+        pack_gqa=False,
+        tile_m=128,
+        tile_n=64,
+        num_stages=1,
+        num_threads=128,
+    )
+
+    assert kernel.arch == Arch.sm_80


### PR DESCRIPTION
## Summary
- restore the intended SM80-style control flow for `FlashAttentionForwardSm120` so DGX Spark does not fall into the TMA epilogue path at runtime
- initialize the SM120 backward `dQ_single_wg` state and keep the shared SM80/SM120 backward launcher on concrete softmax-scale values so the Spark backward path compiles cleanly again
- add a regression test that verifies the SM120 forward object keeps its effective arch pinned to `Arch.sm_80`

## Test plan
- [x] Force a fresh Spark compile with cache disabled and run a full FA4 forward+backward smoke test on `NVIDIA GB10` / compute capability `12.1`
- [x] Benchmark forward on Spark with `B=8, S=8192, H=32, D=64, causal=False`: FA4 `46.52 ms / 94.5 TFLOPS`, SDPA `50.18 ms / 87.6 TFLOPS`
- [x] Instantiate `FlashAttentionForwardSm120` directly and verify the effective arch stays `Arch.sm_80`


Made with [Cursor](https://cursor.com)