### PR TITLE
cute: don't widen intentionally-empty offset windows to full attention

### DIFF
--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -268,11 +268,12 @@ def _resolve_causal_local_window(causal, window_size_left, window_size_right, ma
     """
     if mask_mod is not None:
         return False, False, window_size_left, window_size_right
-    if causal:
-        window_size_right = 0
-    if window_size_left is not None and window_size_right is not None and window_size_left + window_size_right < 0:
+    if (window_size_left is not None and window_size_right is not None
+            and window_size_left < 0 and window_size_right < 0):
         window_size_left = None
         window_size_right = None
+    if causal:
+        window_size_right = 0
     if window_size_left is not None or window_size_right is not None:
         if window_size_left is None and window_size_right == 0:
             causal, local = True, False


### PR DESCRIPTION
Claude code wrote this PR, but I ran into this bug / identified the fix first.

The _resolve_causal_local_window helper previously treated any (window_size_left, window_size_right) pair whose sum was negative as equivalent to "no window", setting both to None. The intent (per PR #2251) was to normalize the FA2 legacy "(-1, -1) = no window" sentinel into the cute API's None/None.

The sum-based check is too loose: it also catches valid intentionally-empty offset windows. A query at position i with window_size=(7, -8) selects keys at positions [i - 7, i - 8], which is empty by design. Callers that pass such windows expect the kernel to respect them (row_max = -inf, LSE = -inf, zero output). Instead, the sum test fires (7 + (-8) = -1 < 0), both window args are cleared to None, and the kernel ends up attending to every key, producing a finite LSE and nonzero output for what should be an empty row.

Replace the sum-based test with "both sides negative", which matches the original intent -- FA2 users pass negative sentinels on both sides, not one positive and one negative -- and preserves all mixed-sign offset window configurations. Move the normalization before the `if causal: right = 0` rewrite so legacy `(-1, -1)` combined with causal=True still normalizes correctly (the old ordering zeroed right before the check could observe both original signs).

The online-softmax path already emits LSE = -inf and zero output when row_sum == 0, so intentionally-empty windows flow through the kernel correctly on their own once the interface stops rewriting them.