### PR TITLE
Fix SM90 bwd crash for head_dim in (128, 192]

### DIFF
--- a/flash_attn/cute/flash_bwd_postprocess.py
+++ b/flash_attn/cute/flash_bwd_postprocess.py
@@ -43,12 +43,15 @@ class FlashAttentionBackwardPostprocess:
         dQ_swapAB: bool = False,
         use_2cta_instrs: bool = False,
         cluster_size: int = 1,  # for varlen offsets
+        hdim_multiple_of: int = 32,
     ):
         """
         :param head_dim: head dimension
         :type head_dim: int
         :param tile_m: m block size
         :type tile_m: int
+        :param hdim_multiple_of: tile_hdim alignment; must match the bwd
+            kernel (SM90: 16 default, 64 when ``dKV_swapAB=True``).
         """
         self.dtype = dtype
         self.tile_m = tile_m
@@ -56,8 +59,6 @@ class FlashAttentionBackwardPostprocess:
             "Only Ampere (8.x), Hopper (9.x), and Blackwell (10.x, 11.x, 12.x) are supported"
         )
         self.arch = arch
-        # padding head_dim to a multiple of 32 as k_block_size
-        hdim_multiple_of = 32
         self.tile_hdim = int(math.ceil(head_dim / hdim_multiple_of) * hdim_multiple_of)
         self.check_hdim_oob = head_dim != self.tile_hdim
         self.num_threads = num_threads

--- a/flash_attn/cute/flash_bwd_postprocess.py
+++ b/flash_attn/cute/flash_bwd_postprocess.py
@@ -54,12 +54,14 @@ class FlashAttentionBackwardPostprocess:
         dQ_swapAB: bool = False,
         use_2cta_instrs: bool = False,
         cluster_size: int = 1,  # for varlen offsets
+        hdim_multiple_of: int = 32,
     ):
         """
         :param head_dim: head dimension
         :type head_dim: int
         :param tile_m: m block size
         :type tile_m: int
+        :param hdim_multiple_of: accumulator alignment shared with the main backward kernel.
         """
         self.dtype = dtype
         self.tile_m = tile_m
@@ -67,8 +69,6 @@ class FlashAttentionBackwardPostprocess:
             "Only Ampere (8.x), Hopper (9.x), and Blackwell (10.x, 11.x, 12.x) are supported"
         )
         self.arch = arch
-        # padding head_dim to a multiple of 32 as k_block_size
-        hdim_multiple_of = 32
         self.tile_hdim = int(math.ceil(head_dim / hdim_multiple_of) * hdim_multiple_of)
         self.check_hdim_oob = head_dim != self.tile_hdim
         self.num_threads = num_threads

--- a/flash_attn/cute/flash_bwd_preprocess.py
+++ b/flash_attn/cute/flash_bwd_preprocess.py
@@ -43,6 +43,7 @@ class FlashAttentionBackwardPreprocess:
         head_dim_v: int,
         tile_m: int = 128,
         num_threads: int = 256,
+        hdim_multiple_of: int = 32,
     ):
         """
         All contiguous dimensions must be at least 16 bytes aligned which indicates the head dimension
@@ -54,12 +55,12 @@ class FlashAttentionBackwardPreprocess:
         :type tile_m: int
         :param num_threads: number of threads
         :type num_threads: int
+        :param hdim_multiple_of: tile_hdim alignment; must match the bwd
+            kernel (SM90: 16 default, 64 when ``dKV_swapAB=True``).
         """
         self.use_pdl = BaseDSL._get_dsl().get_arch_enum() >= Arch.sm_90a
         self.dtype = dtype
         self.tile_m = tile_m
-        # padding head_dim to a multiple of 32 as k_block_size
-        hdim_multiple_of = 32
         self.head_dim_padded = int(math.ceil(head_dim / hdim_multiple_of) * hdim_multiple_of)
         self.head_dim_v_padded = int(math.ceil(head_dim_v / hdim_multiple_of) * hdim_multiple_of)
         self.check_hdim_v_oob = head_dim_v != self.head_dim_v_padded

--- a/flash_attn/cute/flash_bwd_preprocess.py
+++ b/flash_attn/cute/flash_bwd_preprocess.py
@@ -48,6 +48,7 @@ class FlashAttentionBackwardPreprocess:
         pack_gqa: bool = False,
         qhead_per_kvhead: int = 1,
         nheads_kv: int = 1,
+        hdim_multiple_of: int = 32,
     ):
         """
         All contiguous dimensions must be at least 16 bytes aligned which indicates the head dimension
@@ -59,12 +60,11 @@ class FlashAttentionBackwardPreprocess:
         :type tile_m: int
         :param num_threads: number of threads
         :type num_threads: int
+        :param hdim_multiple_of: accumulator alignment shared with the main backward kernel.
         """
         self.use_pdl = BaseDSL._get_dsl().get_arch_enum() >= Arch.sm_90a
         self.dtype = dtype
         self.tile_m = tile_m
