### PR TITLE
Fix long MSVC linker commands on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ import re
 import ast
 import glob
 import shutil
+import tempfile
 from pathlib import Path
 from typing import Literal, Optional
 from packaging.version import parse, Version
@@ -636,6 +637,35 @@ class NinjaBuildExtension(BuildExtension):
             os.environ["MAX_JOBS"] = str(max_jobs)
 
         super().__init__(*args, **kwargs)
+
+    def build_extensions(self) -> None:
+        original_spawn = None
+        if sys.platform == "win32" and self.compiler.compiler_type == "msvc":
+            original_spawn = self.compiler.spawn
+
+            def spawn(cmd):
+                if not cmd or Path(str(cmd[0])).name.lower() != "link.exe":
+                    return original_spawn(cmd)
+                cmd = [str(arg) for arg in cmd]
+                if len(subprocess.list2cmdline(cmd)) <= 32767:
+                    return original_spawn(cmd)
+                # Temporary workaround adapted from https://github.com/pypa/distutils/pull/406
+                # until setuptools/distutils ships response-file handling for long MSVC links.
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    rsp_path = Path(tmpdir) / "cmdline.txt"
+                    rsp_path.write_text(
+                        "\n".join(subprocess.list2cmdline([arg]) for arg in cmd[1:]) + "\n",
+                        encoding="ascii",
+                    )
+                    return original_spawn([cmd[0], f"@{rsp_path}"])
+
+            self.compiler.spawn = spawn
+
+        try:
+            super().build_extensions()
+        finally:
+            if original_spawn is not None:
+                self.compiler.spawn = original_spawn
 
 
 # Build install_requires based on platform


### PR DESCRIPTION
Similar fix as https://github.com/pypa/distutils/pull/406

Bringing this fix here as new distutils updates may take time to percolate across the community. This PR will immediately unblock users who would like to build flash-attention on RDNA3/4 on windows (https://github.com/Dao-AILab/flash-attention/pull/2054)