### PR TITLE
[Cute,Sm80] Fix forward GQA correctness — pack_gqa flag without pack_…

### DIFF
--- a/flash_attn/cute/flash_bwd.py
+++ b/flash_attn/cute/flash_bwd.py
@@ -426,7 +426,7 @@ class FlashAttentionBackwardSm80:
             headdim_v=mV.shape[2],
             total_q=mK.shape[0],
             tile_shape_mn=(self.n_block_size, self.m_block_size),
-            qhead_per_kvhead_packgqa=self.qhead_per_kvhead if cutlass.const_expr(self.pack_gqa) else 1,
+            qhead_per_kvhead_packgqa=1,  # SM80 bwd never calls pack_gqa_layout (rows are not packed)
             mCuSeqlensQ=mCuSeqlensK,
             mSeqUsedQ=mSeqUsedK,
         )
@@ -566,7 +566,7 @@ class FlashAttentionBackwardSm80:
                 mdO_cur = cute.domain_offset((seqlen.offset_q, 0), mdO[None, head_idx, None])
                 mdPsum_cur = cute.domain_offset((padded_offset_q,), mdPsum[head_idx, None])
                 mdQaccum_cur = cute.domain_offset((padded_offset_q * self.head_dim_padded,), mdQaccum[head_idx, None])
-            head_idx_kv = head_idx // self.qhead_per_kvhead if cutlass.const_expr(not self.pack_gqa) else head_idx
+            head_idx_kv = head_idx // self.qhead_per_kvhead  # SM80 bwd never packs
 
             if cutlass.const_expr(not seqlen.has_cu_seqlens_k):
                 mK_cur, mV_cur = [t[batch_idx, None, head_idx_kv, None] for t in (mK, mV)]
@@ -1056,7 +1056,7 @@ class FlashAttentionBackwardSm80:
         gmem_thr_copy_dV = gmem_tiled_copy_dV.get_slice(tidx)
 
         batch_idx = batch_size
-        head_idx_kv = num_head // self.qhead_per_kvhead if cutlass.const_expr(not self.pack_gqa) else num_head
+        head_idx_kv = num_head // self.qhead_per_kvhead  # SM80 bwd never packs
 
         if cutlass.const_expr(self.qhead_per_kvhead == 1):
             # Make sure all threads have finished reading K and V, otherwise we get racy dQ
@@ -1135,7 +1135,7 @@ class FlashAttentionBackwardSm80:
         else:  # qhead_per_kvhead > 1, do atomic add
             # For Sm90, we need to sync to avoid racy writes to smem_q
             # For Sm80, we don't need to sync since we're not touching smem
-            head_idx_kv = num_head // self.qhead_per_kvhead if cutlass.const_expr(not self.pack_gqa) else num_head
+            head_idx_kv = num_head // self.qhead_per_kvhead  # SM80 bwd never packs
 
             if cutlass.const_expr(not seqlen.has_cu_seqlens_k):
                 mdK_cur, mdV_cur = [t[batch_idx, head_idx_kv, None] for t in (mdK, mdV)]

--- a/flash_attn/cute/flash_fwd.py
+++ b/flash_attn/cute/flash_fwd.py
@@ -783,7 +783,7 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
             False,  # is_split_kv
             window_size_left,
             window_size_right,
-            qhead_per_kvhead_packgqa=self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
+            qhead_per_kvhead_packgqa=1,  # SM80 forward never calls pack_gqa_layout (rows are not packed)
         )
         seqlen = SeqlenInfoQK.create(
             batch_idx=batch_size,
@@ -995,7 +995,7 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
             seqlen,
             window_size_left,
             window_size_right,
-            self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
+            1,  # SM80 forward never calls pack_gqa_layout (rows are not packed)
         )
         mask_fn = partial(
             mask.apply_mask,


### PR DESCRIPTION
…gqa_layout call

FlashAttentionForwardSm80 set `qhead_per_kvhead_packgqa = qhead_per_kvhead` on BlockInfo and AttentionMask when `pack_gqa=True`, but it never actually calls `pack_gqa_layout` to fold qhead into the seqlen dimension (only flash_fwd_sm100.py and flash_fwd_mla_sm100.py do).

The downstream code in BlockInfo.get_n_block_min_max and AttentionMask.apply_mask then divides row indices by the ratio, treating un-packed rows as packed:
  - wrong causal column limit per row (row 0 = 0/r = 0 happens to be right; all other rows wrong by factor r)
  - wrong K-block iteration range past m_block >= 1

Fix: SM80 forward never packs, so pass 1 (constexpr) at both call sites.

Reproduces and is fixed on RTX PRO 6000 Blackwell Max-Q (sm_120a, which inherits from FlashAttentionForwardSm80).