### PR TITLE
[Tests,MLA] Close coverage gaps in test_flash_attn_mla_absorbed

### DIFF
--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -1756,7 +1756,7 @@ def test_flash_attn_invalid_head_dim(head_dim):
 @pytest.mark.parametrize("nheads", [16, 128])
 @pytest.mark.parametrize("kv_sparsity", [False, True])
 # @pytest.mark.parametrize("kv_sparsity", [True])
-@pytest.mark.parametrize("gather_kv_length", [2048])
+@pytest.mark.parametrize("gather_kv_length", [1024, 2048])
 @pytest.mark.parametrize(
     "seqlen_q,seqlen_k",
     [
@@ -1783,6 +1783,7 @@ def test_flash_attn_invalid_head_dim(head_dim):
         (1024, 1023),
         (2048, 2048),
         (1, 8192),
+        (4096, 4096),
     ],
 )
 # @pytest.mark.parametrize('seqlen_q,seqlen_k', [(128, 128)])
@@ -1823,7 +1824,7 @@ def test_flash_attn_mla_absorbed(
     torch.cuda.synchronize()
     batch_size = 9 if seqlen_k <= 2048 else 2
     # batch_size = 2
-    nheads = 128
+    # nheads = 128
     nheads_kv = nheads if mha_type == "mha" else (8 if mha_type == "gqa" else 1)
     dtype_ref = torch.bfloat16 if dtype == torch.float8_e4m3fn else dtype
     dv_vals = [512]
@@ -1980,6 +1981,7 @@ def test_flash_attn_mla_absorbed(
             assert (out - out_ref).abs().max().item() <= rtol * (
                 out_pt - out_ref
             ).abs().max().item() + fwd_atol
+            assert not torch.isnan(lse).any(), "LSE contains NaN"
 
             repeats = 1000
             for iter in range(repeats):
@@ -2015,10 +2017,11 @@ def test_flash_attn_mla_absorbed(
 @pytest.mark.parametrize("local_enum", [0])
 @pytest.mark.parametrize("causal", [False, True])
 # @pytest.mark.parametrize("causal", [False])
+# @pytest.mark.parametrize("add_unused_qkv", [False, True])
 @pytest.mark.parametrize("add_unused_qkv", [False])
 @pytest.mark.parametrize("kv_sparsity", [False, True])
 # @pytest.mark.parametrize("kv_sparsity", [False])
-@pytest.mark.parametrize("gather_kv_length", [2048])
+@pytest.mark.parametrize("gather_kv_length", [1024, 2048])
 @pytest.mark.parametrize("d", [64])
 @pytest.mark.parametrize("nheads", [16, 128])
 # @pytest.mark.parametrize("nheads", [128])
@@ -2372,6 +2375,10 @@ def test_flash_attn_mla_absorbed_varlen(
             assert (out_cmp - out_ref_cmp).abs().max().item() <= rtol * (
                 out_pt_cmp - out_ref_cmp
             ).abs().max().item() + fwd_atol
+            # LSE sanity: only valid positions (packed unpad path; padded path
+            # can legitimately contain uninit tail beyond seqused_q).
+            if unpad_q:
+                assert not torch.isnan(lse).any(), "LSE contains NaN"
 
             repeats = 1000
             for iter in range(repeats):


### PR DESCRIPTION
## Summary

Motivated by https://github.com/Dao-AILab/flash-attention/pull/2441

Expands the two MLA-absorbed tests with a few low-risk cases and fixes a stale `nheads` parametrize.

The added coverage stays within what the MLA-absorbed kernel already supports per the guards in `interface.py:633-648`. Existing skips under `qv` (`softcap` / `learnable_sink` / `local` / `paged` / `fp8` / `split_kv` / `score_mod` / `mask_mod`) are unchanged.

#### Non-varlen `test_flash_attn_mla_absorbed`

- **Remove the hardcoded `nheads = 128` override**  
  The override made the `nheads: [16, 128]` parametrize stale, since the test body always ran with `nheads=128`. Removing it restores the intended coverage for `nheads=16`, which is meant to exercise the head-sharding path. The existing `if kv_sparsity and nheads != 128: pytest.skip()` guard is kept as-is.

- **`gather_kv_length: [2048] → [1024, 2048]`**  
  Adds a second value on the `kv_sparsity=True` path.

- **Add `seqlen=(4096, 4096)`**  
  The existing table covered `(2048, 2048)` and `(1, 8192)`, but nothing with both Q and K in the mid-prefill range.

- **Check `lse` is NaN-free**  
  `lse` is used by backward and split-KV combine, so NaNs there can slip past the current `out` diff check.

#### Varlen `test_flash_attn_mla_absorbed_varlen`

- **`gather_kv_length: [2048] → [1024, 2048]`**  
  Same reason as above.

- **Check `lse` for NaNs when `unpad_q=True`**  
  Gated on `unpad_q` since the padded path can legitimately have uninitialized tail beyond `seqused_q`.

## Test plan

- [x] `pytest tests/cute/test_flash_attn.py::test_flash_attn_mla_absorbed tests/cute/test_flash_attn.py::test_flash_attn_mla_absorbed_varlen` on B200 — **1920 passed / 640 skipped / 0 failed** (~50 min)

## Scope notes

A few more axes were tried earlier (`tiny seqlens (1,1) / (1,3) / (2,1)`, `zero_lengths_q/k=True`, `add_unused_qkv=True`), but those appear to hit a separate MLA varlen issue: FA4 returns zeros where the reference has real values (`Output max diff ~5.25` vs. `Pytorch max diff ~0.03`).

The cases that seem to trigger it are:

- `add_unused_qkv=True` with short K (`seqlen_k=1`) or with `kv_sparsity=True`
- `zero_lengths_k=True` across most `unpad_*` / `varlen_mode` combinations

That looks separate from this test expansion, so it is left out of this PR and can be followed up separately.