### PR TITLE
[cute,bwd] fix PDL race in bwd_preprocess, which corrupting dpsum on SM90+

### DIFF
--- a/flash_attn/cute/flash_bwd_preprocess.py
+++ b/flash_attn/cute/flash_bwd_preprocess.py
@@ -241,6 +241,14 @@ class FlashAttentionBackwardPreprocess:
         work_tile = tile_scheduler.initial_work_tile_info()
         m_block, head_idx, batch_idx, _ = work_tile.tile_idx
 
+        # This kernel is launched with use_pdl=True, so the GPU may start executing it in
+        # "prologue" mode while the previous stream kernel is still running. We must wait
+        # before touching any upstream GMEM outputs (mO, mdO, mLSE); otherwise we risk
+        # reading a partially-written dout, which silently corrupts dpsum = sum(O * dO) and
+        # propagates to dQ/dK via dS = P * (dP - dpsum).
+        if const_expr(self.use_pdl):
+            cute.arch.griddepcontrol_wait()
+
         if work_tile.is_valid_tile:
             # ///////////////////////////////////////////////////////////////////////////////
             # Get the appropriate tiles for this thread block.


### PR DESCRIPTION
## Bug: `bwd_preprocess` missing `griddepcontrol_wait()`, causing silent gradient corruption on SM90+

### Root Cause

`FlashAttentionBackwardPreprocess.kernel` is launched with `use_pdl=True` (on SM90+), but had
no `griddepcontrol_wait()` before its first GMEM read. Under PDL, the GPU is allowed to start
this kernel's prologue while the **previous stream kernel is still running**. If the upstream
kernel (e.g. the output projection backward in the same transformer layer, which writes `dout`)
hasn't finished writing to global memory yet, `bwd_preprocess` reads a partially-written `dout`
and computes a wrong `dpsum = sum(O * dO)`. This silently corrupts `dS = P * (dP - dpsum)`,
and consequently **dQ and dK** (but not dV, which doesn't depend on dpsum).

### Impact & Why the Bug Is Hard to Notice

The bug only manifests under a specific combination of conditions, which is why it can go
undetected in common workloads:

- **Hardware speed**: <span style="color:red">**On GB200 (SM100)**</span> the race window is large enough to trigger the bug
  reliably within the first few training steps. On Hopper (SM90) the window is much narrower
  and the bug was only observed once after 3000+ steps.
- **Architecture**: SM90+ only. `use_pdl` is `False` on SM80 and below; the race cannot occur.
- **MHA vs GQA**: GQA backward allocates `dk_accum`/`dv_accum` via `torch.zeros` (required for
  multi-head accumulation). These `cudaMemsetAsync` ops happen to land on the stream just before
  `bwd_preprocess` launches, accidentally breaking the PDL chain. MHA skips this entirely
  (`dKV_postprocess=False`), leaving the race exposed. This explains why LLM (GQA) workloads
  rarely see the bug while VIT (MHA) workloads do.
- **Deterministic mode**: `deterministic=True` allocates several `torch.zeros` semaphore tensors,
  whose `cudaMemsetAsync` ops again accidentally prevent the PDL overlap.


### Fix

Add `griddepcontrol_wait()` after the pure-register prologue work (tile index computation)
and before the first GMEM read.

```python
# flash_bwd_preprocess.py — inside kernel(), before gO / gdO reads
if const_expr(self.use_pdl):
    cute.arch.griddepcontrol_wait()
```

### Evidence

The following observations all point to the same race between `bwd_preprocess` and the
upstream kernel:

| Observation | Explanation |
|---|---|
| **dQ / dK NaN or grossly wrong; dV normal** | dV = P.T @ dO doesn't use dpsum; dQ/dK both go through dS = P*(dP-dpsum) |
| **`deterministic=True / GQA` eliminates NaN** | deter mode allocates `torch.zeros` semaphore tensors; each `cudaMemsetAsync` accidentally inserts a stream barrier that prevents the PDL overlap |
| **`torch.zeros(1)` dummy tensor before bwd_preprocess eliminates NaN** | Any `cudaMemsetAsync` on the stream before preprocess launches breaks the PDL chain |
| **`stream.synchronize()` before bwd_preprocess eliminates NaN; after has no effect** | Before: forces upstream to complete, dpsum is computed correctly. After: dpsum is already computed with stale data, damage is done |


### Reproduction

Stably reproducible in our internal VLM training setup (GB200, 4-GPU, VIT encoder with
FA4 backward, non-causal, head_dim=64, MHA, non-deterministic): NaN gradients appear
within the first few training steps.

TODO: a standalone minimal reproducer (e.g. single-GPU ViT-like loop) is not yet available.
A likely candidate: run a few backward passes through a multi-layer MHA attention stack
(head_dim=64, non-causal, non-deterministic) on GB200 and check for dQ/dK NaN.
