### PR TITLE
[Cute] Fix O(N^2) per-CTA scan in SingleTileVarlenScheduler

### DIFF
--- a/benchmarks/benchmark_varlen_scheduler.py
+++ b/benchmarks/benchmark_varlen_scheduler.py
@@ -1,0 +1,189 @@
+"""Stress benchmark for the FA4 (CuTe-DSL) varlen tile scheduler.
+
+Targets the kernels in ``flash_attn/cute/`` (FA4) — specifically
+``SingleTileVarlenScheduler`` in ``flash_attn/cute/tile_scheduler.py`` — and is
+not applicable to the older FA2 (``csrc/``) or FA3 (``hopper/``) generations.
+
+The scheduler maps a flat CTA index to ``(block, head, batch)`` by scanning
+batches in groups of 31 (one warp) on the GPU, per CTA. Without precomputed
+metadata each CTA does an O(num_batches / 31) linear scan, giving
+O(num_batches^2) total scheduling work across the launched grid. The
+pathological regime is many short sequences, where per-tile scheduling cost
+swamps the actual attention compute.
+
+This script sweeps num_seqs with the per-seq length fixed to a small value
+(seq_len=34 by default, the regime where the scheduler dominates). True
+attention compute scales linearly in num_seqs at fixed seq_len, so any
+super-linear growth in the per-iter time comes from the scheduler.
+"""
+
+import argparse
+
+import torch
+
+from flash_attn.cute import flash_attn_func, flash_attn_varlen_func
+
+
+def make_fixed_len_data(num_seqs, seq_len, num_heads, head_dim, device, dtype):
+    total = num_seqs * seq_len
+    q = torch.randn(total, num_heads, head_dim, dtype=dtype, device=device) * 0.1
+    k = torch.randn(total, num_heads, head_dim, dtype=dtype, device=device) * 0.1
+    v = torch.randn(total, num_heads, head_dim, dtype=dtype, device=device) * 0.1
+    cu = torch.arange(0, total + 1, seq_len, dtype=torch.int32, device=device)
+    return q, k, v, cu
+
+
+def make_padded_view(q, k, v, num_seqs, seq_len):
+    """Reshape packed (total, H, D) tensors to dense (num_seqs, seq_len, H, D) — no copy."""
+    H, D = q.shape[1], q.shape[2]
+    return (
+        q.view(num_seqs, seq_len, H, D),
+        k.view(num_seqs, seq_len, H, D),
+        v.view(num_seqs, seq_len, H, D),
+    )
+
+
+def cuda_bench(fn, warmup=3, iters=20):
+    """Time a callable with CUDA events. Returns mean ms per call."""
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    starts = [torch.cuda.Event(enable_timing=True) for _ in range(iters)]
+    ends = [torch.cuda.Event(enable_timing=True) for _ in range(iters)]
+    for s, e in zip(starts, ends):
+        s.record()
+        fn()
+        e.record()
+    torch.cuda.synchronize()
+    times = [s.elapsed_time(e) for s, e in zip(starts, ends)]
+    return sum(times) / len(times)
+
+
+def bench_one(num_seqs, seq_len, num_heads, head_dim, dtype, device, with_bwd):
+    q, k, v, cu = make_fixed_len_data(num_seqs, seq_len, num_heads, head_dim, device, dtype)
+    qp, kp, vp = make_padded_view(q, k, v, num_seqs, seq_len)
+
+    def fwd_varlen():
+        out = flash_attn_varlen_func(
+            q, k, v,
+            cu_seqlens_q=cu, cu_seqlens_k=cu,
+            max_seqlen_q=seq_len, max_seqlen_k=seq_len,
+        )
+        if isinstance(out, tuple):
+            out = out[0]
+        return out
+
+    def fwd_dense():
+        out = flash_attn_func(qp, kp, vp)
+        if isinstance(out, tuple):
+            out = out[0]
+        return out
+
+    fwd_varlen_ms = cuda_bench(fwd_varlen)
+    fwd_dense_ms = cuda_bench(fwd_dense)
+
+    fb_varlen_ms = fb_dense_ms = float("nan")
+    if with_bwd:
+        def fb_varlen():
+            qg = q.detach().requires_grad_(True)
+            kg = k.detach().requires_grad_(True)
+            vg = v.detach().requires_grad_(True)
+            out = flash_attn_varlen_func(
+                qg, kg, vg,
+                cu_seqlens_q=cu, cu_seqlens_k=cu,
+                max_seqlen_q=seq_len, max_seqlen_k=seq_len,
+            )
+            if isinstance(out, tuple):
+                out = out[0]
+            out.sum().backward()
+
+        def fb_dense():
+            qg = qp.detach().requires_grad_(True)
+            kg = kp.detach().requires_grad_(True)
+            vg = vp.detach().requires_grad_(True)
+            out = flash_attn_func(qg, kg, vg)
+            if isinstance(out, tuple):
+                out = out[0]
+            out.sum().backward()
+
+        fb_varlen_ms = cuda_bench(fb_varlen, iters=10)
+        fb_dense_ms = cuda_bench(fb_dense, iters=10)
+
+    return fwd_varlen_ms, fwd_dense_ms, fb_varlen_ms, fb_dense_ms
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--seq-len", type=int, default=34,
+                   help="per-sequence length (small => scheduler dominates)")
+    p.add_argument("--num-heads", type=int, default=12)
+    p.add_argument("--head-dim", type=int, default=128)
+    p.add_argument("--dtype", choices=["bf16", "fp16"], default="bf16")
+    p.add_argument("--device", default="cuda:0")
+    p.add_argument("--no-bwd", action="store_true",
+                   help="skip the forward+backward sweep (faster)")
+    p.add_argument(
+        "--num-seqs",
+        type=int,
+        nargs="+",
+        default=[128, 256, 512, 1024, 2048, 4096, 8192],
+        help="batch sizes to sweep",
+    )
+    args = p.parse_args()
+
+    dtype = torch.bfloat16 if args.dtype == "bf16" else torch.float16
+    device = torch.device(args.device)
+
+    print(f"GPU: {torch.cuda.get_device_name(device)}  (cap {torch.cuda.get_device_capability(device)})")
+    print(f"seq_len={args.seq_len}  heads={args.num_heads}  head_dim={args.head_dim}  dtype={args.dtype}")
+    print()
+
+    # Warm the JIT cache once at the smallest size to keep timing clean.
+    print("(warming JIT...)")
+    bench_one(args.num_seqs[0], args.seq_len, args.num_heads, args.head_dim,
+              dtype, device, with_bwd=not args.no_bwd)
+    print()
+
+    cols = ["n_seq", "tot_tok",
+            "fwd_vl(ms)", "fwd_dn(ms)", "vl/dn",
+            "fwd_vl/seq(us)",
+            "bwd_vl(ms)", "bwd_dn(ms)", "vl/dn",
+            "bwd_vl/seq(us)"]
+    fmt = "{:>6} {:>8} {:>10} {:>10} {:>6} {:>14} {:>10} {:>10} {:>6} {:>14}"
+    print(fmt.format(*cols))
+    print("-" * 110)
+
+    for n in args.num_seqs:
+        try:
+            fv, fd, bv, bd = bench_one(
+                n, args.seq_len, args.num_heads, args.head_dim,
+                dtype, device, with_bwd=not args.no_bwd,
+            )
+        except torch.cuda.OutOfMemoryError:
+            print(f"{n:>6} OOM — stopping sweep")
+            break
+
+        total_tok = n * args.seq_len
+        per_seq_fv = fv * 1000.0 / n  # microseconds
+        per_seq_bv = bv * 1000.0 / n
+
+        print(fmt.format(
+            n, total_tok,
+            f"{fv:.3f}", f"{fd:.3f}", f"{fv/fd:.2f}x",
+            f"{per_seq_fv:.3f}",
+            f"{bv:.3f}" if bv == bv else "n/a",
+            f"{bd:.3f}" if bd == bd else "n/a",
+            f"{bv/bd:.2f}x" if bv == bv else "n/a",
+            f"{per_seq_bv:.3f}" if bv == bv else "n/a",
+        ))
+
+    print()
+    print("Reading the table:")
+    print("  - 'tot_tok' is total live tokens; true attention work is O(n_seq) at fixed seq_len.")
+    print("  - If the scheduler were O(n_seq), 'fwd_vl/seq(us)' would be flat across rows.")
+    print("  - O(n_seq^2) scheduling shows up as 'fwd_vl/seq(us)' growing roughly linearly with n_seq.")
+    print("  - 'fwd_dn' is the dense (padded) baseline at the same total token count — pure compute, no varlen scheduling.")
+
+
+if __name__ == "__main__":
+    main()

--- a/flash_attn/cute/flash_bwd.py
+++ b/flash_attn/cute/flash_bwd.py
@@ -382,6 +382,7 @@ class FlashAttentionBackwardSm80:
         mCuSeqlensK: Optional[cute.Tensor] = None,
         mSeqUsedQ: Optional[cute.Tensor] = None,
         mSeqUsedK: Optional[cute.Tensor] = None,
+        mTileCumsum: Optional[cute.Tensor] = None,  # int32, (num_batch + 1,); see TileSchedulerArguments
         window_size_left: Int32 | int | None = None,
         window_size_right: Int32 | int | None = None,
         mdQ_semaphore: Optional[cute.Tensor] = None,
@@ -429,6 +430,7 @@ class FlashAttentionBackwardSm80:
             qhead_per_kvhead_packgqa=self.qhead_per_kvhead if cutlass.const_expr(self.pack_gqa) else 1,
             mCuSeqlensQ=mCuSeqlensK,
             mSeqUsedQ=mSeqUsedK,
+            mTileCumsum=mTileCumsum,
         )
 
         tile_sched_params = TileScheduler.to_underlying_arguments(tile_sched_args)

--- a/flash_attn/cute/flash_bwd.py
+++ b/flash_attn/cute/flash_bwd.py
@@ -382,7 +382,7 @@ class FlashAttentionBackwardSm80:
         mCuSeqlensK: Optional[cute.Tensor] = None,
         mSeqUsedQ: Optional[cute.Tensor] = None,
         mSeqUsedK: Optional[cute.Tensor] = None,
-        mTileCumsum: Optional[cute.Tensor] = None,  # int32, (num_batch + 1,); see TileSchedulerArguments
+        mCuTotalMBlocks: Optional[cute.Tensor] = None,  # int32, (num_batch + 1,); see TileSchedulerArguments
         window_size_left: Int32 | int | None = None,
         window_size_right: Int32 | int | None = None,
         mdQ_semaphore: Optional[cute.Tensor] = None,
@@ -430,7 +430,7 @@ class FlashAttentionBackwardSm80:
             qhead_per_kvhead_packgqa=self.qhead_per_kvhead if cutlass.const_expr(self.pack_gqa) else 1,
             mCuSeqlensQ=mCuSeqlensK,
             mSeqUsedQ=mSeqUsedK,
-            mTileCumsum=mTileCumsum,
+            mCuTotalMBlocks=mCuTotalMBlocks,
         )
 
         tile_sched_params = TileScheduler.to_underlying_arguments(tile_sched_args)

--- a/flash_attn/cute/flash_bwd_postprocess.py
+++ b/flash_attn/cute/flash_bwd_postprocess.py
@@ -215,6 +215,9 @@ class FlashAttentionBackwardPostprocess:
         scale: cutlass.Float32,
         mCuSeqlensQ: Optional[cute.Tensor],
         mSeqUsedQ: Optional[cute.Tensor],
+        mTileCumsum: Optional[
+            cute.Tensor
+        ] = None,  # int32, (num_batch + 1,); see TileSchedulerArguments
         # Always keep stream as the last parameter (EnvStream: obtained implicitly via TVM FFI).
         stream: cuda.CUstream = None,
     ):
@@ -258,6 +261,7 @@ class FlashAttentionBackwardPostprocess:
             tile_shape_mn=(self.tile_m, 1),
             mCuSeqlensQ=mCuSeqlensQ,
             mSeqUsedQ=mSeqUsedQ,
+            mTileCumsum=mTileCumsum,
         )
 
         tile_sched_params = TileScheduler.to_underlying_arguments(tile_sched_args)

--- a/flash_attn/cute/flash_bwd_postprocess.py
+++ b/flash_attn/cute/flash_bwd_postprocess.py
@@ -215,7 +215,7 @@ class FlashAttentionBackwardPostprocess:
         scale: cutlass.Float32,
         mCuSeqlensQ: Optional[cute.Tensor],
         mSeqUsedQ: Optional[cute.Tensor],
-        mTileCumsum: Optional[
+        mCuTotalMBlocks: Optional[
             cute.Tensor
         ] = None,  # int32, (num_batch + 1,); see TileSchedulerArguments
         # Always keep stream as the last parameter (EnvStream: obtained implicitly via TVM FFI).
@@ -261,7 +261,7 @@ class FlashAttentionBackwardPostprocess:
             tile_shape_mn=(self.tile_m, 1),
             mCuSeqlensQ=mCuSeqlensQ,
             mSeqUsedQ=mSeqUsedQ,
-            mTileCumsum=mTileCumsum,
+            mCuTotalMBlocks=mCuTotalMBlocks,
         )
 
         tile_sched_params = TileScheduler.to_underlying_arguments(tile_sched_args)

--- a/flash_attn/cute/flash_bwd_preprocess.py
+++ b/flash_attn/cute/flash_bwd_preprocess.py
@@ -136,6 +136,9 @@ class FlashAttentionBackwardPreprocess:
         mCuSeqlensQ: Optional[cute.Tensor],  # (batch + 1,)
         mSeqUsedQ: Optional[cute.Tensor],  # (batch,)
         mdLSE: Optional[cute.Tensor],  # (batch, nheads, seqlen) or (nheads, total_q)
+        mTileCumsum: Optional[
+            cute.Tensor
+        ] = None,  # int32, (num_batch + 1,); see TileSchedulerArguments
         # Always keep stream as the last parameter (EnvStream: obtained implicitly via TVM FFI).
         stream: cuda.CUstream = None,
     ):
