### PR TITLE
[ROCm Windows] fix build failed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -673,7 +673,7 @@ if ROCM_BACKEND == "triton":
     # Note: torch is excluded because pip resolves it to CUDA PyTorch from PyPI, overwriting any pre-installed ROCm PyTorch. Users must have torch installed.
     install_requires = [
         "einops",
-        "triton==3.5.1" if sys.platform != "win32" else "triton-windows",
+        "triton==3.5.1" if sys.platform != "win32" else "triton-windows>=3.6.0",
     ]
 else:
     install_requires = [

--- a/setup.py
+++ b/setup.py
@@ -673,7 +673,7 @@ if ROCM_BACKEND == "triton":
     # Note: torch is excluded because pip resolves it to CUDA PyTorch from PyPI, overwriting any pre-installed ROCm PyTorch. Users must have torch installed.
     install_requires = [
         "einops",
-        "triton==3.5.1",
+        "triton==3.5.1" if sys.platform != "win32" else "triton-windows",
     ]
 else:
     install_requires = [


### PR DESCRIPTION
I encountered some issues while trying to build fa2 on ROCm Windows:

<del>

### CK backend:

#### In the link phase, the cmd length will exceed the maximum length 32,767: https://github.com/pypa/distutils/pull/406

Fix: write each obj line by line to the rsp file.

#### Building uses the `hipcc.exe` in the ROCm SDK and its llvm `clang.exe`, but no linker is specified, and it defaults to MSVC `link.exe`, which caused some issues (even with MSVC environment activated).

Fix: change to llvm's `lld-link.exe`.

####

After these two changes:

```
[...]
DEBUG [2669/2669] H:\ROCm\.venv\Lib\site-packages\_rocm_sdk_devel\bin\hipcc.exe  -std=c++20 -Xcompiler -D__HIP_PLATFORM_AMD__=1 -Xcompiler -DUSE_ROCM=1 -Xcompiler -DHIPBLAS_V2 -Xcompiler -fms-runtime-lib=dll -IH:\ROCm\flash-attention\csrc\composable_kernel\include -IH:\ROCm\flash-attention\csrc\composable_kernel\library\include -IH:\ROCm\flash-attention\csrc\composable_kernel\example\ck_tile\01_fmha -IH:\ROCm\.venv\Lib\site-packages\torch\include -IH:\ROCm\.venv\Lib\site-packages\torch\include\torch\csrc\api\include -IH:\ROCm\.venv\Lib\site-packages\torch\include\THH -IH:\ROCm\.venv\Lib\site-packages\_rocm_sdk_devel\include -IH:\ROCm\.venv\include -IC:\Users\Administrator\AppData\Roaming\uv\python\cpython-3.13-windows-x86_64-none\include -IC:\Users\Administrator\AppData\Roaming\uv\python\cpython-3.13-windows-x86_64-none\Include -c H:\ROCm\flash-attention\csrc\flash_attn_ck\mha_varlen_fwd.hip -o H:\ROCm\flash-attention\build\temp.win-amd64-cpython-313\Release\csrc\flash_attn_ck\mha_varlen_fwd.obj -DCUDA_HAS_FP16=1 -D__HIP_NO_HALF_OPERATORS__=1 -D__HIP_NO_HALF_CONVERSIONS__=1 -DHIP_ENABLE_WARP_SYNC_BUILTINS=1 -fms-extensions -Wno-ignored-attributes -D__HIP_PLATFORM_AMD__=1 -DUSE_ROCM=1 -DHIPBLAS_V2 -fms-runtime-lib=dll --offload-arch=gfx1201 -O3 -std=c++20 -Wno-unknown-warning-option -Wno-unused-command-line-argument -Wno-shift-count-overflow -Wno-deprecated-declarations -Wno-pass-failed -Wno-inconsistent-dllimport -Wno-cuda-compat -fbracket-depth=1024 -DCK_TILE_FMHA_FWD_FAST_EXP2=1 -fgpu-flush-denormals-to-zero -DCK_ENABLE_BF16 -DCK_ENABLE_BF8 -DCK_ENABLE_FP16 -DCK_ENABLE_FP32 -DCK_ENABLE_FP64 -DCK_ENABLE_FP8 -DCK_ENABLE_INT8 -DCK_USE_XDL -DUSE_PROF_API=1 -D__HIP_PLATFORM_HCC__=1 -D_CRT_SECURE_NO_WARNINGS -DCK_TILE_FLOAT_TO_BFLOAT16_DEFAULT=3 -mllvm --lsr-drop-solution=1 -fno-offload-uniform-block -mllvm -enable-post-misched=0 -mllvm -amdgpu-early-inline-all=true -mllvm -amdgpu-function-calls=false -DHIPIFY_V2 -DTORCH_API_INCLUDE_EXTENSION_H -DTORCH_EXTENSION_NAME=flash_attn_2_cuda -fno-gpu-rdc
DEBUG Link RSP: build\lib.win-amd64-cpython-313\flash_attn_2_cuda.cp313-win_amd64.pyd.rsp (2669 objects, cmd reduced from 592201 to 929 chars)
DEBUG H:\ROCm\.venv\Lib\site-packages\_rocm_sdk_devel\lib\llvm\bin\lld-link.exe @build\lib.win-amd64-cpython-313\flash_attn_2_cuda.cp313-win_amd64.pyd.rsp /nologo /INCREMENTAL:NO /LTCG /DLL /MANIFEST:EMBED,ID=2 /MANIFESTUAC:NO /LIBPATH:H:\ROCm\.venv\Lib\site-packages\torch\lib /LIBPATH:H:\ROCm\.venv\Lib\site-packages\_rocm_sdk_devel\lib /LIBPATH:H:\ROCm\.venv\Lib\site-packages\_rocm_sdk_devel\hip\lib /LIBPATH:H:\ROCm\.venv\libs /LIBPATH:C:\Users\Administrator\AppData\Roaming\uv\python\cpython-3.13-windows-x86_64-none\libs /LIBPATH:C:\Users\Administrator\AppData\Roaming\uv\python\cpython-3.13-windows-x86_64-none /LIBPATH:H:\ROCm\.venv\PCbuild\amd64 c10.lib torch.lib torch_cpu.lib torch_python.lib amdhip64.lib c10_hip.lib torch_hip.lib /OUT:build\lib.win-amd64-cpython-313\flash_attn_2_cuda.cp313-win_amd64.pyd /IMPLIB:H:\ROCm\flash-attention\build\temp.win-amd64-cpython-313\Release\build\flash_attn_2_cuda.cp313-win_amd64.lib
DEBUG installing to build\bdist.win-amd64\wheel
DEBUG running install
[...]
```

</del>

### Triton backend:

#### The default requirement is `triton==3.5.1`, but it is not provided by aiter yet on Windows.

Fix: use `triton-windows` instead.