### PR TITLE
ci: use /tmp for apptainer tmpdir to fix xattrerror on VAST

### DIFF
--- a/.github/actions/gpu-test/action.yml
+++ b/.github/actions/gpu-test/action.yml
@@ -45,10 +45,10 @@ runs:
         PULL_REF=$(echo "$FA4_IMAGE" | sed 's/:[^@]*@/@/')
         echo "PULL_REF=$PULL_REF"
         echo "SIF=$SIF"
-        mkdir -p "$CI_WORK_DIR/apptainer_tmp" "$CI_WORK_DIR/apptainer_cache"
+        mkdir -p "$CI_WORK_DIR/apptainer_cache" /tmp/apptainer_tmp
         if [ ! -f "$SIF" ]; then
           echo "Pulling $PULL_REF → $SIF"
-          APPTAINER_TMPDIR="$CI_WORK_DIR/apptainer_tmp" \
+          APPTAINER_TMPDIR="/tmp/apptainer_tmp" \
           APPTAINER_CACHEDIR="$CI_WORK_DIR/apptainer_cache" \
           apptainer pull "$SIF" "docker://$PULL_REF"
         else


### PR DESCRIPTION
  ## Summary                                                                                                
                                                                                                            
  - VAST filesystem (`/scratch`) does not support xattr, which Apptainer                                    
    requires when extracting container layers into its tmpdir                                               
  - Move `APPTAINER_TMPDIR` from `$CI_WORK_DIR/apptainer_tmp` to                                            
    `/tmp/apptainer_tmp` (local fs, xattr supported)                                                        
  - `CI_WORK_DIR` is retained for SIF caching and `apptainer_cache`                                         
    where persistence matters                                                                               
                                                                                                            
  ## Test plan                                                                                              
                                                                                                            
  - [x] Verify apptainer pull succeeds on VAST runner without xattr error                                   
  - [x] Verify SIF cache still works across runs (stored under `$CI_WORK_DIR`) 