### PR TITLE
[SM100] Guard gO None in empty-tile correction

### DIFF
--- a/flash_attn/cute/block_sparse_utils.py
+++ b/flash_attn/cute/block_sparse_utils.py
@@ -729,6 +729,8 @@ def handle_block_sparse_empty_tile_correction_sm100(
 
         if const_expr(gmem_tiled_copy_O is None):
             pipeline_o_epi.producer_acquire_w_index_phase(stage, corr_epi_producer_phase)
+
+        gO_stage = gO[None, None, stage] if const_expr(gO is not None) else None
         correction_epilogue(
             thr_mma_pv,
             tOtO[None, None, None, stage],
@@ -739,7 +741,7 @@ def handle_block_sparse_empty_tile_correction_sm100(
             Float32(0.0),  # zero scale ensures empty tile writes zeros into staged outputs
             sO[None, None, stage],
             mO_cur,
-            gO[None, None, stage],
+            gO_stage,
             gmem_tiled_copy_O,
         )
         if const_expr(gmem_tiled_copy_O is None):


### PR DESCRIPTION
# [SM100][BlockSparse] Guard `gO` indexing with `None` check in empty-tile correction

## Symptom

`cute.compile` raises a Python `TypeError` at trace time, the kernel never launches. Triggers when **all** of the following hold:

1. SM100 (GB200).
2. FlexAttention with a BlockMask (i.e. `use_block_sparsity=True`).
3. GQA with `m_block_size % qhead_per_kvhead != 0` (default `m_block_size=128`, so any `qhead_per_kvhead ∈ {3, 5, 6, 7, ...}`).

```
  File ".../flash_attn/cute/block_sparse_utils.py", line 743, in handle_block_sparse_empty_tile_correction_sm100
    gO[None, None, stage],
    ~~^^^^^^^^^^^^^^^^^^^
TypeError: 'NoneType' object is not subscriptable
```

## Root cause

In `flash_fwd_sm100.py:445-451`, `use_tma_O = False` whenever `pack_gqa=True and m_block_size % qhead_per_kvhead != 0`, which leaves `gO` unassigned (`None`).
When CuteDSL later traces `handle_block_sparse_empty_tile_correction_sm100`, the line `gO[None, None, stage]` is evaluated as plain Python and hits `None.__getitem__` → `TypeError`.

## Fix

Mirror the existing guard from the has-work path (`flash_fwd_sm100.py:2504`):

```diff
--- a/flash_attn/cute/block_sparse_utils.py
+++ b/flash_attn/cute/block_sparse_utils.py
@@
-        gO_stage = gO[None, None, stage]
+        gO_stage = gO[None, None, stage] if const_expr(gO is not None) else None
```

`correction_epilogue` already accepts `gO_stage=None`, so there is no IR-level behavior change.

## Repro

`bug_reproduce.py` — single file, FlexAttention + FA4 backend, GQA chosen so that `128 % qhead_per_kvhead != 0`:

```python
import math
from functools import partial
import torch
from torch.nn.attention.flex_attention import create_block_mask, flex_attention

assert torch.cuda.get_device_capability(0) == (10, 0), "sm_100 only."
device, dtype = torch.device("cuda:0"), torch.bfloat16
B, Hq, Hkv, S, D = 1, 12, 2, 512, 128

torch.manual_seed(0)
q = torch.randn(B, Hq,  S, D, device=device, dtype=dtype)
k = torch.randn(B, Hkv, S, D, device=device, dtype=dtype)
v = torch.randn(B, Hkv, S, D, device=device, dtype=dtype)
scale = 1.0 / math.sqrt(D)

def causal(b, h, q_idx, kv_idx):
    return q_idx >= kv_idx

block_mask = create_block_mask(
    causal, B=None, H=None, Q_LEN=S, KV_LEN=S,
    BLOCK_SIZE=(256, 128), device=device, _compile=True,
)

def reference():
    k_rep = k.repeat_interleave(Hq // Hkv, dim=1)
    v_rep = v.repeat_interleave(Hq // Hkv, dim=1)
    scores = torch.einsum("bhqd,bhkd->bhqk", q.float(), k_rep.float()) * scale
    mask = torch.tril(torch.ones(S, S, device=device, dtype=torch.bool))
    scores = scores.masked_fill(~mask, float("-inf"))
    return torch.einsum("bhqk,bhkd->bhqd", scores.softmax(-1), v_rep.float()).to(dtype)

flex = torch.compile(partial(flex_attention, kernel_options={"BACKEND": "FLASH"}), dynamic=None)
out = flex(q, k, v, block_mask=block_mask, enable_gqa=True, scale=scale)
torch.cuda.synchronize()
diff = (out.float() - reference().float()).abs()
print(f"max abs err : {diff.max().item():.3e}")
print(f"mean abs err: {diff.mean().item():.3e}")
```

**Without the patch** (trace-time crash, no kernel launched):
```
TypeError: 'NoneType' object is not subscriptable  (block_sparse_utils.py:733)
```

**With the patch** (compared against fp32 brute-force SDPA):
```
out shape   : (1, 12, 512, 128)
max abs err : 7.812e-03
mean abs err: 1.436e-04
```