-        # padding head_dim to a multiple of 32 as k_block_size
-        hdim_multiple_of = 32
         self.head_dim_padded = int(math.ceil(head_dim / hdim_multiple_of) * hdim_multiple_of)
         self.head_dim_v_padded = int(math.ceil(head_dim_v / hdim_multiple_of) * hdim_multiple_of)
         self.check_hdim_v_oob = head_dim_v != self.head_dim_v_padded

--- a/flash_attn/cute/flash_bwd_sm90.py
+++ b/flash_attn/cute/flash_bwd_sm90.py
@@ -75,8 +75,11 @@ class FlashAttentionBackwardSm90:
         dQ_single_wg: bool = False,
     ):
         self.dtype = dtype
-        # padding head_dim to a multiple of 16 as k_block_size
-        hdim_multiple_of = 16
+        # padding head_dim to a multiple of 16 as k_block_size, or 64 when
+        # dKV_swapAB=True (needed for WGMMA M=64 atom to partition the dK/dV
+        # accumulator — otherwise head_dim in {144, 160, 176} crash the CuTe
+        # tiled-mma partition).
+        hdim_multiple_of = 64 if dKV_swapAB else 16
         self.tile_hdim = int(math.ceil(head_dim / hdim_multiple_of) * hdim_multiple_of)
         head_dim_v = head_dim_v if head_dim_v is not None else head_dim
         self.same_hdim_kv = head_dim == head_dim_v

--- a/flash_attn/cute/flash_bwd_sm90.py
+++ b/flash_attn/cute/flash_bwd_sm90.py
@@ -76,8 +76,8 @@ class FlashAttentionBackwardSm90:
         dQ_single_wg: bool = False,
     ):
         self.dtype = dtype
