### PR TITLE
[CuTe, Bwd] Fix backward compile key churn due to pickling, max_seqlen is a tensor

### DIFF
--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -1320,7 +1320,7 @@ def _flash_attn_bwd(
     else:
         batch_size = cu_seqlens_q.shape[0] - 1
         total_q = q.shape[0]
-        seqlen_q = max_seqlen_q if max_seqlen_q is not None else total_q
+        seqlen_q = int(max_seqlen_q) if max_seqlen_q is not None else total_q
 
     if cu_seqlens_k is None:
         batch_size, seqlen_k = k.shape[:2]
@@ -1328,7 +1328,7 @@ def _flash_attn_bwd(
     else:
         batch_size = cu_seqlens_k.shape[0] - 1
         total_k = k.shape[0]
-        seqlen_k = max_seqlen_k if max_seqlen_k is not None else total_k
+        seqlen_k = int(max_seqlen_k) if max_seqlen_k is not None else total_k
 
     num_head_kv = k.shape[-2]
 

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -1320,7 +1320,7 @@ def _flash_attn_bwd(
     else:
         batch_size = cu_seqlens_q.shape[0] - 1
         total_q = q.shape[0]
-        seqlen_q = int(max_seqlen_q) if max_seqlen_q is not None else total_q
+        seqlen_q = max_seqlen_q if max_seqlen_q is not None else total_q
 
     if cu_seqlens_k is None:
         batch_size, seqlen_k = k.shape[:2]
@@ -1328,7 +1328,7 @@ def _flash_attn_bwd(
     else:
         batch_size = cu_seqlens_k.shape[0] - 1
         total_k = k.shape[0]
-        seqlen_k = int(max_seqlen_k) if max_seqlen_k is not None else total_k
+        seqlen_k = max_seqlen_k if max_seqlen_k is not None else total_k
 
     num_head_kv = k.shape[-2]
 
@@ -1339,6 +1339,16 @@ def _flash_attn_bwd(
     num_n_blocks = seqlen_k_rounded // n_block_size
     if cluster_size == 2 and num_n_blocks % cluster_size != 0:
         seqlen_k_rounded = seqlen_k_rounded + n_block_size
+
+    # The single-block specialization below only guards against TVM stride poisoning,
+    # which is a host-side branch predicate that selects a kernel variant. When
+    # max_seqlen is passed as a tensor (e.g. HF/TE varlen), seqlen_*_rounded are tensors,
+    # so `seqlen_*_rounded // block == 1` would leak a tensor into the compile key. Its
+    # pickle hash differs every call, forcing a recompile per step. Only specialize when
+    # the seqlen is already a host scalar; tensor callers fall back to the multi-block
+    # default, keeping the key stable with no device sync.
+    single_q_block = (not torch.is_tensor(seqlen_q_rounded)) and (seqlen_q_rounded // m_block_size == 1)
+    single_k_block = (not torch.is_tensor(seqlen_k_rounded)) and (seqlen_k_rounded // n_block_size == 1)
 
     if cu_seqlens_k is None:
         assert k.shape == (batch_size, seqlen_k, num_head_kv, head_dim)
@@ -1590,8 +1600,8 @@ def _flash_attn_bwd(
             get_broadcast_dims(v),
             get_broadcast_dims(dout),
             # Prevent TVM stride poisoning when only one block is present.
-            (seqlen_q_rounded // m_block_size == 1),
-            (seqlen_k_rounded // n_block_size == 1),
+            single_q_block,
+            single_k_block,
         )
     else:
         compile_key = (
@@ -1625,8 +1635,8 @@ def _flash_attn_bwd(
             get_broadcast_dims(v),
             get_broadcast_dims(dout),
             # Prevent TVM stride poisoning when only one block is present.
-            (seqlen_q_rounded // m_block_size == 1),
-            (seqlen_k_rounded // n_block_size == 1),
+            single_q_block,
+            single_k_block,
         )
 
     if compile_key not in _flash_attn_bwd.compile_cache:


### PR DESCRIPTION
## Problem

When `max_seqlen_q` / `max_seqlen_k` are passed as `torch.Tensor` (which HuggingFace Transformers does via `_prepare_from_posids` in the varlen path), the backward compile key in `_flash_attn_bwd` contains `torch.Tensor` values instead of Python scalars.

Specifically, `seqlen_q` and `seqlen_k` remain tensors, so `seqlen_q_rounded // m_block_size == 1` evaluates to `torch.Tensor(False)` rather than `bool`. Since `pickle.dumps(torch.Tensor)` produces a unique hash per tensor object, every backward call generates a new compile key even though the actual kernel parameters are identical. This means that each call will not reuse any previous JIT compiled kernel and instead recompile each time, producing thousands of identical .o files in the JIT cache (if enabled, or recomputes in memory each time), and also takes ~8-13s, massively slowing down training.

### Root Cause

In `_flash_attn_bwd` (line 1323):
```python
seqlen_q = max_seqlen_q if max_seqlen_q is not None else total_q
```

When `max_seqlen_q` is a `torch.Tensor`, all downstream arithmetic produces tensors that leak into the compile key tuple elements `[29]` and `[30]`.

## Fix

Just need to cast `max_seqlen_q` / `max_seqlen_k` to `int()` before they enter the sequence length computation:

```python
seqlen_q = int(max_seqlen_q) if max_seqlen_q is not None else total_q
seqlen_k = int(max_seqlen_k) if max_seqlen_k is not None else total_k
```

## Verification

Tested on NVIDIA B200 (SM 10.0) with `flash-attn-4==4.0.0b10` and `transformers==5.6.2`:

**Before fix** — 10 steps with varying packed seq lengths via HF `_flash_attention_forward`:
```
step 0: bwd_keys=1  disk=1
step 1: bwd_keys=2  disk=2
...
step 9: bwd_keys=10 disk=10   # new kernel every step...
```

**After fix**:
```
step 0: bwd_keys=1  disk=4  [JIT]
step 1: bwd_keys=1  disk=4  [cached]
...
step 9: bwd_keys=1  disk=4  [cached]   # 1 kernel for all steps
```

### Reproduction

```python
from flash_attn.cute import flash_attn_varlen_func
import torch

for max_sl in [512, 768, 1024]:
    cu = torch.tensor([0, max_sl], dtype=torch.int32, device="cuda")
    max_t = torch.tensor(max_sl, dtype=torch.int32, device="cuda")  # tensor, not int
    q = torch.randn(max_sl, 8, 128, dtype=torch.bfloat16, device="cuda", requires_grad=True)
    k = torch.randn(max_sl, 8, 128, dtype=torch.bfloat16, device="cuda", requires_grad=True)
    v = torch.randn(max_sl, 8, 128, dtype=torch.bfloat16, device="cuda", requires_grad=True)
    out = flash_attn_varlen_func(q, k, v, cu_seqlens_q=cu, cu_seqlens_k=cu,
                                  max_seqlen_q=max_t, max_seqlen_k=max_t, causal=True)
    out[0].sum().backward()
    # Without fix: 3 unique compile keys. With fix: 1.
```