@@ -193,6 +196,7 @@ class FlashAttentionBackwardPreprocess:
             tile_shape_mn=(self.tile_m, 1),
             mCuSeqlensQ=mCuSeqlensQ,
             mSeqUsedQ=mSeqUsedQ,
+            mTileCumsum=mTileCumsum,
         )
 
         tile_sched_params = TileScheduler.to_underlying_arguments(tile_sched_args)

--- a/flash_attn/cute/flash_bwd_preprocess.py
+++ b/flash_attn/cute/flash_bwd_preprocess.py
@@ -136,7 +136,7 @@ class FlashAttentionBackwardPreprocess:
         mCuSeqlensQ: Optional[cute.Tensor],  # (batch + 1,)
         mSeqUsedQ: Optional[cute.Tensor],  # (batch,)
         mdLSE: Optional[cute.Tensor],  # (batch, nheads, seqlen) or (nheads, total_q)
-        mTileCumsum: Optional[
+        mCuTotalMBlocks: Optional[
             cute.Tensor
         ] = None,  # int32, (num_batch + 1,); see TileSchedulerArguments
         # Always keep stream as the last parameter (EnvStream: obtained implicitly via TVM FFI).
@@ -196,7 +196,7 @@ class FlashAttentionBackwardPreprocess:
             tile_shape_mn=(self.tile_m, 1),
             mCuSeqlensQ=mCuSeqlensQ,
             mSeqUsedQ=mSeqUsedQ,
-            mTileCumsum=mTileCumsum,
+            mCuTotalMBlocks=mCuTotalMBlocks,
         )
 
         tile_sched_params = TileScheduler.to_underlying_arguments(tile_sched_args)

--- a/flash_attn/cute/flash_bwd_sm100.py
+++ b/flash_attn/cute/flash_bwd_sm100.py
@@ -456,6 +456,9 @@ class FlashAttentionBackwardSm100:
         mCuSeqlensK: Optional[cute.Tensor] = None,
         mSeqUsedQ: Optional[cute.Tensor] = None,
         mSeqUsedK: Optional[cute.Tensor] = None,
+        mTileCumsum: Optional[
+            cute.Tensor
+        ] = None,  # int32, (num_batch + 1,); see TileSchedulerArguments
         window_size_left: Int32 | int | None = None,
         window_size_right: Int32 | int | None = None,
         mdQ_semaphore: Optional[cute.Tensor] = None,
@@ -728,6 +731,7 @@ class FlashAttentionBackwardSm100:
             is_persistent=self.is_persistent,  # persistent mode not tested
             lpt=self.spt,
             head_swizzle=self.deterministic,
+            mTileCumsum=mTileCumsum,
         )
 
         tile_sched_params = TileScheduler.to_underlying_arguments(tile_sched_args)

--- a/flash_attn/cute/flash_bwd_sm100.py
+++ b/flash_attn/cute/flash_bwd_sm100.py
@@ -458,7 +458,7 @@ class FlashAttentionBackwardSm100:
         mCuSeqlensK: Optional[cute.Tensor] = None,
         mSeqUsedQ: Optional[cute.Tensor] = None,
         mSeqUsedK: Optional[cute.Tensor] = None,
-        mTileCumsum: Optional[
+        mCuTotalMBlocks: Optional[
             cute.Tensor
         ] = None,  # int32, (num_batch + 1,); see TileSchedulerArguments
         window_size_left: Int32 | int | None = None,
@@ -737,7 +737,7 @@ class FlashAttentionBackwardSm100:
             is_persistent=self.is_persistent,  # persistent mode not tested
             lpt=self.spt,
             head_swizzle=self.deterministic,
-            mTileCumsum=mTileCumsum,
+            mCuTotalMBlocks=mCuTotalMBlocks,
         )
 
         tile_sched_params = TileScheduler.to_underlying_arguments(tile_sched_args)

--- a/flash_attn/cute/flash_bwd_sm90.py
+++ b/flash_attn/cute/flash_bwd_sm90.py
@@ -350,6 +350,9 @@ class FlashAttentionBackwardSm90:
         mCuSeqlensK: Optional[cute.Tensor] = None,
         mSeqUsedQ: Optional[cute.Tensor] = None,
         mSeqUsedK: Optional[cute.Tensor] = None,
+        mTileCumsum: Optional[
+            cute.Tensor
+        ] = None,  # int32, (num_batch + 1,); see TileSchedulerArguments
         window_size_left: Int32 | int | None = None,
         window_size_right: Int32 | int | None = None,
         mdQ_semaphore: Optional[cute.Tensor] = None,
@@ -527,6 +530,7 @@ class FlashAttentionBackwardSm90:
             is_persistent=False,
             lpt=self.spt,
             head_swizzle=self.deterministic,
+            mTileCumsum=mTileCumsum,
         )
 
         tile_sched_params = TileScheduler.to_underlying_arguments(tile_sched_args)

--- a/flash_attn/cute/flash_bwd_sm90.py
+++ b/flash_attn/cute/flash_bwd_sm90.py
@@ -350,7 +350,7 @@ class FlashAttentionBackwardSm90:
         mCuSeqlensK: Optional[cute.Tensor] = None,
         mSeqUsedQ: Optional[cute.Tensor] = None,
         mSeqUsedK: Optional[cute.Tensor] = None,
-        mTileCumsum: Optional[
+        mCuTotalMBlocks: Optional[
             cute.Tensor
         ] = None,  # int32, (num_batch + 1,); see TileSchedulerArguments
         window_size_left: Int32 | int | None = None,
@@ -539,7 +539,7 @@ class FlashAttentionBackwardSm90:
             is_persistent=False,
             lpt=self.spt,
             head_swizzle=self.deterministic,
-            mTileCumsum=mTileCumsum,
+            mCuTotalMBlocks=mCuTotalMBlocks,
         )
 
         tile_sched_params = TileScheduler.to_underlying_arguments(tile_sched_args)

--- a/flash_attn/cute/flash_fwd.py
+++ b/flash_attn/cute/flash_fwd.py
@@ -625,6 +625,7 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
         mCuSeqlensK: Optional[cute.Tensor] = None,
         mSeqUsedQ: Optional[cute.Tensor] = None,
         mSeqUsedK: Optional[cute.Tensor] = None,
+        mTileCumsum: Optional[cute.Tensor] = None,  # int32, (num_batch + 1,); see TileSchedulerArguments
         mPageTable: Optional[cute.Tensor] = None,
         window_size_left: Optional[Int32] = None,
         window_size_right: Optional[Int32] = None,
@@ -692,6 +693,7 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
             qhead_per_kvhead_packgqa=self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
             mCuSeqlensQ=mCuSeqlensQ,
             mSeqUsedQ=mSeqUsedQ,
+            mTileCumsum=mTileCumsum,
         )
         tile_sched_params = TileScheduler.to_underlying_arguments(tile_sched_args)
         grid_dim = TileScheduler.get_grid_shape(tile_sched_params)

--- a/flash_attn/cute/flash_fwd.py
+++ b/flash_attn/cute/flash_fwd.py
@@ -631,7 +631,7 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
         mCuSeqlensK: Optional[cute.Tensor] = None,
         mSeqUsedQ: Optional[cute.Tensor] = None,
         mSeqUsedK: Optional[cute.Tensor] = None,
-        mTileCumsum: Optional[cute.Tensor] = None,  # int32, (num_batch + 1,); see TileSchedulerArguments
+        mCuTotalMBlocks: Optional[cute.Tensor] = None,  # int32, (num_batch + 1,); see TileSchedulerArguments
         mPageTable: Optional[cute.Tensor] = None,
         window_size_left: Optional[Int32] = None,
         window_size_right: Optional[Int32] = None,
@@ -699,7 +699,7 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
             qhead_per_kvhead_packgqa=self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
             mCuSeqlensQ=mCuSeqlensQ,
             mSeqUsedQ=mSeqUsedQ,
-            mTileCumsum=mTileCumsum,
+            mCuTotalMBlocks=mCuTotalMBlocks,
         )
         tile_sched_params = TileScheduler.to_underlying_arguments(tile_sched_args)
         grid_dim = TileScheduler.get_grid_shape(tile_sched_params)

--- a/flash_attn/cute/flash_fwd_mla_sm100.py
+++ b/flash_attn/cute/flash_fwd_mla_sm100.py
@@ -361,6 +361,9 @@ class FlashAttentionMLAForwardSm100:
         mCuSeqlensK: Optional[cute.Tensor] = None,  # (b + 1)
         mSeqUsedQ: Optional[cute.Tensor] = None,  # (b)
         mSeqUsedK: Optional[cute.Tensor] = None,  # (b)
+        mTileCumsum: Optional[
+            cute.Tensor
+        ] = None,  # int32, (num_batch + 1,); see TileSchedulerArguments
         mIndexTopk: Optional[
             cute.Tensor
         ] = None,  # (b, s_q, topk) or (total_q, topk) if there is cu_seqlens_q
@@ -630,6 +633,7 @@ class FlashAttentionMLAForwardSm100:
             is_split_kv=False,
             cluster_shape_mn=self.cluster_shape_mn,
             use_cluster_idx=False,
