### PR TITLE
Enable split-kv for blocksparse tensors

### DIFF
--- a/flash_attn/cute/block_sparse_utils.py
+++ b/flash_attn/cute/block_sparse_utils.py
@@ -551,9 +551,19 @@ def consume_block_sparse_loads(
 
 
 @cute.jit
+def split_block_range(block_count, split_idx: Int32, num_splits: Int32):
+    """Return the half-open block-list range assigned to one SplitKV partition."""
+    blocks_per_split = cute.ceil_div(block_count, num_splits)
+    block_begin = cutlass.min(split_idx * blocks_per_split, block_count)
+    block_end = cutlass.min(block_begin + blocks_per_split, block_count)
+    return block_begin, block_end
+
+
+@cute.jit
 def load_block_list_sm100(
     block_indices: cute.Tensor,
-    block_count,
+    block_begin,
+    block_end,
     load_q_with_first: cutlass.Constexpr,
     q_stage: cutlass.Constexpr,
     kv_producer_state,
@@ -563,9 +573,10 @@ def load_block_list_sm100(
     pipeline_kv,
 ):
     """SM100 version of load_block_list (no intra_wg_overlap, no extra_tx_count)."""
+    block_count = block_end - block_begin
     if block_count > 0:
         # First iteration: load Q alongside K if requested
-        n_block_first = block_indices[block_count - 1]
+        n_block_first = block_indices[block_end - 1]
 
         if const_expr(load_q_with_first):
             # SM100 loads Q0 and optionally Q1
@@ -582,7 +593,7 @@ def load_block_list_sm100(
 
         # Remaining blocks
         for offset in cutlass.range(1, block_count):
-            n_block = block_indices[block_count - 1 - offset]
+            n_block = block_indices[block_end - 1 - offset]
             load_K(block=n_block, producer_state=kv_producer_state, page_idx=None)
             kv_producer_state.advance()
             load_V(block=n_block, producer_state=kv_producer_state, page_idx=None)
@@ -598,7 +609,9 @@ def produce_block_sparse_loads_sm100(
     batch_idx,
     head_idx,
     m_block,
-    seqlen_info,
+    seqlen_info: SeqlenInfoQK,
+    split_idx: Int32,
+    num_splits: Int32,
     kv_producer_state,
     load_Q,
     load_K,
@@ -633,8 +646,10 @@ def produce_block_sparse_loads_sm100(
         seqlen_info,
     )
 
-    mask_empty = curr_mask_block_cnt == 0
-    full_empty = curr_full_block_cnt == 0
+    mask_begin, mask_end = split_block_range(curr_mask_block_cnt, split_idx, num_splits)
+    full_begin, full_end = split_block_range(curr_full_block_cnt, split_idx, num_splits)
+    mask_empty = mask_begin == mask_end
+    full_empty = full_begin == full_end
 
     q_phase_flipped = False
 
@@ -642,7 +657,8 @@ def produce_block_sparse_loads_sm100(
         # No masked blocks: process full list with Q loading
         kv_producer_state = load_block_list_sm100(
             curr_full_block_idx,
-            curr_full_block_cnt,
+            full_begin,
+            full_end,
             load_q_with_first=True,
             q_stage=q_stage,
             kv_producer_state=kv_producer_state,
@@ -656,7 +672,8 @@ def produce_block_sparse_loads_sm100(
         # Process masked blocks with Q loading
         kv_producer_state = load_block_list_sm100(
             curr_mask_block_idx,
-            curr_mask_block_cnt,
+            mask_begin,
+            mask_end,
             load_q_with_first=True,
             q_stage=q_stage,
             kv_producer_state=kv_producer_state,
@@ -671,7 +688,8 @@ def produce_block_sparse_loads_sm100(
             # Process full blocks without Q loading
             kv_producer_state = load_block_list_sm100(
                 curr_full_block_idx,
-                curr_full_block_cnt,
+                full_begin,
+                full_end,
                 load_q_with_first=False,
                 q_stage=q_stage,
                 kv_producer_state=kv_producer_state,
@@ -693,26 +711,29 @@ def get_total_block_count(
     batch_idx,
     head_idx,
     m_block,
+    split_idx: Int32,
+    num_splits: Int32,
     qhead_per_kvhead: cutlass.Constexpr,
     q_subtile_factor: cutlass.Constexpr,
     seqlen_info: SeqlenInfoQK,
 ):
     m_block_sparse = sparse_tensor_m_block(m_block, qhead_per_kvhead, q_subtile_factor)
-    mask_block_cnt, _, full_block_cnt, *_ = blocksparse_tensors
+    (
+        curr_mask_block_cnt,
+        _,
+        curr_full_block_cnt,
+        _,
+    ) = get_curr_blocksparse_tensors(
+        batch_idx,
+        head_idx,
+        m_block_sparse,
+        blocksparse_tensors,
+        seqlen_info,
+    )
 
-    if const_expr(len(mask_block_cnt.shape) == 2):
-        # varlen path: tensors are [num_heads, total_m_block]
-        curr_m = seqlen_info.m_block_offset + m_block_sparse
-        total = mask_block_cnt[head_idx, curr_m]
-        if const_expr(full_block_cnt is not None):
-            total += full_block_cnt[head_idx, curr_m]
-    else:
-        # non-varlen: tensors are [batch, num_heads, m_block]
-        total = mask_block_cnt[batch_idx, head_idx, m_block_sparse]
-        if const_expr(full_block_cnt is not None):
-            total += full_block_cnt[batch_idx, head_idx, m_block_sparse]
-
-    return total
+    mask_begin, mask_end = split_block_range(curr_mask_block_cnt, split_idx, num_splits)
+    full_begin, full_end = split_block_range(curr_full_block_cnt, split_idx, num_splits)
+    return mask_end - mask_begin + full_end - full_begin
 
 
 @cute.jit
@@ -839,7 +860,9 @@ def softmax_block_sparse_sm100(
     batch_idx,
     head_idx,
     m_block,
-    seqlen_info,
+    seqlen_info: SeqlenInfoQK,
+    split_idx: Int32,
+    num_splits: Int32,
     softmax_step: Callable,
     mask_fn: Callable,
     mask_fn_none: Callable,
@@ -870,13 +893,17 @@ def softmax_block_sparse_sm100(
         seqlen_info,
     )
 
-    total_block_cnt = curr_mask_block_cnt + curr_full_block_cnt
+    mask_begin, mask_end = split_block_range(curr_mask_block_cnt, split_idx, num_splits)
+    full_begin, full_end = split_block_range(curr_full_block_cnt, split_idx, num_splits)
+    split_mask_block_cnt = mask_end - mask_begin
+    split_full_block_cnt = full_end - full_begin
+    total_block_cnt = split_mask_block_cnt + split_full_block_cnt
 
     if total_block_cnt == 0:
         sm_stats_barrier.arrive_w_index(index=stage_idx * 4 + warp_idx)
     else:
-        if curr_mask_block_cnt > 0:
-            mask_n_block = curr_mask_block_idx[curr_mask_block_cnt - 1]
+        if split_mask_block_cnt > 0:
+            mask_n_block = curr_mask_block_idx[mask_end - 1]
             (
                 mma_si_consumer_phase,
                 si_corr_producer_phase,
@@ -889,8 +916,8 @@ def softmax_block_sparse_sm100(
                 is_first=True,
                 mask_fn=partial(mask_fn, mask_seqlen=True, check_q_boundary=check_m_boundary),
             )
-            for i in cutlass.range(1, curr_mask_block_cnt):
-                mask_n_block = curr_mask_block_idx[curr_mask_block_cnt - 1 - i]
+            for i in cutlass.range(1, split_mask_block_cnt):
+                mask_n_block = curr_mask_block_idx[mask_end - 1 - i]
                 (
                     mma_si_consumer_phase,
                     si_corr_producer_phase,
@@ -903,9 +930,9 @@ def softmax_block_sparse_sm100(
                     mask_fn=partial(mask_fn, mask_seqlen=False, check_q_boundary=check_m_boundary),
                 )
 
-        if curr_full_block_cnt > 0:
-            full_n_block = curr_full_block_idx[curr_full_block_cnt - 1]
-            if curr_mask_block_cnt == 0:
+        if split_full_block_cnt > 0:
+            full_n_block = curr_full_block_idx[full_end - 1]
+            if split_mask_block_cnt == 0:
                 (
                     mma_si_consumer_phase,
                     si_corr_producer_phase,
@@ -935,8 +962,8 @@ def softmax_block_sparse_sm100(
                         mask_fn_none, mask_seqlen=True, check_q_boundary=check_m_boundary
                     ),
                 )
-            for i in cutlass.range(1, curr_full_block_cnt):
-                full_n_block = curr_full_block_idx[curr_full_block_cnt - 1 - i]
+            for i in cutlass.range(1, split_full_block_cnt):
+                full_n_block = curr_full_block_idx[full_end - 1 - i]
                 (
                     mma_si_consumer_phase,
                     si_corr_producer_phase,

--- a/flash_attn/cute/flash_fwd_sm100.py
+++ b/flash_attn/cute/flash_fwd_sm100.py
@@ -1211,6 +1211,7 @@ class FlashAttentionForwardSm100:
                     num_splits,
                     SeqlenInfoCls,
                     mma_tile_coord_v,
+                    blocksparse_tensors=blocksparse_tensors,
                     tile_scheduler=tile_scheduler,
                 )
 
@@ -1499,6 +1500,8 @@ class FlashAttentionForwardSm100:
                     head_idx,
                     m_block,
                     seqlen,
+                    split_idx,
+                    num_splits,
                     kv_producer_state,
                     load_Q,
                     load_K,
@@ -1646,6 +1649,8 @@ class FlashAttentionForwardSm100:
                     batch_idx,
                     head_idx,
                     m_block,
+                    split_idx,
+                    num_splits,
                     self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
                     self.q_subtile_factor if self.q_subtile_factor is not None else 1,
                     seqlen_info=seqlen,
@@ -2013,6 +2018,8 @@ class FlashAttentionForwardSm100:
                     batch_idx,
                     head_idx,
                     m_block,
+                    split_idx,
+                    num_splits,
                     self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
                     self.q_subtile_factor if self.q_subtile_factor is not None else 1,
                     seqlen_info=seqlen,
@@ -2072,6 +2079,8 @@ class FlashAttentionForwardSm100:
                     head_idx,
                     m_block,
                     seqlen,
+                    split_idx,
+                    num_splits,
                     softmax_step,
                     mask_fn,
                     mask_fn_none,
@@ -2427,6 +2436,8 @@ class FlashAttentionForwardSm100:
                     batch_idx,
                     head_idx,
                     m_block,
+                    split_idx,
+                    num_splits,
                     self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
                     self.q_subtile_factor if self.q_subtile_factor is not None else 1,
                     seqlen_info=seqlen,
@@ -2841,6 +2852,7 @@ class FlashAttentionForwardSm100:
         num_splits: int,
         SeqlenInfoCls: Callable,
         mma_tile_coord_v: Int32 = 0,
+        blocksparse_tensors: Optional[BlockSparseTensors] = None,
         tile_scheduler=None,
     ):
         epi_consumer_phase = Int32(0)
@@ -2849,8 +2861,9 @@ class FlashAttentionForwardSm100:
             m_block, head_idx, batch_idx, split_idx = work_tile.tile_idx
             seqlen = SeqlenInfoCls(batch_idx)
             n_block_min, n_block_max = block_info.get_n_block_min_max(seqlen, m_block, split_idx, num_splits)
+            has_work = const_expr(self.use_block_sparsity or not self.is_split_kv) or n_block_min < n_block_max
 
-            if const_expr(not self.is_split_kv) or n_block_min < n_block_max:
+            if has_work:
                 if const_expr(self.is_split_kv):
                     mO_cur = seqlen.offset_batch_Q(mO, batch_idx, dim=3)[None, None, head_idx, split_idx]
                 else:

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -604,10 +604,6 @@ def _flash_attn_fwd(
         head_dim_idx = 0 if block_sparse_tensors.mask_block_cnt.ndim == 2 else 1
         if pack_gqa and block_sparse_tensors.mask_block_cnt.shape[head_dim_idx] != 1:
             pack_gqa = False
-        if is_split_kv:
-            raise NotImplementedError(
-                "Block sparsity is not yet supported with SplitKV. TODO: partition sparse block lists per split."
-            )
         if cu_seqlens_q is not None:
             assert block_sparse_tensors.cu_total_m_blocks is not None, (
                 "Varlen block sparsity requires block_sparse_tensors.cu_total_m_blocks."

--- a/tests/cute/test_mask_mod.py
+++ b/tests/cute/test_mask_mod.py
@@ -2258,6 +2258,146 @@ def test_dq_write_order_document_mask(seqlen_q, seqlen_k, spt):
     _run_write_order_test(doc_mask, seqlen_q, seqlen_k, block_size=128, B=B, H=H, spt=spt)
 
 
+@pytest.mark.skipif(COMPUTE_CAPABILITY not in (10, 11), reason="SM100/SM110 SplitKV block sparse forward only")
+def test_block_sparse_splitkv_matches_unsplit():
+    torch.manual_seed(123)
+    batch_size = 1
+    nheads = 4
+    seqlen = 2048
+    headdim = 64
+    tile_m = 128
+    tile_n = 128
+    dtype = torch.bfloat16
+    sparse_tile_m = 2 * tile_m
+
+    mask_mod_cute, mask_mod_flex = get_mask_pair("causal", seqlen_q=seqlen, seqlen_k=seqlen)
+    tensors = create_tensors(
+        batch_size, seqlen, seqlen, nheads, nheads, headdim, headdim, dtype
+    )
+
+    bm = create_block_mask(
+        mask_mod_flex,
+        batch_size,
+        nheads,
+        seqlen,
+        seqlen,
+        device="cuda",
+        BLOCK_SIZE=(sparse_tile_m, tile_n),
+    )
+    (_, _, kv_mask_cnt, kv_mask_idx, full_kv_cnt, full_kv_idx, *_) = bm.as_tuple()
+    block_sparse_fwd = BlockSparseTensorsTorch(
+        mask_block_cnt=kv_mask_cnt,
+        mask_block_idx=kv_mask_idx,
+        full_block_cnt=full_kv_cnt,
+        full_block_idx=full_kv_idx,
+        block_size=(sparse_tile_m, tile_n),
+    )
+
+    out_unsplit, lse_unsplit = _flash_attn_fwd(
+        q=tensors["q"],
+        k=tensors["k"],
+        v=tensors["v"],
+        out=tensors["out"].clone(),
+        lse=tensors["lse"].clone(),
+        softmax_scale=1.0 / math.sqrt(headdim),
+        causal=False,
+        mask_mod=mask_mod_cute,
+        block_sparse_tensors=block_sparse_fwd,
+        num_splits=1,
+        return_lse=True,
+    )
+    out_split, lse_split = _flash_attn_fwd(
+        q=tensors["q"],
+        k=tensors["k"],
+        v=tensors["v"],
+        out=tensors["out"].clone(),
+        lse=tensors["lse"].clone(),
+        softmax_scale=1.0 / math.sqrt(headdim),
+        causal=False,
+        mask_mod=mask_mod_cute,
+        block_sparse_tensors=block_sparse_fwd,
+        num_splits=3,
+        return_lse=True,
+    )
+
+    out_ref = compute_reference_flex_attn(tensors, mask_mod_flex, block_size=(sparse_tile_m, tile_n))
+    out_ref_fp32 = compute_reference_flex_attn(
+        {name: tensor.float() for name, tensor in tensors.items()},
+        mask_mod_flex,
+        block_size=(sparse_tile_m, tile_n),
+    )
+
+    assert_fwd_matches_reference(out_split, out_ref_fp32, out_ref)
+    assert torch.allclose(lse_split, lse_unsplit, atol=2e-3, rtol=2e-3)
+
+
+@pytest.mark.skipif(COMPUTE_CAPABILITY not in (10, 11), reason="SM100/SM110 SplitKV block sparse forward only")
+def test_block_sparse_splitkv_oversplit_sparse_blocks():
+    torch.manual_seed(321)
+    batch_size = 1
+    nheads = 4
+    seqlen_q = 513
+    seqlen_k = 1024
+    headdim = 64
+    tile_m = 128
+    tile_n = 128
+    dtype = torch.bfloat16
+    sparse_tile_m = 2 * tile_m
+
+    mask_mod_cute, mask_mod_flex = get_mask_pair("block_diagonal", seqlen_q=seqlen_q, seqlen_k=seqlen_k)
+    tensors = create_tensors(
+        batch_size, seqlen_q, seqlen_k, nheads, nheads, headdim, headdim, dtype
+    )
+    bm = create_block_mask(
+        mask_mod_flex,
+        batch_size,
+        nheads,
+        seqlen_q,
+        seqlen_k,
+        device="cuda",
+        BLOCK_SIZE=(sparse_tile_m, tile_n),
+    )
+    (_, _, kv_mask_cnt, kv_mask_idx, full_kv_cnt, full_kv_idx, *_) = bm.as_tuple()
+    block_sparse_fwd = BlockSparseTensorsTorch(
+        mask_block_cnt=kv_mask_cnt,
+        mask_block_idx=kv_mask_idx,
+        full_block_cnt=full_kv_cnt,
+        full_block_idx=full_kv_idx,
+        block_size=(sparse_tile_m, tile_n),
+    )
+
+    out_unsplit, _ = _flash_attn_fwd(
+        q=tensors["q"],
+        k=tensors["k"],
+        v=tensors["v"],
+        out=tensors["out"].clone(),
+        lse=tensors["lse"].clone(),
+        softmax_scale=1.0 / math.sqrt(headdim),
+        causal=False,
+        mask_mod=mask_mod_cute,
+        block_sparse_tensors=block_sparse_fwd,
+        num_splits=1,
+        return_lse=True,
+    )
+    out_split, _ = _flash_attn_fwd(
+        q=tensors["q"],
+        k=tensors["k"],
+        v=tensors["v"],
+        out=tensors["out"].clone(),
+        lse=tensors["lse"].clone(),
+        softmax_scale=1.0 / math.sqrt(headdim),
+        causal=False,
+        mask_mod=mask_mod_cute,
+        block_sparse_tensors=block_sparse_fwd,
+        num_splits=8,
+        return_lse=True,
+    )
+
+    assert not torch.isnan(out_split).any()
+    assert torch.isfinite(out_split).all()
+    assert torch.allclose(out_split, out_unsplit, atol=4e-3, rtol=4e-3)
+
+
 def test_compact_block_sparse_indices():
     """Test that compact block sparse index tensors (idx.shape[3] < n_blocks) work correctly.
 

--- a/tests/cute/test_mask_mod_varlen.py
+++ b/tests/cute/test_mask_mod_varlen.py
@@ -618,6 +618,18 @@ def test_varlen_global_masks(seqlens_q, seqlens_k, mask_name):
 # =============================================================================
 
 
+@cute.jit
+def cute_all_true_mask(
+    batch: cute.TensorSSA,
+    head: cute.TensorSSA,
+    m_idx: cute.TensorSSA,
+    n_idx: cute.TensorSSA,
+    seqlen_info,
+    aux_tensors,
+) -> cute.TensorSSA:
+    return m_idx >= utils.scalar_to_ssa(0, cutlass.Int32)
+
+
 def _make_block_sparse_tensors(
     mask_mod,
     seqlens_q,
@@ -691,6 +703,7 @@ def _run_fwd(
     seqused_k=None,
     block_sparse_tensors=None,
     aux_tensors=None,
+    num_splits=1,
 ):
     out = torch.empty_like(q)
     return _flash_attn_fwd(
@@ -718,6 +731,7 @@ def _run_fwd(
         block_sparse_tensors=block_sparse_tensors,
         return_lse=False,
         aux_tensors=aux_tensors,
+        num_splits=num_splits,
     )[0]
 
 
@@ -889,6 +903,131 @@ def test_varlen_block_sparse(
     assert max_err <= 0.01, (
         f"block-sparse output differs from mask-mod-only by {max_err}"
     )
+
+
+VARLEN_BLOCK_SPARSE_SPLITKV_SEQLENS = [
+    ([128], [2048]),
+    ([96], [1536]),
+    ([128, 64], [2048, 1024]),
+    ([1, 128], [256, 2048]),
+]
+
+VARLEN_BLOCK_SPARSE_SPLITKV_MASKS = [
+    "all_true",
+    "causal",
+    "sliding_window",
+    "prefix_lm",
+    "block_diagonal",
+]
+
+
+def _get_splitkv_varlen_mask(mask_name, max_seqlen_q, max_seqlen_k):
+    match mask_name:
+        case "all_true":
+            return cute_all_true_mask
+        case "causal":
+            return get_mask_pair("causal", seqlen_q=max_seqlen_q, seqlen_k=max_seqlen_k)[0]
+        case "sliding_window":
+            return get_mask_pair(
+                "sliding_window",
+                seqlen_q=max_seqlen_q,
+                seqlen_k=max_seqlen_k,
+                window_size=512,
+            )[0]
+        case _:
+            return get_mask_pair(mask_name)[0]
+
+
+@pytest.mark.skipif(COMPUTE_CAPABILITY not in (10, 11), reason="SM100/SM110 SplitKV forward only")
+@pytest.mark.parametrize("use_seqused_k", [False, True])
+@pytest.mark.parametrize("mask_name", VARLEN_BLOCK_SPARSE_SPLITKV_MASKS)
+@pytest.mark.parametrize("seqlens_q,seqlens_k", VARLEN_BLOCK_SPARSE_SPLITKV_SEQLENS)
+def test_varlen_block_sparse_splitkv_matches_unsplit(seqlens_q, seqlens_k, mask_name, use_seqused_k):
+    """Varlen block-sparse SplitKV should match the unsplit block-sparse path."""
+    torch.manual_seed(123)
+    random.seed(123)
+    device = "cuda"
+    num_heads = 4
+    head_dim = 128
+    dtype = torch.bfloat16
+    sparse_tile_m = 256 if sum(seqlens_q) > 128 else 128
+    tile_n = 128
+    max_seqlen_q = max(seqlens_q)
+    max_seqlen_k = max(seqlens_k)
+
+    q = torch.randn(sum(seqlens_q), num_heads, head_dim, device=device, dtype=dtype)
+    cu_seqlens_q = torch.tensor(
+        [0] + list(torch.tensor(seqlens_q).cumsum(0).tolist()),
+        device=device,
+        dtype=torch.int32,
+    )
+    mask_mod = _get_splitkv_varlen_mask(mask_name, max_seqlen_q, max_seqlen_k)
+
+    if use_seqused_k:
+        k = torch.randn(
+            len(seqlens_k), max_seqlen_k, num_heads, head_dim, device=device, dtype=dtype
+        )
+        v = torch.randn_like(k)
+        cu_seqlens_k = None
+        seqused_k = torch.tensor(seqlens_k, dtype=torch.int32, device=device)
+    else:
+        k = torch.randn(sum(seqlens_k), num_heads, head_dim, device=device, dtype=dtype)
+        v = torch.randn_like(k)
+        cu_seqlens_k = torch.tensor(
+            [0] + list(torch.tensor(seqlens_k).cumsum(0).tolist()),
+            device=device,
+            dtype=torch.int32,
+        )
+        seqused_k = None
+
+    block_sparse_tensors = _make_block_sparse_tensors(
+        mask_mod=mask_mod,
+        seqlens_q=seqlens_q,
+        seqlens_k=seqlens_k,
+        num_heads=1,
+        tile_m=sparse_tile_m,
+        tile_n=tile_n,
+        device=device,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        seqused_k=seqused_k,
+    )
+
+    out_unsplit = _run_fwd(
+        q,
+        k,
+        v,
+        mask_mod,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        seqused_k=seqused_k,
+        block_sparse_tensors=block_sparse_tensors,
+    )
+    out_split = _run_fwd(
+        q,
+        k,
+        v,
+        mask_mod,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        seqused_k=seqused_k,
+        block_sparse_tensors=block_sparse_tensors,
+        num_splits=3,
+    )
+    out_no_block_sparsity = _run_fwd(
+        q,
+        k,
+        v,
+        mask_mod,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        seqused_k=seqused_k,
+    )
+
+    assert not torch.isnan(out_split).any(), "NaN in SplitKV block-sparse output"
+    assert torch.isfinite(out_split).all(), "Inf in SplitKV block-sparse output"
+    assert (out_unsplit - out_no_block_sparsity).abs().max().item() <= 0.01
+    assert (out_split - out_no_block_sparsity).abs().max().item() <= 0.01
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stacked PRs:
 * #2537
 * __->__#2536


--- --- ---

Enable split-kv for blocksparse tensors


Perf:

```Shell

Final results:
|   Sq |     Sk |   splits |   median us | speedup   |   mask blocks/qtile |   full blocks/qtile |
|------|--------|----------|-------------|-----------|---------------------|---------------------|
|  128 |  32768 |        1 |       342   | 1.00x     |                 256 |                   0 |
|  128 |  32768 |        2 |       221   | 1.55x     |                 256 |                   0 |
|  128 |  32768 |        4 |       115.1 | 2.97x     |                 256 |                   0 |
|  128 |  32768 |        8 |        63.2 | 5.41x     |                 256 |                   0 |
|  128 |  32768 |       16 |        37.6 | 9.10x     |                 256 |                   0 |
|  128 |  65536 |        1 |       678.1 | 1.00x     |                 512 |                   0 |
|  128 |  65536 |        2 |       433.8 | 1.56x     |                 512 |                   0 |
|  128 |  65536 |        4 |       221.8 | 3.06x     |                 512 |                   0 |
|  128 |  65536 |        8 |       117.3 | 5.78x     |                 512 |                   0 |
|  128 |  65536 |       16 |        64.8 | 10.46x    |                 512 |                   0 |
|  128 | 131072 |        1 |      1351.5 | 1.00x     |                1024 |                   0 |
|  128 | 131072 |        2 |       859.9 | 1.57x     |                1024 |                   0 |
|  128 | 131072 |        4 |       435.2 | 3.11x     |                1024 |                   0 |
|  128 | 131072 |        8 |       225   | 6.01x     |                1024 |                   0 |
|  128 | 131072 |       16 |       118.6 | 11.39x    |                1024 |                   0 |
|  256 |  32768 |        1 |       347.5 | 1.00x     |                   2 |                 254 |
|  256 |  32768 |        2 |       177.7 | 1.96x     |                   2 |                 254 |
|  256 |  32768 |        4 |        95.7 | 3.63x     |                   2 |                 254 |
|  256 |  32768 |        8 |        54.9 | 6.33x     |                   2 |                 254 |
|  256 |  32768 |       16 |        35.2 | 9.87x     |                   2 |                 254 |
|  256 |  65536 |        1 |       686   | 1.00x     |                   2 |                 510 |
|  256 |  65536 |        2 |       345.6 | 1.99x     |                   2 |                 510 |
|  256 |  65536 |        4 |       179.9 | 3.81x     |                   2 |                 510 |
|  256 |  65536 |        8 |        96.9 | 7.08x     |                   2 |                 510 |
|  256 |  65536 |       16 |        57.1 | 12.01x    |                   2 |                 510 |
|  256 | 131072 |        1 |      1363.3 | 1.00x     |                   2 |                1022 |
|  256 | 131072 |        2 |       680.8 | 2.00x     |                   2 |                1022 |
|  256 | 131072 |        4 |       347.6 | 3.92x     |                   2 |                1022 |
|  256 | 131072 |        8 |       181.5 | 7.51x     |                   2 |                1022 |
|  256 | 131072 |       16 |        99.1 | 13.76x    |                   2 |                1022 |
|  512 |  32768 |        1 |       347.5 | 1.00x     |                   2 |                 253 |
|  512 |  32768 |        2 |       178.7 | 1.94x     |                   2 |                 253 |
|  512 |  32768 |        4 |        96.7 | 3.59x     |                   2 |                 253 |
|  512 |  32768 |        8 |        55.5 | 6.26x     |                   2 |                 253 |
|  512 |  32768 |       16 |        36.1 | 9.62x     |                   2 |                 253 |
|  512 |  65536 |        1 |       686.3 | 1.00x     |                   2 |                 509 |
|  512 |  65536 |        2 |       346.5 | 1.98x     |                   2 |                 509 |
|  512 |  65536 |        4 |       180.7 | 3.80x     |                   2 |                 509 |
|  512 |  65536 |        8 |        98.4 | 6.98x     |                   2 |                 509 |
|  512 |  65536 |       16 |        58.5 | 11.74x    |                   2 |                 509 |
|  512 | 131072 |        1 |      1363.6 | 1.00x     |                   2 |                1021 |
|  512 | 131072 |        2 |       683   | 2.00x     |                   2 |                1021 |
|  512 | 131072 |        4 |       350.8 | 3.89x     |                   2 |                1021 |
|  512 | 131072 |        8 |       182.9 | 7.45x     |                   2 |                1021 |
|  512 | 131072 |       16 |       101.5 | 13.44x    |                   2 |                1021 |
```