### PR TITLE
Add safety margin and hard cap to MAX_JOBS auto-calculation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -623,12 +623,17 @@ class NinjaBuildExtension(BuildExtension):
 
             # calculate the maximum allowed NUM_JOBS based on free memory
             free_memory_gb = psutil.virtual_memory().available / (1024 ** 3)  # free memory in GB
+            # Reserve memory for OS, kernel, and other processes:
+            # at least 16 GB or 15% of free memory, whichever is larger.
+            reserved_memory_gb = max(16, free_memory_gb * 0.15)
+            usable_memory_gb = max(0, free_memory_gb - reserved_memory_gb)
             # Assume worst-case peak observed memory usage of ~5GB per NVCC thread.
-            # Limit: peak_threads = max_jobs * nvcc_threads and peak_threads * 5GB <= free_memory.
-            max_num_jobs_memory = max(1, int(free_memory_gb / (5 * nvcc_threads)))
+            # Limit: peak_threads = max_jobs * nvcc_threads and peak_threads * 5GB <= usable_memory.
+            max_num_jobs_memory = max(1, int(usable_memory_gb / (5 * nvcc_threads)))
 
             # pick lower value of jobs based on cores vs memory metric to minimize oom and swap usage during compilation
-            max_jobs = max(1, min(max_num_jobs_cores, max_num_jobs_memory))
+            # Cap at 32 to avoid diminishing returns from extreme parallelism on high-memory machines.
+            max_jobs = max(1, min(max_num_jobs_cores, max_num_jobs_memory, 32))
             print(
                 f"Auto set MAX_JOBS to `{max_jobs}`, NVCC_THREADS to `{nvcc_threads}`. "
                 "If you see memory pressure, please use a lower `MAX_JOBS=N` or `NVCC_THREADS=N` value."


### PR DESCRIPTION
## Summary

- Add memory reservation (max of 16 GB or 15% of free memory) before computing `MAX_JOBS`, so the build doesn't try to use 100% of available RAM
- Cap `MAX_JOBS` at 32 to prevent extreme parallelism on high-memory machines where diminishing returns increase OOM risk

## Problem

The current `NinjaBuildExtension` formula (`free_memory / (5 * nvcc_threads)`) uses nearly all available memory with zero safety margin. On a high-memory machine (880 GB RAM, 96 CPUs, CUDA 13.0), this results in `MAX_JOBS=42` and 168 concurrent nvcc threads consuming ~840 GB — leaving only ~10 GB (1.2%) headroom. Any memory spike from heavy template files, OS overhead, or other processes causes OOM and system crash (observed as hard reboot with no clean shutdown).

The issue is amplified on CUDA 13.x where the default `FLASH_ATTN_CUDA_ARCHS="80;90;100;110;120"` produces 6 gencode targets, increasing per-process memory usage beyond the 5 GB/thread estimate from PR #2079.

## Impact on build speed

| Machine RAM | Before | After | Slowdown |
|---|---|---|---|
| 32 GB | MAX_JOBS=1 | MAX_JOBS=1 | none |
| 64 GB | MAX_JOBS=3 | MAX_JOBS=2 | ~33% |
| 256 GB | MAX_JOBS=12 | MAX_JOBS=10 | ~17% |
| 512 GB | MAX_JOBS=25 | MAX_JOBS=21 | ~16% |
| 880 GB | MAX_JOBS=42 | MAX_JOBS=31 | ~26% |

Users who want maximum parallelism can still override with `MAX_JOBS=N`.

Fixes #2493