### PR TITLE
[CuTe, sm90, sm100] Feat: enable chunked causal attention for low-latency streaming workloads

### DIFF
--- a/flash_attn/cute/block_info.py
+++ b/flash_attn/cute/block_info.py
@@ -35,6 +35,8 @@ class BlockInfo:
                 m_idx_max = cute.ceil_div(m_idx_max, self.qhead_per_kvhead_packgqa)
             n_idx = m_idx_max + seqlen_info.seqlen_k - seqlen_info.seqlen_q
             n_idx_right = n_idx if const_expr(self.is_causal) else n_idx + self.window_size_right
+            if const_expr(self.is_causal and seqlen_info.has_chunk_size):
+                n_idx_right = ((n_idx - 1) // seqlen_info.chunk_size + 1) * seqlen_info.chunk_size
             n_block_max = min(n_block_max, cute.ceil_div(n_idx_right, self.tile_n))
         n_block_min = 0
         if const_expr(self.is_local and self.window_size_left is not None):
@@ -62,6 +64,17 @@ class BlockInfo:
             n_idx_min = n_block * self.tile_n
             m_idx = n_idx_min + seqlen_info.seqlen_q - seqlen_info.seqlen_k
             m_idx_right = m_idx if const_expr(self.is_causal) else m_idx - self.window_size_right
+            if const_expr(self.is_causal and seqlen_info.has_chunk_size):
+                # Chunk attention semantics (chunk_mask[q, k] = ((q + kq_diff) // cs + 1) * cs > k).
+                # The smallest valid q for a given KV block is chunk_start(n_idx_min) - kq_diff,
+                # i.e. chunk_start of the KV index itself (not of n_idx_min - kq_diff). Computing
+                # chunk_start on m_idx = n_idx_min - kq_diff is only equivalent when kq_diff is
+                # a multiple of chunk_size; otherwise the result can be off and even skip valid
+                # m_blocks when kq_diff < 0. Compute chunk_start on n_idx_min and subtract kq_diff.
+                m_idx_right = (
+                    (n_idx_min // seqlen_info.chunk_size) * seqlen_info.chunk_size
+                    + seqlen_info.seqlen_q - seqlen_info.seqlen_k
+                )
             m_block_min = max(m_block_min, m_idx_right // self.tile_m)
         if const_expr(self.is_local and self.window_size_left is not None):
             n_idx_max = (n_block + 1) * self.tile_n

--- a/flash_attn/cute/flash_bwd.py
+++ b/flash_attn/cute/flash_bwd.py
@@ -389,6 +389,7 @@ class FlashAttentionBackwardSm80:
         mdV_semaphore: Optional[cute.Tensor] = None,
         aux_tensors: Optional[list] = None,
         blocksparse_tensors: Optional[BlockSparseTensors] = None,
+        mChunkSize: Optional[cute.Tensor] = None,
         # Always keep stream as the last parameter (EnvStream: obtained implicitly via TVM FFI).
         stream: cuda.CUstream = None,
     ):
@@ -470,6 +471,7 @@ class FlashAttentionBackwardSm80:
             SharedStorage,
             tile_sched_params,
             TileScheduler,
+            mChunkSize,
         ).launch(
             grid=grid_dim,
             block=[self.num_threads, 1, 1],
@@ -514,6 +516,7 @@ class FlashAttentionBackwardSm80:
         SharedStorage: cutlass.Constexpr,
         tile_sched_params: ParamsBase,
         TileScheduler: cutlass.Constexpr[Callable],
+        mChunkSize: Optional[cute.Tensor] = None,
     ):
         # Thread index, block index
         tidx, _, _ = cute.arch.thread_idx()
@@ -532,6 +535,7 @@ class FlashAttentionBackwardSm80:
                 mCuSeqlensK=mCuSeqlensK,
                 mSeqUsedQ=mSeqUsedQ,
                 mSeqUsedK=mSeqUsedK,
+                mChunkSize=mChunkSize,
                 tile_m=self.m_block_size,
                 tile_n=self.n_block_size,
             )

--- a/flash_attn/cute/flash_bwd_sm100.py
+++ b/flash_attn/cute/flash_bwd_sm100.py
@@ -466,6 +466,7 @@ class FlashAttentionBackwardSm100:
         aux_tensors: Optional[list] = None,
         # Block-sparse tensors (Q direction - for iterating m_blocks per n_block):
         blocksparse_tensors: Optional[BlockSparseTensors] = None,
+        mChunkSize: Optional[cute.Tensor] = None,
         # Always keep stream as the last parameter (EnvStream: obtained implicitly via TVM FFI).
         stream: cuda.CUstream = None,
     ):
@@ -1001,6 +1002,7 @@ class FlashAttentionBackwardSm100:
             aux_tensors,
             fastdiv_mods,
             blocksparse_tensors,
+            mChunkSize,
         ).launch(
             grid=grid_dim,
             block=[self.threads_per_cta, 1, 1],
@@ -1074,6 +1076,7 @@ class FlashAttentionBackwardSm100:
         aux_tensors: Optional[list] = None,
         fastdiv_mods=(None, None),
         blocksparse_tensors: Optional[BlockSparseTensors] = None,
+        mChunkSize: Optional[cute.Tensor] = None,
     ):
         warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
         bidx, _, _ = cute.arch.block_idx()
@@ -1408,6 +1411,7 @@ class FlashAttentionBackwardSm100:
             mCuSeqlensK=mCuSeqlensK,
             mSeqUsedQ=mSeqUsedQ,
             mSeqUsedK=mSeqUsedK,
+            mChunkSize=mChunkSize,
             tile_m=self.tile_m,
             tile_n=self.tile_n * self.cluster_shape_mnk[0],
         )

--- a/flash_attn/cute/flash_bwd_sm90.py
+++ b/flash_attn/cute/flash_bwd_sm90.py
@@ -357,6 +357,7 @@ class FlashAttentionBackwardSm90:
         mdV_semaphore: Optional[cute.Tensor] = None,
         aux_tensors: Optional[list] = None,
         blocksparse_tensors: Optional[BlockSparseTensors] = None,
+        mChunkSize: Optional[cute.Tensor] = None,
         # Always keep stream as the last parameter (EnvStream: obtained implicitly via TVM FFI).
         stream: cuda.CUstream = None,
     ):
@@ -611,6 +612,7 @@ class FlashAttentionBackwardSm90:
             mdV_semaphore,
             window_size_left,
             window_size_right,
