### PR TITLE
Fix: pass `stream` to SM100 MLA kernel

### DIFF
--- a/flash_attn/cute/flash_fwd_mla_sm100.py
+++ b/flash_attn/cute/flash_fwd_mla_sm100.py
@@ -718,6 +718,7 @@ class FlashAttentionMLAForwardSm100:
             ),
             cluster=self.cluster_shape_mnk,
             smem=SharedStorage.size_in_bytes(),
+            stream=stream,
         )
 
     @cute.kernel


### PR DESCRIPTION
`FlashAttentionMLAForwardSm100.__call__()` does not pass `stream` through to `self.kernel().launch()`, so the operation is carried out on the default CUDA stream, leading to potential races with PyTorch ops. Simple 1-line fix.