### PR TITLE
 Build Fix: Update abi3 tag to cp310 and minimum python version to 3.10

### DIFF
--- a/hopper/setup.py
+++ b/hopper/setup.py
@@ -703,9 +703,9 @@ class CachedWheelsCommand(_bdist_wheel):
             # If the wheel could not be downloaded, build from source
             super().run()
 
-# Get the PyTorch version as a tuple of numbers 
-torch_version_str = torch.__version__.split('+')[0]
-torch_major_minor = tuple(map(int, torch_version_str.split('.')[:2]))
+# Get the PyTorch version using packaging.version for robust PEP 440 parsing
+torch_version = parse(torch.__version__)
+torch_major_minor = (torch_version.major, torch_version.minor)
 
 # Determine the minimum Python version supported by this PyTorch
 if torch_major_minor >= (2, 11):

--- a/hopper/setup.py
+++ b/hopper/setup.py
@@ -602,7 +602,6 @@ if not SKIP_CUDA_BUILD:
       
     if major >= 2 and minor >= 9:
         flash_api_source = "flash_api_stable.cpp"
-        # Use the environment variable if provided, otherwise default to 2.9 hex
         stable_args = ["-DTORCH_TARGET_VERSION=0x0209000000000000"]
     else:
         flash_api_source = "flash_api.cpp"

--- a/hopper/setup.py
+++ b/hopper/setup.py
@@ -648,8 +648,8 @@ if not SKIP_CUDA_BUILD:
             name=f"{PACKAGE_NAME}._C",
             sources=sources,
             extra_compile_args={
-                "cxx":["-O3", "-std=c++17"] + stable_args,
-                "nvcc": nvcc_flags,
+                "cxx":["-O3", "-std=c++17"] + stable_args + feature_args,
+                "nvcc": nvcc_threads_args() + nvcc_flags + cc_flag + feature_args,
             },
             include_dirs=include_dirs,
             py_limited_api=True,

--- a/hopper/setup.py
+++ b/hopper/setup.py
@@ -646,7 +646,7 @@ if not SKIP_CUDA_BUILD:
             name=f"{PACKAGE_NAME}._C",
             sources=sources,
             extra_compile_args={
-                "cxx":["-O3", "-std=c++17"] + stable_args + feature_args,
+                "cxx":["-O3", "-std=c++17", "-DPy_LIMITED_API=0x03090000"] + stable_args + feature_args,
                 "nvcc": nvcc_threads_args() + nvcc_flags + cc_flag + feature_args,
             },
             include_dirs=include_dirs,

--- a/hopper/setup.py
+++ b/hopper/setup.py
@@ -603,8 +603,7 @@ if not SKIP_CUDA_BUILD:
     if major >= 2 and minor >= 9:
         flash_api_source = "flash_api_stable.cpp"
         # Use the environment variable if provided, otherwise default to 2.9 hex
-        target_env = os.environ.get("TORCH_TARGET_VERSION", "0x0209000000000000")
-        stable_args = [f"-DTORCH_TARGET_VERSION={target_env}"]
+        stable_args = ["-DTORCH_TARGET_VERSION=0x0209000000000000"]
     else:
         flash_api_source = "flash_api.cpp"
 

--- a/hopper/setup.py
+++ b/hopper/setup.py
@@ -646,7 +646,7 @@ if not SKIP_CUDA_BUILD:
             name=f"{PACKAGE_NAME}._C",
             sources=sources,
             extra_compile_args={
-                "cxx":["-O3", "-std=c++17", "-DPy_LIMITED_API=0x03090000"] + stable_args + feature_args,
+                "cxx": ["-O3", "-std=c++17", "-DPy_LIMITED_API=0x03090000"] + stable_args + feature_args,
                 "nvcc": nvcc_threads_args() + nvcc_flags + cc_flag + feature_args,
             },
             include_dirs=include_dirs,

--- a/hopper/setup.py
+++ b/hopper/setup.py
@@ -13,7 +13,6 @@ import platform
 import sysconfig
 import tarfile
 import itertools
-import importlib.metadata
 
 from setuptools import setup, find_packages
 import subprocess
@@ -417,12 +416,34 @@ def nvcc_threads_args():
     nvcc_threads = os.getenv("NVCC_THREADS") or "2"
     return ["--threads", nvcc_threads]
 
+#
+# Fallbacks in case metadata is missing
+dynamic_abi_tag = "cp39"
+dynamic_python_requires = ">=3.9"
+
+try:
+    target = os.environ.get("TORCH_TARGET_VERSION")
+    if target:
+        # Parse hex string for PyTorch 2.9
+        major, minor = (int(target, 16) >> 56) & 0xFF, (int(target, 16) >> 48) & 0xFF
+    else:
+        # Fallback to the installed PyTorch version
+        major, minor = map(int, torch.__version__.split('.')[:2])
+        
+    # Since PyTorch 2.9+ dropped Python 3.9 support
+    if major >= 2 and minor >= 9:
+        dynamic_abi_tag = "cp310"
+        dynamic_python_requires = ">=3.10"
+except Exception:
+    pass # Sets cp39
+
+# Create the dynamic options dictionary that will be passed to setup()
+dynamic_options = {"bdist_wheel": {"py_limited_api": dynamic_abi_tag}}
 
 # NVIDIA_TOOLCHAIN_VERSION = {"nvcc": "12.3.107"}
 NVIDIA_TOOLCHAIN_VERSION = {"nvcc": "12.6.85", "ptxas": "12.8.93"}
 
 exe_extension = sysconfig.get_config_var("EXE")