+            mChunkSize,
         ).launch(
             grid=grid_dim,
             block=[self.num_threads, 1, 1],
@@ -666,6 +668,7 @@ class FlashAttentionBackwardSm90:
         mdV_semaphore: Optional[cute.Tensor] = None,
         window_size_left: Optional[Int32] = None,
         window_size_right: Optional[Int32] = None,
+        mChunkSize: Optional[cute.Tensor] = None,
     ):
         warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
 
@@ -739,6 +742,7 @@ class FlashAttentionBackwardSm90:
             mCuSeqlensK=mCuSeqlensK,
             mSeqUsedQ=mSeqUsedQ,
             mSeqUsedK=mSeqUsedK,
+            mChunkSize=mChunkSize,
             tile_m=self.tile_m,
             tile_n=self.tile_n,
         )

--- a/flash_attn/cute/flash_fwd.py
+++ b/flash_attn/cute/flash_fwd.py
@@ -631,6 +631,7 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
         learnable_sink: Optional[cute.Tensor] = None,
         blocksparse_tensors: Optional[BlockSparseTensors] = None,
         aux_tensors=None,
+        mChunkSize: Optional[cute.Tensor] = None,
         # Always keep stream as the last parameter (EnvStream: obtained implicitly via TVM FFI).
         stream: cuda.CUstream = None,
     ):
@@ -728,6 +729,7 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
             TileScheduler,
             aux_tensors,
             fastdiv_mods,
+            mChunkSize,
         ).launch(
             grid=grid_dim,
             block=[self.num_threads, 1, 1],
@@ -767,6 +769,7 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
         TileScheduler: cutlass.Constexpr[Callable],
         aux_tensors=None,
         fastdiv_mods=None,
+        mChunkSize: Optional[cute.Tensor] = None,
     ):
         # Thread index, block index
         tidx, _, _ = cute.arch.thread_idx()
@@ -793,6 +796,7 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
             mCuSeqlensK=mCuSeqlensK,
             mSeqUsedQ=mSeqUsedQ,
             mSeqUsedK=mSeqUsedK,
+            mChunkSize=mChunkSize,
         )
         n_block_min, n_block_max = block_info.get_n_block_min_max(seqlen, m_block)
         # For varlen, wasted grid tiles (where batch_idx >= num_batch) will have

--- a/flash_attn/cute/flash_fwd_sm100.py
+++ b/flash_attn/cute/flash_fwd_sm100.py
@@ -374,6 +374,7 @@ class FlashAttentionForwardSm100:
         descale_tensors: Optional[DescaleTensors] = None,
         blocksparse_tensors: Optional[BlockSparseTensors] = None,
         aux_tensors: Optional[list] = None,
+        mChunkSize: Optional[cute.Tensor] = None,
         # Always keep stream as the last parameter (EnvStream: obtained implicitly via TVM FFI).
         stream: cuda.CUstream = None,
     ):
@@ -764,6 +765,7 @@ class FlashAttentionForwardSm100:
             aux_tensors,
             fastdiv_mods,
             head_divmod,
+            mChunkSize,
         ).launch(
             grid=grid_dim,
             block=[self.threads_per_cta, 1, 1],
@@ -811,6 +813,7 @@ class FlashAttentionForwardSm100:
         aux_tensors: Optional[list] = None,
         fastdiv_mods=(None, None),
         head_divmod=None,
+        mChunkSize: Optional[cute.Tensor] = None,
     ):
         """The device kernel implementation of the Fused Multi-Head Attention.
 
@@ -1059,6 +1062,7 @@ class FlashAttentionForwardSm100:
             mCuBlockIdxOffsets=(
                 blocksparse_tensors.cu_block_idx_offsets if blocksparse_tensors is not None else None
             ),
+            mChunkSize=mChunkSize,
         )
         AttentionMaskCls = partial(
             AttentionMask,

--- a/flash_attn/cute/flash_fwd_sm90.py
+++ b/flash_attn/cute/flash_fwd_sm90.py
@@ -172,6 +172,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         learnable_sink: Optional[cute.Tensor] = None,
         blocksparse_tensors: Optional[BlockSparseTensors] = None,
         aux_tensors: Optional[list] = None,
+        mChunkSize: Optional[cute.Tensor] = None,
         # Always keep stream as the last parameter (EnvStream: obtained implicitly via TVM FFI).
         stream: cuda.CUstream = None,
     ):
@@ -390,6 +391,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
             SharedStorage,
             aux_tensors,
             fastdiv_mods,
+            mChunkSize,
         ).launch(
             grid=grid_dim,
             block=[self.num_threads, 1, 1],
@@ -436,6 +438,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         SharedStorage: cutlass.Constexpr[Callable],
         aux_tensors=Optional[list[cute.Tensor]],
         fastdiv_mods=None,
+        mChunkSize: Optional[cute.Tensor] = None,
     ):
         warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
         # Prefetch tma descriptor
@@ -559,6 +562,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
             mCuBlockIdxOffsets=(
                 blocksparse_tensors.cu_block_idx_offsets if blocksparse_tensors is not None else None
             ),
+            mChunkSize=mChunkSize,
             # Don't need to pass in tile_mn because we won't access offset_padded
         )
         AttentionMaskCls = partial(

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -321,6 +321,7 @@ def _flash_attn_fwd(
     k_descale: Optional[torch.Tensor] = None,
     v_descale: Optional[torch.Tensor] = None,
     gather_kv_indices: Optional[torch.Tensor] = None,
+    chunk_size: Optional[torch.Tensor] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """Forward pass for FlashAttention.
 
@@ -414,6 +415,7 @@ def _flash_attn_fwd(
                 seqused_k,
                 page_table,
                 learnable_sink,
+                chunk_size,
             )
         ), "inputs must be on CUDA device"
     arch = _get_device_arch() if _arch is None else _arch
@@ -716,6 +718,7 @@ def _flash_attn_fwd(
         gather_kv_length,
         sparse_kv,
         disable_sparse_kv_bitmask,
+        chunk_size is None,
         fa_logging.get_fa_log_level(),
     )
 
