### PR TITLE
[Cute,hd256] Post-merge cleanup: dead code, duplicate imports

### DIFF
--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -45,12 +45,9 @@ from flash_attn.cute.flash_bwd_postprocess import FlashAttentionBackwardPostproc
 from flash_attn.cute.flash_fwd_combine import FlashAttentionForwardCombine
 from flash_attn.cute.flash_fwd_mla_sm100 import FlashAttentionMLAForwardSm100
 
-from cutlass import Int32
-
 # SM100 head_dim=256 2CTA kernel imports
 from flash_attn.cute.sm100_hd256_2cta_fmha_forward import BlackwellFusedMultiHeadAttentionForward
 from flash_attn.cute.sm100_hd256_2cta_fmha_backward import BlackwellFusedMultiHeadAttentionBackward
-from flash_attn.cute.mask import Sm100MaskEnum as MaskEnum
 
 from flash_attn.cute.block_sparsity import (
     BlockSparseTensorsTorch,

--- a/flash_attn/cute/mask.py
+++ b/flash_attn/cute/mask.py
@@ -1376,8 +1376,6 @@ class Sm100FusedMask:
         :param window_size_right: Right-side sliding window size for attention masking.
         :type window_size_right: Optional[int]
         """
-
-        tidx, tidy, tidx = cute.arch.thread_idx()
         offset = 0
         # NOTE: causal masking in this repo aligns the *end* of Q with the *end* of K
         # when seqlen_k != seqlen_q (same as the test/reference implementation):
@@ -1439,7 +1437,6 @@ class Sm100FusedMask:
         - If apply_semantic_window=True, apply causal/local window constraints.
         - Always apply residual OOB masking (index_k>=seqlen_k or index_q>=seqlen_q).
         """
-        tidx, tidy, tidx = cute.arch.thread_idx()
         offset = 0
         if cutlass.const_expr(apply_semantic_window):
             # Match WINDOW_MASK_INFERENCE semantics: end-align Q/K when lengths differ.

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -144,7 +144,7 @@ def test_flash_attn_output(
         pytest.xfail("has_qv: local not supported yet")
     if has_qv and has_learnable_sink:
         pytest.xfail("has_qv: learnable sink not supported yet")
-    # TODO(wangsiyu): SM100/SM110 head_dim=256 2CTA kernel currently does not support the following features.
+    # TODO(wangsiyu): SM100 head_dim=256 2CTA kernel currently does not support the following features.
     # Remove these skips when support is added.
     if d == 256 and IS_SM100:
         if has_learnable_sink:
@@ -540,7 +540,7 @@ def test_flash_attn_varlen_output(
     local = local_enum > 0
     if local and causal:
         pytest.skip()
-    # TODO(wangsiyu): SM100/SM110 head_dim=256 2CTA kernel currently does not support the following features.
+    # TODO(wangsiyu): SM100 head_dim=256 2CTA kernel currently does not support the following features.
     # Remove these skips when support is added.
     if d == 256 and IS_SM100:
         if has_learnable_sink:


### PR DESCRIPTION
## Follow-up Cleanup for hd256 Feature (#2412)

Follow-up polish for the newly merged hd256 feature (#2412), based on Copilot review comments. No kernel code was changed and there is no behavior change.

### Changes

- **`flash_attn/cute/interface.py`**
  - Removed duplicate `Int32` import
  - Removed unused `MaskEnum` import

- **`flash_attn/cute/mask.py`**
  - Removed two dead `thread_idx()` lines in:
    - `Sm100FusedMask.apply_mask`
    - `apply_mask_via_causal_local`
  - These were leftover debug scaffolding and were never used

- **`tests/cute/test_flash_attn.py`**
  - Removed stray `/SM110` from two TODO comments
  - The hd256 2CTA path is SM100-only, so SM110 was not applicable

### Intentionally Unchanged

Two Copilot flags were reviewed and left unchanged because they are false positives:

- **`warp_reduction` in `utils.py`**
  - Current logic is correct for all existing callers

- **CLC scheduler in `tile_scheduler.py`**
  - The apparent axis mismatch is intentional; the scheduler is axis-agnostic by design

### Validation

- `pre-commit run` passed cleanly on all three files
- Smoke test:
  - `78 passed, 78 skipped, 0 failed`
- Regression benchmark vs `origin/main`:
  - **45/48 cells within ±2%**
  - The remaining 3 outliers (`+3.4%`, `-2.4%`, `+3.6%`) fall in an already noisy region
  - No systematic drift observed
  - Aggregated mean delta per category stayed within **±0.3%**
`