-
 
 cmdclass = {}
 ext_modules = []
@@ -577,13 +598,13 @@ if not SKIP_CUDA_BUILD:
         sources_bwd_sm80 = []
     
     # Choose between flash_api.cpp and flash_api_stable.cpp based on torch version
-    torch_version = parse(torch.__version__)
-    target_version = parse("2.9.0.dev20250830")
     stable_args = []
       
-    if torch_version >= target_version:
+    if major >= 2 and minor >= 9:
         flash_api_source = "flash_api_stable.cpp"
-        stable_args = ["-DTORCH_TARGET_VERSION=0x0209000000000000"]  # Targets minimum runtime version torch 2.9.0
+        # Use the environment variable if provided, otherwise default to 2.9 hex
+        target_env = os.environ.get("TORCH_TARGET_VERSION", "0x0209000000000000")
+        stable_args = [f"-DTORCH_TARGET_VERSION={target_env}"]
     else:
         flash_api_source = "flash_api.cpp"
 
@@ -627,8 +648,8 @@ if not SKIP_CUDA_BUILD:
             name=f"{PACKAGE_NAME}._C",
             sources=sources,
             extra_compile_args={
-                "cxx": ["-O3", "-std=c++17", "-DPy_LIMITED_API=0x03090000"] + stable_args + feature_args,
-                "nvcc": nvcc_threads_args() + nvcc_flags + cc_flag + feature_args,
+                "cxx":["-O3", "-std=c++17"] + stable_args,
+                "nvcc": nvcc_flags,
             },
             include_dirs=include_dirs,
             py_limited_api=True,
@@ -703,26 +724,6 @@ class CachedWheelsCommand(_bdist_wheel):
             print("Precompiled wheel not found. Building from source...")
             # If the wheel could not be downloaded, build from source
             super().run()
-
-# Fallbacks in case metadata is missing
-dynamic_abi_tag = "cp39"
-dynamic_python_requires = ">=3.9"
-
-try:
-    # Derive minimum Python version from installed torch distribution metadata
-    torch_requires_python = importlib.metadata.metadata("torch").get("Requires-Python", "")
-    
-    # Extract the minor version from strings like ">=3.10.0" or ">=3.9"
-    match = re.search(r'3\.(\d+)', torch_requires_python)
-    if match:
-        minor_version = match.group(1)
-        dynamic_abi_tag = f"cp3{minor_version}"
-        dynamic_python_requires = f">=3.{minor_version}"
-except Exception:
-    pass # Sets cp39
-
-# Create the dynamic options dictionary that will be passed to setup()
-dynamic_options = {"bdist_wheel": {"py_limited_api": dynamic_abi_tag}}
 
 setup(
     name=PACKAGE_NAME,

--- a/hopper/setup.py
+++ b/hopper/setup.py
@@ -703,6 +703,21 @@ class CachedWheelsCommand(_bdist_wheel):
             # If the wheel could not be downloaded, build from source
             super().run()
 
+# Get the PyTorch version as a tuple of numbers 
+torch_version_str = torch.__version__.split('+')[0]
+torch_major_minor = tuple(map(int, torch_version_str.split('.')[:2]))
+
+# Determine the minimum Python version supported by this PyTorch
+if torch_major_minor >= (2, 11):
+    # PyTorch 2.11 and newer require Python 3.10+
+    dynamic_abi_tag = "cp310"
+else:
+    # Older PyTorch versions support Python 3.9
+    dynamic_abi_tag = "cp39"
+
+# Create the dynamic options dictionary that will be passed to setup()
+dynamic_options = {"bdist_wheel": {"py_limited_api": dynamic_abi_tag}}
+
 setup(
     name=PACKAGE_NAME,
     version=get_package_version(),
@@ -739,4 +754,5 @@ setup(
         "packaging",
         "ninja",
     ],
+    options=dynamic_options,
 )

--- a/hopper/setup.py
+++ b/hopper/setup.py
@@ -416,34 +416,12 @@ def nvcc_threads_args():
     nvcc_threads = os.getenv("NVCC_THREADS") or "2"
     return ["--threads", nvcc_threads]
 
-#
-# Fallbacks in case metadata is missing
-dynamic_abi_tag = "cp39"
-dynamic_python_requires = ">=3.9"
-
-try:
-    target = os.environ.get("TORCH_TARGET_VERSION")
-    if target:
-        # Parse hex string for PyTorch 2.9
-        major, minor = (int(target, 16) >> 56) & 0xFF, (int(target, 16) >> 48) & 0xFF
-    else:
-        # Fallback to the installed PyTorch version
-        major, minor = map(int, torch.__version__.split('.')[:2])
-        
-    # Since PyTorch 2.9+ dropped Python 3.9 support
-    if major >= 2 and minor >= 9:
-        dynamic_abi_tag = "cp310"
-        dynamic_python_requires = ">=3.10"
-except Exception:
-    pass # Sets cp39
-
-# Create the dynamic options dictionary that will be passed to setup()
-dynamic_options = {"bdist_wheel": {"py_limited_api": dynamic_abi_tag}}
 
 # NVIDIA_TOOLCHAIN_VERSION = {"nvcc": "12.3.107"}
 NVIDIA_TOOLCHAIN_VERSION = {"nvcc": "12.6.85", "ptxas": "12.8.93"}
 
 exe_extension = sysconfig.get_config_var("EXE")
+
 
 cmdclass = {}
 ext_modules = []
@@ -598,11 +576,13 @@ if not SKIP_CUDA_BUILD:
         sources_bwd_sm80 = []
     
     # Choose between flash_api.cpp and flash_api_stable.cpp based on torch version
+    torch_version = parse(torch.__version__)
+    target_version = parse("2.9.0.dev20250830")
     stable_args = []
       
-    if major >= 2 and minor >= 9:
+    if torch_version >= target_version:
         flash_api_source = "flash_api_stable.cpp"
-        stable_args = ["-DTORCH_TARGET_VERSION=0x0209000000000000"]
+        stable_args = ["-DTORCH_TARGET_VERSION=0x0209000000000000"]  # Targets minimum runtime version torch 2.9.0
     else:
         flash_api_source = "flash_api.cpp"
 
@@ -752,12 +732,12 @@ setup(
     else {
         "bdist_wheel": CachedWheelsCommand,
     },
-    python_requires=dynamic_python_requires,
+    python_requires=">=3.10",
     install_requires=[
         "torch",
         "einops",
         "packaging",
         "ninja",
     ],
-    options=dynamic_options,
+    options={"bdist_wheel": {"py_limited_api": "cp310"}},
 )

--- a/hopper/setup.py
+++ b/hopper/setup.py
@@ -739,5 +739,4 @@ setup(
         "packaging",
         "ninja",
     ],
-    options={"bdist_wheel": {"py_limited_api": "cp39"}},
 )