-        # padding head_dim to a multiple of 16 as k_block_size
-        hdim_multiple_of = 16
+        # Swapped dK/dV accumulators put head_dim on WGMMA's 64-row M axis.
+        hdim_multiple_of = 64 if dKV_swapAB else 16
         self.tile_hdim = int(math.ceil(head_dim / hdim_multiple_of) * hdim_multiple_of)
         head_dim_v = head_dim_v if head_dim_v is not None else head_dim
         self.same_hdim_kv = head_dim == head_dim_v

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -1059,6 +1059,7 @@ def make_fake_bwd_tensors(dtype, has_gqa, varlen_q, varlen_k):
 
 def _compile_bwd_preprocess(
     dtype, head_dim, head_dim_v, m_block_size, has_cuseqlens_q, has_seqused_q, has_dlse,
+    hdim_multiple_of,
 ):
     """Compile bwd preprocess kernel using cute fake tensors (no real GPU tensors needed)."""
     mQ, mK, mV, mO, mdO, mdQ, mdK, mdV, mLSE, mLSElog2, mPdPsum, mdQaccum, mdKaccum, mdVaccum = make_fake_bwd_tensors(
@@ -1069,7 +1070,9 @@ def _compile_bwd_preprocess(
     mCuSeqlensQ = fake_tensor(Int32, (batchp1,), divisibility=1) if has_cuseqlens_q else None
     mSequsedQ = fake_tensor(Int32, (batch,), divisibility=1) if has_seqused_q else None
     mdLSE = fake_tensor(Float32, mLSE.shape, divisibility=1) if has_dlse else None
-    fa_bwd_pre = FlashAttentionBackwardPreprocess(dtype, head_dim, head_dim_v, m_block_size)
+    fa_bwd_pre = FlashAttentionBackwardPreprocess(
+        dtype, head_dim, head_dim_v, m_block_size, hdim_multiple_of=hdim_multiple_of,
+    )
     return cute.compile(
         fa_bwd_pre, mO, mdO, mPdPsum, mLSE, mLSElog2, mdQaccum, mCuSeqlensQ, mSequsedQ, mdLSE,
         cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True),
@@ -1081,11 +1084,16 @@ def _bwd_preprocess(
     out, dout, dpsum, lse, lse_log2, dq_accum,
     cu_seqlens_q, seqused_q, dlse,
     dtype, head_dim, head_dim_v, m_block_size,
+    hdim_multiple_of=32,
 ):
-    """Backward preprocess: compute (o * dout).sum(dim=-1) - dLSE, lse * log2_e, and zero out dq_accum."""
+    """Backward preprocess: compute (o * dout).sum(dim=-1) - dLSE, lse * log2_e, and zero out dq_accum.
+
+    ``hdim_multiple_of`` must match the bwd kernel's ``tile_hdim`` alignment
+    so the zero-fill covers the full buffer."""
     is_varlen = cu_seqlens_q is not None
     compile_key = (
-        dtype, head_dim, head_dim_v, m_block_size, is_varlen, seqused_q is not None, dlse is not None,
+        dtype, head_dim, head_dim_v, m_block_size, is_varlen, seqused_q is not None,
+        dlse is not None, hdim_multiple_of,
     )
     if compile_key not in _bwd_preprocess.compile_cache:
         _bwd_preprocess.compile_cache[compile_key] = _compile_bwd_preprocess(*compile_key)
@@ -1101,7 +1109,7 @@ _bwd_preprocess.compile_cache = get_jit_cache("bwd_pre")
 def _compile_bwd_postprocess(
     dtype, hdim, block_size, num_threads, atom_layout, swap_ab,
     has_cuseqlens_q, has_seqused_q,
-    use_2cta_instrs, cluster_size, arch,
+    use_2cta_instrs, cluster_size, arch, hdim_multiple_of,
 ):
     """Compile bwd postprocess kernel using cute fake tensors."""
     mQ, mK, mV, mO, mdO, mdQ, mdK, mdV, mLSE, mLSElog2, mPdPsum, mdQaccum, mdKaccum, mdVaccum = make_fake_bwd_tensors(
@@ -1115,6 +1123,7 @@ def _compile_bwd_postprocess(
         dtype, hdim, arch, block_size, num_threads, atom_layout, swap_ab,
         use_2cta_instrs=use_2cta_instrs,
         cluster_size=cluster_size,
+        hdim_multiple_of=hdim_multiple_of,
     )
     return cute.compile(
         fa_bwd_post, mdQaccum, mdQ, Float32(0.0), mCuSeqlensQ, mSeqUsedQ,
@@ -1128,13 +1137,15 @@ def _bwd_postprocess_convert(
     cu_seqlens, seqused,
     arch, dtype, hdim, block_size, num_threads,
     atom_layout, swap_ab,
-    use_2cta_instrs=False, cluster_size=1,
+    use_2cta_instrs=False, cluster_size=1, hdim_multiple_of=32,
 ):
-    """Backward postprocess: convert float32 accumulator to bf16/fp16 output."""
+    """Backward postprocess: convert float32 accumulator to bf16/fp16 output.
+
+    ``hdim_multiple_of`` must match the bwd kernel's ``tile_hdim`` alignment."""
     compile_key = (
         dtype, hdim, block_size, num_threads, atom_layout, swap_ab,
         cu_seqlens is not None, seqused is not None,
-        use_2cta_instrs, cluster_size, arch,
+        use_2cta_instrs, cluster_size, arch, hdim_multiple_of,
     )
     if compile_key not in _bwd_postprocess_convert.compile_cache:
         _bwd_postprocess_convert.compile_cache[compile_key] = _compile_bwd_postprocess(*compile_key)
@@ -1386,7 +1397,11 @@ def _flash_attn_bwd(
     else:
         _validate_tensor(dv, "dv", v.shape, out_torch_dtype, device)
 
-    head_dim_rounded = (head_dim + 32 - 1) // 32 * 32
+    # Must match the bwd kernel's internal tile_hdim rounding. SM90 uses 16
+    # by default and 64 when dKV_swapAB=True (WGMMA M=64 alignment); other
+    # archs use 32. Allocation must be >= the kernel's stride or we OOB.
+    _bwd_hdim_mul = 64 if ((arch // 10 == 9) and dKV_swapAB) else 32
+    head_dim_rounded = (head_dim + _bwd_hdim_mul - 1) // _bwd_hdim_mul * _bwd_hdim_mul
 
     if cu_seqlens_q is None:
         dq_accum = torch.empty(
@@ -1471,6 +1486,7 @@ def _flash_attn_bwd(
         out, dout, dpsum, lse, lse_log2, dq_accum,
         cu_seqlens_q, seqused_q, dlse,
         dtype, head_dim, head_dim_v, m_block_size,
+        hdim_multiple_of=_bwd_hdim_mul,
     )
     # num_threads: SM90 derives from BwdConfig.num_wg, SM120 is set to 128 above,
     # SM100/SM110 uses default from function signature (384).
@@ -1744,6 +1760,7 @@ def _flash_attn_bwd(
         arch, dtype, head_dim, m_block_size, num_threads_post_dQ,
         AtomLayoutMdQ, dQ_swapAB,
         use_2cta_instrs=use_2cta_instrs, cluster_size=1,
+        hdim_multiple_of=_bwd_hdim_mul,
     )
 
     if dKV_postprocess:
@@ -1754,6 +1771,7 @@ def _flash_attn_bwd(
             arch, dtype, head_dim, n_block_size, num_threads_post_dKV,
             AtomLayoutNdKV, dKV_swapAB,
             cluster_size=cluster_size,
+            hdim_multiple_of=_bwd_hdim_mul,
         )
         # Postprocess: convert dv_accum from float32 to dv in bf16/fp16
         _bwd_postprocess_convert(
@@ -1762,6 +1780,7 @@ def _flash_attn_bwd(
             arch, dtype, head_dim_v, n_block_size, num_threads_post_dKV,
             AtomLayoutNdKV, dKV_swapAB,
             cluster_size=cluster_size,
+            hdim_multiple_of=_bwd_hdim_mul,
         )
 
     return dq, dk, dv

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -1631,6 +1631,7 @@ def _compile_bwd_preprocess(
     qhead_per_kvhead,
     nheads_kv,
     has_cu_total_m_blocks,
+    hdim_multiple_of,
 ):
     """Compile bwd preprocess kernel using cute fake tensors (no real GPU tensors needed)."""
     mQ, mK, mV, mO, mdO, mdQ, mdK, mdV, mLSE, mLSElog2, mPdPsum, mdQaccum, mdKaccum, mdVaccum, mScaleP = make_fake_bwd_tensors(
@@ -1654,6 +1655,7 @@ def _compile_bwd_preprocess(
         pack_gqa=pack_gqa,
         qhead_per_kvhead=qhead_per_kvhead,
         nheads_kv=nheads_kv,
+        hdim_multiple_of=hdim_multiple_of,
     )
     return cute.compile(
         fa_bwd_pre, mO, mdO, mPdPsum, mLSE, mLSElog2, mdQaccum, mCuSeqlensQ, mSequsedQ, mdLSE,
@@ -1676,6 +1678,7 @@ def _bwd_preprocess(
     nheads_kv=1,         # only used with pack_gqa
     softmax_scale=1.0,   # only used with scale_p
     cu_total_m_blocks=None,
+    hdim_multiple_of=32,
     *,
     fake_mode,
 ):
@@ -1708,6 +1711,7 @@ def _bwd_preprocess(
         qhead_per_kvhead,
         nheads_kv,
         cu_total_m_blocks is not None,
+        hdim_multiple_of,
     )
     if compile_key not in _bwd_preprocess.compile_cache:
         _bwd_preprocess.compile_cache[compile_key] = _compile_bwd_preprocess(*compile_key)
@@ -1727,6 +1731,7 @@ def _compile_bwd_postprocess(
     use_2cta_instrs, cluster_size, arch,
     has_cu_total_m_blocks,
     learnable_sink_dtype,
+    hdim_multiple_of,
 ):
     """Compile bwd postprocess kernel using cute fake tensors."""
     mQ, mK, mV, mO, mdO, mdQ, mdK, mdV, mLSE, mLSElog2, mPdPsum, mdQaccum, mdKaccum, mdVaccum, mScaleP = make_fake_bwd_tensors(
@@ -1751,6 +1756,7 @@ def _compile_bwd_postprocess(
         dtype, hdim, arch, block_size, num_threads, atom_layout, swap_ab,
         use_2cta_instrs=use_2cta_instrs,
         cluster_size=cluster_size,
+        hdim_multiple_of=hdim_multiple_of,
     )
     return cute.compile(
         fa_bwd_post, mdQaccum, mdQ, Float32(0.0), mCuSeqlensQ, mSeqUsedQ,
@@ -1769,6 +1775,7 @@ def _bwd_postprocess_convert(
     use_2cta_instrs=False, cluster_size=1,
     cu_total_m_blocks=None,
     sink_tensors=None,
+    hdim_multiple_of=32,
     *,
     fake_mode,
 ):
@@ -1794,6 +1801,7 @@ def _bwd_postprocess_convert(
             if sink_tensors is not None
             else None
         ),
+        hdim_multiple_of,
     )
     if compile_key not in _bwd_postprocess_convert.compile_cache:
         _bwd_postprocess_convert.compile_cache[compile_key] = _compile_bwd_postprocess(*compile_key)
@@ -2124,7 +2132,9 @@ def _flash_attn_bwd(
     else:
         _validate_tensor(dv, "dv", v.shape, out_torch_dtype, device)
 
-    head_dim_rounded = (head_dim + 32 - 1) // 32 * 32
+    # Keep accumulator allocation, zeroing, and readback aligned with SM90's swapped MMA.
+    hdim_multiple_of = 64 if arch // 10 == 9 and dKV_swapAB else 32
+    head_dim_rounded = (head_dim + hdim_multiple_of - 1) // hdim_multiple_of * hdim_multiple_of
 
     if cu_seqlens_q is None:
         dq_accum = (
@@ -2239,6 +2249,7 @@ def _flash_attn_bwd(
         dtype, head_dim, head_dim_v, m_block_size,
         cu_total_m_blocks=cu_total_m_blocks_q,
         fake_mode=fake_mode,
+        hdim_multiple_of=hdim_multiple_of,
     )
     # num_threads: SM90 derives from BwdConfig.num_wg, SM120 is set to 128 above,
     # SM100/SM110 uses default from function signature (384).
@@ -2616,6 +2627,7 @@ def _flash_attn_bwd(
                 else None
             ),
             fake_mode=fake_mode,
+            hdim_multiple_of=hdim_multiple_of,
         )
 
         if dKV_postprocess:
@@ -2628,6 +2640,7 @@ def _flash_attn_bwd(
                 cluster_size=cluster_size,
                 cu_total_m_blocks=cu_total_m_blocks_k if cluster_size == 1 else None,
                 fake_mode=fake_mode,
+                hdim_multiple_of=hdim_multiple_of,
             )
             # Postprocess: convert dv_accum from float32 to dv in bf16/fp16
             _bwd_postprocess_convert(
@@ -2638,6 +2651,7 @@ def _flash_attn_bwd(
                 cluster_size=cluster_size,
                 cu_total_m_blocks=cu_total_m_blocks_k if cluster_size == 1 else None,
                 fake_mode=fake_mode,
+                hdim_multiple_of=hdim_multiple_of,
             )
 
     return (dq, dk, dv) if learnable_sink is None else (dq, dk, dv, dsink)

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -197,6 +197,138 @@ def test_flash_attn_value_dim_larger_than_query_dim():
     torch.testing.assert_close(out.float(), reference, atol=0.04, rtol=0.04)
 
 
+def check_sm90_hdim_padding(
+    d: int,
+    seqlen_q: int = 257,
+    seqlen_k: int = 513,
+    mask: str = "causal",
+    varlen: bool = False,
+    dtype: torch.dtype = torch.bfloat16,
+    d_v: int = 128,
+) -> None:
+    """Check the public forward/backward path against FP64 and low-precision eager."""
+    torch.manual_seed(0)
+    q = torch.randn(2, seqlen_q, 4, d, device="cuda", dtype=dtype, requires_grad=True)
+    k = torch.randn(2, seqlen_k, 4, d, device="cuda", dtype=dtype, requires_grad=True)
+    v = torch.randn(2, seqlen_k, 4, d_v, device="cuda", dtype=dtype, requires_grad=True)
+    causal = mask == "causal"
+    window = (32, 16) if mask == "local" else (None, None)
+    q_mask = k_mask = None
+    if varlen:
+        q_mask = (
+            torch.arange(seqlen_q, device="cuda")[None, :]
+            < torch.tensor([seqlen_q - 17, seqlen_q], device="cuda")[:, None]
+        )
+        k_mask = (
+            torch.arange(seqlen_k, device="cuda")[None, :]
+            < torch.tensor([seqlen_k - 23, seqlen_k], device="cuda")[:, None]
+        )
+        q_packed = torch.cat((q[0, : seqlen_q - 17], q[1]))
+        k_packed = torch.cat((k[0, : seqlen_k - 23], k[1]))
+        v_packed = torch.cat((v[0, : seqlen_k - 23], v[1]))
+        out, _ = flash_attn_varlen_func(
+            q_packed,
+            k_packed,
+            v_packed,
+            cu_seqlens_q=torch.tensor(
+                [0, seqlen_q - 17, 2 * seqlen_q - 17], device="cuda", dtype=torch.int32
+            ),
+            cu_seqlens_k=torch.tensor(
+                [0, seqlen_k - 23, 2 * seqlen_k - 23], device="cuda", dtype=torch.int32
+            ),
+            max_seqlen_q=seqlen_q,
+            max_seqlen_k=seqlen_k,
+            causal=causal,
+            window_size=window,
+        )
+    else:
+        out, _ = flash_attn_func(q, k, v, causal=causal, window_size=window)
+    dout = torch.randn_like(out)
+    grads = torch.autograd.grad(out, (q, k, v), dout)
+    if is_fake_mode():
+        return
+
+    q_ref, k_ref, v_ref = [x.detach().double().requires_grad_() for x in (q, k, v)]
+    out_ref, _ = attention_ref(
+        q_ref,
+        k_ref,
+        v_ref,
+        q_mask,
+        k_mask,
+        causal=causal,
+        window_size=window,
+        upcast=False,
+    )
+    out_pt, _ = attention_ref(
+        q,
+        k,
+        v,
+        q_mask,
+        k_mask,
+        causal=causal,
+        window_size=window,
+        upcast=False,
+        reorder_ops=True,
+    )
+    if varlen:
+        out_ref = torch.cat((out_ref[0, : seqlen_q - 17], out_ref[1]))
+        out_pt = torch.cat((out_pt[0, : seqlen_q - 17], out_pt[1]))
+    grads_ref = torch.autograd.grad(out_ref, (q_ref, k_ref, v_ref), dout.double())
+    grads_pt = torch.autograd.grad(out_pt, (q, k, v), dout)
+    for name, actual, reference, eager in zip(
+        ("out", "dq", "dk", "dv"),
+        (out, *grads),
+        (out_ref, *grads_ref),
+        (out_pt, *grads_pt),
+    ):
+        assert actual.isfinite().all(), name
+        error = (actual.double() - reference).abs()
+        eager_error = (eager.double() - reference).abs()
+        # Follow the attention tests' 2x eager-error allowance, including output rounding.
+        rounding = 2 * torch.finfo(dtype).eps * reference.abs()
+        check_tensor_vs_ref(
+            name, actual.double(), reference, eager.double(), atol=rounding.max().item()
+        )
+        assert error.mean() <= 2 * eager_error.mean() + rounding.mean(), name
+
+
+@pytest.mark.skipif(not IS_SM90, reason="SM90 backward padding regression")
+@pytest.mark.parametrize("d", [136, 144, 152, 160, 168, 176, 184, 192])
+@pytest.mark.parametrize("seqlen_q,seqlen_k", [(113, 211), (257, 513)])
+@pytest.mark.parametrize("mask", ["dense", "causal", "local"])
+@pytest.mark.parametrize("varlen", [False, True])
+@maybe_fake_tensor_mode(USE_FAKE_TENSOR)
+def test_flash_attn_sm90_hdim_padding(d, seqlen_q, seqlen_k, mask, varlen):
+    check_sm90_hdim_padding(d, seqlen_q, seqlen_k, mask, varlen)
+
+
+@pytest.mark.skipif(not IS_SM90, reason="SM90 backward padding regression")
+@pytest.mark.parametrize("d,d_v", [(144, 64), (160, 96)])
+@pytest.mark.parametrize("varlen", [False, True])
+@maybe_fake_tensor_mode(USE_FAKE_TENSOR)
+def test_flash_attn_sm90_hdim_padding_value_dim(d, d_v, varlen):
+    check_sm90_hdim_padding(d, varlen=varlen, d_v=d_v)
+
+
+@pytest.mark.skipif(not IS_SM90, reason="SM90 backward padding regression")
+@pytest.mark.parametrize(
+    "d_first,d_second",
+    [(144, 160), (160, 144), (144, 176), (176, 144), (128, 144), (144, 192)],
+)
+@maybe_fake_tensor_mode(USE_FAKE_TENSOR)
+def test_flash_attn_sm90_hdim_padding_reuse(d_first, d_second):
+    """Dimensions sharing padded storage must remain correct back-to-back."""
+    check_sm90_hdim_padding(d_first)
+    check_sm90_hdim_padding(d_second)
+
+
+@pytest.mark.skipif(not IS_SM90, reason="SM90 backward padding regression")
+@pytest.mark.parametrize("d", [144, 176])
+@maybe_fake_tensor_mode(USE_FAKE_TENSOR)
+def test_flash_attn_sm90_hdim_padding_fp16(d):
+    check_sm90_hdim_padding(d, dtype=torch.float16)
+
+
 @pytest.mark.parametrize("head_dim", [72, 104])
 @pytest.mark.parametrize("causal", [False, True])
 @maybe_fake_tensor_mode(USE_FAKE_TENSOR)

--- a/tests/cute/test_hdim_padding.py
+++ b/tests/cute/test_hdim_padding.py
@@ -1,0 +1,228 @@
+# Copyright (c) 2026
+
+"""Tests for SM90 bwd tile_hdim alignment and stride consistency.
+
+Covers head_dim in ``(128, 192]`` (the dKV_swapAB=True bwd config).
+``head_dim in {136, 144, 152, 160, 168, 176}`` requires a multiple-of-64
+tile_hdim for the SM90 WGMMA M=64 atom to partition the dK/dV
+accumulator, and the preprocess / postprocess / dq_accum allocation
+must all agree on that stride."""
+
+import gc
+import os
+import random
+from functools import wraps
+
+import pytest
+import torch
+
+from flash_attn.cute.interface import (
+    _flash_attn_bwd,
+    _flash_attn_fwd,
+    flash_attn_func,
+)
+from flash_attn.cute.testing import (
+    attention_ref,
+    is_fake_mode,
+    maybe_fake_tensor_mode,
+)
+
+
+USE_FAKE_TENSOR = int(os.getenv("FLASH_ATTENTION_FAKE_TENSOR", 0)) == 1
+IS_SM90 = torch.cuda.get_device_capability()[0] == 9
+
+
+def retry_on_oom(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except torch.OutOfMemoryError:
+            if hasattr(_flash_attn_fwd, "compile_cache"):
+                _flash_attn_fwd.compile_cache.clear()
+            if hasattr(_flash_attn_bwd, "compile_cache"):
+                _flash_attn_bwd.compile_cache.clear()
+            gc.collect()
+            torch.cuda.empty_cache()
+            return func(*args, **kwargs)
+
+    return wrapper
+
+
+SWAPAB_HEAD_DIMS = [136, 144, 152, 160, 168, 176, 184, 192]
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.parametrize("mha_type", ["mha", "gqa"])
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("has_window", [False, True])
+@pytest.mark.parametrize("d", SWAPAB_HEAD_DIMS)
+@pytest.mark.parametrize("seqlen_q,seqlen_k", [(128, 128), (512, 512), (113, 211)])
+@retry_on_oom
+@maybe_fake_tensor_mode(USE_FAKE_TENSOR)
+def test_hdim_padding_fwd_bwd(seqlen_q, seqlen_k, d, has_window, causal, mha_type, dtype):
+    if not IS_SM90:
+        pytest.skip("dKV_swapAB=True config is SM90-specific")
+    if has_window and causal:
+        pytest.skip("redundant with causal=True")
+    if mha_type != "mha":
+        pytest.xfail("SM90 GQA bwd currently requires head_dim == head_dim_v")
+
+    device = "cuda"
+    random.seed(0)
+    torch.manual_seed(0)
+    batch = 2
+    nheads = 4
+    nheads_kv = nheads if mha_type == "mha" else 2
+    dtype_ref = dtype
+    d_v = 128
+
+    q_ref = (
+        torch.randn(batch, seqlen_q, nheads, d, device=device, dtype=dtype_ref)
+        .to(dtype)
+        .to(dtype_ref)
+        .requires_grad_()
+    )
+    k_ref = (
+        torch.randn(batch, seqlen_k, nheads_kv, d, device=device, dtype=dtype_ref)
+        .to(dtype)
+        .to(dtype_ref)
+        .requires_grad_()
+    )
+    v_ref = (
+        torch.randn(batch, seqlen_k, nheads_kv, d_v, device=device, dtype=dtype_ref)
+        .to(dtype)
+        .to(dtype_ref)
+        .requires_grad_()
+    )
+
+    window_size = (None, None)
+    if has_window:
+        w_left = random.randrange(1, max(seqlen_k, 2))
+        window_size = (w_left, 0 if causal else random.randrange(0, seqlen_k))
+
+    q, k, v = [x.detach().to(dtype).requires_grad_() for x in (q_ref, k_ref, v_ref)]
+
+    out_ref, _ = attention_ref(
+        q_ref, k_ref, v_ref, causal=causal, window_size=window_size, upcast=True
+    )
+    out_pt, _ = attention_ref(
+        q_ref,
+        k_ref,
+        v_ref,
+        causal=causal,
+        window_size=window_size,
+        upcast=False,
+        reorder_ops=True,
+    )
+
+    out, _lse = flash_attn_func(
+        q,
+        k,
+        v,
+        causal=causal,
+        window_size=window_size,
+    )
+
+    if is_fake_mode():
+        return
+
+    fwd_atol = 2 * (out_ref + 0.3 - 0.3 - out_ref).abs().max().item()
+    rtol = 2.0
+    fwd_err = (out - out_ref).abs().max().item()
+    pt_err = (out_pt - out_ref).abs().max().item()
+    assert fwd_err <= rtol * pt_err + fwd_atol, (
+        f"fwd d={d}: kernel err {fwd_err:.3e} > {rtol} * pt err {pt_err:.3e} + {fwd_atol:.3e}"
+    )
+
+    g = torch.randn_like(out)
+    dq, dk, dv = torch.autograd.grad(out, (q, k, v), g)
+    dq_ref, dk_ref, dv_ref = torch.autograd.grad(
+        out_ref,
+        (q_ref, k_ref, v_ref),
+        g,
+        retain_graph=True,
+    )
+    dq_pt, dk_pt, dv_pt = torch.autograd.grad(out_pt, (q_ref, k_ref, v_ref), g)
+
+    for name, kernel_g, ref_g, pt_g in [
+        ("dq", dq, dq_ref, dq_pt),
+        ("dk", dk, dk_ref, dk_pt),
+        ("dv", dv, dv_ref, dv_pt),
+    ]:
+        atol = 2 * (ref_g + 0.3 - 0.3 - ref_g).abs().max().item()
+        kernel_err = (kernel_g - ref_g).abs().max().item()
+        pt_err = (pt_g - ref_g).abs().max().item()
+        assert kernel_err <= rtol * pt_err + atol, (
+            f"bwd d={d} {name}: kernel err {kernel_err:.3e} > "
+            f"{rtol} * pt err {pt_err:.3e} + {atol:.3e}"
+        )
+
+
+@pytest.mark.parametrize(
+    "d_first,d_second",
+    [
+        (144, 160),
+        (160, 144),
+        (144, 176),
+        (176, 144),
+        (128, 144),
+        (144, 192),
+    ],
+)
+@retry_on_oom
+def test_cross_hdim_no_stale_accum(d_first, d_second):
+    """Two head_dims that share a padded tile_hdim (e.g. 144 and 160 both
+    pad to 192) must be independently correct when run back-to-back in
+    the same process — if preprocess zero-fills less than the bwd kernel
+    writes, the second call reads stale accumulator data left by the
+    first."""
+    if not IS_SM90:
+        pytest.skip("dKV_swapAB=True config is SM90-specific")
+
+    device = "cuda"
+    dtype = torch.bfloat16
+    batch, seqlen, heads, d_v = 1, 128, 2, 128
+    rtol = 2.0
+
+    def one_trial(d):
+        random.seed(0)
+        torch.manual_seed(0)
+        q_ref = torch.randn(batch, seqlen, heads, d, device=device, dtype=dtype).requires_grad_()
+        k_ref = torch.randn(batch, seqlen, heads, d, device=device, dtype=dtype).requires_grad_()
+        v_ref = torch.randn(batch, seqlen, heads, d_v, device=device, dtype=dtype).requires_grad_()
+        q, k, v = [x.detach().to(dtype).requires_grad_() for x in (q_ref, k_ref, v_ref)]
+        out_ref, _ = attention_ref(q_ref, k_ref, v_ref, causal=True, upcast=True)
+        out_pt, _ = attention_ref(
+            q_ref,
+            k_ref,
+            v_ref,
+            causal=True,
+            upcast=False,
+            reorder_ops=True,
+        )
+        out, _ = flash_attn_func(q, k, v, causal=True)
+        g = torch.randn_like(out)
+        dq, dk, dv = torch.autograd.grad(out, (q, k, v), g)
+        dq_ref, dk_ref, dv_ref = torch.autograd.grad(
+            out_ref,
+            (q_ref, k_ref, v_ref),
+            g,
+            retain_graph=True,
+        )
+        dq_pt, dk_pt, dv_pt = torch.autograd.grad(out_pt, (q_ref, k_ref, v_ref), g)
+        for name, kernel_g, ref_g, pt_g in [
+            ("dq", dq, dq_ref, dq_pt),
+            ("dk", dk, dk_ref, dk_pt),
+            ("dv", dv, dv_ref, dv_pt),
+        ]:
+            atol = 2 * (ref_g + 0.3 - 0.3 - ref_g).abs().max().item()
+            kernel_err = (kernel_g - ref_g).abs().max().item()
+            pt_err = (pt_g - ref_g).abs().max().item()
+            assert kernel_err <= rtol * pt_err + atol, (
+                f"d={d} {name}: kernel err {kernel_err:.3e} > "
+                f"{rtol} * pt err {pt_err:.3e} + {atol:.3e}"
+            )
+
+    one_trial(d_first)
+    one_trial(d_second)


### PR DESCRIPTION
Debugged and authored mainly with Claude code- you can see it's lightly edited description below, but basically  some minor bug fixes are required for uncommon (144, 160, 176, etc) head dimensions. I verified I did not create any performance regressions. Everything was tested on a H200.

The dKV_swapAB=True bwd config (128 < head_dim <= 192 with head_dim_v <= 128) puts head_dim on the WGMMA M axis of the dK/dV accumulator. SM90 bf16 WGMMA has M=64, so tile_hdim needs to be a multiple of 64 for CuTe's tiled-MMA partition to succeed. The current 16-multiple rounding (flash_bwd_sm90.py:79) leaves head_dim in {136, 144, 152, 160, 168, 176} misaligned, crashing at build time:

    failed to partition '!cute.shape<"(144,96)">' with tiled_mma

Bump tile_hdim to 64-multiple in the dKV_swapAB=True branch. This stride also appears in three other places that must agree:

* interface.py head_dim_rounded (dq/dk/dv accum allocation)
* flash_bwd_preprocess.py head_dim_padded (accum zero-fill)
* flash_bwd_postprocess.py tile_hdim (accum read stride)

Each of these was hardcoded to a 32-multiple default and needs to match the bwd kernel's alignment. Thread a single hdim_multiple_of through from _flash_attn_bwd. The mismatch also caused a silent correctness bug: preprocess zeroing less than the bwd kernel wrote left the tail rows of dq_accum reading stale data producing wrong gradients for head_dims that share a padded tile_hdim.