### PR TITLE
[Cute,Sm100] Refactor sScale smem indexing to a 3-mode CuTe layout

### DIFF
--- a/flash_attn/cute/block_sparse_utils.py
+++ b/flash_attn/cute/block_sparse_utils.py
@@ -654,7 +654,8 @@ def handle_block_sparse_empty_tile_correction_sm100(
     head_idx: Int32,
     batch_idx: Int32,
     split_idx: Int32,
-    sScale: cute.Tensor,
+    sScaleSum: cute.Tensor,  # (m_block_size, q_stage) — softmax row_sum view
+    sScaleMax: cute.Tensor,  # (m_block_size, q_stage) — softmax row_max view
     stats: list,
     correction_epilogue: Callable,
     thr_mma_pv: cute.core.ThrMma,
@@ -715,9 +716,9 @@ def handle_block_sparse_empty_tile_correction_sm100(
                         fastmath=True,
                     )
         if tidx < m_block_size:
-            sScale[tidx, stage, 0] = row_sum_value
+            sScaleSum[tidx, stage] = row_sum_value
             if const_expr(mLSE is not None or learnable_sink is not None):
-                sScale[tidx, stage, 1] = row_max_value
+                sScaleMax[tidx, stage] = row_max_value
         acc_flag = row_sum_value == Float32(0.0) or row_sum_value != row_sum_value
         stats[stage] = (row_sum_value, row_max_value, acc_flag)
 

--- a/flash_attn/cute/block_sparse_utils.py
+++ b/flash_attn/cute/block_sparse_utils.py
@@ -654,8 +654,7 @@ def handle_block_sparse_empty_tile_correction_sm100(
     head_idx: Int32,
     batch_idx: Int32,
     split_idx: Int32,
-    sScaleSum: cute.Tensor,  # (m_block_size, q_stage) — softmax row_sum view
-    sScaleMax: cute.Tensor,  # (m_block_size, q_stage) — softmax row_max view
+    sScale: cute.Tensor,
     stats: list,
     correction_epilogue: Callable,
     thr_mma_pv: cute.core.ThrMma,
@@ -716,9 +715,9 @@ def handle_block_sparse_empty_tile_correction_sm100(
                         fastmath=True,
                     )
         if tidx < m_block_size:
-            sScaleSum[tidx, stage] = row_sum_value
+            sScale[tidx, stage, 0] = row_sum_value
             if const_expr(mLSE is not None or learnable_sink is not None):
-                sScaleMax[tidx, stage] = row_max_value
+                sScale[tidx, stage, 1] = row_max_value
         acc_flag = row_sum_value == Float32(0.0) or row_sum_value != row_sum_value
         stats[stage] = (row_sum_value, row_max_value, acc_flag)
 

--- a/flash_attn/cute/block_sparse_utils.py
+++ b/flash_attn/cute/block_sparse_utils.py
@@ -715,10 +715,9 @@ def handle_block_sparse_empty_tile_correction_sm100(
                         fastmath=True,
                     )
         if tidx < m_block_size:
-            scale_row_idx = tidx + stage * m_block_size
-            sScale[scale_row_idx] = row_sum_value
+            sScale[tidx, stage, 0] = row_sum_value
             if const_expr(mLSE is not None or learnable_sink is not None):
-                sScale[scale_row_idx + q_stage * m_block_size] = row_max_value
+                sScale[tidx, stage, 1] = row_max_value
         acc_flag = row_sum_value == Float32(0.0) or row_sum_value != row_sum_value
         stats[stage] = (row_sum_value, row_max_value, acc_flag)
 

--- a/flash_attn/cute/flash_fwd_sm100.py
+++ b/flash_attn/cute/flash_fwd_sm100.py
@@ -1001,12 +1001,8 @@ class FlashAttentionForwardSm100:
         else:
             sO = cute.make_tensor(cute.recast_ptr(sQ.iterator, sO_layout.inner, self.o_dtype), sO_layout.outer)
 
-        # sScale stores per-(thread, stage) softmax stats. Encode the structure
-        # in a 3-mode CuTe layout (M_BLOCK, Q_STAGE, FIELD) so accesses are
-        # natural multi-dim coords (sScale[tidx, stage, 0]=row_sum,
-        # sScale[tidx, stage, 1]=row_max) instead of hand-rolled offset math.
-        # Default col-major strides give (1, m_block_size, q_stage*m_block_size),
-        # i.e. identical flat memory layout to the prior 1-D allocation.
+        # sScale: per-(thread, stage) softmax stats as (M_BLOCK, Q_STAGE, FIELD);
+        # FIELD 0 = row_sum, 1 = row_max. Col-major strides match the prior 1-D layout.
         sScale = storage.sScale.get_tensor(
             cute.make_layout((self.m_block_size, self.q_stage, 2))
         )

--- a/flash_attn/cute/flash_fwd_sm100.py
+++ b/flash_attn/cute/flash_fwd_sm100.py
@@ -1002,14 +1002,16 @@ class FlashAttentionForwardSm100:
             sO = cute.make_tensor(cute.recast_ptr(sQ.iterator, sO_layout.inner, self.o_dtype), sO_layout.outer)
 
         # sScale stores per-(thread, stage) softmax stats. Encode the structure
-        # in a 3-mode CuTe layout (M_BLOCK, Q_STAGE, FIELD) so accesses are
-        # natural multi-dim coords (sScale[tidx, stage, 0]=row_sum,
-        # sScale[tidx, stage, 1]=row_max) instead of hand-rolled offset math.
+        # in a 3-mode CuTe layout (M_BLOCK, Q_STAGE, FIELD), then slice into two
+        # named per-field views so consumers index by (tidx, stage) instead of
+        # repeating offset arithmetic OR carrying a magic 0/1 field index.
         # Default col-major strides give (1, m_block_size, q_stage*m_block_size),
         # i.e. identical flat memory layout to the prior 1-D allocation.
-        sScale = storage.sScale.get_tensor(
+        sScale3d = storage.sScale.get_tensor(
             cute.make_layout((self.m_block_size, self.q_stage, 2))
         )
+        sScaleSum = sScale3d[None, None, 0]  # (m_block_size, q_stage) row_sum view
+        sScaleMax = sScale3d[None, None, 1]  # (m_block_size, q_stage) row_max view
 
         thr_mma_qk = tiled_mma_qk.get_slice(mma_tile_coord_v)
         thr_mma_pv = tiled_mma_pv.get_slice(mma_tile_coord_v)
@@ -1226,7 +1228,8 @@ class FlashAttentionForwardSm100:
                 softmax_scale=softmax_scale,
                 descale_tensors=descale_tensors,
                 thr_mma_qk=thr_mma_qk,
-                sScale=sScale,
+                sScaleSum=sScaleSum,
+                sScaleMax=sScaleMax,
                 mLSE=mLSE,
                 pipeline_s_p_o=pipeline_s_p_o,
                 pipeline_p_lastsplit=pipeline_p_lastsplit,
@@ -1270,7 +1273,8 @@ class FlashAttentionForwardSm100:
                 thr_mma_pv,
                 tStS,
                 tOtO,
-                sScale,
+                sScaleSum,
+                sScaleMax,
                 mO,
                 mLSE,
                 sO,
@@ -1839,7 +1843,8 @@ class FlashAttentionForwardSm100:
         descale_tensors: Optional[DescaleTensors],
         thr_mma_qk: cute.core.ThrMma,
         tStS: cute.Tensor,  # ((TILE_M, TILE_N), 1, 1, q_stage)
-        sScale: cute.Tensor,
+        sScaleSum: cute.Tensor,  # (m_block_size, q_stage) — softmax row_sum view
+        sScaleMax: cute.Tensor,  # (m_block_size, q_stage) — softmax row_max view
         mLSE: Optional[cute.Tensor],
         pipeline_s_p_o: pipeline.PipelineAsync,
         pipeline_p_lastsplit: pipeline.PipelineAsync,
@@ -2028,7 +2033,7 @@ class FlashAttentionForwardSm100:
                 tStS_t2r=tStS_t2r,
                 tStScale_r2t=tStScale_r2t,
                 tStP_r2t=tStP_r2t,
-                sScale=sScale,
+                sScaleSum=sScaleSum,
                 stage=stage,
                 batch_idx=batch_idx,
                 head_idx=head_idx,
@@ -2078,9 +2083,9 @@ class FlashAttentionForwardSm100:
                     self.q_subtile_factor if self.q_subtile_factor is not None else 1,
                 )
                 if not empty_tile:
-                    sScale[tidx, stage, 0] = softmax.row_sum[0]
+                    sScaleSum[tidx, stage] = softmax.row_sum[0]
                     if const_expr(mLSE is not None or learnable_sink is not None):
-                        sScale[tidx, stage, 1] = softmax.row_max[0]
+                        sScaleMax[tidx, stage] = softmax.row_max[0]
                     # if tidx == 0:
                     #     cute.printf("softmax row sum stage %d: %f, row_max = %f\n", stage, softmax.row_sum[0], softmax.row_max[0])
                     # See block_sparse_utils.py NOTE [SM100 block-sparse empty tiles: mbarrier contract].
@@ -2147,9 +2152,9 @@ class FlashAttentionForwardSm100:
                             # Now that we no longer already have the 1st iteration, need mask_seqlen=True here
 
                     # Dense path always writes scale / signals
-                    sScale[tidx, stage, 0] = softmax.row_sum[0]
+                    sScaleSum[tidx, stage] = softmax.row_sum[0]
                     if const_expr(mLSE is not None or learnable_sink is not None):
-                        sScale[tidx, stage, 1] = softmax.row_max[0]
+                        sScaleMax[tidx, stage] = softmax.row_max[0]
                     # pipeline_sm_stats.producer_commit_w_index(stage)
                     sm_stats_barrier.arrive_w_index(index=stage * 4 + warp_idx)
 
@@ -2203,7 +2208,7 @@ class FlashAttentionForwardSm100:
         tStS_t2r: cute.Tensor,
         tStScale_r2t: cute.Tensor,
         tStP_r2t: cute.Tensor,
-        sScale: cute.Tensor,
+        sScaleSum: cute.Tensor,  # (m_block_size, q_stage) — softmax row_sum view
         stage: int | Int32,
         batch_idx: Int32,
         head_idx: Int32,
@@ -2270,7 +2275,7 @@ class FlashAttentionForwardSm100:
             # cute.copy(thr_tmem_store_scale, tSrScale_r2t, tStScale_r2t)
             # cute.arch.fence_view_async_tmem_store()
             thread_idx = thr_tmem_load.thr_idx
-            sScale[thread_idx, stage, 0] = acc_scale
+            sScaleSum[thread_idx, stage] = acc_scale
             # if thread_idx == 0: cute.printf("softmax acc_scale stage %d: %f, row_max = %f\n", stage, acc_scale, row_max)
         # Notify correction wg that row_max is ready
         # pipeline_sm_stats.producer_commit_w_index(stage)
@@ -2327,7 +2332,8 @@ class FlashAttentionForwardSm100:
         thr_mma_pv: cute.core.ThrMma,
         tStS: cute.Tensor,
         tOtO: cute.Tensor,
-        sScale: cute.Tensor,
+        sScaleSum: cute.Tensor,  # (m_block_size, q_stage) — softmax row_sum view
+        sScaleMax: cute.Tensor,  # (m_block_size, q_stage) — softmax row_max view
         mO: cute.Tensor,
         mLSE: cute.Tensor,
         sO: cute.Tensor,
@@ -2441,7 +2447,7 @@ class FlashAttentionForwardSm100:
                         # cute.copy(tiled_tmem_load_vec, tStScales_t2r[stage], tSrScale_t2r)
                         # cute.arch.fence_view_async_tmem_load()
                         # scale = tSrScale_t2r[0]
-                        scale = sScale[tidx, stage, 0]
+                        scale = sScaleSum[tidx, stage]
                         should_rescale = cute.arch.vote_ballot_sync(scale < 1.0) != 0
                         # should_rescale = True
                         # if tidx == 0: cute.printf("Correction scale i = %d, for stage %d: %f, should_rescale = %d\n", i, stage, scale, should_rescale)
@@ -2479,9 +2485,9 @@ class FlashAttentionForwardSm100:
                     # cute.copy(tiled_tmem_load_vec, tStScales_t2r[stage], tSrScale_t2r)
                     # cute.arch.fence_view_async_tmem_load()
                     # scale = tSrScale_t2r[0]
-                    row_sum = sScale[tidx, stage, 0]
+                    row_sum = sScaleSum[tidx, stage]
                     if const_expr(mLSE is not None or learnable_sink is not None):
-                        row_max = sScale[tidx, stage, 1]
+                        row_max = sScaleMax[tidx, stage]
                     else:
                         row_max = None
                     pipeline_sm_stats.consumer_release_w_index(stage)
@@ -2552,7 +2558,8 @@ class FlashAttentionForwardSm100:
                         head_idx,
                         batch_idx,
                         split_idx,
-                        sScale,
+                        sScaleSum,
+                        sScaleMax,
                         stats,
                         self.correction_epilogue,
                         thr_mma_pv,

--- a/flash_attn/cute/flash_fwd_sm100.py
+++ b/flash_attn/cute/flash_fwd_sm100.py
@@ -1002,16 +1002,14 @@ class FlashAttentionForwardSm100:
             sO = cute.make_tensor(cute.recast_ptr(sQ.iterator, sO_layout.inner, self.o_dtype), sO_layout.outer)
 
         # sScale stores per-(thread, stage) softmax stats. Encode the structure
-        # in a 3-mode CuTe layout (M_BLOCK, Q_STAGE, FIELD), then slice into two
-        # named per-field views so consumers index by (tidx, stage) instead of
-        # repeating offset arithmetic OR carrying a magic 0/1 field index.
+        # in a 3-mode CuTe layout (M_BLOCK, Q_STAGE, FIELD) so accesses are
+        # natural multi-dim coords (sScale[tidx, stage, 0]=row_sum,
+        # sScale[tidx, stage, 1]=row_max) instead of hand-rolled offset math.
         # Default col-major strides give (1, m_block_size, q_stage*m_block_size),
         # i.e. identical flat memory layout to the prior 1-D allocation.
-        sScale3d = storage.sScale.get_tensor(
+        sScale = storage.sScale.get_tensor(
             cute.make_layout((self.m_block_size, self.q_stage, 2))
         )
-        sScaleSum = sScale3d[None, None, 0]  # (m_block_size, q_stage) row_sum view
-        sScaleMax = sScale3d[None, None, 1]  # (m_block_size, q_stage) row_max view
 
         thr_mma_qk = tiled_mma_qk.get_slice(mma_tile_coord_v)
         thr_mma_pv = tiled_mma_pv.get_slice(mma_tile_coord_v)
@@ -1228,8 +1226,7 @@ class FlashAttentionForwardSm100:
                 softmax_scale=softmax_scale,
                 descale_tensors=descale_tensors,
                 thr_mma_qk=thr_mma_qk,
-                sScaleSum=sScaleSum,
-                sScaleMax=sScaleMax,
+                sScale=sScale,
                 mLSE=mLSE,
                 pipeline_s_p_o=pipeline_s_p_o,
                 pipeline_p_lastsplit=pipeline_p_lastsplit,
@@ -1273,8 +1270,7 @@ class FlashAttentionForwardSm100:
                 thr_mma_pv,
                 tStS,
                 tOtO,
-                sScaleSum,
-                sScaleMax,
+                sScale,
                 mO,
                 mLSE,
                 sO,
@@ -1843,8 +1839,7 @@ class FlashAttentionForwardSm100:
         descale_tensors: Optional[DescaleTensors],
         thr_mma_qk: cute.core.ThrMma,
         tStS: cute.Tensor,  # ((TILE_M, TILE_N), 1, 1, q_stage)
-        sScaleSum: cute.Tensor,  # (m_block_size, q_stage) — softmax row_sum view
-        sScaleMax: cute.Tensor,  # (m_block_size, q_stage) — softmax row_max view
+        sScale: cute.Tensor,
         mLSE: Optional[cute.Tensor],
         pipeline_s_p_o: pipeline.PipelineAsync,
         pipeline_p_lastsplit: pipeline.PipelineAsync,
@@ -2033,7 +2028,7 @@ class FlashAttentionForwardSm100:
                 tStS_t2r=tStS_t2r,
                 tStScale_r2t=tStScale_r2t,
                 tStP_r2t=tStP_r2t,
-                sScaleSum=sScaleSum,
+                sScale=sScale,
                 stage=stage,
                 batch_idx=batch_idx,
                 head_idx=head_idx,
@@ -2083,9 +2078,9 @@ class FlashAttentionForwardSm100:
                     self.q_subtile_factor if self.q_subtile_factor is not None else 1,
                 )
                 if not empty_tile:
-                    sScaleSum[tidx, stage] = softmax.row_sum[0]
+                    sScale[tidx, stage, 0] = softmax.row_sum[0]
                     if const_expr(mLSE is not None or learnable_sink is not None):
-                        sScaleMax[tidx, stage] = softmax.row_max[0]
+                        sScale[tidx, stage, 1] = softmax.row_max[0]
                     # if tidx == 0:
                     #     cute.printf("softmax row sum stage %d: %f, row_max = %f\n", stage, softmax.row_sum[0], softmax.row_max[0])
                     # See block_sparse_utils.py NOTE [SM100 block-sparse empty tiles: mbarrier contract].
@@ -2152,9 +2147,9 @@ class FlashAttentionForwardSm100:
                             # Now that we no longer already have the 1st iteration, need mask_seqlen=True here
 
                     # Dense path always writes scale / signals
-                    sScaleSum[tidx, stage] = softmax.row_sum[0]
+                    sScale[tidx, stage, 0] = softmax.row_sum[0]
                     if const_expr(mLSE is not None or learnable_sink is not None):
-                        sScaleMax[tidx, stage] = softmax.row_max[0]
+                        sScale[tidx, stage, 1] = softmax.row_max[0]
                     # pipeline_sm_stats.producer_commit_w_index(stage)
                     sm_stats_barrier.arrive_w_index(index=stage * 4 + warp_idx)
 
@@ -2208,7 +2203,7 @@ class FlashAttentionForwardSm100:
         tStS_t2r: cute.Tensor,
         tStScale_r2t: cute.Tensor,
         tStP_r2t: cute.Tensor,
-        sScaleSum: cute.Tensor,  # (m_block_size, q_stage) — softmax row_sum view
+        sScale: cute.Tensor,
         stage: int | Int32,
         batch_idx: Int32,
         head_idx: Int32,
@@ -2275,7 +2270,7 @@ class FlashAttentionForwardSm100:
             # cute.copy(thr_tmem_store_scale, tSrScale_r2t, tStScale_r2t)
             # cute.arch.fence_view_async_tmem_store()
             thread_idx = thr_tmem_load.thr_idx
-            sScaleSum[thread_idx, stage] = acc_scale
+            sScale[thread_idx, stage, 0] = acc_scale
             # if thread_idx == 0: cute.printf("softmax acc_scale stage %d: %f, row_max = %f\n", stage, acc_scale, row_max)
         # Notify correction wg that row_max is ready
         # pipeline_sm_stats.producer_commit_w_index(stage)
@@ -2332,8 +2327,7 @@ class FlashAttentionForwardSm100:
         thr_mma_pv: cute.core.ThrMma,
         tStS: cute.Tensor,
         tOtO: cute.Tensor,
-        sScaleSum: cute.Tensor,  # (m_block_size, q_stage) — softmax row_sum view
-        sScaleMax: cute.Tensor,  # (m_block_size, q_stage) — softmax row_max view
+        sScale: cute.Tensor,
         mO: cute.Tensor,
         mLSE: cute.Tensor,
         sO: cute.Tensor,
@@ -2447,7 +2441,7 @@ class FlashAttentionForwardSm100:
                         # cute.copy(tiled_tmem_load_vec, tStScales_t2r[stage], tSrScale_t2r)
                         # cute.arch.fence_view_async_tmem_load()
                         # scale = tSrScale_t2r[0]
-                        scale = sScaleSum[tidx, stage]
+                        scale = sScale[tidx, stage, 0]
                         should_rescale = cute.arch.vote_ballot_sync(scale < 1.0) != 0
                         # should_rescale = True
                         # if tidx == 0: cute.printf("Correction scale i = %d, for stage %d: %f, should_rescale = %d\n", i, stage, scale, should_rescale)
@@ -2485,9 +2479,9 @@ class FlashAttentionForwardSm100:
                     # cute.copy(tiled_tmem_load_vec, tStScales_t2r[stage], tSrScale_t2r)
                     # cute.arch.fence_view_async_tmem_load()
                     # scale = tSrScale_t2r[0]
-                    row_sum = sScaleSum[tidx, stage]
+                    row_sum = sScale[tidx, stage, 0]
                     if const_expr(mLSE is not None or learnable_sink is not None):
-                        row_max = sScaleMax[tidx, stage]
+                        row_max = sScale[tidx, stage, 1]
                     else:
                         row_max = None
                     pipeline_sm_stats.consumer_release_w_index(stage)
@@ -2558,8 +2552,7 @@ class FlashAttentionForwardSm100:
                         head_idx,
                         batch_idx,
                         split_idx,
-                        sScaleSum,
-                        sScaleMax,
+                        sScale,
                         stats,
                         self.correction_epilogue,
                         thr_mma_pv,

--- a/flash_attn/cute/flash_fwd_sm100.py
+++ b/flash_attn/cute/flash_fwd_sm100.py
@@ -1001,7 +1001,15 @@ class FlashAttentionForwardSm100:
         else:
             sO = cute.make_tensor(cute.recast_ptr(sQ.iterator, sO_layout.inner, self.o_dtype), sO_layout.outer)
 
-        sScale = storage.sScale.get_tensor(cute.make_layout(self.q_stage * self.m_block_size * 2))
+        # sScale stores per-(thread, stage) softmax stats. Encode the structure
+        # in a 3-mode CuTe layout (M_BLOCK, Q_STAGE, FIELD) so accesses are
+        # natural multi-dim coords (sScale[tidx, stage, 0]=row_sum,
+        # sScale[tidx, stage, 1]=row_max) instead of hand-rolled offset math.
+        # Default col-major strides give (1, m_block_size, q_stage*m_block_size),
+        # i.e. identical flat memory layout to the prior 1-D allocation.
+        sScale = storage.sScale.get_tensor(
+            cute.make_layout((self.m_block_size, self.q_stage, 2))
+        )
 
         thr_mma_qk = tiled_mma_qk.get_slice(mma_tile_coord_v)
         thr_mma_pv = tiled_mma_pv.get_slice(mma_tile_coord_v)
@@ -2070,11 +2078,9 @@ class FlashAttentionForwardSm100:
                     self.q_subtile_factor if self.q_subtile_factor is not None else 1,
                 )
                 if not empty_tile:
-                    sScale[tidx + stage * self.m_block_size] = softmax.row_sum[0]
+                    sScale[tidx, stage, 0] = softmax.row_sum[0]
                     if const_expr(mLSE is not None or learnable_sink is not None):
-                        sScale[
-                            tidx + stage * self.m_block_size + self.q_stage * self.m_block_size
-                        ] = softmax.row_max[0]
+                        sScale[tidx, stage, 1] = softmax.row_max[0]
                     # if tidx == 0:
                     #     cute.printf("softmax row sum stage %d: %f, row_max = %f\n", stage, softmax.row_sum[0], softmax.row_max[0])
                     # See block_sparse_utils.py NOTE [SM100 block-sparse empty tiles: mbarrier contract].
@@ -2141,11 +2147,9 @@ class FlashAttentionForwardSm100:
                             # Now that we no longer already have the 1st iteration, need mask_seqlen=True here
 
                     # Dense path always writes scale / signals
-                    sScale[tidx + stage * self.m_block_size] = softmax.row_sum[0]
+                    sScale[tidx, stage, 0] = softmax.row_sum[0]
                     if const_expr(mLSE is not None or learnable_sink is not None):
-                        sScale[
-                            tidx + stage * self.m_block_size + self.q_stage * self.m_block_size
-                        ] = softmax.row_max[0]
+                        sScale[tidx, stage, 1] = softmax.row_max[0]
                     # pipeline_sm_stats.producer_commit_w_index(stage)
                     sm_stats_barrier.arrive_w_index(index=stage * 4 + warp_idx)
 
@@ -2266,7 +2270,7 @@ class FlashAttentionForwardSm100:
             # cute.copy(thr_tmem_store_scale, tSrScale_r2t, tStScale_r2t)
             # cute.arch.fence_view_async_tmem_store()
             thread_idx = thr_tmem_load.thr_idx
-            sScale[thread_idx + stage * self.m_block_size] = acc_scale
+            sScale[thread_idx, stage, 0] = acc_scale
             # if thread_idx == 0: cute.printf("softmax acc_scale stage %d: %f, row_max = %f\n", stage, acc_scale, row_max)
         # Notify correction wg that row_max is ready
         # pipeline_sm_stats.producer_commit_w_index(stage)
@@ -2437,7 +2441,7 @@ class FlashAttentionForwardSm100:
                         # cute.copy(tiled_tmem_load_vec, tStScales_t2r[stage], tSrScale_t2r)
                         # cute.arch.fence_view_async_tmem_load()
                         # scale = tSrScale_t2r[0]
-                        scale = sScale[tidx + stage * self.m_block_size]
+                        scale = sScale[tidx, stage, 0]
                         should_rescale = cute.arch.vote_ballot_sync(scale < 1.0) != 0
                         # should_rescale = True
                         # if tidx == 0: cute.printf("Correction scale i = %d, for stage %d: %f, should_rescale = %d\n", i, stage, scale, should_rescale)
@@ -2475,9 +2479,9 @@ class FlashAttentionForwardSm100:
                     # cute.copy(tiled_tmem_load_vec, tStScales_t2r[stage], tSrScale_t2r)
                     # cute.arch.fence_view_async_tmem_load()
                     # scale = tSrScale_t2r[0]
-                    row_sum = sScale[tidx + stage * self.m_block_size]
+                    row_sum = sScale[tidx, stage, 0]
                     if const_expr(mLSE is not None or learnable_sink is not None):
-                        row_max = sScale[tidx + stage * self.m_block_size + self.q_stage * self.m_block_size]
+                        row_max = sScale[tidx, stage, 1]
                     else:
                         row_max = None
                     pipeline_sm_stats.consumer_release_w_index(stage)


### PR DESCRIPTION
> Authored by an AI assistant (Claude). Code-quality refactor only — no
> behavior or perf change. Opened as a CuTe-layout-algebra exercise.

## What

`sScale` (per-(thread, q_stage) softmax row_sum / row_max in smem) was a
flat 1-D buffer with hand-rolled offsets:

```python
sScale[tidx + stage * self.m_block_size]                                      # row_sum
sScale[tidx + stage * self.m_block_size + self.q_stage * self.m_block_size]  # row_max
```

Replaced with a 3-mode CuTe layout `(m_block_size, q_stage, 2)`:

```python
sScale[tidx, stage, 0]   # row_sum
sScale[tidx, stage, 1]   # row_max
```

Default col-major strides give `(1, m_block_size, q_stage*m_block_size)` —
bit-identical flat layout to before. Pure structural change.

Files: `flash_fwd_sm100.py`, `block_sparse_utils.py`.

## Note on branch history

A middle `[experiment]` commit slices sScale into per-field views; it is
reverted in the next commit. Net PR diff = just the 3-mode layout refactor.

## Test plan

- `ruff check` / `ruff format --check` clean on changed files.
- No functional change intended; flat memory layout is bitwise identical.


edit 1: Ran unit tests as well.
edit 2: this doesn't change the output ptx 