### PR TITLE
Fix CK varlen num_splits plumbing

### DIFF
--- a/csrc/flash_attn_ck/flash_api.cpp
+++ b/csrc/flash_attn_ck/flash_api.cpp
@@ -40,7 +40,8 @@ mha_varlen_fwd(at::Tensor &q,                               // total_q x num_hea
                int window_size_right,
                const float softcap,
                const bool return_softmax,
-               std::optional<at::Generator> gen_);
+               std::optional<at::Generator> gen_,
+               int num_splits = 0);
 
 std::vector<at::Tensor>
 mha_bwd(const at::Tensor &dout,                   // batch_size x seqlen_q x num_heads, x multiple_of(head_size_og, 8)

--- a/csrc/flash_attn_ck/mha_varlen_fwd.cpp
+++ b/csrc/flash_attn_ck/mha_varlen_fwd.cpp
@@ -342,7 +342,8 @@ mha_varlen_fwd(at::Tensor &q,                   // total_q x num_heads x head_si
                int window_size_right,
                const float /*softcap*/,
                const bool return_dropout_randval,
-               std::optional<at::Generator> gen_)
+               std::optional<at::Generator> gen_,
+               int num_splits)
 {
     auto q_dtype = q.dtype();
     TORCH_CHECK(q_dtype == torch::kFloat16 || q_dtype == torch::kBFloat16,
@@ -473,7 +474,6 @@ mha_varlen_fwd(at::Tensor &q,                   // total_q x num_heads x head_si
         if (return_dropout_randval) {p.zero_();}
     }
 
-    int num_splits = 0;
     num_splits = flash::override_num_splits_if_necessary(batch_size, num_heads, max_seqlen_q, head_size, 0, num_splits);
     TORCH_CHECK(num_splits > 0, "num_splits should greater than 0");
     TORCH_CHECK(num_splits <= 128, "num_splits greater than 128 is not supported");


### PR DESCRIPTION
## Summary
- Add the trailing `num_splits` argument to the ROCm CK `mha_varlen_fwd` declaration and definition.
- Use the caller-provided `num_splits` value instead of hardcoding `0` before CK split-kv selection.
- Align the CK backend with the Python wrapper and CUDA implementation after #2448/#2476.

## Tests
- `git diff --check`
- `python3` signature alignment check