@@ -726,11 +729,12 @@ def _flash_attn_fwd(
             seqused_q_tensor,
             seqused_k_tensor,
             learnable_sink_tensor,
+            chunk_size_tensor,
         ) = [
             to_cute_tensor(t, assumed_align=4, leading_dim=0)
             if t is not None
             else None
-            for t in (cu_seqlens_q, cu_seqlens_k, seqused_q, seqused_k, learnable_sink)
+            for t in (cu_seqlens_q, cu_seqlens_k, seqused_q, seqused_k, learnable_sink, chunk_size)
         ]
         page_table_tensor = (
             to_cute_tensor(page_table, assumed_align=4, leading_dim=1)
@@ -975,6 +979,7 @@ def _flash_attn_fwd(
             compile_args.extend([
                 sparse_tensors,
                 cute_aux_tensors,
+                chunk_size_tensor,
             ])
             compile_args.append(current_stream)
             _flash_attn_fwd.compile_cache[compile_key] = cute.compile(
@@ -1047,6 +1052,7 @@ def _flash_attn_fwd(
                 if normalized_block_sparse_tensors is not None
                 else None,
                 aux_tensors,
+                chunk_size,
             ])
             _flash_attn_fwd.compile_cache[compile_key](*call_args)
     if is_split_kv:
@@ -1245,6 +1251,7 @@ def _flash_attn_bwd(
     aux_tensors: Optional[list[torch.Tensor]] = None,
     block_sparse_tensors: Optional[BlockSparseTensorsTorch] = None,
     dlse: Optional[torch.Tensor] = None,
+    chunk_size: Optional[torch.Tensor] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     arch = _get_device_arch()
     assert arch // 10 in [9, 10, 11, 12], "Unsupported compute capability. Supported: 9.x, 10.x, 11.x, 12.x"
@@ -1640,6 +1647,7 @@ def _flash_attn_bwd(
             # Prevent TVM stride poisoning when only one block is present.
             (seqlen_q_rounded // m_block_size == 1),
             (seqlen_k_rounded // n_block_size == 1),
+            chunk_size is None,
         )
     else:
         compile_key = (
@@ -1676,6 +1684,7 @@ def _flash_attn_bwd(
             # Prevent TVM stride poisoning when only one block is present.
             (seqlen_q_rounded // m_block_size == 1),
             (seqlen_k_rounded // n_block_size == 1),
+            chunk_size is None,
         )
 
     if compile_key not in _flash_attn_bwd.compile_cache:
@@ -1688,9 +1697,9 @@ def _flash_attn_bwd(
             dk_accum_tensor, dv_accum_tensor = [
                 to_cute_tensor(t) for t in (dk_accum, dv_accum)
             ]
-        cu_seqlens_q_tensor, cu_seqlens_k_tensor, seqused_q_tensor, seqused_k_tensor = [
+        cu_seqlens_q_tensor, cu_seqlens_k_tensor, seqused_q_tensor, seqused_k_tensor, chunk_size_tensor = [
             to_cute_tensor(t, assumed_align=4) if t is not None else None
-            for t in (cu_seqlens_q, cu_seqlens_k, seqused_q, seqused_k)
+            for t in (cu_seqlens_q, cu_seqlens_k, seqused_q, seqused_k, chunk_size)
         ]
         dQ_semaphore_tensor, dK_semaphore_tensor, dV_semaphore_tensor = [
             utils.convert_from_dlpack_leading_static(t.detach(), leading_dim=3, alignment=4, stride_order=t.dim_order())
@@ -1832,6 +1841,7 @@ def _flash_attn_bwd(
             dV_semaphore_tensor,
             cute_aux_tensors,
             sparse_tensors_compile,
+            chunk_size_tensor,
             current_stream,
             options="--enable-tvm-ffi",
         )
@@ -1870,6 +1880,7 @@ def _flash_attn_bwd(
             )
             if normalized_block_sparse_tensors is not None
             else None,
+            chunk_size,
         )
     # Postprocess: convert dq_accum from float32 to dq in bf16/fp16
     # hd=256 2CTA backward has its own internal postprocess, skip here.
@@ -2035,6 +2046,7 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
         block_sparse_tensors: Optional[list] = None,
         aux_tensors: Optional[list] = None,
         return_lse: bool = False,
+        chunk_size: Optional[torch.Tensor] = None,
     ):
         out, lse = _flash_attn_fwd(
             q,
@@ -2063,6 +2075,7 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
             aux_tensors=aux_tensors,
             return_lse=return_lse,
             gather_kv_indices=gather_kv_indices,
+            chunk_size=chunk_size,
         )
         ctx.save_for_backward(
             q,
@@ -2074,6 +2087,7 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
             cu_seqlens_k,
             seqused_q,
             seqused_k,
+            chunk_size,
             *(aux_tensors or ()),
         )
         ctx.softmax_scale = softmax_scale
@@ -2091,7 +2105,7 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, dout, dlse):
-        q, k, v, out, lse, cu_seqlens_q, cu_seqlens_k, seqused_q, seqused_k, *aux = ctx.saved_tensors
+        q, k, v, out, lse, cu_seqlens_q, cu_seqlens_k, seqused_q, seqused_k, chunk_size, *aux = ctx.saved_tensors
         aux_tensors = aux if aux else None
         if not ctx.return_lse:
             dlse = None
@@ -2120,9 +2134,10 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
             score_mod_bwd=ctx.score_mod_bwd,
             aux_tensors=aux_tensors,
             dlse=dlse,
+            chunk_size=chunk_size,
         )
 
-        return dq, dk, dv, *((None,) * 30)
+        return dq, dk, dv, *((None,) * 31)
 
 
 def flash_attn_func(
@@ -2199,6 +2214,7 @@ def flash_attn_varlen_func(
     block_sparse_tensors: Optional[BlockSparseTensorsTorch] = None,
     aux_tensors: Optional[list] = None,
     return_lse: bool = False,
+    chunk_size: Optional[torch.Tensor] = None,
 ):
     """
     Explanation of some optional arguments:
@@ -2214,6 +2230,17 @@ def flash_attn_varlen_func(
     min_seqlen_k: for varlen, specifies the minimum kv sequence length for any batch.
         Used with gather_kv_indices to determine if we need oob masking.
     """
+    if -1 in window_size:
+        window_size = tuple(None if w == -1 else w for w in window_size)
+
+    if chunk_size is not None:
+        assert chunk_size.device == q.device, "Chunk attention requires chunk_size on the same device as q"
+        assert chunk_size.dtype == torch.int32, "chunk_size must be int32"
+        assert cu_seqlens_q is not None, "Chunk attention requires cu_seqlens_q"
+        assert len(cu_seqlens_q) - 1 == len(chunk_size), "Chunk size must match number of sequences"
+        assert causal, "Chunk attention only supports causal mode"
+        assert window_size == (None, None), "Chunk attention only supports global attention"
+
     return FlashAttnVarlenFunc.apply(
         q,
         k,
@@ -2242,6 +2269,7 @@ def flash_attn_varlen_func(
         block_sparse_tensors,
         aux_tensors,
         return_lse,
+        chunk_size,
     )
 
 

--- a/flash_attn/cute/mask.py
+++ b/flash_attn/cute/mask.py
@@ -120,6 +120,14 @@ class AttentionMask:
     def seqlen_k(self) -> Int32:
         return self.seqlen_info.seqlen_k
 
+    @property
+    def has_chunk_size(self) -> bool:
+        return self.seqlen_info.has_chunk_size
+
+    @property
+    def chunk_size(self) -> Int32:
+        return self.seqlen_info.chunk_size
+
     @cute.jit
     def apply_mask(
         self,
@@ -257,6 +265,12 @@ class AttentionMask:
                                 mma_m_idx, r % threads_per_row, width=threads_per_row
                             )
                         col_limit_right = row_idx + causal_row_offset
+                        if const_expr(self.has_chunk_size):
+                            kq_diff = self.seqlen_k - self.seqlen_q
+                            base_offset = causal_row_offset - 1 - kq_diff
+                            aligned_row = row_idx + kq_diff
+                            chunk_boundary = (aligned_row // self.chunk_size + 1) * self.chunk_size
+                            col_limit_right = chunk_boundary + base_offset
                         if const_expr(mask_seqlen):
                             col_limit_right = cutlass.min(col_limit_right, seqlenk_col_limit)
                         if const_expr(not r2p):
@@ -329,12 +343,16 @@ class AttentionMask:
                 if const_expr(mask_causal):
                     for c in cutlass.range(cute.size(tScS_mn.shape[1]), unroll_full=True):
                         col0 = t0ScS_mn[0, c][COL]
-                        # If col0 is beyond the column limit, we want to mask out the entire
-                        # column, by setting row limit to be self.tile_m.
+                        causal_limit = col0 - causal_row_offset
+                        if const_expr(self.has_chunk_size):
+                            kq_diff = self.seqlen_k - self.seqlen_q
+                            abs_kv = col0 + thr_col_offset + n_block * self.tile_n
+                            chunk_start = (abs_kv // self.chunk_size) * self.chunk_size
+                            causal_limit = chunk_start - kq_diff - m_block * self.tile_m - thr_row_offset
                         row_limit_top = (
                             self.tile_m
                             if col0 >= seqlenk_col_limit and mask_seqlen
-                            else col0 - causal_row_offset
+                            else causal_limit
                         )
                         for r in cutlass.range(cute.size(tScS_mn.shape[0]), unroll_full=True):
                             acc_S_mn[r, c] = (
@@ -485,6 +503,12 @@ class AttentionMask:
                 row_idx = row_idx // self.qhead_per_kvhead_packgqa
             if const_expr(mask_causal):
                 col_limit_right = row_idx + causal_row_offset + 1
+                if const_expr(self.has_chunk_size):
+                    kq_diff = self.seqlen_k - self.seqlen_q
+                    base_offset = causal_row_offset - kq_diff
+                    aligned_row = row_idx + kq_diff
+                    chunk_boundary = (aligned_row // self.chunk_size + 1) * self.chunk_size
+                    col_limit_right = chunk_boundary + base_offset
                 if const_expr(mask_seqlen):
                     col_limit_right = cutlass.min(col_limit_right, seqlenk_col_limit)
                 # if cute.arch.thread_idx()[0] % 32 == 0:
@@ -666,6 +690,12 @@ class AttentionMask:
                 # if tidx < 32:
                 #     cute.printf("tidx = {}, {} {}, {} {}", tidx, tScS_t2r[0][0], tScS_t2r[0][1], tScS_t2r[1][0], tScS_t2r[1][1])
                 row_limit_top = causal_offset
+                if const_expr(self.has_chunk_size):
+                    col_idx = tScS_t2r[0][COL] + n_block * self.tile_n
+                    if const_expr(self.qhead_per_kvhead_packgqa != 1):
+                        col_idx = col_idx // self.qhead_per_kvhead_packgqa
+                    chunk_start = (col_idx // self.chunk_size) * self.chunk_size
+                    row_limit_top = causal_offset + chunk_start - col_idx
                 if const_expr(mask_seqlen):
                     # If col is beyond the column limit, we want to mask out the entire
                     # column, by setting row limit to be self.tile_m.

--- a/flash_attn/cute/seqlen_info.py
+++ b/flash_attn/cute/seqlen_info.py
@@ -78,6 +78,8 @@ class SeqlenInfoQK:
     has_cu_seqlens_k: cutlass.Constexpr[bool]
     has_seqused_q: cutlass.Constexpr[bool]
     has_seqused_k: cutlass.Constexpr[bool]
+    has_chunk_size: cutlass.Constexpr[bool]
+    chunk_size: Int32
 
     @staticmethod
     def create(
@@ -92,9 +94,15 @@ class SeqlenInfoQK:
         mCuBlockIdxOffsets: Optional[cute.Tensor] = None,
         tile_m: cutlass.Constexpr[Int32] = 128,
         tile_n: cutlass.Constexpr[Int32] = 128,
+        mChunkSize: cutlass.Constexpr[cute.Tensor] = None,
     ):
         offset_q = 0 if const_expr(mCuSeqlensQ is None) else mCuSeqlensQ[batch_idx]
         offset_k = 0 if const_expr(mCuSeqlensK is None) else mCuSeqlensK[batch_idx]
+        chunk_size = (
+            -1
+            if const_expr(mChunkSize is None)
+            else mChunkSize[batch_idx]
+        )
         padded_offset_q = (
             0
             if const_expr(mCuSeqlensQ is None)
@@ -142,6 +150,8 @@ class SeqlenInfoQK:
             has_cu_seqlens_k=mCuSeqlensK is not None,
             has_seqused_q=mSeqUsedQ is not None,
             has_seqused_k=mSeqUsedK is not None,
+            has_chunk_size=mChunkSize is not None,
+            chunk_size=chunk_size,
         )
 
     def offset_batch_Q(

--- a/tests/cute/test_chunk_attn.py
+++ b/tests/cute/test_chunk_attn.py
@@ -1,0 +1,492 @@
+import gc
+import random
+import time
+from functools import wraps
+
+import pytest
+import torch
+
+from flash_attn.cute.interface import _flash_attn_bwd, _flash_attn_fwd, flash_attn_varlen_func
+from flash_attn.cute.testing import generate_random_padding_mask
+
+
+COMPUTE_CAPABILITY = torch.cuda.get_device_capability()[0] if torch.cuda.is_available() else 0
+IS_SM90 = COMPUTE_CAPABILITY == 9
+IS_SM100_OR_SM110 = COMPUTE_CAPABILITY in (10, 11)
+SUPPORTS_DETERMINISTIC_BWD = COMPUTE_CAPABILITY in (9, 10, 11)
+USE_FAKE_TENSOR = False
+
+
+def retry_on_oom(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except torch.OutOfMemoryError as e:
+            if "out of memory" not in str(e).lower():
+                raise
+            if hasattr(_flash_attn_fwd, "compile_cache"):
+                _flash_attn_fwd.compile_cache.clear()
+            if hasattr(_flash_attn_bwd, "compile_cache"):
+                _flash_attn_bwd.compile_cache.clear()
+            gc.collect()
+            torch.cuda.empty_cache()
+            return func(*args, **kwargs)
+
+    return wrapper
+
+
+def _repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
+    if n_rep == 1:
+        return hidden_states
+    seqlen, num_kv_heads, head_dim = hidden_states.shape
+    hidden_states = hidden_states[:, :, None, :].expand(seqlen, num_kv_heads, n_rep, head_dim)
+    return hidden_states.reshape(seqlen, num_kv_heads * n_rep, head_dim)
+
+
+def _make_cu_seqlens(seqlens, device="cuda") -> torch.Tensor:
+    return torch.tensor([0] + list(torch.tensor(seqlens).cumsum(0).tolist()), device=device, dtype=torch.int32)
+
+
+def _make_chunk_sizes(mode: str, batch_size: int, base_chunk_size: int, device="cuda") -> torch.Tensor:
+    if mode == "constant":
+        chunk_sizes = [base_chunk_size] * batch_size
+    elif mode == "per_batch":
+        chunk_sizes = [max(1, base_chunk_size + (i % 3 - 1) * 7) for i in range(batch_size)]
+    elif mode == "tail_oversized":
+        chunk_sizes = [base_chunk_size if i % 2 == 0 else base_chunk_size * 3 + 17 for i in range(batch_size)]
+    else:
+        raise ValueError(f"unknown chunk size mode: {mode}")
+    return torch.tensor(chunk_sizes, device=device, dtype=torch.int32)
+
+
+def _heads_for_mha_type(mha_type: str) -> tuple[int, int]:
+    num_heads = 8
+    if mha_type == "mha":
+        return num_heads, num_heads
+    if mha_type == "gqa":
+        return num_heads, 2
+    if mha_type == "mqa":
+        return num_heads, 1
+    raise ValueError(f"unknown mha_type: {mha_type}")
+
+
+def _tolerances(dtype: torch.dtype) -> tuple[float, float]:
+    # bf16 dK/dV can differ by about one ULP from the PyTorch reference because
+    # the kernel and reference accumulate reductions in different orders.
+    return (2e-2, 4e-2) if dtype == torch.bfloat16 else (3e-3, 3e-3)
+
+
+def chunk_attn_ref_varlen(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    cu_seqlens_k: torch.Tensor,
+    chunk_size: torch.Tensor,
+    softmax_scale: float | None = None,
+) -> torch.Tensor:
+    """Reference for chunk attention on packed varlen tensors.
+
+    For batch b:
+        keep(q, k) = ((q + seqlen_k - seqlen_q) // chunk_size[b] + 1) * chunk_size[b] > k
+    """
+    dtype = q.dtype
+    head_dim = q.shape[-1]
+    num_q_heads = q.shape[1]
+    num_kv_heads = k.shape[1]
+    n_rep = num_q_heads // num_kv_heads
+    softmax_scale = head_dim ** (-0.5) if softmax_scale is None else softmax_scale
+
+    outputs = []
+    for batch_idx in range(len(cu_seqlens_q) - 1):
+        q_start, q_end = cu_seqlens_q[batch_idx].item(), cu_seqlens_q[batch_idx + 1].item()
+        k_start, k_end = cu_seqlens_k[batch_idx].item(), cu_seqlens_k[batch_idx + 1].item()
+        seqlen_q = q_end - q_start
+        seqlen_k = k_end - k_start
+        kq_diff = seqlen_k - seqlen_q
+        chunk = chunk_size[batch_idx].item()
+
+        q_b = q[q_start:q_end]
+        k_b = _repeat_kv(k[k_start:k_end], n_rep)
+        v_b = _repeat_kv(v[k_start:k_end], n_rep)
+
+        scores = torch.bmm(q_b.permute(1, 0, 2), k_b.permute(1, 2, 0)).float() * softmax_scale
+        q_range = torch.arange(seqlen_q, device=q.device).unsqueeze(1)
+        k_range = torch.arange(seqlen_k, device=q.device).unsqueeze(0)
+        chunk_mask = ((q_range + kq_diff) // chunk + 1) * chunk > k_range
+        scores.masked_fill_(~chunk_mask.unsqueeze(0), float("-inf"))
+        probs = torch.softmax(scores, dim=-1).to(dtype)
+        outputs.append(torch.bmm(probs, v_b.permute(1, 0, 2)).permute(1, 0, 2))
+
+    return torch.cat(outputs, dim=0)
+
+
+def _run_chunk_varlen_case(
+    *,
+    seqlens_q: list[int],
+    seqlens_k: list[int],
+    head_dim: int,
+    dtype: torch.dtype,
+    mha_type: str,
+    chunk_size: int,
+    chunk_size_mode: str = "constant",
+    deterministic: bool = False,
+    kv_layout: str = "packed",
+):
+    assert len(seqlens_q) == len(seqlens_k)
+    assert kv_layout in ("packed", "padded")
+    device = "cuda"
+    batch_size = len(seqlens_q)
+    num_heads, num_kv_heads = _heads_for_mha_type(mha_type)
+    chunk_size_tensor = _make_chunk_sizes(chunk_size_mode, batch_size, chunk_size, device=device)
+    cu_seqlens_q = _make_cu_seqlens(seqlens_q, device=device)
+    cu_seqlens_k = _make_cu_seqlens(seqlens_k, device=device)
+    total_q = sum(seqlens_q)
+    total_k = sum(seqlens_k)
+    max_seqlen_q = max(seqlens_q)
+    max_seqlen_k = max(seqlens_k)
+
+    q_ref = torch.randn(
+        total_q, num_heads, head_dim, device=device, dtype=dtype, requires_grad=True
+    )
+    k_ref = torch.randn(
+        total_k, num_kv_heads, head_dim, device=device, dtype=dtype, requires_grad=True
+    )
+    v_ref = torch.randn(
+        total_k, num_kv_heads, head_dim, device=device, dtype=dtype, requires_grad=True
+    )
+
+    out_ref = chunk_attn_ref_varlen(q_ref, k_ref, v_ref, cu_seqlens_q, cu_seqlens_k, chunk_size_tensor)
+
+    q = q_ref.detach().clone().requires_grad_(True)
+    if kv_layout == "packed":
+        k = k_ref.detach().clone().requires_grad_(True)
+        v = v_ref.detach().clone().requires_grad_(True)
+        cu_seqlens_k_arg = cu_seqlens_k
+        seqused_k_arg = None
+    else:
+        k_padded = torch.zeros(
+            batch_size, max_seqlen_k, num_kv_heads, head_dim, device=device, dtype=dtype
+        )
+        v_padded = torch.zeros_like(k_padded)
+        for batch_idx, seqlen in enumerate(seqlens_k):
+            start, end = cu_seqlens_k[batch_idx].item(), cu_seqlens_k[batch_idx + 1].item()
+            k_padded[batch_idx, :seqlen] = k_ref.detach()[start:end]
+            v_padded[batch_idx, :seqlen] = v_ref.detach()[start:end]
+        k = k_padded.requires_grad_(True)
+        v = v_padded.requires_grad_(True)
+        cu_seqlens_k_arg = None
+        seqused_k_arg = torch.tensor(seqlens_k, device=device, dtype=torch.int32)
+
+    out, _ = flash_attn_varlen_func(
+        q,
+        k,
+        v,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k_arg,
+        seqused_k=seqused_k_arg,
+        max_seqlen_q=max_seqlen_q,
+        max_seqlen_k=max_seqlen_k,
+        causal=True,
+        deterministic=deterministic,
+        chunk_size=chunk_size_tensor,
+    )
+
+    fwd_tol, bwd_tol = _tolerances(dtype)
+    torch.testing.assert_close(out_ref, out, atol=fwd_tol, rtol=fwd_tol)
+
+    grad = torch.randn_like(out)
+    out_ref.backward(grad)
+    out.backward(grad)
+    torch.testing.assert_close(q_ref.grad, q.grad, atol=bwd_tol, rtol=bwd_tol)
+    if kv_layout == "packed":
+        torch.testing.assert_close(k_ref.grad, k.grad, atol=bwd_tol, rtol=bwd_tol)
+        torch.testing.assert_close(v_ref.grad, v.grad, atol=bwd_tol, rtol=bwd_tol)
+    else:
+        k_grad = torch.cat([k.grad[b, :seqlen] for b, seqlen in enumerate(seqlens_k)], dim=0)
+        v_grad = torch.cat([v.grad[b, :seqlen] for b, seqlen in enumerate(seqlens_k)], dim=0)
+        torch.testing.assert_close(k_ref.grad, k_grad, atol=bwd_tol, rtol=bwd_tol)
+        torch.testing.assert_close(v_ref.grad, v_grad, atol=bwd_tol, rtol=bwd_tol)
+
+    return out.detach(), q.detach(), k.detach(), v.detach(), chunk_size_tensor
+
+
+def _run_flash_chunk_once(q, k, v, grad, cu_seqlens_q, cu_seqlens_k, max_seqlen_q, max_seqlen_k, chunk_size):
+    q_run = q.detach().clone().requires_grad_(True)
+    k_run = k.detach().clone().requires_grad_(True)
+    v_run = v.detach().clone().requires_grad_(True)
+    out, _ = flash_attn_varlen_func(
+        q_run,
+        k_run,
+        v_run,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        max_seqlen_q=max_seqlen_q,
+        max_seqlen_k=max_seqlen_k,
+        causal=True,
+        deterministic=True,
+        chunk_size=chunk_size,
+    )
+    out.backward(grad)
+    return out.detach(), q_run.grad.detach(), k_run.grad.detach(), v_run.grad.detach()
+
+
+CHUNK_CASES = [
+    pytest.param([41, 128, 257], [41, 128, 257], 8, "constant", id="equal-varlen-small-chunk"),
+    pytest.param([68, 99], [112, 154], 4, "constant", id="k-longer-kqdiff-not-multiple"),
+    pytest.param([128, 31, 256], [193, 203, 320], 60, "per_batch", id="mixed-qk-per-batch"),
+    pytest.param([511, 37], [511, 37], 300, "tail_oversized", id="oversized-tail-chunk"),
+    pytest.param([1024], [1024], 500, "constant", id="1k-long-chunk-500"),
+]
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("mha_type", ["mha", "gqa", "mqa"])
+@pytest.mark.parametrize("head_dim", [64, 128])
+@pytest.mark.parametrize("deterministic", [False, True])
+@pytest.mark.parametrize("seqlens_q,seqlens_k,chunk_size,chunk_size_mode", CHUNK_CASES)
+@retry_on_oom
+def test_chunk_attn_varlen_output(
+    seqlens_q,
+    seqlens_k,
+    chunk_size,
+    chunk_size_mode,
+    deterministic,
+    head_dim,
+    mha_type,
+    dtype,
+):
+    if deterministic and not SUPPORTS_DETERMINISTIC_BWD:
+        pytest.skip("deterministic backward is supported on SM90/SM100/SM110")
+    seed = 1000 + head_dim + len(seqlens_q) * 17 + int(deterministic)
+    random.seed(seed)
+    torch.random.manual_seed(seed)
+    torch.cuda.empty_cache()
+    _run_chunk_varlen_case(
+        seqlens_q=seqlens_q,
+        seqlens_k=seqlens_k,
+        head_dim=head_dim,
+        dtype=dtype,
+        mha_type=mha_type,
+        chunk_size=chunk_size,
+        chunk_size_mode=chunk_size_mode,
+        deterministic=deterministic,
+    )
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("mha_type", ["mha", "gqa", "mqa"])
+@pytest.mark.parametrize("kv_layout", ["packed", "padded"])
+@pytest.mark.parametrize("head_dim", [64, 128])
+@retry_on_oom
+def test_chunk_attn_varlen_from_padding_masks(head_dim, kv_layout, mha_type, dtype):
+    """Covers cu_seqlens_q with either packed KV or padded KV + seqused_k."""
+    device = "cuda"
+    seed = 1234 + head_dim + (0 if kv_layout == "packed" else 100)
+    random.seed(seed)
+    torch.random.manual_seed(seed)
+    torch.cuda.empty_cache()
+
+    batch_size = 5
+    max_seqlen_q, max_seqlen_k = 257, 384
+    query_padding_mask = generate_random_padding_mask(
+        max_seqlen_q, batch_size, device, mode="random"
+    )
+    key_padding_mask = generate_random_padding_mask(
+        max_seqlen_k, batch_size, device, mode="third"
+    )
+    seqlens_q = query_padding_mask.sum(-1).tolist()
+    seqlens_k = key_padding_mask.sum(-1).tolist()
+    # Keep every sequence non-empty so chunk causal rows always have at least one valid key.
+    seqlens_q = [max(1, int(s)) for s in seqlens_q]
+    seqlens_k = [max(sq, int(sk)) for sq, sk in zip(seqlens_q, seqlens_k)]
+
+    _run_chunk_varlen_case(
+        seqlens_q=seqlens_q,
+        seqlens_k=seqlens_k,
+        head_dim=head_dim,
+        dtype=dtype,
+        mha_type=mha_type,
+        chunk_size=49,
+        chunk_size_mode="per_batch",
+        kv_layout=kv_layout,
+    )
+
+
+@pytest.mark.skipif(
+    not SUPPORTS_DETERMINISTIC_BWD,
+    reason="deterministic backward is supported on SM90/SM100/SM110",
+)
+@pytest.mark.parametrize(
+    "seqlens_q,seqlens_k,chunk_size",
+    [
+        ([128, 192], [128, 192], 8),
+        ([68, 99], [112, 154], 4),
+        ([256, 37, 113], [320, 113, 203], 60),
+    ],
+)
+@retry_on_oom
+def test_chunk_attn_deterministic_reproducibility(seqlens_q, seqlens_k, chunk_size):
+    """Repeated deterministic=True backward runs should be bit-identical."""
+    seed = 2024 + chunk_size
+    random.seed(seed)
+    torch.random.manual_seed(seed)
+    torch.cuda.empty_cache()
+
+    device = "cuda"
+    num_heads, num_kv_heads = _heads_for_mha_type("gqa")
+    head_dim = 64
+    dtype = torch.float16
+    cu_seqlens_q = _make_cu_seqlens(seqlens_q, device=device)
+    cu_seqlens_k = _make_cu_seqlens(seqlens_k, device=device)
+    chunk_size_tensor = _make_chunk_sizes("per_batch", len(seqlens_q), chunk_size, device=device)
+    q = torch.randn(sum(seqlens_q), num_heads, head_dim, device=device, dtype=dtype)
+    k = torch.randn(sum(seqlens_k), num_kv_heads, head_dim, device=device, dtype=dtype)
+    v = torch.randn(sum(seqlens_k), num_kv_heads, head_dim, device=device, dtype=dtype)
+    max_seqlen_q = max(seqlens_q)
+    max_seqlen_k = max(seqlens_k)
+
+    out_warmup, _, _, _ = _run_flash_chunk_once(
+        q, k, v, torch.ones(sum(seqlens_q), num_heads, head_dim, device=device, dtype=dtype),
+        cu_seqlens_q, cu_seqlens_k, max_seqlen_q, max_seqlen_k, chunk_size_tensor,
+    )
+    grad = torch.randn_like(out_warmup)
+    out_ref, dq_ref, dk_ref, dv_ref = _run_flash_chunk_once(
+        q, k, v, grad, cu_seqlens_q, cu_seqlens_k, max_seqlen_q, max_seqlen_k, chunk_size_tensor
+    )
+    for _ in range(3):
+        out_i, dq_i, dk_i, dv_i = _run_flash_chunk_once(
+            q, k, v, grad, cu_seqlens_q, cu_seqlens_k, max_seqlen_q, max_seqlen_k, chunk_size_tensor
+        )
+        assert torch.equal(out_ref, out_i), "fwd output not bit-identical across deterministic runs"
+        assert torch.equal(dq_ref, dq_i), "dq not bit-identical under deterministic=True"
+        assert torch.equal(dk_ref, dk_i), "dk not bit-identical under deterministic=True"
+        assert torch.equal(dv_ref, dv_i), "dv not bit-identical under deterministic=True"
+
+
+@pytest.mark.skipif(
+    not IS_SM100_OR_SM110,
+    reason="regression exercises SM100/SM110 deterministic semaphore ordering",
+)
+def test_chunk_attn_sm100_deterministic_boundary_regression():
+    """Regression for chunks whose boundary bumps n_block_max_for_m_block in SM100 bwd."""
+    random.seed(60)
+    torch.random.manual_seed(60)
+    torch.cuda.empty_cache()
+    _run_chunk_varlen_case(
+        seqlens_q=[71, 119],
+        seqlens_k=[127, 185],
+        head_dim=64,
+        dtype=torch.float16,
+        mha_type="gqa",
+        chunk_size=60,
+        chunk_size_mode="constant",
+        deterministic=True,
+    )
+
+
+def test_chunk_attn_api_validation():
+    device = "cuda"
+    q = torch.randn(4, 2, 64, device=device, dtype=torch.float16)
+    k = torch.randn_like(q)
+    v = torch.randn_like(q)
+    cu_seqlens = torch.tensor([0, 4], device=device, dtype=torch.int32)
+    chunk_size = torch.tensor([2], device=device, dtype=torch.int32)
+
+    with pytest.raises(AssertionError, match="causal"):
+        flash_attn_varlen_func(
+            q,
+            k,
+            v,
+            cu_seqlens_q=cu_seqlens,
+            cu_seqlens_k=cu_seqlens,
+            max_seqlen_q=4,
+            max_seqlen_k=4,
+            causal=False,
+            chunk_size=chunk_size,
+        )
+    with pytest.raises(AssertionError, match="global attention"):
+        flash_attn_varlen_func(
+            q,
+            k,
+            v,
+            cu_seqlens_q=cu_seqlens,
+            cu_seqlens_k=cu_seqlens,
+            max_seqlen_q=4,
+            max_seqlen_k=4,
+            causal=True,
+            window_size=(32, -1),
+            chunk_size=chunk_size,
+        )
+    with pytest.raises(AssertionError, match="int32"):
+        flash_attn_varlen_func(
+            q,
+            k,
+            v,
+            cu_seqlens_q=cu_seqlens,
+            cu_seqlens_k=cu_seqlens,
+            max_seqlen_q=4,
+            max_seqlen_k=4,
+            causal=True,
+            chunk_size=chunk_size.to(torch.int64),
+        )
+
+
+def demo_chunk_attn_varlen():
+    """Small executable demo: `python tests/cute/test_chunk_attn.py`."""
+    device = "cuda"
+    dtype = torch.bfloat16
+    batch_size = 2
+    seqlen = 1024
+    num_heads = 16
+    head_dim = 128
+    chunk_size = 64
+    torch.random.manual_seed(0)
+
+    cu_seqlens = torch.tensor([0, seqlen, batch_size * seqlen], device=device, dtype=torch.int32)
+    chunk_size_tensor = torch.tensor([chunk_size] * batch_size, device=device, dtype=torch.int32)
+    q = torch.randn(batch_size * seqlen, num_heads, head_dim, device=device, dtype=dtype)
+    k = torch.randn_like(q)
+    v = torch.randn_like(q)
+
+    for _ in range(10):
+        flash_attn_varlen_func(
+            q,
+            k,
+            v,
+            cu_seqlens_q=cu_seqlens,
+            cu_seqlens_k=cu_seqlens,
+            max_seqlen_q=seqlen,
+            max_seqlen_k=seqlen,
+            causal=True,
+            chunk_size=chunk_size_tensor,
+        )
+
+    torch.cuda.synchronize()
+    start = time.time()
+    repeat = 50
+    for _ in range(repeat):
+        out, _ = flash_attn_varlen_func(
+            q,
+            k,
+            v,
+            cu_seqlens_q=cu_seqlens,
+            cu_seqlens_k=cu_seqlens,
+            max_seqlen_q=seqlen,
+            max_seqlen_k=seqlen,
+            causal=True,
+            chunk_size=chunk_size_tensor,
+        )
+    torch.cuda.synchronize()
+    elapsed_ms = (time.time() - start) * 1000 / repeat
+    print(
+        "flash_attn_varlen_func chunk demo: "
+        f"batch={batch_size}, seqlen={seqlen}, heads={num_heads}, "
+        f"head_dim={head_dim}, chunk_size={chunk_size}, time={elapsed_ms:.3f} ms, "
+        f"out_norm={out.float().norm().item():.3f}"
+    )
+
+
+if __name__ == "__main__":
+    demo_chunk_attn_varlen()


### PR DESCRIPTION
# Chunk Attention

Any suggestions and feedback are welcome.

## Overview

Chunk attention is a chunk-causal attention variant where query tokens are
partitioned into fixed-size chunks. Each query token can attend to all keys up to
the end of its current chunk.

It keeps the exact softmax attention computation, but changes the causal mask
from "each token can only see its past" to "each token can see previous chunks
and the full current chunk". In other words, the attention boundary advances by
chunks instead of by individual tokens.

This is useful for streaming workloads where token-level causality is too strict,
but full-sequence attention is too late or too expensive. Common examples include
streaming speech recognition, real-time speech-to-speech models, and full-duplex
voice assistants.

## Why Chunk Attention Is Needed

Standard causal attention exposes context one token at a time. This works well
for autoregressive text generation, but speech systems often benefit from a small
amount of bounded right context. For example, nearby future frames can help
resolve phoneme boundaries, short silences, prosody, and word endings.

```text
streaming speech:

audio frames:  f0 f1 f2 f3 | f4 f5 f6 f7 | f8 f9 f10 f11 | ...
               chunk 0    | chunk 1    | chunk 2        |

standard causal at f1: sees f0..f1
chunk attention at f1: sees f0..f3

standard causal at f5: sees f0..f5
chunk attention at f5: sees f0..f7
```

The latency is still bounded: the model only waits until the current chunk is
available, instead of waiting for the full sequence.

This pattern appears in streaming speech literature under names such as
chunk-wise attention, chunk-aware attention, shifted chunk attention, and
streaming chunked attention. Related work includes Streaming Chunk-Aware
Multihead Attention for online ASR, Chunked Attention-based Encoder-Decoder
models for streaming speech recognition, SSCFormer, and Shifted Chunk Encoder
for streaming Transformer/Conformer ASR.

In short, chunk attention is useful when token-level causality is too restrictive
but full-sequence attention introduces too much latency. It is especially useful
for streaming speech, low-latency speech-to-speech generation, turn-taking,
interruption handling, endpointing, and full-duplex interaction.

## Core Idea

For each batch item, chunk attention takes a `chunk_size`. Query positions are
partitioned into consecutive chunks:

```text
query positions:

0        7 8       15 16      23 24      31
| chunk 0 | chunk 1 | chunk 2 | chunk 3 |
```

With `chunk_size = 8`, all query tokens in chunk 0 can attend to keys `0..7`,
all query tokens in chunk 1 can attend to keys `0..15`, all query tokens in
chunk 2 can attend to keys `0..23`, and so on.

Compared with standard causal attention:

```text
standard causal:

q=0   sees k <= 0
q=1   sees k <= 1
q=2   sees k <= 2
...
q=15  sees k <= 15
```

Chunk attention makes every query in the same chunk share the same right
boundary:

```text
chunk causal, chunk_size = 8:

q=0   sees k < 8
q=1   sees k < 8
...
q=7   sees k < 8
q=8   sees k < 16
...
q=15  sees k < 16
```

So the mask advances by chunks rather than by individual query tokens. The
attention computation itself remains unchanged; only the visibility mask is
different.

## Related Work

Chunked or chunk-wise attention is a common design in low-latency speech models:

- [Streaming Chunk-Aware Multihead Attention for Online End-to-End Speech Recognition](https://arxiv.org/abs/2006.01712)
- [Chunked Attention-based Encoder-Decoder Model for Streaming Speech Recognition](https://arxiv.org/abs/2309.08436)
- [SSCFormer: Push the Limit of Chunk-wise Conformer for Streaming ASR](https://arxiv.org/abs/2211.11419)
- [Shifted Chunk Encoder for Transformer Based Streaming End-to-End ASR](https://arxiv.org/abs/2203.15206)

Recent real-time and full-duplex speech-to-speech systems also motivate this
type of bounded-context attention, because they must process incoming speech
incrementally while generating responses with low latency.
