### PR TITLE
Fix varlen backward preprocess predicate slicing

### DIFF
--- a/flash_attn/cute/flash_bwd_preprocess.py
+++ b/flash_attn/cute/flash_bwd_preprocess.py
@@ -13,7 +13,6 @@
 # So the main backward kernel is unchanged; we just replace D with D' = D - dLSE here.
 import math
 import operator
-from functools import partial
 from typing import Callable, Type, Optional
 
 import cuda.bindings.driver as cuda
@@ -365,9 +364,6 @@ class FlashAttentionBackwardPreprocess:
             tOpO = None
             if const_expr(self.check_hdim_v_oob):
                 tOpO = copy_utils.predicate_k(tOcO, limit=headdim_v)
-            # Each copy will use the same predicate
-            copy = partial(copy_utils.copy, pred=tOpO)
-
             tOrO = cute.make_rmem_tensor_like(tOgO)
             tOrdO = cute.make_rmem_tensor_like(tOgdO)
             if const_expr(self.check_hdim_v_oob):
@@ -378,8 +374,9 @@ class FlashAttentionBackwardPreprocess:
                 # Instead of using tOcO, we using t0OcO and subtract the offset from the limit.
                 # This is bc the entries of t0OcO are known at compile time.
                 if t0OcO[0, m, 0][0] < seqlen_limit - tOcO[0][0]:
-                    copy(tOgO[None, m, None], tOrO[None, m, None])
-                    copy(tOgdO[None, m, None], tOrdO[None, m, None])
+                    copy_pred = tOpO[None, m, None] if const_expr(self.check_hdim_v_oob) else None
+                    copy_utils.copy(tOgO[None, m, None], tOrO[None, m, None], pred=copy_pred)
+                    copy_utils.copy(tOgdO[None, m, None], tOrdO[None, m, None], pred=copy_pred)
             # O and dO loads are done; signal that the next kernel can start.
             # Correctness is ensured by griddepcontrol_wait() in bwd_sm90 before it reads our outputs.
             if const_expr(self.use_pdl):

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -1668,6 +1668,83 @@ def test_flash_attn_bwd_preallocated_outputs(seqlen_q, seqlen_k, d, causal, dtyp
     assert torch.allclose(dv, dv_ref, atol=1e-5, rtol=1e-5)
 
 
+@pytest.mark.parametrize("head_dim,head_dim_v", [(104, 104), (128, 104)])
+def test_flash_attn_bwd_preprocess_varlen_head_dim_v_not_multiple_of_32(
+    head_dim, head_dim_v
+):
+    import cutlass
+
+    from flash_attn.cute.interface import _bwd_preprocess
+
+    device = "cuda"
+    dtype = torch.bfloat16
+    torch.random.manual_seed(42)
+    seqlens = [128, 128]
+    total_seqlen = sum(seqlens)
+    nheads = 4
+    m_block_size = 128
+    cu_seqlens = torch.tensor(
+        [0, seqlens[0], total_seqlen], device=device, dtype=torch.int32
+    )
+    total_seqlen_padded = (
+        (total_seqlen + cu_seqlens.shape[0] * m_block_size - 1)
+        // m_block_size
+        * m_block_size
+    )
+    head_dim_rounded = (head_dim + 31) // 32 * 32
+
+    out = torch.randn(total_seqlen, nheads, head_dim_v, device=device, dtype=dtype)
+    dout = torch.randn_like(out)
+    dpsum = torch.full(
+        (nheads, total_seqlen_padded), torch.nan, device=device, dtype=torch.float32
+    )
+    lse = torch.randn(nheads, total_seqlen, device=device, dtype=torch.float32)
+    lse_log2 = torch.empty(nheads, total_seqlen_padded, device=device, dtype=torch.float32)
+    dq_accum = torch.full(
+        (nheads, total_seqlen_padded * head_dim_rounded),
+        torch.nan,
+        device=device,
+        dtype=torch.float32,
+    )
+
+    _bwd_preprocess(
+        out,
+        dout,
+        dpsum,
+        lse,
+        lse_log2,
+        dq_accum,
+        cu_seqlens_q=cu_seqlens,
+        seqused_q=None,
+        dlse=None,
+        dtype=cutlass.BFloat16,
+        head_dim=head_dim,
+        head_dim_v=head_dim_v,
+        m_block_size=m_block_size,
+    )
+    torch.cuda.synchronize()
+
+    padded_offsets = [
+        (sum(seqlens[:batch_idx]) + batch_idx * m_block_size)
+        // m_block_size
+        * m_block_size
+        for batch_idx in range(len(seqlens))
+    ]
+    valid_slices = [
+        slice(offset, offset + seqlen)
+        for offset, seqlen in zip(padded_offsets, seqlens)
+    ]
+    dpsum_actual = torch.cat([dpsum[:, valid_slice] for valid_slice in valid_slices], dim=1)
+    dpsum_ref = torch.einsum("thd,thd->ht", out.float(), dout.float())
+    torch.testing.assert_close(dpsum_actual, dpsum_ref, atol=1e-4, rtol=1e-4)
+
+    dq_accum_rows = dq_accum.view(nheads, total_seqlen_padded, head_dim_rounded)
+    dq_accum_actual = torch.cat(
+        [dq_accum_rows[:, valid_slice] for valid_slice in valid_slices], dim=1
+    )
+    assert torch.count_nonzero(dq_accum_actual) == 0
+
+
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 @pytest.mark.parametrize("causal", [False, True])
 @pytest.mark.parametrize("d", [64, 128])


### PR DESCRIPTION
## Summary
- slice the O/dO out-of-bounds predicate to match each per-row copy in backward preprocess
- add a focused regression test for varlen backward preprocess with `head_dim_v=104`
- verify the computed `dpsum` values and padded `dq_accum` initialization, not only successful compilation

## Details
For `head_dim_v` values that are padded to a multiple of 32, backward preprocess builds a predicate for the full O/dO copy tile. The loop copies `tOgO[None, m, None]` and `tOgdO[None, m, None]`, so passing the full predicate leaves the predicate shape wider than the sliced copy operand. Slicing the predicate by the same `m` coordinate makes the predicate shape match the copy shape.

Fixes #2492.

## Validation
Refreshed onto current `main` (`b54df16`) and validated on NVIDIA GB10 / SM121 with PyTorch 2.13.0+cu130 and nvidia-cutlass-dsl 4.6.0.dev0:

- `FLASH_ATTENTION_CUTE_DSL_CACHE_ENABLED=1 pytest -q -x tests/cute/test_flash_attn.py::test_flash_attn_bwd_preprocess_varlen_head_dim_v_not_multiple_of_32` — 2 passed
- exact public repro from #2492 (`head_dim=104`, 16 heads, two 3600-token varlen sequences) — forward and backward passed; q/k/v gradients were all finite
- `ruff check` and `ruff format --check` for `flash_bwd_preprocess.py`
- `python -m compileall -q flash_attn/cute/flash_bwd_preprocess.py tests/cute/test_flash_attn.py`
