### PR TITLE
[CuTe,Bwd] guard softcap for varlen backward

### DIFF
--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -1419,7 +1419,7 @@ def _flash_attn_bwd(
         )
         score_mod = utils.create_softcap_scoremod(softcap)
         score_mod_bwd = utils.create_softcap_scoremod_bwd(softcap)
-    elif score_mod is not None:
+    if score_mod is not None:
         assert score_mod_bwd is not None, "score_mod_bwd is required when score_mod is provided"
         assert cu_seqlens_q is None and cu_seqlens_k is None, (
             "varlen + score_mod not supported in bwd yet"

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -842,6 +842,7 @@ def test_flash_attn_varlen_output(
                 or (IS_SM100 and d == 256 and dv == 256)
             )
             and not has_learnable_sink
+            and softcap == 0.0 # TODO: support softcap != 0.0 in varlen bwd
             # and False
         ):
             if d > 192 and IS_SM90:


### PR DESCRIPTION
Softcap is currently not supported in varlen backward, but is not properly guarded. This is a band-aid fix until score_mod is supported with varlen in backward.

For example, `pytest tests/cute/test_flash_attn.py::test_flash_attn_varlen_output -k "True-True-True-False-random-128-217-128-False-True-0-15.0"` (here `15.0` is the softcap) fails validation due to incorrect `dQ`.

cc: @drisspg 