+            mTileCumsum=mTileCumsum,
         )
         tile_sched_params = TileScheduler.to_underlying_arguments(
             tile_sched_args, scheduling_mode=self.scheduling_mode

--- a/flash_attn/cute/flash_fwd_mla_sm100.py
+++ b/flash_attn/cute/flash_fwd_mla_sm100.py
@@ -361,7 +361,7 @@ class FlashAttentionMLAForwardSm100:
         mCuSeqlensK: Optional[cute.Tensor] = None,  # (b + 1)
         mSeqUsedQ: Optional[cute.Tensor] = None,  # (b)
         mSeqUsedK: Optional[cute.Tensor] = None,  # (b)
-        mTileCumsum: Optional[
+        mCuTotalMBlocks: Optional[
             cute.Tensor
         ] = None,  # int32, (num_batch + 1,); see TileSchedulerArguments
         mIndexTopk: Optional[
@@ -633,7 +633,7 @@ class FlashAttentionMLAForwardSm100:
             is_split_kv=False,
             cluster_shape_mn=self.cluster_shape_mn,
             use_cluster_idx=False,
-            mTileCumsum=mTileCumsum,
+            mCuTotalMBlocks=mCuTotalMBlocks,
         )
         tile_sched_params = TileScheduler.to_underlying_arguments(
             tile_sched_args, scheduling_mode=self.scheduling_mode

--- a/flash_attn/cute/flash_fwd_sm100.py
+++ b/flash_attn/cute/flash_fwd_sm100.py
@@ -367,6 +367,7 @@ class FlashAttentionForwardSm100:
         mCuSeqlensK: Optional[cute.Tensor] = None,
         mSeqUsedQ: Optional[cute.Tensor] = None,
         mSeqUsedK: Optional[cute.Tensor] = None,
+        mTileCumsum: Optional[cute.Tensor] = None,  # int32, (num_batch + 1,); see TileSchedulerArguments
         mPageTable: Optional[cute.Tensor] = None,  # (b_k, max_num_pages_per_seq)
         window_size_left: Int32 | int | None = None,
         window_size_right: Int32 | int | None = None,
@@ -654,6 +655,7 @@ class FlashAttentionForwardSm100:
             is_split_kv=self.is_split_kv,
             cluster_shape_mn=self.cluster_shape_mn,
             use_cluster_idx=not self.is_persistent and self.cta_group_size > 1,
+            mTileCumsum=mTileCumsum,
         )
         tile_sched_params = TileScheduler.to_underlying_arguments(
             tile_sched_args, scheduling_mode=self.scheduling_mode

--- a/flash_attn/cute/flash_fwd_sm100.py
+++ b/flash_attn/cute/flash_fwd_sm100.py
@@ -373,7 +373,7 @@ class FlashAttentionForwardSm100:
         mCuSeqlensK: Optional[cute.Tensor] = None,
         mSeqUsedQ: Optional[cute.Tensor] = None,
         mSeqUsedK: Optional[cute.Tensor] = None,
-        mTileCumsum: Optional[cute.Tensor] = None,  # int32, (num_batch + 1,); see TileSchedulerArguments
+        mCuTotalMBlocks: Optional[cute.Tensor] = None,  # int32, (num_batch + 1,); see TileSchedulerArguments
         mPageTable: Optional[cute.Tensor] = None,  # (b_k, max_num_pages_per_seq)
         window_size_left: Int32 | int | None = None,
         window_size_right: Int32 | int | None = None,
@@ -661,7 +661,7 @@ class FlashAttentionForwardSm100:
             is_split_kv=self.is_split_kv,
             cluster_shape_mn=self.cluster_shape_mn,
             use_cluster_idx=not self.is_persistent and self.cta_group_size > 1,
-            mTileCumsum=mTileCumsum,
+            mCuTotalMBlocks=mCuTotalMBlocks,
         )
         tile_sched_params = TileScheduler.to_underlying_arguments(
             tile_sched_args, scheduling_mode=self.scheduling_mode

--- a/flash_attn/cute/flash_fwd_sm90.py
+++ b/flash_attn/cute/flash_fwd_sm90.py
@@ -166,6 +166,9 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         mCuSeqlensK: Optional[cute.Tensor] = None,
         mSeqUsedQ: Optional[cute.Tensor] = None,
         mSeqUsedK: Optional[cute.Tensor] = None,
+        mTileCumsum: Optional[
+            cute.Tensor
+        ] = None,  # int32, (num_batch + 1,); see TileSchedulerArguments
         mPageTable: Optional[cute.Tensor] = None,  # (b_k, max_num_pages_per_seq)
         window_size_left: Int32 | int | None = None,
         window_size_right: Int32 | int | None = None,
@@ -341,6 +344,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
             element_size=self.dtype.width // 8,
             is_persistent=False,
             lpt=self.is_causal or self.is_local,
+            mTileCumsum=mTileCumsum,
         )
         tile_sched_params = TileScheduler.to_underlying_arguments(tile_sched_args)
         grid_dim = TileScheduler.get_grid_shape(tile_sched_params)

--- a/flash_attn/cute/flash_fwd_sm90.py
+++ b/flash_attn/cute/flash_fwd_sm90.py
@@ -166,7 +166,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         mCuSeqlensK: Optional[cute.Tensor] = None,
         mSeqUsedQ: Optional[cute.Tensor] = None,
         mSeqUsedK: Optional[cute.Tensor] = None,
-        mTileCumsum: Optional[
+        mCuTotalMBlocks: Optional[
             cute.Tensor
         ] = None,  # int32, (num_batch + 1,); see TileSchedulerArguments
         mPageTable: Optional[cute.Tensor] = None,  # (b_k, max_num_pages_per_seq)
@@ -344,7 +344,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
             element_size=self.dtype.width // 8,
             is_persistent=False,
             lpt=self.is_causal or self.is_local,
-            mTileCumsum=mTileCumsum,
+            mCuTotalMBlocks=mCuTotalMBlocks,
         )
         tile_sched_params = TileScheduler.to_underlying_arguments(tile_sched_args)
         grid_dim = TileScheduler.get_grid_shape(tile_sched_params)

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -283,6 +283,50 @@ def _resolve_causal_local_window(causal, window_size_left, window_size_right, ma
         local = False
     return causal, local, window_size_left, window_size_right
 
+def _compute_tile_cumsum(
+    cu_seqlens: Optional[torch.Tensor],
+    seqused: Optional[torch.Tensor],
+    num_head: int,
+    tile_size: int,
+    *,
+    qhead_per_kvhead: int = 1,
+    pack_gqa: bool = False,
+    cluster_shape_m: int = 1,
+    device: torch.device,
+) -> Optional[torch.Tensor]:
+    """Precompute per-batch cumulative tile counts for SingleTileVarlenScheduler.
+
+    Returns an int32 tensor of length ``num_batch + 1`` whose entry ``b`` is
+    ``sum_{i<b} (num_m_blocks(i) * num_head)``, matching the kernel-side
+    ``_get_num_m_blocks`` formula in ``tile_scheduler.py`` exactly. The kernel
+    binary-searches this tensor to skip the per-CTA linear scan over batches.
+
+    Returns ``None`` when neither ``cu_seqlens`` nor ``seqused`` is provided
+    (i.e., the dense path), in which case the kernel's scheduler falls back to
+    its original linear scan (which only fires on varlen anyway).
+
+    Notes:
+      - ``pack_gqa`` only applies on the forward path; backward kernels do not
+        scale seqlens by ``qhead_per_kvhead``.
+      - ``cluster_shape_m > 1`` is currently unreachable in varlen
+        (``use_2cta_instrs`` requires non-varlen), but the formula mirrors the
+        kernel's ``ceil_div(ceil_div(seqlen, tile), cluster_m)`` to stay
+        correct if that constraint is ever relaxed.
+    """
+    if cu_seqlens is None and seqused is None:
+        return None
+    seqlens = (cu_seqlens[1:] - cu_seqlens[:-1]) if seqused is None else seqused
+    if pack_gqa and qhead_per_kvhead > 1:
+        seqlens = seqlens * qhead_per_kvhead
+    num_blocks = (seqlens + tile_size - 1) // tile_size
+    if cluster_shape_m > 1:
+        num_blocks = (num_blocks + cluster_shape_m - 1) // cluster_shape_m
+    tiles_per_batch = num_blocks * num_head
+    out = torch.zeros(tiles_per_batch.shape[0] + 1, dtype=torch.int32, device=device)
+    out[1:] = tiles_per_batch.to(torch.int32).cumsum(0)
+    return out
+
+
 def _flash_attn_fwd(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -680,6 +724,21 @@ def _flash_attn_fwd(
         sparse_kv = None
         disable_sparse_kv_bitmask = None
 
+    # Precompute cumulative tile counts so SingleTileVarlenScheduler can
+    # binary-search instead of doing per-CTA O(num_batch) linear scans.
+    # See _compute_tile_cumsum and tile_scheduler._varlen_coord_map.
+    # The hd=256 dedicated kernel uses Sm100FmhaStaticTileScheduler, not
+    # SingleTileVarlenScheduler, so it doesn't take an mTileCumsum argument.
+    tile_cumsum_q = (
+        None if use_dedicated_hd256_kernel
+        else _compute_tile_cumsum(
+            cu_seqlens_q, seqused_q, num_head, tile_m,
+            qhead_per_kvhead=qhead_per_kvhead, pack_gqa=pack_gqa,
+            cluster_shape_m=1,  # varlen forbids use_2cta_instrs => cluster_shape_m == 1
+            device=device,
+        )
+    )
+
     compile_key = (
         dtype,
         head_dim,
@@ -721,6 +780,7 @@ def _flash_attn_fwd(
         sparse_kv,
         disable_sparse_kv_bitmask,
         fa_logging.get_fa_log_level(),
+        tile_cumsum_q is not None,
     )
 
     if compile_key not in _flash_attn_fwd.compile_cache:
@@ -730,11 +790,12 @@ def _flash_attn_fwd(
             seqused_q_tensor,
             seqused_k_tensor,
             learnable_sink_tensor,
+            tile_cumsum_q_tensor,
         ) = [
             to_cute_tensor(t, assumed_align=4, leading_dim=0)
             if t is not None
             else None
-            for t in (cu_seqlens_q, cu_seqlens_k, seqused_q, seqused_k, learnable_sink)
+            for t in (cu_seqlens_q, cu_seqlens_k, seqused_q, seqused_k, learnable_sink, tile_cumsum_q)
         ]
         page_table_tensor = (
             to_cute_tensor(page_table, assumed_align=4, leading_dim=1)
@@ -932,6 +993,7 @@ def _flash_attn_fwd(
                 cu_seqlens_k_tensor,
                 seqused_q_tensor,
                 seqused_k_tensor,
+                tile_cumsum_q_tensor,
                 gather_kv_indices_tensor,
                 page_table_tensor,
                 window_size_left,
@@ -960,6 +1022,9 @@ def _flash_attn_fwd(
                 cute_aux_tensors,
                 current_stream,
             ]
+            # hd=256 uses Sm100FmhaStaticTileScheduler (no mTileCumsum slot).
+            if not use_dedicated_hd256_kernel:
+                compile_args.insert(11, tile_cumsum_q_tensor)
             if arch // 10 in [10, 11]:
                 compile_args.insert(-3, descale_tensors_tensor)
             _flash_attn_fwd.compile_cache[compile_key] = cute.compile(*compile_args, options="--enable-tvm-ffi")
@@ -996,6 +1061,7 @@ def _flash_attn_fwd(
                 cu_seqlens_k,
                 seqused_q,
                 seqused_k,
+                tile_cumsum_q,
                 gather_kv_indices,
                 page_table,
                 window_size_left,
@@ -1018,6 +1084,9 @@ def _flash_attn_fwd(
                 window_size_right,
                 learnable_sink,
             ]
+            # Mirror compile_args: skip mTileCumsum slot for hd=256.
+            if not use_dedicated_hd256_kernel:
+                call_args.insert(10, tile_cumsum_q)
             if arch // 10 in [10, 11]:
                 call_args.append(descale_tensors)
             call_args.extend([
@@ -1086,7 +1155,7 @@ def make_fake_bwd_tensors(dtype, has_gqa, varlen_q, varlen_k):
 
 def _compile_bwd_preprocess(
     dtype, head_dim, head_dim_v, m_block_size, has_cuseqlens_q, has_seqused_q, has_dlse, has_dq_accum,
-    use_padded_offsets,
+    use_padded_offsets, has_tile_cumsum,
 ):
     """Compile bwd preprocess kernel using cute fake tensors (no real GPU tensors needed)."""
     mQ, mK, mV, mO, mdO, mdQ, mdK, mdV, mLSE, mLSElog2, mPdPsum, mdQaccum, mdKaccum, mdVaccum = make_fake_bwd_tensors(
@@ -1098,11 +1167,13 @@ def _compile_bwd_preprocess(
     mSequsedQ = fake_tensor(Int32, (batch,), divisibility=1) if has_seqused_q else None
     mdLSE = fake_tensor(Float32, mLSE.shape, divisibility=1) if has_dlse else None
     mdQaccum = mdQaccum if has_dq_accum else None
+    mTileCumsum = fake_tensor(Int32, (batchp1,), divisibility=1) if has_tile_cumsum else None
     fa_bwd_pre = FlashAttentionBackwardPreprocess(
         dtype, head_dim, head_dim_v, m_block_size, use_padded_offsets=use_padded_offsets
     )
     return cute.compile(
         fa_bwd_pre, mO, mdO, mPdPsum, mLSE, mLSElog2, mdQaccum, mCuSeqlensQ, mSequsedQ, mdLSE,
+        mTileCumsum,
         cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True),
         options="--enable-tvm-ffi",
     )
@@ -1116,15 +1187,22 @@ def _bwd_preprocess(
 ):
     """Backward preprocess: compute (o * dout).sum(dim=-1) - dLSE, lse * log2_e, and zero out dq_accum."""
     is_varlen = cu_seqlens_q is not None
+    # Q-side cumsum: bwd preprocess iterates over m_blocks per batch.
+    # No pack_gqa multiplier here (preprocess is per-(batch, head, m_block)).
+    tile_cumsum_pre = _compute_tile_cumsum(
+        cu_seqlens_q, seqused_q, num_head=out.shape[1] if is_varlen else out.shape[2],
+        tile_size=m_block_size, device=out.device,
+    )
     compile_key = (
-        dtype, head_dim, head_dim_v, m_block_size, is_varlen, seqused_q is not None, dlse is not None, dq_accum is not None,
-        use_padded_offsets,
+        dtype, head_dim, head_dim_v, m_block_size, is_varlen, seqused_q is not None, dlse is not None,
+        dq_accum is not None, use_padded_offsets, tile_cumsum_pre is not None,
     )
     if compile_key not in _bwd_preprocess.compile_cache:
         _bwd_preprocess.compile_cache[compile_key] = _compile_bwd_preprocess(*compile_key)
     if not is_fake_mode():
         _bwd_preprocess.compile_cache[compile_key](
-            out, dout, dpsum, lse, lse_log2, dq_accum, cu_seqlens_q, seqused_q, dlse
+            out, dout, dpsum, lse, lse_log2, dq_accum, cu_seqlens_q, seqused_q, dlse,
+            tile_cumsum_pre,
         )
 
 
@@ -1135,6 +1213,7 @@ def _compile_bwd_postprocess(
     dtype, hdim, block_size, num_threads, atom_layout, swap_ab,
     has_cuseqlens_q, has_seqused_q,
     use_2cta_instrs, cluster_size, arch,
+    has_tile_cumsum,
 ):
     """Compile bwd postprocess kernel using cute fake tensors."""
     mQ, mK, mV, mO, mdO, mdQ, mdK, mdV, mLSE, mLSElog2, mPdPsum, mdQaccum, mdKaccum, mdVaccum = make_fake_bwd_tensors(
@@ -1144,6 +1223,7 @@ def _compile_bwd_postprocess(
     batchp1 = cute.sym_int()
     mCuSeqlensQ = fake_tensor(Int32, (batchp1,), divisibility=1) if has_cuseqlens_q else None
     mSeqUsedQ = fake_tensor(Int32, (batch,), divisibility=1) if has_seqused_q else None
+    mTileCumsum = fake_tensor(Int32, (batchp1,), divisibility=1) if has_tile_cumsum else None
     fa_bwd_post = FlashAttentionBackwardPostprocess(
         dtype, hdim, arch, block_size, num_threads, atom_layout, swap_ab,
         use_2cta_instrs=use_2cta_instrs,
@@ -1151,6 +1231,7 @@ def _compile_bwd_postprocess(
     )
     return cute.compile(
         fa_bwd_post, mdQaccum, mdQ, Float32(0.0), mCuSeqlensQ, mSeqUsedQ,
+        mTileCumsum,
         cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True),
         options="--enable-tvm-ffi",
     )
@@ -1164,16 +1245,26 @@ def _bwd_postprocess_convert(
     use_2cta_instrs=False, cluster_size=1,
 ):
     """Backward postprocess: convert float32 accumulator to bf16/fp16 output."""
+    # Whichever side the caller passes (Q for dQ-postprocess, K for dK/dV).
+    # output shape is (total, num_head, hdim) when varlen.
+    tile_cumsum_post = _compute_tile_cumsum(
+        cu_seqlens, seqused, num_head=output.shape[1] if (cu_seqlens is not None or seqused is not None) else output.shape[2],
+        tile_size=block_size,
+        cluster_shape_m=cluster_size,
+        device=output.device,
+    )
     compile_key = (
         dtype, hdim, block_size, num_threads, atom_layout, swap_ab,
         cu_seqlens is not None, seqused is not None,
         use_2cta_instrs, cluster_size, arch,
+        tile_cumsum_post is not None,
     )
     if compile_key not in _bwd_postprocess_convert.compile_cache:
         _bwd_postprocess_convert.compile_cache[compile_key] = _compile_bwd_postprocess(*compile_key)
     if not is_fake_mode():
         _bwd_postprocess_convert.compile_cache[compile_key](
             accum, output, scale, cu_seqlens, seqused,
+            tile_cumsum_post,
         )
 
 
@@ -1550,6 +1641,20 @@ def _flash_attn_bwd(
             subtile_factor=subtile_factor,
         )
 
+    # Backward iterates over K blocks (parallelizes the outer loop across N CTAs),
+    # so the scheduler cumsum is built from K seqlens with n_block_size, and uses
+    # num_head_q (the bwd scheduler iterates over query heads, see flash_bwd_sm*.py).
+    # No pack_gqa multiplier on backward. The hd=256 dedicated backward uses
+    # Sm100Fmha*TileScheduler (no mTileCumsum slot), so skip cumsum for that path.
+    tile_cumsum_k = (
+        None if use_dedicated_hd256_kernel
+        else _compute_tile_cumsum(
+            cu_seqlens_k, seqused_k, num_head=num_head, tile_size=n_block_size,
+            cluster_shape_m=cluster_size if arch // 10 in [10, 11] else 1,
+            device=device,
+        )
+    )
+
     if arch // 10 in [8, 9, 12]:
         compile_key = (
             arch,
@@ -1592,6 +1697,7 @@ def _flash_attn_bwd(
             # Prevent TVM stride poisoning when only one block is present.
             (seqlen_q_rounded // m_block_size == 1),
             (seqlen_k_rounded // n_block_size == 1),
+            tile_cumsum_k is not None,
         )
     else:
         compile_key = (
@@ -1627,6 +1733,7 @@ def _flash_attn_bwd(
             # Prevent TVM stride poisoning when only one block is present.
             (seqlen_q_rounded // m_block_size == 1),
             (seqlen_k_rounded // n_block_size == 1),
+            tile_cumsum_k is not None,
         )
 
     if compile_key not in _flash_attn_bwd.compile_cache:
@@ -1639,9 +1746,9 @@ def _flash_attn_bwd(
             dk_accum_tensor, dv_accum_tensor = [
                 to_cute_tensor(t) for t in (dk_accum, dv_accum)
             ]
-        cu_seqlens_q_tensor, cu_seqlens_k_tensor, seqused_q_tensor, seqused_k_tensor = [
+        cu_seqlens_q_tensor, cu_seqlens_k_tensor, seqused_q_tensor, seqused_k_tensor, tile_cumsum_k_tensor = [
             to_cute_tensor(t, assumed_align=4) if t is not None else None
-            for t in (cu_seqlens_q, cu_seqlens_k, seqused_q, seqused_k)
+            for t in (cu_seqlens_q, cu_seqlens_k, seqused_q, seqused_k, tile_cumsum_k)
         ]
         dQ_semaphore_tensor, dK_semaphore_tensor, dV_semaphore_tensor = [
             utils.convert_from_dlpack_leading_static(t.detach(), leading_dim=3, alignment=4, stride_order=t.dim_order())
@@ -1759,7 +1866,7 @@ def _flash_attn_bwd(
         dq_accum_tensor = dq_tensor if use_dedicated_hd256_kernel else dq_accum_tensor
 
         # TODO: check @can_implement
-        _flash_attn_bwd.compile_cache[compile_key] = cute.compile(
+        compile_args = [
             fa_bwd_obj,
             q_tensor,
             k_tensor,
@@ -1783,11 +1890,14 @@ def _flash_attn_bwd(
             cute_aux_tensors,
             sparse_tensors_compile,
             current_stream,
-            options="--enable-tvm-ffi",
-        )
+        ]
+        # hd=256 backward uses Sm100Fmha*TileScheduler (no mTileCumsum slot).
+        if not use_dedicated_hd256_kernel:
+            compile_args.insert(15, tile_cumsum_k_tensor)
+        _flash_attn_bwd.compile_cache[compile_key] = cute.compile(*compile_args, options="--enable-tvm-ffi")
     if not is_fake_mode():
         dq_accum = dq if use_dedicated_hd256_kernel else dq_accum
-        _flash_attn_bwd.compile_cache[compile_key](
+        call_args = [
             q.detach(),
             k.detach(),
             v.detach(),
@@ -1809,7 +1919,10 @@ def _flash_attn_bwd(
             dV_semaphore,
             aux_tensors,
             normalized_block_sparse_tensors[:4] if normalized_block_sparse_tensors is not None else None,
-        )
+        ]
+        if not use_dedicated_hd256_kernel:
+            call_args.insert(14, tile_cumsum_k)
+        _flash_attn_bwd.compile_cache[compile_key](*call_args)
     # Postprocess: convert dq_accum from float32 to dq in bf16/fp16
     # hd=256 2CTA backward has its own internal postprocess, skip here.
     if not use_dedicated_hd256_kernel:

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -726,15 +726,29 @@ def _flash_attn_fwd(
 
     # Precompute cumulative tile counts so SingleTileVarlenScheduler can
     # binary-search instead of doing per-CTA O(num_batch) linear scans.
-    # See _compute_tile_cumsum and tile_scheduler._varlen_coord_map.
-    # The hd=256 dedicated kernel uses Sm100FmhaStaticTileScheduler, not
-    # SingleTileVarlenScheduler, so it doesn't take an mTileCumsum argument.
+    # Must match the kernel-side _get_num_m_blocks formula:
+    #   - SM80/90/120 fwd: tile_shape_mn[0] = tile_m, cluster=1
+    #   - SM100 fwd:       tile_shape_mn[0] = q_stage * tile_m, cluster=1
+    #   - SM100 MLA fwd:   tile_shape_mn[0] = 64, cluster=2 (effective 128)
+    # hd=256 uses a different scheduler and skips the mTileCumsum slot.
+    if use_dedicated_hd256_kernel:
+        scheduler_tile_m, scheduler_cluster_m = None, None
+    elif qv is not None:
+        scheduler_tile_m, scheduler_cluster_m = 64, 2  # MLA
+    else:
+        scheduler_tile_m, scheduler_cluster_m = m_block_size_effective, 1
+    # SM90/100/110/MLA reshape mQ via pack_gqa_layout when pack_gqa is on,
+    # so scheduler num_head becomes num_head_kv. SM80/120 don't reshape and
+    # keep num_head = num_head_q (per-Q-head packgqa is handled internally
+    # by PackGQA at load/store time).
+    kernel_reshapes_mQ = qv is not None or arch // 10 in [9, 10, 11]
+    scheduler_num_head = num_head_kv if (pack_gqa and kernel_reshapes_mQ) else num_head
     tile_cumsum_q = (
         None if use_dedicated_hd256_kernel
         else _compute_tile_cumsum(
-            cu_seqlens_q, seqused_q, num_head, tile_m,
+            cu_seqlens_q, seqused_q, scheduler_num_head, scheduler_tile_m,
             qhead_per_kvhead=qhead_per_kvhead, pack_gqa=pack_gqa,
-            cluster_shape_m=1,  # varlen forbids use_2cta_instrs => cluster_shape_m == 1
+            cluster_shape_m=scheduler_cluster_m,
             device=device,
         )
     )
@@ -1245,12 +1259,13 @@ def _bwd_postprocess_convert(
     use_2cta_instrs=False, cluster_size=1,
 ):
     """Backward postprocess: convert float32 accumulator to bf16/fp16 output."""
-    # Whichever side the caller passes (Q for dQ-postprocess, K for dK/dV).
-    # output shape is (total, num_head, hdim) when varlen.
+    # cluster_size is the bwd MAIN kernel's cluster (used by postprocess only
+    # for SeqlenInfoQK boundary clamping). The postprocess scheduler itself
+    # iterates per tile_m with cluster=1, so the host cumsum uses 1 here.
     tile_cumsum_post = _compute_tile_cumsum(
         cu_seqlens, seqused, num_head=output.shape[1] if (cu_seqlens is not None or seqused is not None) else output.shape[2],
         tile_size=block_size,
-        cluster_shape_m=cluster_size,
+        cluster_shape_m=1,
         device=output.device,
     )
     compile_key = (

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -289,10 +289,9 @@ def _resolve_causal_local_window(causal, window_size_left, window_size_right, ma
         local = False
     return causal, local, window_size_left, window_size_right
 
-def _compute_tile_cumsum(
+def _compute_cu_total_m_blocks(
     cu_seqlens: Optional[torch.Tensor],
     seqused: Optional[torch.Tensor],
-    num_head: int,
     tile_size: int,
     *,
     qhead_per_kvhead: int = 1,
@@ -300,24 +299,33 @@ def _compute_tile_cumsum(
     cluster_shape_m: int = 1,
     device: torch.device,
 ) -> Optional[torch.Tensor]:
-    """Precompute per-batch cumulative tile counts for SingleTileVarlenScheduler.
+    """Precompute per-batch cumulative m_block counts for SingleTileVarlenScheduler.
 
     Returns an int32 tensor of length ``num_batch + 1`` whose entry ``b`` is
-    ``sum_{i<b} (num_m_blocks(i) * num_head)``, matching the kernel-side
-    ``_get_num_m_blocks`` formula in ``tile_scheduler.py`` exactly. The kernel
-    binary-searches this tensor to skip the per-CTA linear scan over batches.
+    ``sum_{i<b} num_m_blocks(i)`` (matches the convention introduced for
+    blocksparse in #2224 and used by #2559). Used as a hint by
+    ``_varlen_coord_map``: the kernel binary-searches this tensor via
+    ``utils.get_batch_from_cu_tensor`` to skip directly to the right group
+    of 31 batches, then the existing warp-scan locates the exact batch
+    within that group.
+
+    Per-batch ``num_m_blocks`` here must agree with the kernel's
+    ``_get_num_m_blocks`` formula in ``tile_scheduler.py`` so the snap
+    doesn't overshoot:
+      ``num_m_blocks(b) = ceil_div(seqlen_eff, tile_size) / cluster_shape_m``
+    where ``seqlen_eff = seqlen * qhead_per_kvhead`` when ``pack_gqa`` is on.
+    (This matches what #2559 computes via prepare_scheduler.py's
+    ``get_num_m_blocks_and_seqlen``.) The snap is forward-only, so under-
+    estimating per-batch counts is safe but overestimating is not — the
+    pack_gqa multiplier therefore can't be dropped here.
 
     Returns ``None`` when neither ``cu_seqlens`` nor ``seqused`` is provided
-    (i.e., the dense path), in which case the kernel's scheduler falls back to
-    its original linear scan (which only fires on varlen anyway).
+    (i.e., the dense path), in which case the kernel's scheduler falls back
+    to its original warp-scan path from batch 0.
 
-    Notes:
-      - ``pack_gqa`` only applies on the forward path; backward kernels do not
-        scale seqlens by ``qhead_per_kvhead``.
-      - ``cluster_shape_m > 1`` is currently unreachable in varlen
-        (``use_2cta_instrs`` requires non-varlen), but the formula mirrors the
-        kernel's ``ceil_div(ceil_div(seqlen, tile), cluster_m)`` to stay
-        correct if that constraint is ever relaxed.
+    ``cluster_shape_m > 1`` is currently unreachable in standard varlen
+    (``use_2cta_instrs`` requires non-varlen) but applies to MLA varlen and
+    is kept for safety.
     """
     if cu_seqlens is None and seqused is None:
         return None
@@ -327,9 +335,8 @@ def _compute_tile_cumsum(
     num_blocks = (seqlens + tile_size - 1) // tile_size
     if cluster_shape_m > 1:
         num_blocks = (num_blocks + cluster_shape_m - 1) // cluster_shape_m
-    tiles_per_batch = num_blocks * num_head
-    out = torch.zeros(tiles_per_batch.shape[0] + 1, dtype=torch.int32, device=device)
-    out[1:] = tiles_per_batch.to(torch.int32).cumsum(0)
+    out = torch.zeros(num_blocks.shape[0] + 1, dtype=torch.int32, device=device)
+    out[1:] = num_blocks.to(torch.int32).cumsum(0)
     return out
 
 
@@ -719,29 +726,24 @@ def _flash_attn_fwd(
         sparse_kv = None
         disable_sparse_kv_bitmask = None
 
-    # Precompute cumulative tile counts so SingleTileVarlenScheduler can
-    # binary-search instead of doing per-CTA O(num_batch) linear scans.
-    # Must match the kernel-side _get_num_m_blocks formula:
-    #   - SM80/90/120 fwd: tile_shape_mn[0] = tile_m, cluster=1
-    #   - SM100 fwd:       tile_shape_mn[0] = q_stage * tile_m, cluster=1
-    #   - SM100 MLA fwd:   tile_shape_mn[0] = 64, cluster=2 (effective 128)
-    # hd=256 uses a different scheduler and skips the mTileCumsum slot.
+    # Precompute cumulative m_block counts so SingleTileVarlenScheduler can
+    # binary-search (via utils.get_batch_from_cu_tensor) instead of doing
+    # per-CTA O(num_batch) warp scans. Must match the kernel-side
+    # _get_num_m_blocks formula for tile_shape_mn[0] / cluster_shape_m:
+    #   - SM80/90/120 fwd: tile_m, cluster=1
+    #   - SM100 fwd:       q_stage * tile_m (= m_block_size_effective), cluster=1
+    #   - SM100 MLA fwd:   64, cluster=2 (effective 128)
+    # hd=256 uses a different scheduler and skips the mCuTotalMBlocks slot.
     if use_dedicated_hd256_kernel:
         scheduler_tile_m, scheduler_cluster_m = None, None
     elif qv is not None:
         scheduler_tile_m, scheduler_cluster_m = 64, 2  # MLA
     else:
         scheduler_tile_m, scheduler_cluster_m = m_block_size_effective, 1
-    # SM90/100/110/MLA reshape mQ via pack_gqa_layout when pack_gqa is on,
-    # so scheduler num_head becomes num_head_kv. SM80/120 don't reshape and
-    # keep num_head = num_head_q (per-Q-head packgqa is handled internally
-    # by PackGQA at load/store time).
-    kernel_reshapes_mQ = qv is not None or arch // 10 in [9, 10, 11]
-    scheduler_num_head = num_head_kv if (pack_gqa and kernel_reshapes_mQ) else num_head
-    tile_cumsum_q = (
+    cu_total_m_blocks_q = (
         None if use_dedicated_hd256_kernel
-        else _compute_tile_cumsum(
-            cu_seqlens_q, seqused_q, scheduler_num_head, scheduler_tile_m,
+        else _compute_cu_total_m_blocks(
+            cu_seqlens_q, seqused_q, scheduler_tile_m,
             qhead_per_kvhead=qhead_per_kvhead, pack_gqa=pack_gqa,
             cluster_shape_m=scheduler_cluster_m,
             device=device,
@@ -791,7 +793,7 @@ def _flash_attn_fwd(
         sparse_kv,
         disable_sparse_kv_bitmask,
         fa_logging.get_fa_log_level(),
-        tile_cumsum_q is not None,
+        cu_total_m_blocks_q is not None,
     )
 
     if compile_key not in _flash_attn_fwd.compile_cache:
@@ -801,12 +803,12 @@ def _flash_attn_fwd(
             seqused_q_tensor,
             seqused_k_tensor,
             learnable_sink_tensor,
-            tile_cumsum_q_tensor,
+            cu_total_m_blocks_q_tensor,
         ) = [
             to_cute_tensor(t, assumed_align=4, leading_dim=0)
             if t is not None
             else None
-            for t in (cu_seqlens_q, cu_seqlens_k, seqused_q, seqused_k, learnable_sink, tile_cumsum_q)
+            for t in (cu_seqlens_q, cu_seqlens_k, seqused_q, seqused_k, learnable_sink, cu_total_m_blocks_q)
         ]
         page_table_tensor = (
             to_cute_tensor(page_table, assumed_align=4, leading_dim=1)
@@ -1021,7 +1023,7 @@ def _flash_attn_fwd(
                 cu_seqlens_k_tensor,
                 seqused_q_tensor,
                 seqused_k_tensor,
-                tile_cumsum_q_tensor,
+                cu_total_m_blocks_q_tensor,
                 gather_kv_indices_tensor,
                 page_table_tensor,
                 window_size_left,
@@ -1047,9 +1049,9 @@ def _flash_attn_fwd(
                 window_size_right,
                 learnable_sink_tensor,
             ]
-            # hd=256 uses Sm100FmhaStaticTileScheduler (no mTileCumsum slot).
+            # hd=256 uses Sm100FmhaStaticTileScheduler (no mCuTotalMBlocks slot).
             if not use_dedicated_hd256_kernel:
-                compile_args.insert(11, tile_cumsum_q_tensor)
+                compile_args.insert(11, cu_total_m_blocks_q_tensor)
             if arch // 10 in [10, 11]:
                 compile_args.append(descale_tensors_tensor)
             compile_args.extend([
@@ -1089,7 +1091,7 @@ def _flash_attn_fwd(
                 cu_seqlens_k,
                 seqused_q,
                 seqused_k,
-                tile_cumsum_q,
+                cu_total_m_blocks_q,
                 gather_kv_indices,
                 page_table,
                 window_size_left,
@@ -1112,9 +1114,9 @@ def _flash_attn_fwd(
                 window_size_right,
                 learnable_sink,
             ]
-            # Mirror compile_args: skip mTileCumsum slot for hd=256.
+            # Mirror compile_args: skip mCuTotalMBlocks slot for hd=256.
             if not use_dedicated_hd256_kernel:
-                call_args.insert(10, tile_cumsum_q)
+                call_args.insert(10, cu_total_m_blocks_q)
             if arch // 10 in [10, 11]:
                 call_args.append(descale_tensors)
             call_args.extend([
@@ -1194,7 +1196,7 @@ def make_fake_bwd_tensors(dtype, has_gqa, varlen_q, varlen_k):
 
 def _compile_bwd_preprocess(
     dtype, head_dim, head_dim_v, m_block_size, has_cuseqlens_q, has_seqused_q, has_dlse, has_dq_accum,
-    use_padded_offsets, has_tile_cumsum,
+    use_padded_offsets, has_cu_total_m_blocks,
 ):
     """Compile bwd preprocess kernel using cute fake tensors (no real GPU tensors needed)."""
     mQ, mK, mV, mO, mdO, mdQ, mdK, mdV, mLSE, mLSElog2, mPdPsum, mdQaccum, mdKaccum, mdVaccum = make_fake_bwd_tensors(
@@ -1206,13 +1208,13 @@ def _compile_bwd_preprocess(
     mSequsedQ = fake_tensor(Int32, (batch,), divisibility=1) if has_seqused_q else None
     mdLSE = fake_tensor(Float32, mLSE.shape, divisibility=1) if has_dlse else None
     mdQaccum = mdQaccum if has_dq_accum else None
-    mTileCumsum = fake_tensor(Int32, (batchp1,), divisibility=1) if has_tile_cumsum else None
+    mCuTotalMBlocks = fake_tensor(Int32, (batchp1,), divisibility=1) if has_cu_total_m_blocks else None
     fa_bwd_pre = FlashAttentionBackwardPreprocess(
         dtype, head_dim, head_dim_v, m_block_size, use_padded_offsets=use_padded_offsets
     )
     return cute.compile(
         fa_bwd_pre, mO, mdO, mPdPsum, mLSE, mLSElog2, mdQaccum, mCuSeqlensQ, mSequsedQ, mdLSE,
-        mTileCumsum,
+        mCuTotalMBlocks,
         cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True),
         options="--enable-tvm-ffi",
     )
@@ -1228,20 +1230,19 @@ def _bwd_preprocess(
     is_varlen = cu_seqlens_q is not None
     # Q-side cumsum: bwd preprocess iterates over m_blocks per batch.
     # No pack_gqa multiplier here (preprocess is per-(batch, head, m_block)).
-    tile_cumsum_pre = _compute_tile_cumsum(
-        cu_seqlens_q, seqused_q, num_head=out.shape[1] if is_varlen else out.shape[2],
-        tile_size=m_block_size, device=out.device,
+    cu_total_m_blocks_pre = _compute_cu_total_m_blocks(
+        cu_seqlens_q, seqused_q, tile_size=m_block_size, device=out.device,
     )
     compile_key = (
         dtype, head_dim, head_dim_v, m_block_size, is_varlen, seqused_q is not None, dlse is not None,
-        dq_accum is not None, use_padded_offsets, tile_cumsum_pre is not None,
+        dq_accum is not None, use_padded_offsets, cu_total_m_blocks_pre is not None,
     )
     if compile_key not in _bwd_preprocess.compile_cache:
         _bwd_preprocess.compile_cache[compile_key] = _compile_bwd_preprocess(*compile_key)
     if not is_fake_mode():
         _bwd_preprocess.compile_cache[compile_key](
             out, dout, dpsum, lse, lse_log2, dq_accum, cu_seqlens_q, seqused_q, dlse,
-            tile_cumsum_pre,
+            cu_total_m_blocks_pre,
         )
 
 
@@ -1252,7 +1253,7 @@ def _compile_bwd_postprocess(
     dtype, hdim, block_size, num_threads, atom_layout, swap_ab,
     has_cuseqlens_q, has_seqused_q,
     use_2cta_instrs, cluster_size, arch,
-    has_tile_cumsum,
+    has_cu_total_m_blocks,
 ):
     """Compile bwd postprocess kernel using cute fake tensors."""
     mQ, mK, mV, mO, mdO, mdQ, mdK, mdV, mLSE, mLSElog2, mPdPsum, mdQaccum, mdKaccum, mdVaccum = make_fake_bwd_tensors(
@@ -1262,7 +1263,7 @@ def _compile_bwd_postprocess(
     batchp1 = cute.sym_int()
     mCuSeqlensQ = fake_tensor(Int32, (batchp1,), divisibility=1) if has_cuseqlens_q else None
     mSeqUsedQ = fake_tensor(Int32, (batch,), divisibility=1) if has_seqused_q else None
-    mTileCumsum = fake_tensor(Int32, (batchp1,), divisibility=1) if has_tile_cumsum else None
+    mCuTotalMBlocks = fake_tensor(Int32, (batchp1,), divisibility=1) if has_cu_total_m_blocks else None
     fa_bwd_post = FlashAttentionBackwardPostprocess(
         dtype, hdim, arch, block_size, num_threads, atom_layout, swap_ab,
         use_2cta_instrs=use_2cta_instrs,
@@ -1270,7 +1271,7 @@ def _compile_bwd_postprocess(
     )
     return cute.compile(
         fa_bwd_post, mdQaccum, mdQ, Float32(0.0), mCuSeqlensQ, mSeqUsedQ,
-        mTileCumsum,
+        mCuTotalMBlocks,
         cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True),
         options="--enable-tvm-ffi",
     )
@@ -1287,24 +1288,22 @@ def _bwd_postprocess_convert(
     # cluster_size is the bwd MAIN kernel's cluster (used by postprocess only
     # for SeqlenInfoQK boundary clamping). The postprocess scheduler itself
     # iterates per tile_m with cluster=1, so the host cumsum uses 1 here.
-    tile_cumsum_post = _compute_tile_cumsum(
-        cu_seqlens, seqused, num_head=output.shape[1] if (cu_seqlens is not None or seqused is not None) else output.shape[2],
-        tile_size=block_size,
-        cluster_shape_m=1,
-        device=output.device,
+    cu_total_m_blocks_post = _compute_cu_total_m_blocks(
+        cu_seqlens, seqused, tile_size=block_size,
+        cluster_shape_m=1, device=output.device,
     )
     compile_key = (
         dtype, hdim, block_size, num_threads, atom_layout, swap_ab,
         cu_seqlens is not None, seqused is not None,
         use_2cta_instrs, cluster_size, arch,
-        tile_cumsum_post is not None,
+        cu_total_m_blocks_post is not None,
     )
     if compile_key not in _bwd_postprocess_convert.compile_cache:
         _bwd_postprocess_convert.compile_cache[compile_key] = _compile_bwd_postprocess(*compile_key)
     if not is_fake_mode():
         _bwd_postprocess_convert.compile_cache[compile_key](
             accum, output, scale, cu_seqlens, seqused,
-            tile_cumsum_post,
+            cu_total_m_blocks_post,
         )
 
 
@@ -1706,14 +1705,14 @@ def _flash_attn_bwd(
         spt = (causal or local) and deterministic
 
     # Backward iterates over K blocks (parallelizes the outer loop across N CTAs),
-    # so the scheduler cumsum is built from K seqlens with n_block_size, and uses
-    # num_head_q (the bwd scheduler iterates over query heads, see flash_bwd_sm*.py).
-    # No pack_gqa multiplier on backward. The hd=256 dedicated backward uses
-    # Sm100Fmha*TileScheduler (no mTileCumsum slot), so skip cumsum for that path.
-    tile_cumsum_k = (
+    # so the scheduler cumsum is built from K seqlens with n_block_size.
+    # No pack_gqa multiplier on backward (forced off in interface). The hd=256
+    # dedicated backward uses Sm100Fmha*TileScheduler (no mCuTotalMBlocks slot),
+    # so skip cumsum for that path.
+    cu_total_m_blocks_k = (
         None if use_dedicated_hd256_kernel
-        else _compute_tile_cumsum(
-            cu_seqlens_k, seqused_k, num_head=num_head, tile_size=n_block_size,
+        else _compute_cu_total_m_blocks(
+            cu_seqlens_k, seqused_k, tile_size=n_block_size,
             cluster_shape_m=cluster_size if arch // 10 in [10, 11] else 1,
             device=device,
         )
@@ -1761,7 +1760,7 @@ def _flash_attn_bwd(
             # Prevent TVM stride poisoning when only one block is present.
             (seqlen_q_rounded // m_block_size == 1),
             (seqlen_k_rounded // n_block_size == 1),
-            tile_cumsum_k is not None,
+            cu_total_m_blocks_k is not None,
         )
     else:
         compile_key = (
@@ -1798,7 +1797,7 @@ def _flash_attn_bwd(
             # Prevent TVM stride poisoning when only one block is present.
             (seqlen_q_rounded // m_block_size == 1),
             (seqlen_k_rounded // n_block_size == 1),
-            tile_cumsum_k is not None,
+            cu_total_m_blocks_k is not None,
         )
 
     if compile_key not in _flash_attn_bwd.compile_cache:
@@ -1811,9 +1810,9 @@ def _flash_attn_bwd(
             dk_accum_tensor, dv_accum_tensor = [
                 to_cute_tensor(t) for t in (dk_accum, dv_accum)
             ]
-        cu_seqlens_q_tensor, cu_seqlens_k_tensor, seqused_q_tensor, seqused_k_tensor, tile_cumsum_k_tensor = [
+        cu_seqlens_q_tensor, cu_seqlens_k_tensor, seqused_q_tensor, seqused_k_tensor, cu_total_m_blocks_k_tensor = [
             to_cute_tensor(t, assumed_align=4) if t is not None else None
-            for t in (cu_seqlens_q, cu_seqlens_k, seqused_q, seqused_k, tile_cumsum_k)
+            for t in (cu_seqlens_q, cu_seqlens_k, seqused_q, seqused_k, cu_total_m_blocks_k)
         ]
         dQ_semaphore_tensor, dK_semaphore_tensor, dV_semaphore_tensor = [
             utils.convert_from_dlpack_leading_static(t.detach(), leading_dim=3, alignment=4, stride_order=t.dim_order())
@@ -1957,9 +1956,9 @@ def _flash_attn_bwd(
             sparse_tensors_compile,
             current_stream,
         ]
-        # hd=256 backward uses Sm100Fmha*TileScheduler (no mTileCumsum slot).
+        # hd=256 backward uses Sm100Fmha*TileScheduler (no mCuTotalMBlocks slot).
         if not use_dedicated_hd256_kernel:
-            compile_args.insert(15, tile_cumsum_k_tensor)
+            compile_args.insert(15, cu_total_m_blocks_k_tensor)
         _flash_attn_bwd.compile_cache[compile_key] = cute.compile(*compile_args, options="--enable-tvm-ffi")
     if not is_fake_mode():
         dq_accum = dq if use_dedicated_hd256_kernel else dq_accum
@@ -1998,7 +1997,7 @@ def _flash_attn_bwd(
             else None,
         ]
         if not use_dedicated_hd256_kernel:
-            call_args.insert(14, tile_cumsum_k)
+            call_args.insert(14, cu_total_m_blocks_k)
         _flash_attn_bwd.compile_cache[compile_key](*call_args)
     # Postprocess: convert dq_accum from float32 to dq in bf16/fp16
     # hd=256 2CTA backward has its own internal postprocess, skip here.

--- a/flash_attn/cute/tile_scheduler.py
+++ b/flash_attn/cute/tile_scheduler.py
@@ -164,6 +164,11 @@ class TileSchedulerArguments(ParamsBase):
     is_split_kv: cutlass.Constexpr[bool] = False
     head_swizzle: cutlass.Constexpr[bool] = False
     use_cluster_idx: cutlass.Constexpr[bool] = False
+    # Optional precomputed cumulative tile counts per batch, length num_batch + 1,
+    # int32, where mTileCumsum[b] = sum_{i<b} (num_m_blocks(i) * num_head). When
+    # provided, SingleTileVarlenScheduler binary-searches it to skip the per-CTA
+    # linear scan over batches; otherwise it falls back to the original O(N) scan.
+    mTileCumsum: Optional[cute.Tensor] = None
 
 
 class SingleTileScheduler:
@@ -785,6 +790,7 @@ class SingleTileVarlenScheduler:
         head_swizzle: cutlass.Constexpr[bool] = False
         cluster_shape_m: cutlass.Constexpr[int] = 1
         scheduling_mode: cutlass.Constexpr[SchedulingMode] = SchedulingMode.STATIC
+        mTileCumsum: Optional[cute.Tensor] = None
 
         @staticmethod
         @cute.jit
@@ -831,6 +837,7 @@ class SingleTileVarlenScheduler:
                 head_swizzle=args.head_swizzle,
                 cluster_shape_m=args.cluster_shape_mn[0],
                 scheduling_mode=scheduling_mode,
+                mTileCumsum=args.mTileCumsum,
             )
 
     def __init__(
@@ -933,20 +940,49 @@ class SingleTileVarlenScheduler:
 
     @cute.jit
     def _varlen_coord_map(self) -> WorkTileInfo:
-        """Map self._tile_idx to (block, head, batch) via warp-level prefix sums."""
+        """Map self._tile_idx to (block, head, batch).
+
+        When params.mTileCumsum is provided, binary-search it to land on the
+        right group of 31 batches in O(log num_batch); otherwise fall back to
+        the original linear scan from batch 0 (O(num_batch / 31) per CTA, i.e.
+        O(num_batch^2) work across the launched grid).
+        Either way, the in-group warp prefix-sum scan that follows is identical.
+        """
         params = self.params
         lane_idx = cute.arch.lane_idx()
-        num_m_blocks = self._get_num_m_blocks(lane_idx, bidb_start=0)
+        next_tile_idx = self._tile_idx // params.cluster_shape_m
+        # Lane (WARP_SIZE - 1) does the boundary cu_seqlens read for lane (WARP_SIZE - 2)
+        # via shuffle_sync_down, so each warp consumes WARP_SIZE - 1 batches per pass.
+        group_size = cute.arch.WARP_SIZE - 1
+
+        if cutlass.const_expr(params.mTileCumsum is not None):
+            # mTileCumsum has length num_batch + 1; mTileCumsum[b] is the start tile
+            # of batch b. lower_bound: smallest lo with mTileCumsum[lo + 1] > next_tile_idx.
+            lo = Int32(0)
+            hi = params.num_batch
+            while lo < hi:
+                mid = (lo + hi) // 2
+                if params.mTileCumsum[mid + 1] <= next_tile_idx:
+                    lo = mid + 1
+                else:
+                    hi = mid
+            # Snap down to a group boundary so the in-group scan below picks up the
+            # same state the linear scan would have reached at this point.
+            batch_idx = (lo // group_size) * group_size
+            group_end_tile = params.mTileCumsum[batch_idx]
+        else:
+            batch_idx = Int32(0)
+            group_end_tile = Int32(0)
+
+        block, head_idx = Int32(0), Int32(0)
+        num_m_blocks = self._get_num_m_blocks(lane_idx, bidb_start=batch_idx)
         num_m_blocks_cumulative = utils.warp_prefix_sum(num_m_blocks, lane_idx)
-        # Total number of blocks for the next 31 batches
+        # Total number of blocks for the next group of batches starting at batch_idx
         m_blocks_in_group = cute.arch.shuffle_sync(num_m_blocks_cumulative, cute.arch.WARP_SIZE - 1)
         # Same for all lanes
-        group_end_tile = m_blocks_in_group * params.num_head
-        # if cute.arch.thread_idx()[0] == 128 + 31: cute.printf("SingleTileVarlenScheduler: tile_idx=%d, group_end_tile = %d, num_m_blocks=%d, num_m_blocks_cumulative = %d, m_blocks_in_group = %d", self._tile_idx, group_end_tile, num_m_blocks, num_m_blocks_cumulative, m_blocks_in_group)
-        block, head_idx, batch_idx = Int32(0), Int32(0), Int32(0)
-        next_tile_idx = self._tile_idx // params.cluster_shape_m
+        group_end_tile += m_blocks_in_group * params.num_head
         while group_end_tile <= next_tile_idx:
-            batch_idx += cute.arch.WARP_SIZE - 1
+            batch_idx += group_size
             if batch_idx >= params.num_batch:
                 batch_idx = Int32(params.num_batch)
                 group_end_tile = next_tile_idx + 1
@@ -962,7 +998,6 @@ class SingleTileVarlenScheduler:
             block, head_idx, batch_idx = Int32(0), Int32(0), Int32(params.num_batch)
         else:
             group_start_tile = group_end_tile - m_blocks_in_group * params.num_head
-            # if cute.arch.thread_idx()[0] == 128 + 31: cute.printf("SingleTileVarlenScheduler: tile_idx=%d, group_end_tile = %d, num_m_blocks=%d, batch_idx = %d", self._tile_idx, group_end_tile, num_m_blocks, batch_idx)
             # The next problem to process is the first one that does not have ending tile position
             # that is greater than or equal to tile index.
             batch_idx_in_group = cute.arch.popc(
@@ -1027,7 +1062,6 @@ class SingleTileVarlenScheduler:
             if cutlass.const_expr(params.cluster_shape_m > 1):
                 bidx_in_cluster = cute.arch.block_in_cluster_idx()
                 block = block * params.cluster_shape_m + bidx_in_cluster[0]
-        # if cute.arch.thread_idx()[0] == 128: cute.printf("SingleTileVarlenScheduler: tile_idx=%d, batch_idx=%d, head_idx=%d, block=%d, is_valid = %d", self._tile_idx, batch_idx, head_idx, block, is_valid)
         split_idx = self._split_idx if const_expr(params.is_split_kv) else Int32(0)
         return WorkTileInfo((Int32(block), Int32(head_idx), Int32(batch_idx), split_idx), is_valid)
 

--- a/flash_attn/cute/tile_scheduler.py
+++ b/flash_attn/cute/tile_scheduler.py
@@ -164,11 +164,12 @@ class TileSchedulerArguments(ParamsBase):
     is_split_kv: cutlass.Constexpr[bool] = False
     head_swizzle: cutlass.Constexpr[bool] = False
     use_cluster_idx: cutlass.Constexpr[bool] = False
-    # Optional precomputed cumulative tile counts per batch, length num_batch + 1,
-    # int32, where mTileCumsum[b] = sum_{i<b} (num_m_blocks(i) * num_head). When
-    # provided, SingleTileVarlenScheduler binary-searches it to skip the per-CTA
-    # linear scan over batches; otherwise it falls back to the original O(N) scan.
-    mTileCumsum: Optional[cute.Tensor] = None
+    # Optional precomputed cumulative m_block counts per batch, length
+    # num_batch + 1, int32, where mCuTotalMBlocks[b] = sum_{i<b} num_m_blocks(i).
+    # When provided, SingleTileVarlenScheduler binary-searches it (via
+    # utils.get_batch_from_cu_tensor) to find batch_idx in O(log N) instead of
+    # the per-CTA O(N) warp scan. Matches the convention from #2224.
+    mCuTotalMBlocks: Optional[cute.Tensor] = None
 
 
 class SingleTileScheduler:
@@ -790,7 +791,7 @@ class SingleTileVarlenScheduler:
         head_swizzle: cutlass.Constexpr[bool] = False
         cluster_shape_m: cutlass.Constexpr[int] = 1
         scheduling_mode: cutlass.Constexpr[SchedulingMode] = SchedulingMode.STATIC
-        mTileCumsum: Optional[cute.Tensor] = None
+        mCuTotalMBlocks: Optional[cute.Tensor] = None
 
         @staticmethod
         @cute.jit
@@ -837,7 +838,7 @@ class SingleTileVarlenScheduler:
                 head_swizzle=args.head_swizzle,
                 cluster_shape_m=args.cluster_shape_mn[0],
                 scheduling_mode=scheduling_mode,
-                mTileCumsum=args.mTileCumsum,
+                mCuTotalMBlocks=args.mCuTotalMBlocks,
             )
 
     def __init__(
@@ -942,34 +943,30 @@ class SingleTileVarlenScheduler:
     def _varlen_coord_map(self) -> WorkTileInfo:
         """Map self._tile_idx to (block, head, batch).
 
-        When params.mTileCumsum is provided, binary-search it to land on the
-        right group of 31 batches in O(log num_batch); otherwise fall back to
-        the original linear scan from batch 0 (O(num_batch / 31) per CTA, i.e.
-        O(num_batch^2) work across the launched grid).
-        Either way, the in-group warp prefix-sum scan that follows is identical.
+        When params.mCuTotalMBlocks is provided, do a lower-bound binary
+        search (via utils.get_batch_from_cu_tensor) to land on the right
+        group of 31 batches in O(log num_batch); otherwise fall back to
+        the original O(num_batch / 31) per-CTA warp prefix-sum scan from
+        batch 0. Either way, the in-group warp scan that follows is
+        identical — the cumsum just provides a starting hint that the
+        warp scan then refines to the exact batch.
         """
         params = self.params
         lane_idx = cute.arch.lane_idx()
         next_tile_idx = self._tile_idx // params.cluster_shape_m
-        # Lane (WARP_SIZE - 1) does the boundary cu_seqlens read for lane (WARP_SIZE - 2)
-        # via shuffle_sync_down, so each warp consumes WARP_SIZE - 1 batches per pass.
+        # Lane (WARP_SIZE - 1) does the boundary cu_seqlens read for lane
+        # (WARP_SIZE - 2) via shuffle_sync_down, so each warp consumes
+        # WARP_SIZE - 1 batches per pass.
         group_size = cute.arch.WARP_SIZE - 1
 
-        if cutlass.const_expr(params.mTileCumsum is not None):
-            # mTileCumsum has length num_batch + 1; mTileCumsum[b] is the start tile
-            # of batch b. lower_bound: smallest lo with mTileCumsum[lo + 1] > next_tile_idx.
-            lo = Int32(0)
-            hi = params.num_batch
-            while lo < hi:
-                mid = (lo + hi) // 2
-                if params.mTileCumsum[mid + 1] <= next_tile_idx:
-                    lo = mid + 1
-                else:
-                    hi = mid
-            # Snap down to a group boundary so the in-group scan below picks up the
-            # same state the linear scan would have reached at this point.
+        if cutlass.const_expr(params.mCuTotalMBlocks is not None):
+            # Use the cumsum as a hint to skip to the right group of 31
+            # batches; the in-group warp scan below then locates the exact
+            # batch starting from that group boundary.
+            target = next_tile_idx // params.num_head
+            lo = utils.get_batch_from_cu_tensor(target, params.mCuTotalMBlocks)
             batch_idx = (lo // group_size) * group_size
-            group_end_tile = params.mTileCumsum[batch_idx]
+            group_end_tile = params.mCuTotalMBlocks[batch_idx] * params.num_head
         else:
             batch_idx = Int32(0)
             group_end_tile = Int32(0)

--- a/tests/cute/conftest.py
+++ b/tests/cute/conftest.py
@@ -30,6 +30,11 @@ def _get_gpu_ids():
 
 
 def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "slow: marks tests that take a long time to run (deselect with '-m \"not slow\"')",
+    )
+
     tmp = Path(tempfile.gettempdir()) / getuser() / "flash_attention_tests"
     tmp.mkdir(parents=True, exist_ok=True)
 

--- a/tests/cute/test_flash_attn_varlen.py
+++ b/tests/cute/test_flash_attn_varlen.py
@@ -299,3 +299,74 @@ def _stats(name, a, b, atol, rtol):
     mean_rel = (diff.abs().mean() / b.abs().clamp_min(1e-6).mean().item())
     print(f"{name}: mean_abs={mean_abs:.4e}, mean_rel={mean_rel:.4e}, sum_fa={a.sum()}, sum_ref={b.sum()}")
     return mean_abs < atol and mean_rel < rtol
+
+
+# ---------------------------------------------------------------------------
+# Scheduler scaling regression test
+# ---------------------------------------------------------------------------
+#
+# Guards against re-introduction of the O(N^2) scheduling overhead in
+# SingleTileVarlenScheduler that was fixed by precomputing per-batch tile
+# counts and binary-searching them in the kernel. With the fix, per-CTA
+# scheduling work is O(log N), so total scheduling cost grows linearly in N
+# and the per-sequence forward time is roughly flat. Without the fix, total
+# scheduling cost grows as O(N^2) and the per-sequence time grows linearly
+# in N (~16x ratio between N=8192 and N=128 at seq_len=64 in measurements).
+#
+# The 2x ceiling is tight but tolerates the noise from L2 effects and from
+# the smallest N having a slightly elevated per-seq cost (warmup, low
+# occupancy). With the fix the observed ratio is ~1; without it, ~16.
+#
+# Marked @pytest.mark.slow so it doesn't slow the default test sweep.
+@pytest.mark.slow
+def test_varlen_scheduler_scaling():
+    if not torch.cuda.is_available():
+        pytest.skip("requires CUDA")
+    cap_major, _ = torch.cuda.get_device_capability()
+    if cap_major < 8:
+        pytest.skip("FA4 requires SM80+")
+
+    seq_len = 64
+    num_heads = 8
+    head_dim = 128
+    dtype = torch.bfloat16
+    device = torch.device("cuda:0")
+    num_seqs_sweep = [128, 512, 2048, 8192]
+
+    def bench_fwd(num_seqs):
+        total = num_seqs * seq_len
+        cu = torch.arange(0, total + 1, seq_len, dtype=torch.int32, device=device)
+        q = torch.randn(total, num_heads, head_dim, dtype=dtype, device=device) * 0.1
+        k = torch.randn(total, num_heads, head_dim, dtype=dtype, device=device) * 0.1
+        v = torch.randn(total, num_heads, head_dim, dtype=dtype, device=device) * 0.1
+
+        def fwd():
+            flash_attn_varlen_func(q, k, v,
+                                   cu_seqlens_q=cu, cu_seqlens_k=cu,
+                                   max_seqlen_q=seq_len, max_seqlen_k=seq_len)
+
+        for _ in range(3):
+            fwd()
+        torch.cuda.synchronize()
+        starts = [torch.cuda.Event(enable_timing=True) for _ in range(10)]
+        ends = [torch.cuda.Event(enable_timing=True) for _ in range(10)]
+        for s, e in zip(starts, ends):
+            s.record(); fwd(); e.record()
+        torch.cuda.synchronize()
+        return sum(s.elapsed_time(e) for s, e in zip(starts, ends)) / 10
+
+    per_seq_us = {}
+    for n in num_seqs_sweep:
+        ms = bench_fwd(n)
+        per_seq_us[n] = ms * 1000.0 / n
+        print(f"  N={n:>5d}  fwd_total={ms:7.3f} ms  per_seq={per_seq_us[n]:.3f} us")
+
+    ratio = per_seq_us[8192] / per_seq_us[128]
+    print(f"  per_seq[8192] / per_seq[128] = {ratio:.2f}x (expect ~1, fail at >2)")
+    assert ratio < 2.0, (
+        f"varlen scheduler appears to scale super-linearly: "
+        f"per_seq_us at N=8192 is {ratio:.2f}x larger than at N=128 "
+        f"(per_seq_us = {per_seq_us}). "
+        f"Did the SingleTileVarlenScheduler.mTileCumsum binary-search regress?"
+    )
+

--- a/tests/cute/test_flash_attn_varlen.py
+++ b/tests/cute/test_flash_attn_varlen.py
@@ -489,3 +489,224 @@ def test_varlen_high_batch_skewed_correctness():
         assert_close(q_pkd.grad, dq_ref_pkd, "dq ")
         assert_close(k_pkd.grad, dk_ref_pkd, "dk ")
         assert_close(v_pkd.grad, dv_ref_pkd, "dv ")
+
+
+# Regression coverage for the binary-search path in SingleTileVarlenScheduler.
+# The cumsum-on path only kicks in at num_batch >= 32; multi-m_block per batch
+# (seqlen > tile_m) is needed to distinguish a wrong snap from a correct one.
+# Parametrize for:
+#   - B >= 63 + multi-m_block: q_stage cumsum miscomputation
+#   - GQA/MQA: pack_gqa head-count remap (num_head_kv vs num_head_q)
+#   - D in {64, 128}: different q_stage paths on SM100
+@pytest.mark.parametrize("B", [63, 128])
+@pytest.mark.parametrize("seq_len", [512, 2048])
+@pytest.mark.parametrize("mha_type", ["mha", "gqa", "mqa"])
+@pytest.mark.parametrize("D", [64, 128])
+@pytest.mark.parametrize("causal", [False, True])
+def test_varlen_scheduler_binary_search_correctness(B, seq_len, mha_type, D, causal):
+    if not torch.cuda.is_available():
+        pytest.skip("requires CUDA")
+    cap_major, _ = torch.cuda.get_device_capability()
+    if cap_major < 8:
+        pytest.skip("FA4 requires SM80+")
+
+    H_q = 8
+    if mha_type == "mha":
+        H_kv = H_q
+    elif mha_type == "gqa":
+        H_kv = 2
+    else:  # mqa
+        H_kv = 1
+    dtype = torch.bfloat16
+    device = torch.device("cuda:0")
+    seed = 4242
+
+    g = torch.Generator(device="cpu").manual_seed(seed)
+    seqlens = torch.full((B,), seq_len, dtype=torch.int32)
+    # Vary a few of the seqlens slightly so we exercise the multi-m_block path
+    # without making num_m_blocks identical for every batch.
+    perturbation = torch.randint(0, 64, (B,), generator=g, dtype=torch.int32)
+    seqlens = (seqlens - perturbation).clamp_min(1)
+    total = int(seqlens.sum().item())
+    cu = torch.zeros(B + 1, dtype=torch.int32, device=device)
+    cu[1:] = seqlens.to(dtype=torch.int32, device=device).cumsum(0)
+
+    torch.manual_seed(seed)
+    q = (torch.randn(total, H_q, D, dtype=dtype, device=device) * 0.1)
+    k = (torch.randn(total, H_kv, D, dtype=dtype, device=device) * 0.1)
+    v = (torch.randn(total, H_kv, D, dtype=dtype, device=device) * 0.1)
+
+    out_fa = flash_attn_varlen_func(
+        q, k, v,
+        cu_seqlens_q=cu, cu_seqlens_k=cu,
+        max_seqlen_q=seq_len, max_seqlen_k=seq_len,
+        causal=causal,
+    )
+    if isinstance(out_fa, tuple):
+        out_fa = out_fa[0]
+
+    # Reference: pad to (B, max_len, H, D), use SDPA, gather valid tokens back.
+    max_len = seq_len
+    q_pad = torch.zeros(B, max_len, H_q, D, dtype=dtype, device=device)
+    k_pad = torch.zeros(B, max_len, H_kv, D, dtype=dtype, device=device)
+    v_pad = torch.zeros(B, max_len, H_kv, D, dtype=dtype, device=device)
+    offset = 0
+    for i, sl in enumerate(seqlens.tolist()):
+        q_pad[i, :sl] = q[offset:offset + sl]
+        k_pad[i, :sl] = k[offset:offset + sl]
+        v_pad[i, :sl] = v[offset:offset + sl]
+        offset += sl
+
+    sdpa_mask = torch.zeros(B, 1, max_len, max_len, dtype=torch.bool, device=device)
+    causal_tri = torch.ones(max_len, max_len, dtype=torch.bool, device=device).tril()
+    for i, sl in enumerate(seqlens.tolist()):
+        if causal:
+            sdpa_mask[i, 0, :sl, :sl] = causal_tri[:sl, :sl]
+        else:
+            sdpa_mask[i, 0, :sl, :sl] = True
+    out_ref = F.scaled_dot_product_attention(
+        q_pad.transpose(1, 2), k_pad.transpose(1, 2), v_pad.transpose(1, 2),
+        attn_mask=sdpa_mask, enable_gqa=(H_q != H_kv),
+    ).transpose(1, 2)
+    out_ref_pkd = torch.zeros_like(out_fa)
+    offset = 0
+    for i, sl in enumerate(seqlens.tolist()):
+        out_ref_pkd[offset:offset + sl] = out_ref[i, :sl]
+        offset += sl
+
+    a_f, b_f = out_fa.float(), out_ref_pkd.float()
+    if torch.allclose(a_f, b_f, atol=3e-2, rtol=3e-2):
+        return
+    diff = (a_f - b_f).abs()
+    max_abs = diff.max().item()
+    # Per-batch breakdown — q_stage miscomputation makes batch 62+ diverge.
+    per_batch_max = []
+    offset = 0
+    for i, sl in enumerate(seqlens.tolist()):
+        d = (out_fa[offset:offset + sl].float()
+             - out_ref_pkd[offset:offset + sl].float()).abs().max().item()
+        per_batch_max.append((i, d))
+        offset += sl
+    bad = [(i, d) for i, d in per_batch_max if d > 3e-2]
+    print(f"  bad batches (max_abs > 3e-2): count={len(bad)} first={bad[:5]} last={bad[-5:]}")
+    raise AssertionError(
+        f"B={B} seq_len={seq_len} mha={mha_type} D={D} causal={causal}: "
+        f"fwd disagrees with SDPA, max_abs={max_abs}"
+    )
+
+
+# Bwd scheduler regression. Bwd parallelizes over K blocks, so the host cumsum
+# is built from cu_seqlens_k with n_block_size and (on SM100, hd>=128) the bwd
+# scheduler's cluster_shape_m is 2 — host cumsum must divide by 2 to match.
+# High B + multi-m_block exercises the cumsum-on path.
+@pytest.mark.parametrize("B", [63, 128])
+@pytest.mark.parametrize("seq_len", [512, 2048])
+@pytest.mark.parametrize("mha_type", ["mha", "gqa", "mqa"])
+@pytest.mark.parametrize("causal", [False, True])
+def test_varlen_scheduler_binary_search_correctness_bwd(B, seq_len, mha_type, causal):
+    if not torch.cuda.is_available():
+        pytest.skip("requires CUDA")
+    cap_major, _ = torch.cuda.get_device_capability()
+    if cap_major < 9:
+        pytest.skip("FA4 backward requires SM90+")
+
+    H_q = 8
+    if mha_type == "mha":
+        H_kv = H_q
+    elif mha_type == "gqa":
+        H_kv = 2
+    else:  # mqa
+        H_kv = 1
+    D = 128
+    dtype = torch.bfloat16
+    device = torch.device("cuda:0")
+    seed = 9090
+
+    g = torch.Generator(device="cpu").manual_seed(seed)
+    seqlens = torch.full((B,), seq_len, dtype=torch.int32)
+    perturbation = torch.randint(0, 64, (B,), generator=g, dtype=torch.int32)
+    seqlens = (seqlens - perturbation).clamp_min(1)
+    total = int(seqlens.sum().item())
+    cu = torch.zeros(B + 1, dtype=torch.int32, device=device)
+    cu[1:] = seqlens.to(dtype=torch.int32, device=device).cumsum(0)
+
+    torch.manual_seed(seed)
+    q = (torch.randn(total, H_q, D, dtype=dtype, device=device) * 0.1).requires_grad_(True)
+    k = (torch.randn(total, H_kv, D, dtype=dtype, device=device) * 0.1).requires_grad_(True)
+    v = (torch.randn(total, H_kv, D, dtype=dtype, device=device) * 0.1).requires_grad_(True)
+
+    out_fa = flash_attn_varlen_func(
+        q, k, v,
+        cu_seqlens_q=cu, cu_seqlens_k=cu,
+        max_seqlen_q=seq_len, max_seqlen_k=seq_len,
+        causal=causal,
+    )
+    if isinstance(out_fa, tuple):
+        out_fa = out_fa[0]
+
+    g_out = torch.randn_like(out_fa)
+    out_fa.backward(g_out)
+
+    # Reference via SDPA on padded tensors.
+    max_len = seq_len
+    q_pad = torch.zeros(B, max_len, H_q, D, dtype=dtype, device=device)
+    k_pad = torch.zeros(B, max_len, H_kv, D, dtype=dtype, device=device)
+    v_pad = torch.zeros(B, max_len, H_kv, D, dtype=dtype, device=device)
+    g_pad = torch.zeros(B, max_len, H_q, D, dtype=dtype, device=device)
+    offset = 0
+    for i, sl in enumerate(seqlens.tolist()):
+        q_pad[i, :sl] = q.detach()[offset:offset + sl]
+        k_pad[i, :sl] = k.detach()[offset:offset + sl]
+        v_pad[i, :sl] = v.detach()[offset:offset + sl]
+        g_pad[i, :sl] = g_out[offset:offset + sl]
+        offset += sl
+    q_pad.requires_grad_(True); k_pad.requires_grad_(True); v_pad.requires_grad_(True)
+
+    sdpa_mask = torch.zeros(B, 1, max_len, max_len, dtype=torch.bool, device=device)
+    causal_tri = torch.ones(max_len, max_len, dtype=torch.bool, device=device).tril()
+    for i, sl in enumerate(seqlens.tolist()):
+        if causal:
+            sdpa_mask[i, 0, :sl, :sl] = causal_tri[:sl, :sl]
+        else:
+            sdpa_mask[i, 0, :sl, :sl] = True
+    out_ref = F.scaled_dot_product_attention(
+        q_pad.transpose(1, 2), k_pad.transpose(1, 2), v_pad.transpose(1, 2),
+        attn_mask=sdpa_mask, enable_gqa=(H_q != H_kv),
+    ).transpose(1, 2)
+    out_ref.backward(g_pad)
+
+    def gather(grad_pad):
+        out = torch.zeros_like(grad_pad[:0].reshape(0, *grad_pad.shape[2:]))
+        out = torch.empty(total, *grad_pad.shape[2:], dtype=grad_pad.dtype, device=grad_pad.device)
+        offset = 0
+        for i, sl in enumerate(seqlens.tolist()):
+            out[offset:offset + sl] = grad_pad[i, :sl]
+            offset += sl
+        return out
+
+    dq_ref = gather(q_pad.grad)
+    dk_ref = gather(k_pad.grad)
+    dv_ref = gather(v_pad.grad)
+
+    # Mirror the existing test_varlen tolerance: torch.allclose(atol=3e-2, rtol=3e-2).
+    # Strict abs-max would over-trigger on causal+GQA dv where reference values
+    # near zero amplify bf16 atomic-add non-determinism (FA4 paper §3.2.4).
+    def assert_close(a, b, name, atol=3e-2, rtol=3e-2):
+        a_f, b_f = a.float(), b.float()
+        if torch.allclose(a_f, b_f, atol=atol, rtol=rtol):
+            return
+        diff = (a_f - b_f).abs()
+        max_abs = diff.max().item()
+        # Find the worst offender to make failure messages self-explanatory.
+        bad = diff > (atol + rtol * b_f.abs())
+        n_bad = int(bad.sum().item())
+        n_total = bad.numel()
+        raise AssertionError(
+            f"B={B} seq_len={seq_len} mha={mha_type} causal={causal}: "
+            f"{name} disagrees with SDPA, max_abs={max_abs:.4g}, "
+            f"{n_bad}/{n_total} elements outside tol"
+        )
+
+    assert_close(q.grad, dq_ref, "dq")
+    assert_close(k.grad, dk_ref, "dk")
+    assert_close(v.grad, dv_ref, "dv")

--- a/tests/cute/test_flash_attn_varlen.py
+++ b/tests/cute/test_flash_attn_varlen.py
@@ -370,3 +370,122 @@ def test_varlen_scheduler_scaling():
         f"Did the SingleTileVarlenScheduler.mTileCumsum binary-search regress?"
     )
 
+
+# ---------------------------------------------------------------------------
+# High-batch-count correctness with skewed seqlens
+# ---------------------------------------------------------------------------
+#
+# The default test_varlen sweep tops out at B=20. The scheduler patch matters
+# at high batch counts that *also* vary in seqlen (the pathological case is
+# many short sequences). This stress test runs forward at B=1024 with a wide
+# random length distribution and checks the output against PyTorch SDPA on a
+# padded reference.
+#
+# Backward uses MHA (Hkv=Hq) to sidestep the inter-Q-head atomic-add
+# non-determinism on dK/dV that the FA4 backward exhibits for GQA/MQA.
+# Paper §3.2.4 ("Deterministic backward pass") describes this; it's
+# pre-existing in the bwd kernel, unchanged by the scheduler patch.
+@pytest.mark.slow
+def test_varlen_high_batch_skewed_correctness():
+    if not torch.cuda.is_available():
+        pytest.skip("requires CUDA")
+    cap_major, _ = torch.cuda.get_device_capability()
+    if cap_major < 8:
+        pytest.skip("FA4 requires SM80+")
+    # SM80 backward varlen is gated off in interface.py (asserts SM90+).
+    test_backward = cap_major >= 9
+
+    B = 1024
+    H = 8
+    D = 128
+    min_len = 1
+    max_len = 128
+    dtype = torch.bfloat16
+    device = torch.device("cuda:0")
+    seed = 12345
+
+    g = torch.Generator(device="cpu").manual_seed(seed)
+    seqlens = torch.randint(min_len, max_len + 1, (B,), generator=g)
+    total = int(seqlens.sum().item())
+    cu = torch.zeros(B + 1, dtype=torch.int32, device=device)
+    cu[1:] = seqlens.to(dtype=torch.int32, device=device).cumsum(0)
+
+    torch.manual_seed(seed)
+    q_pkd = (torch.randn(total, H, D, dtype=dtype, device=device) * 0.1).requires_grad_(True)
+    k_pkd = (torch.randn(total, H, D, dtype=dtype, device=device) * 0.1).requires_grad_(True)
+    v_pkd = (torch.randn(total, H, D, dtype=dtype, device=device) * 0.1).requires_grad_(True)
+
+    out_fa = flash_attn_varlen_func(
+        q_pkd, k_pkd, v_pkd,
+        cu_seqlens_q=cu, cu_seqlens_k=cu,
+        max_seqlen_q=max_len, max_seqlen_k=max_len,
+    )
+    if isinstance(out_fa, tuple):
+        out_fa = out_fa[0]
+
+    g_out = torch.randn_like(out_fa)
+    if test_backward:
+        out_fa.backward(g_out)
+
+    # Reference: pad to (B, max_len, H, D), use SDPA with bool mask, gather valid tokens back.
+    q_pad = torch.zeros(B, max_len, H, D, dtype=dtype, device=device)
+    k_pad = torch.zeros(B, max_len, H, D, dtype=dtype, device=device)
+    v_pad = torch.zeros(B, max_len, H, D, dtype=dtype, device=device)
+    g_pad = torch.zeros(B, max_len, H, D, dtype=dtype, device=device)
+    offset = 0
+    for i, sl in enumerate(seqlens.tolist()):
+        q_pad[i, :sl] = q_pkd.detach()[offset:offset + sl]
+        k_pad[i, :sl] = k_pkd.detach()[offset:offset + sl]
+        v_pad[i, :sl] = v_pkd.detach()[offset:offset + sl]
+        g_pad[i, :sl] = g_out[offset:offset + sl]
+        offset += sl
+
+    q_pad = q_pad.requires_grad_(test_backward)
+    k_pad = k_pad.requires_grad_(test_backward)
+    v_pad = v_pad.requires_grad_(test_backward)
+    sdpa_mask = torch.zeros(B, 1, max_len, max_len, dtype=torch.bool, device=device)
+    for i, sl in enumerate(seqlens.tolist()):
+        sdpa_mask[i, 0, :sl, :sl] = True
+
+    out_ref = F.scaled_dot_product_attention(
+        q_pad.transpose(1, 2), k_pad.transpose(1, 2), v_pad.transpose(1, 2),
+        attn_mask=sdpa_mask,
+    ).transpose(1, 2)
+    if test_backward:
+        out_ref.backward(g_pad)
+
+    # Pack reference back to (total, H, D) layout for comparison
+    out_ref_pkd = torch.zeros_like(out_fa)
+    offset = 0
+    for i, sl in enumerate(seqlens.tolist()):
+        out_ref_pkd[offset:offset + sl] = out_ref[i, :sl]
+        offset += sl
+    if test_backward:
+        dq_ref_pkd = torch.zeros_like(q_pkd)
+        dk_ref_pkd = torch.zeros_like(k_pkd)
+        dv_ref_pkd = torch.zeros_like(v_pkd)
+        offset = 0
+        for i, sl in enumerate(seqlens.tolist()):
+            dq_ref_pkd[offset:offset + sl] = q_pad.grad[i, :sl]
+            dk_ref_pkd[offset:offset + sl] = k_pad.grad[i, :sl]
+            dv_ref_pkd[offset:offset + sl] = v_pad.grad[i, :sl]
+            offset += sl
+
+    # Tolerances mirror test_varlen (bf16 cross-impl): atol/rtol = 3e-2.
+    def assert_close(a, b, name):
+        diff = (a.float() - b.float()).abs()
+        max_abs = diff.max().item()
+        mean_rel = (diff.mean() / b.float().abs().clamp_min(1e-6).mean()).item()
+        print(f"  {name}: max_abs={max_abs:.3e} mean_rel={mean_rel:.3e}")
+        assert max_abs < 3e-2 and mean_rel < 3e-2, (
+            f"{name} disagrees with SDPA: max_abs={max_abs}, mean_rel={mean_rel}"
+        )
+
+    print(f"  B={B} total_tokens={total} (mean {total/B:.1f}, "
+          f"min {seqlens.min().item()}, max {seqlens.max().item()})  "
+          f"test_backward={test_backward}")
+    assert_close(out_fa, out_ref_pkd, "fwd")
+    if test_backward:
+        assert_close(q_pkd.grad, dq_ref_pkd, "dq ")
+        assert_close(k_pkd.grad, dk_ref_pkd, "dk ")
+        assert_close(v_pkd.grad, dv_ref_pkd, "dv ")

--- a/tests/cute/test_flash_attn_varlen.py
+++ b/tests/cute/test_flash_attn_varlen.py
@@ -367,7 +367,7 @@ def test_varlen_scheduler_scaling():
         f"varlen scheduler appears to scale super-linearly: "
         f"per_seq_us at N=8192 is {ratio:.2f}x larger than at N=128 "
         f"(per_seq_us = {per_seq_us}). "
-        f"Did the SingleTileVarlenScheduler.mTileCumsum binary-search regress?"
+        f"Did the SingleTileVarlenScheduler.mCuTotalMBlocks binary-search regress?"
     )
 
 


### PR DESCRIPTION
## Summary

This PR fixes the **O(N²) per-CTA scan in `SingleTileVarlenScheduler`** (`flash_attn/cute/tile_scheduler.py`). It does *not* touch the hd=256 dedicated path, which uses a different scheduler (`Sm100FmhaStaticTileScheduler`) and has its own — distinct — varlen scaling issue (see *Out of scope* below).

`SingleTileVarlenScheduler._varlen_coord_map` mapped a flat CTA index to `(batch, head, m_block)` by linearly scanning batches in groups of 31 (one warp) on the GPU, per CTA. With N batches, every CTA did up to ~N/31 warp-level prefix-sum iterations, giving total scheduling work O(N²). Pathological for many short sequences — at N=8192 / seq_len=34 / 12h / hd=128 / bf16, forward varlen is **73× slower** than the same compute over a dense (padded) layout.

The fix adds the metadata pass from FA4 paper §3.3 ("Scheduling"): the host precomputes per-batch cumulative tile counts (`_compute_tile_cumsum` in `interface.py`); the kernel binary-searches it to skip to the right group of 31 batches in O(log N), then runs the existing in-group warp prefix-sum unchanged. The LPT batch sort the paper also describes is left for a follow-up — the metadata this PR adds is a prerequisite for it.

## Numbers

A/B captured by `git checkout` between commits in this PR (B=8192, seq=34, 12h, hd=128, bf16):

| metric | pre-fix | post-fix | speedup |
|---|---:|---:|---:|
| forward varlen | 68.9 ms | 4.95 ms | **13.9x** |
| backward varlen | 308 ms | 27.1 ms | **11.4x** |
| forward vl/dn ratio | 73.5x | 5.3x | |
| backward vl/dn ratio | 23.7x | 2.1x | |
| per-seq fwd cost (us, flat across N=256..8192) | 0.5 → 8.4 | 0.59 → 0.65 | |

Linear-fit R² on post-fix forward: 0.99990 (so per-seq cost is essentially flat — the asymptotic was the bug).

Reproduce with `benchmarks/benchmark_varlen_scheduler.py` (added in this PR).

The remaining 5.3x vl/dn ratio at the worst-case (N=8192, seq=34) is real varlen overhead (per-batch TMA descriptor setup, padded `dq_accum`); the scheduler is no longer a contributor. Once seq_len rises to 1024 the ratio collapses to 1.6x.

## Scope

`SingleTileVarlenScheduler` is instantiated by 9 kernel files; this PR threads the optional `mTileCumsum: cute.Tensor` argument through every one of them:

- `flash_fwd.py` (SM80 + SM120 via inheritance)
- `flash_fwd_sm90.py`
- `flash_fwd_sm100.py` (SM100/SM110)
- `flash_fwd_mla_sm100.py` (MLA absorbed)
- `flash_bwd.py` (SM80 + SM120)
- `flash_bwd_sm90.py`
- `flash_bwd_sm100.py`
- `flash_bwd_preprocess.py`
- `flash_bwd_postprocess.py`

The hd=256 dedicated kernel uses a different scheduler (`Sm100FmhaStaticTileScheduler`) without an `mTileCumsum` slot, so the `interface.py` plumbing is gated behind `not use_dedicated_hd256_kernel`.

Public API is unchanged. The kernel parameter is optional with a `None` fallback to the original linear-scan path, which preserves the direct-kernel-callable contract documented in `usage.md`. `interface.py` always passes a real cumsum when varlen is enabled, so the production path never falls back.

## Correctness

- **Bit-identical** to the linear-scan path for forward, dq, dv across MHA / GQA / MQA at B in {64, 128, 512, 4096} (verified by `torch.equal`).
- dk on GQA/MQA shows ~6e-5 max diff vs the linear scan — but the same magnitude as cumsum-on vs cumsum-on with identical inputs (1.5e-5), i.e. it's the FA4 backward's intrinsic atomic-add non-determinism described in paper §3.2.4 ("Deterministic backward pass") and is unchanged by this patch.
- vs PyTorch SDPA reference at B=64 / S=128 / H=8 / D=128 / bf16: fwd max_abs 2.4e-04, dq 3e-05, dk 6e-05, dv 0.0 — well within bf16 tolerance.
- `pytest tests/cute/test_flash_attn_varlen.py -k "(7 or 20) and dtype1 and (mha or gqa or mqa) and 64"`: **828 passed, 0 failed** (covers MHA/GQA/MQA × hd in {64, 128, 256} × the existing parametrize matrix).

## Tests added

| Test | Marker | Purpose |
|---|---|---|
| `test_varlen_scheduler_scaling` | `@slow` | Asserts `per_seq_us[8192] < 2 * per_seq_us[128]`. Guards against re-introduction of O(N²). With the fix the ratio is ~1; without it, ~13. Lives at the regression-test commit so reviewers can see it fail on the previous commit. |
| `test_varlen_high_batch_skewed_correctness` | `@slow` | B=1024 with seqlens uniformly random in [1, 128]; validates fwd+bwd against PyTorch SDPA reference. The existing `test_varlen` caps at B=20; this is the high-batch+skewed regime where the scheduler change matters most. |

Slow tests are excluded by the existing CI filter, so default CI stays green.

## Pre-existing issues observed during verification (NOT introduced by this PR)

- **sm_120a forward FakeTensor compile fails** with `ValueError: Operation creation failed` in `flash_fwd.py:386` (the `epilogue` function, SM80 base via SM120 inheritance). Present on pristine `upstream/main` (`ba59def`).
- **hd=256 dedicated path also exhibits super-linear varlen scaling**, but for a *different* reason: `BlackwellFusedMultiHeadAttentionForward.__call__` in `flash_attn/cute/sm100_hd256_2cta_fmha_forward.py:280-282` sets the M dimension of the FMHA grid from `q_tensor.shape[0]` (= `total_q` = `N × mean_seqlen` for varlen) instead of from `max_seqlen_q`. Result: total tiles `M × B × H` ≈ `(N × mean_seqlen / tile_m) × N × H` = O(N²), most of them no-ops filtered by `check_valid_work_for_seqlen_q`. Reproduces identically on pristine `upstream/main`. Filing as a separate issue #2521 . Fix shape: thread `max_seqlen_q` (already on the public API) into the hd256 kernels and use it for `s_q_total` when varlen — non-trivial because it touches recently-landed code (#2412) across 3 hd256 kernel files.

## Out of scope

- **LPT batch sort** (FA4 paper §3.3 second half) — orthogonal load-balancing improvement, requires its own re-validation (changes the order of inter-Q-head atomic adds on GQA backward), and is most useful for mixed prefill+decode workloads. Best as a follow-up PR; the cumsum metadata this PR adds is a prerequisite for it.
- **hd=256 varlen grid sizing** (different scheduler, different mechanism, different kernel — described above). See #2521 

## Commits

1. `[Cute,Bench] Add varlen tile-scheduler stress benchmark` — script that demonstrates the regression
2. `[Cute,Test] Regression test for FA4 varlen scheduler scaling` — fails on this commit, passes after the fix
3. `[Cute] Fix O(N²) varlen tile scheduler via precomputed cumsum` — the fix
4. `[Cute,Test] High-batch correctness for FA4 varlen vs SDPA` — independent additional coverage