### PR TITLE
Fix test_flash_attn_fast varlen call after qv positional insert

### DIFF
--- a/tests/cute/test_flash_attn_fast.py
+++ b/tests/cute/test_flash_attn_fast.py
@@ -139,8 +139,8 @@ def test_flash_attn_varlen_output(seqlen, d, causal, mha_type, dtype):
 
     out_varlen, lse = flash_attn_varlen_func(
         q_varlen, k_varlen, v_varlen,
-        cu_seqlens, cu_seqlens,
-        seqlen, seqlen,
+        cu_seqlens_q=cu_seqlens, cu_seqlens_k=cu_seqlens,
+        max_seqlen_q=seqlen, max_seqlen_k=seqlen,
         causal=causal,
     )
 


### PR DESCRIPTION
## Summary
- `flash_attn_varlen_func` now takes `qv` as its 4th positional parameter, which shifted the existing positional call in `tests/cute/test_flash_attn_fast.py` so `cu_seqlens_q/k` and `max_seqlen_q/k` got bound to the wrong slots.
- This caused 132 `AttributeError: 'int' object has no attribute 'shape'` failures at `flash_attn/cute/interface.py:370`, e.g. `test_flash_attn_varlen_output[128-64-False-mha-dtype0]`.
- Fix: switch the call site to keyword arguments. After the fix, the suite passes 240/240.

## Test plan
- [x] `pytest tests/cute/test_flash_attn_fast.py` — 240 passed


cc @jayhshah 