### PR TITLE
[FA4][hd256] Add PDL sync to avoid race between bwd_preprocess and dq_kernel backward

### DIFF
--- a/flash_attn/cute/sm100_hd256_2cta_fmha_backward_dqkernel.py
+++ b/flash_attn/cute/sm100_hd256_2cta_fmha_backward_dqkernel.py
@@ -511,6 +511,7 @@ class BlackwellFusedMultiHeadAttentionBackwardDQKernel:
             cluster=self.cluster_shape_mnk,
             stream=stream,
             min_blocks_per_mp=1,
+            use_pdl=True,
         )
 
     #  GPU device kernel
@@ -844,6 +845,10 @@ class BlackwellFusedMultiHeadAttentionBackwardDQKernel:
         # ///////////////////////////////////////////////////////////////////////////////
         if warp_idx == self.load_warp_id:
             cute.arch.warpgroup_reg_dealloc(self.num_regs_other)
+            # dq_kernel is launched with use_pdl=True so its prologue can overlap the
+            # bwd_preprocess epilogue.  Wait here before touching any preprocess outputs
+            # (lse, sum_OdO) to prevent the same race fixed in PR #2481 for sm90 bwd.
+            cute.arch.griddepcontrol_wait()
 
             while work_tile.is_valid_tile:
                 curr_block_coord = work_tile.tile_idx


### PR DESCRIPTION
## Summary
- Mirrors #2481 (sm90 bwd fix) for sm100 hd256 backward.
- Enables `use_pdl=True` on `dq_kernel` and adds `griddepcontrol_wait()` in the load warp before the first reads of `lse_log2` / `sum_OdO`.
- Without the wait, with PDL enabled, dq's load warp could read partially- written preprocess outputs, corrupting `dpsum` → `dS = P·(dP − dpsum)` → wrong `dQ` (and dK/dV through shared dependencies).

## Verification (PTX, `CUTE_DSL_KEEP_PTX=1`, sm_100a)
- `dq_kernel` emits `griddepcontrol.wait` once, gated to `load_warp_id` (predicate `setp.ne.s32 %p, %r, 9`), placed after `setmaxnreg.dec` and before the tile loop — i.e., before any GMEM read of preprocess outputs.
- `bwd_preprocess` already emits `griddepcontrol.launch_dependents` after the vectorized O/dO global loads (`flash_bwd_preprocess.py:316`, unchanged by this PR).
- `dkdv_kernel` is unchanged here (does not use PDL on this path).

## Performance
Measured on B200 (clock-locked 1755 MHz), `--headdim 256 --bwd --backend fa4 --warmup 5 --rep 50`, comparing `main` vs this PR. Seqlens 4K–131K,=causal {true, false}, MHA (nheads=32, kv=32) and GQA (nheads=32, kv=2).

Long seqlens (≥65K, fully compute-bound) — all configurations within ±1% of `main`, except a single MHA-causal-65K outlier at +5.1% which is paired with an opposite-direction outlier at MHA-causal-32K (−5.8%); both are measurement noise on this branch (run-to-run variance ±20 TFLOPS at this size; long seqlens median Δ ≈ ±0.5%).

Mid seqlens (4K–32K), where PDL overlap is most visible:

| config       | median ΔTF | best  | worst              |
|--------------|-----------:|------:|-------------------:|
| MHA non-causal | +1.1%   | +4.1% | −1.2%              |
| MHA causal     | +0.3%   | +0.3% | −5.8% (32K, noise) |
| GQA non-causal | +1.9%   | +3.3% | −0.2%              |
| GQA causal     | +1.0%   | +3.5% | −2.2%              |

Net: small positive on GQA (consistent with free overlap from PDL), neutral on MHA modulo measurement noise at one mid-seqlen point. No reproducible regression at scale.

## Test plan
- [x] `pytest tests/cute/test_flash_attn.py -k "headdim_256 and not fwd"`
- [x] hd=256 bwd benchmark before/after on B200, one mid-seqlen