--- a/hopper/setup.py
+++ b/hopper/setup.py
@@ -13,6 +13,7 @@ import platform
 import sysconfig
 import tarfile
 import itertools
+import importlib.metadata
 
 from setuptools import setup, find_packages
 import subprocess
@@ -703,17 +704,22 @@ class CachedWheelsCommand(_bdist_wheel):
             # If the wheel could not be downloaded, build from source
             super().run()
 
-# Get the PyTorch version using packaging.version for robust PEP 440 parsing
-torch_version = parse(torch.__version__)
-torch_major_minor = (torch_version.major, torch_version.minor)
+# Fallbacks in case metadata is missing
+dynamic_abi_tag = "cp39"
+dynamic_python_requires = ">=3.9"
 
-# Determine the minimum Python version supported by this PyTorch
-if torch_major_minor >= (2, 11):
-    # PyTorch 2.11 and newer require Python 3.10+
-    dynamic_abi_tag = "cp310"
-else:
-    # Older PyTorch versions support Python 3.9
-    dynamic_abi_tag = "cp39"
+try:
+    # Derive minimum Python version from installed torch distribution metadata
+    torch_requires_python = importlib.metadata.metadata("torch").get("Requires-Python", "")
+    
+    # Extract the minor version from strings like ">=3.10.0" or ">=3.9"
+    match = re.search(r'3\.(\d+)', torch_requires_python)
+    if match:
+        minor_version = match.group(1)
+        dynamic_abi_tag = f"cp3{minor_version}"
+        dynamic_python_requires = f">=3.{minor_version}"
+except Exception:
+    pass # Sets cp39
 
 # Create the dynamic options dictionary that will be passed to setup()
 dynamic_options = {"bdist_wheel": {"py_limited_api": dynamic_abi_tag}}
@@ -747,7 +753,7 @@ setup(
     else {
         "bdist_wheel": CachedWheelsCommand,
     },
-    python_requires=">=3.8",
+    python_requires=dynamic_python_requires,
     install_requires=[
         "torch",
         "einops",


### PR DESCRIPTION
Currently, the setup.py script hardcodes a `cp39-abi3` tag on the output wheel. Since PyTorch 2.9+ dropped support for Python 3.9, this creates a misleading wheel tag. Installing this wheel in a Python 3.9 environment results in an ImportError: undefined symbol crash due to PyTorch C++ ABI mismatches. 

Since Python 3.9 reached EOL in October 2025 and the ecosystem has moved on, this PR simplifies the build process and aligns it with PyTorch's support matrix:
Bumped Python Requirement: Globally updated the wheel tag to cp310 and set python_requires=">=3.10". This officially drops Python 3.9 support and prevents the ABI crash.

Closes Issue #2530

---