### PR TITLE
[CuTe, Flex] Allow score mod use in varlen backward

### DIFF
--- a/flash_attn/cute/flash_bwd_sm100.py
+++ b/flash_attn/cute/flash_bwd_sm100.py
@@ -3039,10 +3039,10 @@ class FlashAttentionBackwardSm100:
             seqlen = SeqlenInfoCls(batch_idx)
 
             recompute_fastdiv_mods_q = const_expr(
-                aux_tensors is not None and (seqlen.has_cu_seqlens_q or seqlen.has_seqused_q)
+                aux_data is not None and (seqlen.has_cu_seqlens_q or seqlen.has_seqused_q)
             )
             recompute_fastdiv_mods_k = const_expr(
-                aux_tensors is not None and (seqlen.has_cu_seqlens_k or seqlen.has_seqused_k)
+                aux_data is not None and (seqlen.has_cu_seqlens_k or seqlen.has_seqused_k)
             )
 
             if const_expr(fastdiv_mods is not None and fastdiv_mods[0] is not None):

--- a/flash_attn/cute/flash_bwd_sm100.py
+++ b/flash_attn/cute/flash_bwd_sm100.py
@@ -935,9 +935,9 @@ class FlashAttentionBackwardSm100:
 
         # 2-CTA: 231424 and 1-CTA: 232448
         # print("SMEM: ", self.shared_storage.size_in_bytes())
-        if const_expr(self.use_block_sparsity or aux_data.tensors is not None):
+        if const_expr(self.use_block_sparsity):
             assert all(x is None for x in (mCuSeqlensQ, mCuSeqlensK, mSeqUsedQ, mSeqUsedK)), (
-                "Variable sequence length is not supported yet for blocksparse or aux tensors in bwd"
+                "Variable sequence length is not supported yet for blocksparse in bwd"
             )
 
         self.kernel(
@@ -3037,6 +3037,24 @@ class FlashAttentionBackwardSm100:
         while work_tile.is_valid_tile:
             n_block, head_idx, batch_idx, _ = work_tile.tile_idx
             seqlen = SeqlenInfoCls(batch_idx)
+
+            recompute_fastdiv_mods_q = const_expr(
+                aux_tensors is not None and (seqlen.has_cu_seqlens_q or seqlen.has_seqused_q)
+            )
+            recompute_fastdiv_mods_k = const_expr(
+                aux_tensors is not None and (seqlen.has_cu_seqlens_k or seqlen.has_seqused_k)
+            )
+
+            if const_expr(fastdiv_mods is not None and fastdiv_mods[0] is not None):
+                seqlen_q_divmod, seqlen_k_divmod = fastdiv_mods
+                fastdiv_mods = (
+                    seqlen_q_divmod
+                    if not recompute_fastdiv_mods_q
+                    else FastDivmodDivisor(seqlen.seqlen_q),
+                    seqlen_k_divmod
+                    if not recompute_fastdiv_mods_k
+                    else FastDivmodDivisor(seqlen.seqlen_k),
+                )
             m_block_min, m_block_max = block_info.get_m_block_min_max(
                 seqlen, n_block // self.cluster_shape_mnk[0]
             )

--- a/flash_attn/cute/flash_bwd_sm100.py
+++ b/flash_attn/cute/flash_bwd_sm100.py
@@ -3039,10 +3039,10 @@ class FlashAttentionBackwardSm100:
             seqlen = SeqlenInfoCls(batch_idx)
 
             recompute_fastdiv_mods_q = const_expr(
-                aux_data is not None and (seqlen.has_cu_seqlens_q or seqlen.has_seqused_q)
+                aux_data.tensors is not None and (seqlen.has_cu_seqlens_q or seqlen.has_seqused_q)
             )
             recompute_fastdiv_mods_k = const_expr(
-                aux_data is not None and (seqlen.has_cu_seqlens_k or seqlen.has_seqused_k)
+                aux_data.tensors is not None and (seqlen.has_cu_seqlens_k or seqlen.has_seqused_k)
             )
 
             if const_expr(fastdiv_mods is not None and fastdiv_mods[0] is not None):

--- a/flash_attn/cute/flash_bwd_sm90.py
+++ b/flash_attn/cute/flash_bwd_sm90.py
@@ -1263,20 +1263,6 @@ class FlashAttentionBackwardSm90:
         PdS_barrier = cutlass.pipeline.NamedBarrier(
             barrier_id=int(NamedBarrierBwd.PdS), num_threads=self.num_mma_threads
         )
-        score_mod_fn = partial(
-            self.apply_score_mod,
-            thr_mma_SdP=thr_mma_SdP,
-            softmax_scale=softmax_scale,
-            aux_data=aux_data,
-            fastdiv_mods=fastdiv_mods,
-        )
-        score_mod_bwd_fn = partial(
-            self.apply_score_mod_bwd,
-            thr_mma_SdP=thr_mma_SdP,
-            softmax_scale=softmax_scale,
-            aux_data=aux_data,
-            fastdiv_mods=fastdiv_mods,
-        )
 
         mma_one_m_block_all = partial(
             self.mma_one_m_block,
@@ -1331,6 +1317,20 @@ class FlashAttentionBackwardSm90:
                 )
 
             mask = AttentionMaskCls(seqlen)
+            score_mod_fn = partial(
+                self.apply_score_mod,
+                thr_mma_SdP=thr_mma_SdP,
+                softmax_scale=softmax_scale,
+                aux_tensors=aux_tensors,
+                fastdiv_mods=fastdiv_mods,
+            )
+            score_mod_bwd_fn = partial(
+                self.apply_score_mod_bwd,
+                thr_mma_SdP=thr_mma_SdP,
+                softmax_scale=softmax_scale,
+                aux_tensors=aux_tensors,
+                fastdiv_mods=fastdiv_mods,
+            )
             score_mod_fn_cur = partial(
                 score_mod_fn,
                 batch_idx=batch_idx,

--- a/flash_attn/cute/flash_bwd_sm90.py
+++ b/flash_attn/cute/flash_bwd_sm90.py
@@ -1311,6 +1311,25 @@ class FlashAttentionBackwardSm90:
         while work_tile.is_valid_tile:
             n_block, head_idx, batch_idx, _ = work_tile.tile_idx
             seqlen = SeqlenInfoCls(batch_idx)
+
+            recompute_fastdiv_mods_q = const_expr(
+                aux_tensors is not None and (seqlen.has_cu_seqlens_q or seqlen.has_seqused_q)
+            )
+            recompute_fastdiv_mods_k = const_expr(
+                aux_tensors is not None and (seqlen.has_cu_seqlens_k or seqlen.has_seqused_k)
+            )
+
+            if const_expr(fastdiv_mods is not None and fastdiv_mods[0] is not None):
+                seqlen_q_divmod, seqlen_k_divmod = fastdiv_mods
+                fastdiv_mods = (
+                    seqlen_q_divmod
+                    if not recompute_fastdiv_mods_q
+                    else FastDivmodDivisor(seqlen.seqlen_q),
+                    seqlen_k_divmod
+                    if not recompute_fastdiv_mods_k
+                    else FastDivmodDivisor(seqlen.seqlen_k),
+                )
+
             mask = AttentionMaskCls(seqlen)
             score_mod_fn_cur = partial(
                 score_mod_fn,

--- a/flash_attn/cute/flash_bwd_sm90.py
+++ b/flash_attn/cute/flash_bwd_sm90.py
@@ -1299,10 +1299,10 @@ class FlashAttentionBackwardSm90:
             seqlen = SeqlenInfoCls(batch_idx)
 
             recompute_fastdiv_mods_q = const_expr(
-                aux_tensors is not None and (seqlen.has_cu_seqlens_q or seqlen.has_seqused_q)
+                aux_data is not None and (seqlen.has_cu_seqlens_q or seqlen.has_seqused_q)
             )
             recompute_fastdiv_mods_k = const_expr(
-                aux_tensors is not None and (seqlen.has_cu_seqlens_k or seqlen.has_seqused_k)
+                aux_data is not None and (seqlen.has_cu_seqlens_k or seqlen.has_seqused_k)
             )
 
             if const_expr(fastdiv_mods is not None and fastdiv_mods[0] is not None):
@@ -1321,14 +1321,14 @@ class FlashAttentionBackwardSm90:
                 self.apply_score_mod,
                 thr_mma_SdP=thr_mma_SdP,
                 softmax_scale=softmax_scale,
-                aux_tensors=aux_tensors,
+                aux_data=aux_data,
                 fastdiv_mods=fastdiv_mods,
             )
             score_mod_bwd_fn = partial(
                 self.apply_score_mod_bwd,
                 thr_mma_SdP=thr_mma_SdP,
                 softmax_scale=softmax_scale,
-                aux_tensors=aux_tensors,
+                aux_data=aux_data,
                 fastdiv_mods=fastdiv_mods,
             )
             score_mod_fn_cur = partial(

--- a/flash_attn/cute/flash_bwd_sm90.py
+++ b/flash_attn/cute/flash_bwd_sm90.py
@@ -1299,10 +1299,10 @@ class FlashAttentionBackwardSm90:
             seqlen = SeqlenInfoCls(batch_idx)
 
             recompute_fastdiv_mods_q = const_expr(
-                aux_data is not None and (seqlen.has_cu_seqlens_q or seqlen.has_seqused_q)
+                aux_data.tensors is not None and (seqlen.has_cu_seqlens_q or seqlen.has_seqused_q)
             )
             recompute_fastdiv_mods_k = const_expr(
-                aux_data is not None and (seqlen.has_cu_seqlens_k or seqlen.has_seqused_k)
+                aux_data.tensors is not None and (seqlen.has_cu_seqlens_k or seqlen.has_seqused_k)
             )
 
             if const_expr(fastdiv_mods is not None and fastdiv_mods[0] is not None):

--- a/flash_attn/cute/flash_fwd_sm100.py
+++ b/flash_attn/cute/flash_fwd_sm100.py
@@ -1089,7 +1089,9 @@ class FlashAttentionForwardSm100:
                 blocksparse_tensors.cu_total_m_blocks if blocksparse_tensors is not None else None
             ),
             mCuBlockIdxOffsets=(
-                blocksparse_tensors.cu_block_idx_offsets if blocksparse_tensors is not None else None
+                blocksparse_tensors.cu_block_idx_offsets
+                if blocksparse_tensors is not None
+                else None
             ),
         )
         AttentionMaskCls = self._generate_attention_mask_cls(

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -1433,6 +1433,7 @@ def _flash_attn_bwd(
         use_2cta_instrs = (
             head_dim >= 128
             and not requested_disable_2cta
+            and softcap == 0.0
             and block_sparse_bwd_supports_2cta(block_sparse_tensors, n_block_size)
         )
         if block_sparse_tensors is not None and head_dim == 192 and not use_2cta_instrs:

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -1351,6 +1351,13 @@ def _flash_attn_bwd(
     aux_scalars = tuple(aux_scalars) if aux_scalars else None
     arch = _get_device_arch()
     assert arch // 10 in [9, 10, 11, 12], "Unsupported compute capability. Supported: 9.x, 10.x, 11.x, 12.x"
+    if block_sparse_tensors is not None:
+        assert (
+            cu_seqlens_q is None
+            and cu_seqlens_k is None
+            and seqused_q is None
+            and seqused_k is None
+        ), "Varlen backward with block sparsity is not yet supported"
     sparse_q = None
     kv_subtile_factor = 1
     if block_sparse_tensors is not None:

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -1433,7 +1433,6 @@ def _flash_attn_bwd(
         use_2cta_instrs = (
             head_dim >= 128
             and not requested_disable_2cta
-            and softcap == 0.0
             and block_sparse_bwd_supports_2cta(block_sparse_tensors, n_block_size)
         )
         if block_sparse_tensors is not None and head_dim == 192 and not use_2cta_instrs:

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -1556,9 +1556,6 @@ def _flash_attn_bwd(
         score_mod_bwd = utils.create_softcap_scoremod_bwd(softcap)
     if score_mod is not None:
         assert score_mod_bwd is not None, "score_mod_bwd is required when score_mod is provided"
-        assert cu_seqlens_q is None and cu_seqlens_k is None, (
-            "varlen + score_mod not supported in bwd yet"
-        )
         if arch // 10 == 8:
             raise NotImplementedError("Custom user-provided score_mod is not supported on SM8x architectures.")
 

--- a/tests/cute/score_mod_definitions.py
+++ b/tests/cute/score_mod_definitions.py
@@ -16,7 +16,9 @@ def score_mod_identity(tSrS_ssa, b_idx, h_idx, q_idx, kv_idx, seqlen_info, aux_t
 
 
 @cute.jit
-def score_mod_identity_vectorized(tSrS_ssa, b_idx, h_idx, q_idx, kv_idx, seqlen_info, aux_tensors):
+def score_mod_identity_vectorized(
+    tSrS_ssa, b_idx, h_idx, q_idx, kv_idx, seqlen_info, aux_tensors
+):
     return tSrS_ssa
 
 
@@ -27,7 +29,9 @@ def score_mod_causal(tSrS_ssa, b_idx, h_idx, q_idx, kv_idx, seqlen_info, aux_ten
 
 
 @cute.jit
-def score_mod_causal_vectorized(tSrS_ssa, b_idx, h_idx, q_idx, kv_idx, seqlen_info, aux_tensors):
+def score_mod_causal_vectorized(
+    tSrS_ssa, b_idx, h_idx, q_idx, kv_idx, seqlen_info, aux_tensors
+):
     mask = cute.make_rmem_tensor(kv_idx.shape, dtype=cutlass.Boolean)
     kv_idx0 = kv_idx[0]
     q_idx0 = q_idx[0]
@@ -45,7 +49,9 @@ def score_mod_rel_bias(tSrS_ssa, b_idx, h_idx, q_idx, kv_idx, seqlen_info, aux_t
 
 
 @cute.jit
-def score_mod_rel_bias_vectorized(tSrS_ssa, b_idx, h_idx, q_idx, kv_idx, seqlen_info, aux_tensors):
+def score_mod_rel_bias_vectorized(
+    tSrS_ssa, b_idx, h_idx, q_idx, kv_idx, seqlen_info, aux_tensors
+):
     q_idx0 = q_idx[0]
     kv_idx0 = kv_idx[0]
     diff0 = q_idx0 - kv_idx0
@@ -56,8 +62,27 @@ def score_mod_rel_bias_vectorized(tSrS_ssa, b_idx, h_idx, q_idx, kv_idx, seqlen_
     return tSrS_ssa + abs_diff.load().to(cutlass.Float32)
 
 
+REL_BIAS_CLAMP = 256
+
+
 @cute.jit
-def score_mod_rel_bias_x2(tSrS_ssa, b_idx, h_idx, q_idx, kv_idx, seqlen_info, aux_tensors):
+def score_mod_rel_bias_clamped(
+    tSrS_ssa, b_idx, h_idx, q_idx, kv_idx, seqlen_info, aux_tensors
+):
+    diff = q_idx - kv_idx
+    abs_diff = cute.TensorSSA(mlir_math.absi(diff), diff.shape, diff.dtype)
+    capped = cute.where(
+        operator.le(abs_diff, cute.full_like(abs_diff, REL_BIAS_CLAMP)),
+        abs_diff,
+        cute.full_like(abs_diff, REL_BIAS_CLAMP),
+    )
+    return tSrS_ssa + capped.to(cutlass.Float32)
+
+
+@cute.jit
+def score_mod_rel_bias_x2(
+    tSrS_ssa, b_idx, h_idx, q_idx, kv_idx, seqlen_info, aux_tensors
+):
     diff = q_idx - kv_idx
     abs_diff = cute.TensorSSA(mlir_math.absi(diff), diff.shape, diff.dtype)
     scaled = abs_diff * cute.full_like(abs_diff, 2)
@@ -79,10 +104,14 @@ def score_mod_rel_bias_x2_vectorized(
 
 
 @cute.jit
-def score_mod_times_two(tSrS_ssa, b_idx, h_idx, q_idx, kv_idx, seqlen_info, aux_tensors):
+def score_mod_times_two(
+    tSrS_ssa, b_idx, h_idx, q_idx, kv_idx, seqlen_info, aux_tensors
+):
     return tSrS_ssa * cute.full_like(tSrS_ssa, 2)
 
+
 score_mod_times_two_vectorized = score_mod_times_two
+
 
 @cute.jit
 def score_mod_alibi(tSrS_ssa, b_idx, h_idx, q_idx, kv_idx, seqlen_info, aux_tensors):
@@ -93,11 +122,16 @@ def score_mod_alibi(tSrS_ssa, b_idx, h_idx, q_idx, kv_idx, seqlen_info, aux_tens
         * cute.full_like(score, 0.125 * 0.6931471805599453 * 1.4426950408889634)
     )
     diff = q_idx - kv_idx
-    abs_diff = cute.TensorSSA(mlir_math.absi(diff), diff.shape, diff.dtype).to(cutlass.Float32)
+    abs_diff = cute.TensorSSA(mlir_math.absi(diff), diff.shape, diff.dtype).to(
+        cutlass.Float32
+    )
     return score - slope * abs_diff
 
+
 @cute.jit
-def score_mod_alibi_vectorized(tSrS_ssa, b_idx, h_idx, q_idx, kv_idx, seqlen_info, aux_tensors):
+def score_mod_alibi_vectorized(
+    tSrS_ssa, b_idx, h_idx, q_idx, kv_idx, seqlen_info, aux_tensors
+):
     score = tSrS_ssa.to(cutlass.Float32)
     slope_exp = (h_idx + cute.full_like(h_idx, 1)) * cute.full_like(h_idx, -8)
     slope = cute.math.exp2(
@@ -113,7 +147,9 @@ def score_mod_alibi_vectorized(tSrS_ssa, b_idx, h_idx, q_idx, kv_idx, seqlen_inf
 
 
 @cute.jit
-def score_mod_sliding_window(tSrS_ssa, b_idx, h_idx, q_idx, kv_idx, seqlen_info, aux_tensors):
+def score_mod_sliding_window(
+    tSrS_ssa, b_idx, h_idx, q_idx, kv_idx, seqlen_info, aux_tensors
+):
     diff = q_idx - kv_idx
     abs_diff = cute.TensorSSA(mlir_math.absi(diff), diff.shape, diff.dtype)
     mask = operator.le(abs_diff, cute.full_like(abs_diff, 256))
@@ -121,7 +157,9 @@ def score_mod_sliding_window(tSrS_ssa, b_idx, h_idx, q_idx, kv_idx, seqlen_info,
 
 
 @cute.jit
-def score_mod_block_diagonal(tSrS_ssa, b_idx, h_idx, q_idx, kv_idx, seqlen_info, aux_tensors):
+def score_mod_block_diagonal(
+    tSrS_ssa, b_idx, h_idx, q_idx, kv_idx, seqlen_info, aux_tensors
+):
     q_block = q_idx // 64
     kv_block = kv_idx // 64
     mask = operator.eq(q_block, kv_block)
@@ -129,14 +167,18 @@ def score_mod_block_diagonal(tSrS_ssa, b_idx, h_idx, q_idx, kv_idx, seqlen_info,
 
 
 @cute.jit
-def score_mod_causal_v2(tSrS_ssa, b_idx, h_idx, q_idx, kv_idx, seqlen_info, aux_tensors):
+def score_mod_causal_v2(
+    tSrS_ssa, b_idx, h_idx, q_idx, kv_idx, seqlen_info, aux_tensors
+):
     diff = q_idx - kv_idx
     mask = operator.ge(diff, cute.full_like(diff, 0))
     return cute.where(mask, tSrS_ssa, cute.full_like(tSrS_ssa, float("-inf")))
 
 
 @cute.jit
-def score_mod_batch_bias(tSrS_ssa, b_idx, h_idx, q_idx, kv_idx, seqlen_info, aux_tensors):
+def score_mod_batch_bias(
+    tSrS_ssa, b_idx, h_idx, q_idx, kv_idx, seqlen_info, aux_tensors
+):
     batch_bias = aux_tensors[0]
     dtype = batch_bias.element_type
     b_frag = cute.make_rmem_tensor(1, cutlass.Int32)
@@ -146,8 +188,11 @@ def score_mod_batch_bias(tSrS_ssa, b_idx, h_idx, q_idx, kv_idx, seqlen_info, aux
     bias_val = (bias_frag.load()).to(cutlass.Float32)
     return tSrS_ssa + bias_val
 
+
 @cute.jit
-def score_mod_batch_bias_vectorized(tSrS_ssa, b_idx, h_idx, q_idx, kv_idx, seqlen_info, aux_tensors):
+def score_mod_batch_bias_vectorized(
+    tSrS_ssa, b_idx, h_idx, q_idx, kv_idx, seqlen_info, aux_tensors
+):
     batch_bias = aux_tensors[0]
     dtype = batch_bias.element_type
     b_idx0 = b_idx[0]
@@ -158,7 +203,9 @@ def score_mod_batch_bias_vectorized(tSrS_ssa, b_idx, h_idx, q_idx, kv_idx, seqle
 
 
 @cute.jit
-def score_mod_dual_buffer(tSrS_ssa, b_idx, h_idx, q_idx, kv_idx, seqlen_info, aux_tensors):
+def score_mod_dual_buffer(
+    tSrS_ssa, b_idx, h_idx, q_idx, kv_idx, seqlen_info, aux_tensors
+):
     head_bias = aux_tensors[0]
     pos_bias = aux_tensors[1]
     dtype = head_bias.element_type
@@ -177,8 +224,17 @@ def score_mod_dual_buffer(tSrS_ssa, b_idx, h_idx, q_idx, kv_idx, seqlen_info, au
 
     return tSrS_ssa + head_val + pos_val
 
+
 @cute.jit
-def score_mod_dual_buffer_vectorized(tSrS_ssa, b_idx, h_idx, q_idx, kv_idx, seqlen_info, aux_tensors):
+def score_mod_squared(tSrS_ssa, b_idx, h_idx, q_idx, kv_idx, seqlen_info, aux_tensors):
+    """Forward: score ** 2."""
+    return tSrS_ssa * tSrS_ssa
+
+
+@cute.jit
+def score_mod_dual_buffer_vectorized(
+    tSrS_ssa, b_idx, h_idx, q_idx, kv_idx, seqlen_info, aux_tensors
+):
     head_bias = aux_tensors[0]
     pos_bias = aux_tensors[1]
     dtype = head_bias.element_type
@@ -310,6 +366,7 @@ def score_mod_global_logical_rel_plus_kv_bias(
 
 # "Stress tests" - score_mods with complex global index usage
 
+
 @cute.jit
 def score_mod_stress_complex_arithmetic(
     tSrS_ssa, b_idx, h_idx, q_idx, kv_idx, seqlen_info, aux_tensors
@@ -360,12 +417,16 @@ def score_mod_stress_conditional_mask(
 
     global_diff = q_idx_global - kv_idx_global
     is_nearby = operator.le(
-        cute.TensorSSA(mlir_math.absi(global_diff), global_diff.shape, global_diff.dtype),
+        cute.TensorSSA(
+            mlir_math.absi(global_diff), global_diff.shape, global_diff.dtype
+        ),
         cute.full_like(global_diff, 512),
     )
 
     both_conditions = is_causal & is_nearby
-    return cute.where(both_conditions, tSrS_ssa + bias_val, cute.full_like(tSrS_ssa, float("-inf")))
+    return cute.where(
+        both_conditions, tSrS_ssa + bias_val, cute.full_like(tSrS_ssa, float("-inf"))
+    )
 
 
 @cute.jit
@@ -411,7 +472,9 @@ def score_mod_stress_multi_buffer(
 
     rel_idx = q_idx - kv_idx + cute.full_like(q_idx, 512)
     rel_idx_clamped = cute.where(
-        operator.lt(rel_idx, cute.full_like(rel_idx, 0)), cute.full_like(rel_idx, 0), rel_idx
+        operator.lt(rel_idx, cute.full_like(rel_idx, 0)),
+        cute.full_like(rel_idx, 0),
+        rel_idx,
     )
     rel_idx_clamped = cute.where(
         operator.gt(rel_idx_clamped, cute.full_like(rel_idx_clamped, 1024)),
@@ -424,7 +487,13 @@ def score_mod_stress_multi_buffer(
     rps_frag[0] = rel_pos_scale[ri_frag[0]]
     rps_val = (rps_frag.load()).to(cutlass.Float32)
 
-    return tSrS_ssa * hs_val + bb_val + qpb_val + kvpb_val + rps_val * cute.full_like(tSrS_ssa, 0.1)
+    return (
+        tSrS_ssa * hs_val
+        + bb_val
+        + qpb_val
+        + kvpb_val
+        + rps_val * cute.full_like(tSrS_ssa, 0.1)
+    )
 
 
 @cute.jit
@@ -499,6 +568,10 @@ def rel_bias_eager(score, b, h, q_idx, kv_idx):
     return score + torch.abs(q_idx - kv_idx)
 
 
+def rel_bias_clamped_eager(score, b, h, q_idx, kv_idx):
+    return score + torch.clamp(torch.abs(q_idx - kv_idx), max=REL_BIAS_CLAMP)
+
+
 def rel_bias_x2_eager(score, b, h, q_idx, kv_idx):
     return score + 2 * torch.abs(q_idx - kv_idx)
 
@@ -524,6 +597,10 @@ def causal_v2_eager(score, b, h, q_idx, kv_idx):
     return torch.where(q_idx - kv_idx >= 0, score, float("-inf"))
 
 
+def squared_eager(score, b, h, q_idx, kv_idx):
+    return score * score
+
+
 def batch_bias_factory(bias_tensor):
     def mod(score, b, h, q_idx, kv_idx):
         return score + bias_tensor[b]
@@ -542,31 +619,33 @@ def packed_kv_bias_factory(bias_tensor, cu_seqlens_k):
     def mod(score, b, h, q_idx, kv_idx):
         # Calculate valid length for this sequence
         start = cu_seqlens_k[b]
-        seq_len = cu_seqlens_k[b+1] - start
+        seq_len = cu_seqlens_k[b + 1] - start
 
         # Clamp kv_idx.
         safe_kv_idx = torch.clamp(kv_idx, max=seq_len - 1)
 
         return score + bias_tensor[start + safe_kv_idx]
+
     return mod
 
 
 def packed_q_bias_factory(bias_tensor, cu_seqlens_q):
     def mod(score, b, h, q_idx, kv_idx):
         start = cu_seqlens_q[b]
-        seq_len = cu_seqlens_q[b+1] - start
+        seq_len = cu_seqlens_q[b + 1] - start
 
         # Clamp q_idx
         safe_q_idx = torch.clamp(q_idx, max=seq_len - 1)
 
         return score + bias_tensor[start + safe_q_idx]
+
     return mod
 
 
 def packed_rel_plus_kv_bias_factory(bias_tensor, cu_seqlens_k):
     def mod(score, b, h, q_idx, kv_idx):
         start = cu_seqlens_k[b]
-        seq_len = cu_seqlens_k[b+1] - start
+        seq_len = cu_seqlens_k[b + 1] - start
 
         # Clamp kv_idx
         safe_kv_idx = torch.clamp(kv_idx, max=seq_len - 1)
@@ -581,12 +660,12 @@ def packed_q_and_kv_bias_factory(q_bias, kv_bias, cu_seqlens_q, cu_seqlens_k):
     def mod(score, b, h, q_idx, kv_idx):
         # Handle Q bounds
         q_start = cu_seqlens_q[b]
-        q_len = cu_seqlens_q[b+1] - q_start
+        q_len = cu_seqlens_q[b + 1] - q_start
         safe_q_idx = torch.clamp(q_idx, max=q_len - 1)
 
         # Handle KV bounds
         kv_start = cu_seqlens_k[b]
-        kv_len = cu_seqlens_k[b+1] - kv_start
+        kv_len = cu_seqlens_k[b + 1] - kv_start
         safe_kv_idx = torch.clamp(kv_idx, max=kv_len - 1)
 
         return score + q_bias[q_start + safe_q_idx] + kv_bias[kv_start + safe_kv_idx]
@@ -667,9 +746,128 @@ def stress_xor_pattern_factory(token_bias, cu_seqlens_q, cu_seqlens_k):
 
     return mod
 
+
 def debug_global_idx_factory(bias, cu_seqlens_k):
     offsets = cu_seqlens_k.tolist()
+
     def mod(score, b, h, q_idx, kv_idx):
         global_kv = offsets[b] + kv_idx
         return score + global_kv.float() * 0.001
+
+    return mod
+
+
+# =============================================================================
+# Backward score_mod functions
+# Signature: (grad, score, b_idx, h_idx, q_idx, kv_idx, seqlen_info, aux_tensors)
+# =============================================================================
+
+
+@cute.jit
+def score_mod_bwd_identity(
+    grad, score, b_idx, h_idx, q_idx, kv_idx, seqlen_info, aux_tensors
+):
+    return grad
+
+
+@cute.jit
+def score_mod_bwd_times_two(
+    grad, score, b_idx, h_idx, q_idx, kv_idx, seqlen_info, aux_tensors
+):
+    """Backward for score_mod_times_two: d(score*2)/d(score) = 2."""
+    return grad * cute.full_like(grad, 2.0)
+
+
+@cute.jit
+def score_mod_bwd_rel_bias(
+    grad, score, b_idx, h_idx, q_idx, kv_idx, seqlen_info, aux_tensors
+):
+    """Backward for score_mod_rel_bias: d(score + |q-kv|)/d(score) = 1."""
+    return grad
+
+
+@cute.jit
+def score_mod_bwd_rel_bias_clamped(
+    grad, score, b_idx, h_idx, q_idx, kv_idx, seqlen_info, aux_tensors
+):
+    """Backward for score_mod_rel_bias_clamped: d(score + min(|q-kv|, C))/dscore = 1."""
+    return grad
+
+
+@cute.jit
+def score_mod_bwd_causal(
+    grad, score, b_idx, h_idx, q_idx, kv_idx, seqlen_info, aux_tensors
+):
+    """Backward for causal masking: d(where(mask, score, -inf))/d(score) = where(mask, 1, 0).
+
+    At unmasked positions (q_idx >= kv_idx), grad passes through.
+    At masked positions (q_idx < kv_idx), the kernel already zeros grad because P=0.
+    """
+    return grad
+
+
+@cute.jit
+def score_mod_bwd_squared(
+    grad, score, b_idx, h_idx, q_idx, kv_idx, seqlen_info, aux_tensors
+):
+    """Backward for score_mod_squared: d(score**2)/d(score) = 2*score."""
+    return grad * cute.full_like(grad, 2.0) * score
+
+
+@cute.jit
+def score_mod_bwd_dual_buffer(
+    grad, score, b_idx, h_idx, q_idx, kv_idx, seqlen_info, aux_tensors
+):
+    """Backward for score_mod_dual_buffer: d(score + head_bias[h] + pos_bias[q])/d(score) = 1."""
+    return grad
+
+
+# -----------------------------------------------------------------------------
+# Example: bwd that needs grad, score, and a global-indexed aux read.
+# Forward: scale[global_kv] * score**2.
+# Backward: d/dscore = 2 * score * scale[global_kv]
+# -----------------------------------------------------------------------------
+
+
+@cute.jit
+def score_mod_scaled_squared(
+    tSrS_ssa, b_idx, h_idx, q_idx, kv_idx, seqlen_info, aux_tensors
+):
+    """Forward: scale[global_kv_idx] * score**2."""
+    offset_k = seqlen_info.offset_k
+    kv_idx_global = kv_idx + offset_k
+    scale = aux_tensors[0]
+    dtype = scale.element_type
+    kv_frag = cute.make_fragment(1, cutlass.Int32)
+    kv_frag.store(kv_idx_global)
+    scale_frag = cute.make_fragment(1, dtype)
+    scale_frag[0] = scale[kv_frag[0]]
+    scale_val = (scale_frag.load()).to(cutlass.Float32)
+    return scale_val * tSrS_ssa * tSrS_ssa
+
+
+@cute.jit
+def score_mod_bwd_scaled_squared(
+    grad, score, b_idx, h_idx, q_idx, kv_idx, seqlen_info, aux_tensors
+):
+    """Backward for score_mod_scaled_squared: d(scale[g_kv]*score**2)/dscore = 2*scale[g_kv]*score."""
+    offset_k = seqlen_info.offset_k
+    kv_idx_global = kv_idx + offset_k
+    scale = aux_tensors[0]
+    dtype = scale.element_type
+    kv_frag = cute.make_fragment(1, cutlass.Int32)
+    kv_frag.store(kv_idx_global)
+    scale_frag = cute.make_fragment(1, dtype)
+    scale_frag[0] = scale[kv_frag[0]]
+    scale_val = (scale_frag.load()).to(cutlass.Float32)
+    return grad * cute.full_like(grad, 2.0) * scale_val * score
+
+
+def scaled_squared_factory(scale_tensor, cu_seqlens_k):
+    """Eager reference for score_mod_scaled_squared (varlen: cu_seqlens_k provides offsets)."""
+
+    def mod(score, b, h, q_idx, kv_idx):
+        kv_global = cu_seqlens_k[b] + kv_idx
+        return scale_tensor[kv_global] * score * score
+
     return mod

--- a/tests/cute/score_mod_definitions.py
+++ b/tests/cute/score_mod_definitions.py
@@ -838,9 +838,9 @@ def score_mod_scaled_squared(
     kv_idx_global = kv_idx + offset_k
     scale = aux_tensors[0]
     dtype = scale.element_type
-    kv_frag = cute.make_fragment(1, cutlass.Int32)
+    kv_frag = cute.make_rmem_tensor(1, cutlass.Int32)
     kv_frag.store(kv_idx_global)
-    scale_frag = cute.make_fragment(1, dtype)
+    scale_frag = cute.make_rmem_tensor(1, dtype)
     scale_frag[0] = scale[kv_frag[0]]
     scale_val = (scale_frag.load()).to(cutlass.Float32)
     return scale_val * tSrS_ssa * tSrS_ssa
@@ -855,9 +855,9 @@ def score_mod_bwd_scaled_squared(
     kv_idx_global = kv_idx + offset_k
     scale = aux_tensors[0]
     dtype = scale.element_type
-    kv_frag = cute.make_fragment(1, cutlass.Int32)
+    kv_frag = cute.make_rmem_tensor(1, cutlass.Int32)
     kv_frag.store(kv_idx_global)
-    scale_frag = cute.make_fragment(1, dtype)
+    scale_frag = cute.make_rmem_tensor(1, dtype)
     scale_frag[0] = scale[kv_frag[0]]
     scale_val = (scale_frag.load()).to(cutlass.Float32)
     return grad * cute.full_like(grad, 2.0) * scale_val * score

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -34,7 +34,6 @@ from flash_attn.cute.interface import (
     _flash_attn_bwd,
 )
 
-
 def retry_on_oom(func):
     @wraps(func)
     def wrapper(*args, **kwargs):
@@ -51,7 +50,6 @@ def retry_on_oom(func):
                 return func(*args, **kwargs)
             else:
                 raise
-
     return wrapper
 
 def print_diff_stats(name, actual, ref, pt=None, verbose=True):
@@ -184,13 +182,9 @@ def test_flash_attn_output(
     # Remove these skips when support is added.
     if d == 256 and IS_SM100:
         if has_learnable_sink:
-            pytest.skip(
-                "SM100 head_dim=256 2CTA kernel does not support learnable_sink yet"
-            )
+            pytest.skip("SM100 head_dim=256 2CTA kernel does not support learnable_sink yet")
         if local:
-            pytest.skip(
-                "SM100 head_dim=256 2CTA kernel does not support local attention yet"
-            )
+            pytest.skip("SM100 head_dim=256 2CTA kernel does not support local attention yet")
         if softcap > 0.0:
             pytest.skip("SM100 head_dim=256 2CTA kernel does not support softcap yet")
         if deterministic:
@@ -256,9 +250,7 @@ def test_flash_attn_output(
             qv_ref = None
         # Put window_size after QKV randn so that window_size changes from test to test
         window_size = (
-            (None, None)
-            if not local
-            else tuple(random.randrange(0, seqlen_k) for _ in range(2))
+            (None, None) if not local else tuple(random.randrange(0, seqlen_k) for _ in range(2))
         )
         if local_enum == 2:
             window_size = (None, -window_size[1])
@@ -336,16 +328,10 @@ def test_flash_attn_output(
             print(f"Pytorch max diff: {(out_pt - out_ref).abs().max().item()}")
             print(f"Pytorch mean diff: {(out_pt - out_ref).abs().mean().item()}")
         # num_splits_vals = [1, 3]
-        pack_gqa_vals = (
-            [True] if has_qv else [False, True, None] if not TEST_BWD_ONLY else [False]
-        )
+        pack_gqa_vals = [True] if has_qv else [False, True, None] if not TEST_BWD_ONLY else [False]
         # SplitKV is not supported for hdim >= 192
         # pack_gqa_vals = [False]
-        num_splits_vals = (
-            [1, 3]
-            if d < 192 and not DISABLE_SPLIT and not TEST_BWD_ONLY and not has_qv
-            else [1]
-        )
+        num_splits_vals = [1, 3] if d < 192 and not DISABLE_SPLIT and not TEST_BWD_ONLY and not has_qv else [1]
         for pack_gqa, num_splits in itertools.product(pack_gqa_vals, num_splits_vals):
             # SplitKV not supported on SM90/SM120 - skip this iteration
             if (IS_SM90 or IS_SM120) and num_splits > 1:
@@ -451,25 +437,19 @@ def test_flash_attn_output(
                 max_idx = diff_dq.argmax()
                 coords = torch.unravel_index(max_idx, diff_dq.shape)
                 print(f"dQ max diff: {diff_dq.max().item()}")
-                print(
-                    f"  at coordinates {tuple(c.item() for c in coords)}: dQ={dq[coords].item()}, dQ_ref={dq_ref[coords].item()}"
-                )
+                print(f"  at coordinates {tuple(c.item() for c in coords)}: dQ={dq[coords].item()}, dQ_ref={dq_ref[coords].item()}")
 
                 diff_dk = (dk - dk_ref).abs()
                 max_idx = diff_dk.argmax()
                 coords = torch.unravel_index(max_idx, diff_dk.shape)
                 print(f"dK max diff: {diff_dk.max().item()}")
-                print(
-                    f"  at coordinates {tuple(c.item() for c in coords)}: dK={dk[coords].item()}, dK_ref={dk_ref[coords].item()}"
-                )
+                print(f"  at coordinates {tuple(c.item() for c in coords)}: dK={dk[coords].item()}, dK_ref={dk_ref[coords].item()}")
 
                 diff_dv = (dv - dv_ref).abs()
                 max_idx = diff_dv.argmax()
                 coords = torch.unravel_index(max_idx, diff_dv.shape)
                 print(f"dV max diff: {diff_dv.max().item()}")
-                print(
-                    f"  at coordinates {tuple(c.item() for c in coords)}: dV={dv[coords].item()}, dV_ref={dv_ref[coords].item()}"
-                )
+                print(f"  at coordinates {tuple(c.item() for c in coords)}: dV={dv[coords].item()}, dV_ref={dv_ref[coords].item()}")
 
             # breakpoint()
             dq_atol = 2 * (dq_ref + 0.3 - 0.3 - dq_ref).abs().max().item() + (
@@ -665,21 +645,15 @@ def test_flash_attn_varlen_output(
     # Remove these skips when support is added.
     if d == 256 and IS_SM100:
         if has_learnable_sink:
-            pytest.skip(
-                "SM100 head_dim=256 2CTA kernel does not support learnable_sink yet"
-            )
+            pytest.skip("SM100 head_dim=256 2CTA kernel does not support learnable_sink yet")
         if local:
-            pytest.skip(
-                "SM100 head_dim=256 2CTA kernel does not support local attention yet"
-            )
+            pytest.skip("SM100 head_dim=256 2CTA kernel does not support local attention yet")
         if softcap > 0.0:
             pytest.skip("SM100 head_dim=256 2CTA kernel does not support softcap yet")
         if deterministic:
             pytest.skip("SM100 head_dim=256 2CTA kernel does not support deterministic mode yet")
         if not unpad_q or not unpad_kv:
-            pytest.skip(
-                "SM100 head_dim=256 2CTA kernel does not support seqused_q/seqused_k mode yet (requires unpad_q=True and unpad_kv=True)"
-            )
+            pytest.skip("SM100 head_dim=256 2CTA kernel does not support seqused_q/seqused_k mode yet (requires unpad_q=True and unpad_kv=True)")
     if (
         causal or local
     ):  # Right now reference only supports causal attention with seqlen_k == seqlen_q
@@ -738,9 +712,7 @@ def test_flash_attn_varlen_output(
             qv_ref = None
         # Put window_size after QKV randn so that window_size changes from test to test
         window_size = (
-            (None, None)
-            if not local
-            else tuple(random.randrange(0, seqlen_k) for _ in range(2))
+            (None, None) if not local else tuple(random.randrange(0, seqlen_k) for _ in range(2))
         )
         if local_enum == 2:
             window_size = (None, window_size[1])
@@ -776,7 +748,6 @@ def test_flash_attn_varlen_output(
             mode=varlen_mode,
             zero_lengths=zero_lengths_k,
         )
-
         def _gen_unused_masks(padding_mask, add_unused, max_seq_len, bs, device):
             if add_unused:
                 another_mask = generate_random_padding_mask(max_seq_len, bs, device)
@@ -893,9 +864,7 @@ def test_flash_attn_varlen_output(
         # pack_gqa_vals = [False]
         # num_splits_vals = [1, 3]
         # SplitKV is not supported for hdim >= 192
-        num_splits_vals = (
-            [1, 3] if d < 192 and not DISABLE_SPLIT and not TEST_BWD_ONLY else [1]
-        )
+        num_splits_vals = [1, 3] if d < 192 and not DISABLE_SPLIT and not TEST_BWD_ONLY else [1]
         for pack_gqa, num_splits in itertools.product(pack_gqa_vals, num_splits_vals):
             # SplitKV not supported on SM90/SM120 - skip this iteration
             if (IS_SM90 or IS_SM120) and num_splits > 1:
@@ -942,9 +911,7 @@ def test_flash_attn_varlen_output(
             # before comparing.
             out_cmp, out_ref_cmp, out_pt_cmp = out, out_ref, out_pt
             if not unpad_q and seqused_q is not None:
-                seqused_mask = (
-                    torch.arange(seqlen_q, device=device)[None, :] < seqused_q[:, None]
-                )
+                seqused_mask = torch.arange(seqlen_q, device=device)[None, :] < seqused_q[:, None]
                 seqused_mask = rearrange(seqused_mask, "b s -> b s 1 1")
                 out_cmp = out.clone().masked_fill_(~seqused_mask, 0.0)
                 out_ref_cmp = out_ref.clone().masked_fill_(~seqused_mask, 0.0)
@@ -1010,7 +977,7 @@ def test_flash_attn_varlen_output(
                     k_unpad if unpad_kv else k,
                     v_unpad if unpad_kv else v,
                 ),
-                g_unpad,
+                g_unpad
             )
             if is_fake_mode():
                 # no more flash_attn cutedsl calls for the rest of the loop
@@ -1066,25 +1033,19 @@ def test_flash_attn_varlen_output(
                 max_idx = diff_dq.argmax()
                 coords = torch.unravel_index(max_idx, diff_dq.shape)
                 print(f"dQ max diff: {diff_dq.max().item()}")
-                print(
-                    f"  at coordinates {tuple(c.item() for c in coords)}: dQ={dq[coords].item()}, dQ_ref={dq_ref[coords].item()}"
-                )
+                print(f"  at coordinates {tuple(c.item() for c in coords)}: dQ={dq[coords].item()}, dQ_ref={dq_ref[coords].item()}")
 
                 diff_dk = (dk - dk_ref).abs()
                 max_idx = diff_dk.argmax()
                 coords = torch.unravel_index(max_idx, diff_dk.shape)
                 print(f"dK max diff: {diff_dk.max().item()}")
-                print(
-                    f"  at coordinates {tuple(c.item() for c in coords)}: dK={dk[coords].item()}, dK_ref={dk_ref[coords].item()}"
-                )
+                print(f"  at coordinates {tuple(c.item() for c in coords)}: dK={dk[coords].item()}, dK_ref={dk_ref[coords].item()}")
 
                 diff_dv = (dv - dv_ref).abs()
                 max_idx = diff_dv.argmax()
                 coords = torch.unravel_index(max_idx, diff_dv.shape)
                 print(f"dV max diff: {diff_dv.max().item()}")
-                print(
-                    f"  at coordinates {tuple(c.item() for c in coords)}: dV={dv[coords].item()}, dV_ref={dv_ref[coords].item()}"
-                )
+                print(f"  at coordinates {tuple(c.item() for c in coords)}: dV={dv[coords].item()}, dV_ref={dv_ref[coords].item()}")
             # breakpoint()
             dq_atol = 2 * (dq_ref + 0.3 - 0.3 - dq_ref).abs().max().item() + (
                 0 if softcap == 0 else 3e-4
@@ -1250,9 +1211,7 @@ def test_flash_attn_kvcache(
             cu_seqlens_q, max_seqlen_q = None, None
         # Put window_size after QKV randn so that window_size changes from test to test
         window_size = (
-            (None, None)
-            if not local
-            else tuple(random.randrange(0, seqlen_k) for _ in range(2))
+            (None, None) if not local else tuple(random.randrange(0, seqlen_k) for _ in range(2))
         )
         if has_learnable_sink:
             learnable_sink = torch.randn(nheads, dtype=torch.bfloat16, device=device)
@@ -1260,7 +1219,9 @@ def test_flash_attn_kvcache(
             learnable_sink = None
 
         seqlen_new = (
-            seqlen_q if seqlen_new_eq_seqlen_q else random.randrange(1, seqlen_q + 1)
+            seqlen_q
+            if seqlen_new_eq_seqlen_q
+            else random.randrange(1, seqlen_q + 1)
         )
         cu_seqlens_k_new = None
         key_new_padding_mask = None
@@ -1343,11 +1304,7 @@ def test_flash_attn_kvcache(
                 (
                     (
                         seqlen_k
-                        - (
-                            seqlen_q
-                            if (causal or local) and rotary_dim > 1
-                            else seqlen_new
-                        )
+                        - (seqlen_q if (causal or local) and rotary_dim > 1 else seqlen_new)
                         + 1
                     )
                     if new_kv
@@ -1380,9 +1337,7 @@ def test_flash_attn_kvcache(
                     ]
                 )
             else:
-                cache_leftpad = torch.zeros(
-                    batch_size, dtype=torch.int32, device=device
-                )
+                cache_leftpad = torch.zeros(batch_size, dtype=torch.int32, device=device)
         else:
             cache_leftpad = None
         if has_batch_idx:
@@ -1687,15 +1642,9 @@ def test_flash_attn_bwd_preallocated_outputs(seqlen_q, seqlen_k, d, causal, dtyp
     batch_size = 2
     nheads = 4
 
-    q = torch.randn(
-        batch_size, seqlen_q, nheads, d, device=device, dtype=dtype, requires_grad=True
-    )
-    k = torch.randn(
-        batch_size, seqlen_k, nheads, d, device=device, dtype=dtype, requires_grad=True
-    )
-    v = torch.randn(
-        batch_size, seqlen_k, nheads, d, device=device, dtype=dtype, requires_grad=True
-    )
+    q = torch.randn(batch_size, seqlen_q, nheads, d, device=device, dtype=dtype, requires_grad=True)
+    k = torch.randn(batch_size, seqlen_k, nheads, d, device=device, dtype=dtype, requires_grad=True)
+    v = torch.randn(batch_size, seqlen_k, nheads, d, device=device, dtype=dtype, requires_grad=True)
 
     out, lse, *_ = _flash_attn_fwd(q, k, v, causal=causal, return_lse=True)
     dout = torch.randn_like(out)
@@ -1731,15 +1680,9 @@ def test_flash_attn_lse_grad(seqlen_q, seqlen_k, d, causal, dtype):
     batch_size = 2
     nheads = 4
 
-    q = torch.randn(
-        batch_size, seqlen_q, nheads, d, device=device, dtype=dtype, requires_grad=True
-    )
-    k = torch.randn(
-        batch_size, seqlen_k, nheads, d, device=device, dtype=dtype, requires_grad=True
-    )
-    v = torch.randn(
-        batch_size, seqlen_k, nheads, d, device=device, dtype=dtype, requires_grad=True
-    )
+    q = torch.randn(batch_size, seqlen_q, nheads, d, device=device, dtype=dtype, requires_grad=True)
+    k = torch.randn(batch_size, seqlen_k, nheads, d, device=device, dtype=dtype, requires_grad=True)
+    v = torch.randn(batch_size, seqlen_k, nheads, d, device=device, dtype=dtype, requires_grad=True)
 
     out, lse = flash_attn_func(q, k, v, causal=causal, return_lse=True)
 
@@ -1761,12 +1704,9 @@ def test_flash_attn_lse_grad(seqlen_q, seqlen_k, d, causal, dtype):
     k_ref = k.detach().float().requires_grad_()
     v_ref = v.detach().float().requires_grad_()
     # (batch, seqlen_q, nheads, d) -> (batch, nheads, seqlen_q, d)
-    qk = torch.einsum("bshd,bthd->bhst", q_ref, k_ref) / (d**0.5)
+    qk = torch.einsum("bshd,bthd->bhst", q_ref, k_ref) / (d ** 0.5)
     if causal:
-        mask = torch.triu(
-            torch.ones(seqlen_q, seqlen_k, device=device, dtype=torch.bool),
-            diagonal=seqlen_k - seqlen_q + 1,
-        )
+        mask = torch.triu(torch.ones(seqlen_q, seqlen_k, device=device, dtype=torch.bool), diagonal=seqlen_k - seqlen_q + 1)
         qk = qk.masked_fill(mask, float("-inf"))
     lse_ref = torch.logsumexp(qk, dim=-1)  # (batch, nheads, seqlen_q)
     p = torch.softmax(qk, dim=-1)
@@ -1794,7 +1734,7 @@ def test_flash_attn_lse_grad(seqlen_q, seqlen_k, d, causal, dtype):
 
     q_ref2 = q.detach().float().requires_grad_()
     k_ref2 = k.detach().float().requires_grad_()
-    qk2 = torch.einsum("bshd,bthd->bhst", q_ref2, k_ref2) / (d**0.5)
+    qk2 = torch.einsum("bshd,bthd->bhst", q_ref2, k_ref2) / (d ** 0.5)
     if causal:
         qk2 = qk2.masked_fill(mask, float("-inf"))
     lse_ref2 = torch.logsumexp(qk2, dim=-1)
@@ -1805,9 +1745,7 @@ def test_flash_attn_lse_grad(seqlen_q, seqlen_k, d, causal, dtype):
     print(f"LSE-only dK max diff: {(dk2.float() - dk_ref2).abs().max().item()}")
     # dV should be zero when only LSE gradient flows (LSE doesn't depend on V)
     print(f"LSE-only dV max: {dv2.abs().max().item()}")
-    assert dv2.abs().max().item() == 0.0, (
-        "dV should be zero when loss depends only on LSE"
-    )
+    assert dv2.abs().max().item() == 0.0, "dV should be zero when loss depends only on LSE"
 
 
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
@@ -1827,15 +1765,9 @@ def test_flash_attn_lse_grad_unused(seqlen_q, seqlen_k, d, causal, dtype):
     batch_size = 2
     nheads = 4
 
-    q = torch.randn(
-        batch_size, seqlen_q, nheads, d, device=device, dtype=dtype, requires_grad=True
-    )
-    k = torch.randn(
-        batch_size, seqlen_k, nheads, d, device=device, dtype=dtype, requires_grad=True
-    )
-    v = torch.randn(
-        batch_size, seqlen_k, nheads, d, device=device, dtype=dtype, requires_grad=True
-    )
+    q = torch.randn(batch_size, seqlen_q, nheads, d, device=device, dtype=dtype, requires_grad=True)
+    k = torch.randn(batch_size, seqlen_k, nheads, d, device=device, dtype=dtype, requires_grad=True)
+    v = torch.randn(batch_size, seqlen_k, nheads, d, device=device, dtype=dtype, requires_grad=True)
     g = torch.randn(batch_size, seqlen_q, nheads, d, device=device, dtype=dtype)
 
     # Case 1: return_lse=False (standard path, lse marked non-differentiable)
@@ -1926,24 +1858,14 @@ def test_flash_attn_paged_deepseek(seqlen_q, page_size):
 
     # Non-paged reference
     out_ref, _ = flash_attn_varlen_func(
-        q,
-        k,
-        v,
-        cu_seqlens_q=cu_seqlens,
-        cu_seqlens_k=cu_seqlens,
-        max_seqlen_q=seqlen_q,
-        max_seqlen_k=seqlen_q,
-        causal=True,
+        q, k, v, cu_seqlens_q=cu_seqlens, cu_seqlens_k=cu_seqlens,
+        max_seqlen_q=seqlen_q, max_seqlen_k=seqlen_q, causal=True,
     )
 
     # Paged
     num_pages = (seqlen_q + page_size - 1) // page_size
-    k_cache_paged = torch.zeros(
-        num_pages, page_size, nheads_kv, d, device=device, dtype=dtype
-    )
-    v_cache_paged = torch.zeros(
-        num_pages, page_size, nheads_kv, dv, device=device, dtype=dtype
-    )
+    k_cache_paged = torch.zeros(num_pages, page_size, nheads_kv, d, device=device, dtype=dtype)
+    v_cache_paged = torch.zeros(num_pages, page_size, nheads_kv, dv, device=device, dtype=dtype)
     for i in range(seqlen_q):
         k_cache_paged[i // page_size, i % page_size] = k[i]
         v_cache_paged[i // page_size, i % page_size] = v[i]
@@ -1951,16 +1873,10 @@ def test_flash_attn_paged_deepseek(seqlen_q, page_size):
     cache_seqlens = torch.tensor([seqlen_q], dtype=torch.int32, device=device)
 
     out, _ = flash_attn_varlen_func(
-        q,
-        k_cache_paged,
-        v_cache_paged,
-        cu_seqlens_q=cu_seqlens,
-        cu_seqlens_k=None,
-        max_seqlen_q=seqlen_q,
-        max_seqlen_k=None,
-        seqused_k=cache_seqlens,
-        page_table=page_table,
-        causal=True,
+        q, k_cache_paged, v_cache_paged,
+        cu_seqlens_q=cu_seqlens, cu_seqlens_k=None,
+        max_seqlen_q=seqlen_q, max_seqlen_k=None,
+        seqused_k=cache_seqlens, page_table=page_table, causal=True,
     )
 
     if is_fake_mode():
@@ -1994,31 +1910,21 @@ def test_flash_attn_paged_hd256_sm100_tma(seqlen_q):
     q = torch.randn(batch_size * seqlen_q, nheads, d, device=device, dtype=dtype)
     k = torch.randn(batch_size * seqlen_q, nheads_kv, d, device=device, dtype=dtype)
     v = torch.randn(batch_size * seqlen_q, nheads_kv, d, device=device, dtype=dtype)
-    cu_seqlens_q = (
-        torch.arange(0, batch_size + 1, dtype=torch.int32, device=device) * seqlen_q
-    )
+    cu_seqlens_q = torch.arange(0, batch_size + 1, dtype=torch.int32, device=device) * seqlen_q
     cu_seqlens_k = cu_seqlens_q.clone()
 
     # Non-paged reference (varlen).
     out_ref, _ = flash_attn_varlen_func(
-        q,
-        k,
-        v,
-        cu_seqlens_q=cu_seqlens_q,
-        cu_seqlens_k=cu_seqlens_k,
-        max_seqlen_q=seqlen_q,
-        max_seqlen_k=seqlen_q,
+        q, k, v,
+        cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=cu_seqlens_k,
+        max_seqlen_q=seqlen_q, max_seqlen_k=seqlen_q,
     )
 
     # Repack into paged layout: (total_pages, page_size, nheads_kv, d).
     num_pages_per_seq = seqlen_q // page_size
     total_pages = batch_size * num_pages_per_seq
-    k_paged = torch.zeros(
-        total_pages, page_size, nheads_kv, d, device=device, dtype=dtype
-    )
-    v_paged = torch.zeros(
-        total_pages, page_size, nheads_kv, d, device=device, dtype=dtype
-    )
+    k_paged = torch.zeros(total_pages, page_size, nheads_kv, d, device=device, dtype=dtype)
+    v_paged = torch.zeros(total_pages, page_size, nheads_kv, d, device=device, dtype=dtype)
     for b in range(batch_size):
         for s in range(seqlen_q):
             pi = b * num_pages_per_seq + s // page_size
@@ -2031,23 +1937,15 @@ def test_flash_attn_paged_hd256_sm100_tma(seqlen_q):
 
     # Paged via hd256 2CTA TMA paged path — run twice for determinism.
     out_paged_0, _ = flash_attn_varlen_func(
-        q,
-        k_paged,
-        v_paged,
-        cu_seqlens_q=cu_seqlens_q,
-        cu_seqlens_k=None,
-        max_seqlen_q=seqlen_q,
-        max_seqlen_k=seqlen_q,
+        q, k_paged, v_paged,
+        cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=None,
+        max_seqlen_q=seqlen_q, max_seqlen_k=seqlen_q,
         page_table=page_table,
     )
     out_paged_1, _ = flash_attn_varlen_func(
-        q,
-        k_paged,
-        v_paged,
-        cu_seqlens_q=cu_seqlens_q,
-        cu_seqlens_k=None,
-        max_seqlen_q=seqlen_q,
-        max_seqlen_k=seqlen_q,
+        q, k_paged, v_paged,
+        cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=None,
+        max_seqlen_q=seqlen_q, max_seqlen_k=seqlen_q,
         page_table=page_table,
     )
 
@@ -2056,9 +1954,7 @@ def test_flash_attn_paged_hd256_sm100_tma(seqlen_q):
 
     print(f"Paged vs non-paged max diff: {(out_paged_0 - out_ref).abs().max().item()}")
     print(f"Paged determinism diff: {(out_paged_1 - out_paged_0).abs().max().item()}")
-    assert torch.allclose(out_paged_0, out_ref, atol=1e-3, rtol=1e-3), (
-        "Paged output does not match non-paged reference"
-    )
+    assert torch.allclose(out_paged_0, out_ref, atol=1e-3, rtol=1e-3), "Paged output does not match non-paged reference"
     assert torch.equal(out_paged_1, out_paged_0), "Paged output is not deterministic"
 
 
@@ -2086,29 +1982,19 @@ def test_flash_attn_paged_hd256_sm100_tma_gqa(nheads_kv):
     q = torch.randn(batch_size * seqlen_q, nheads, d, device=device, dtype=dtype)
     k = torch.randn(batch_size * seqlen_q, nheads_kv, d, device=device, dtype=dtype)
     v = torch.randn(batch_size * seqlen_q, nheads_kv, d, device=device, dtype=dtype)
-    cu_seqlens_q = (
-        torch.arange(0, batch_size + 1, dtype=torch.int32, device=device) * seqlen_q
-    )
+    cu_seqlens_q = torch.arange(0, batch_size + 1, dtype=torch.int32, device=device) * seqlen_q
     cu_seqlens_k = cu_seqlens_q.clone()
 
     out_ref, _ = flash_attn_varlen_func(
-        q,
-        k,
-        v,
-        cu_seqlens_q=cu_seqlens_q,
-        cu_seqlens_k=cu_seqlens_k,
-        max_seqlen_q=seqlen_q,
-        max_seqlen_k=seqlen_q,
+        q, k, v,
+        cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=cu_seqlens_k,
+        max_seqlen_q=seqlen_q, max_seqlen_k=seqlen_q,
     )
 
     num_pages_per_seq = seqlen_q // page_size
     total_pages = batch_size * num_pages_per_seq
-    k_paged = torch.zeros(
-        total_pages, page_size, nheads_kv, d, device=device, dtype=dtype
-    )
-    v_paged = torch.zeros(
-        total_pages, page_size, nheads_kv, d, device=device, dtype=dtype
-    )
+    k_paged = torch.zeros(total_pages, page_size, nheads_kv, d, device=device, dtype=dtype)
+    v_paged = torch.zeros(total_pages, page_size, nheads_kv, d, device=device, dtype=dtype)
     for b in range(batch_size):
         for s in range(seqlen_q):
             pi = b * num_pages_per_seq + s // page_size
@@ -2120,22 +2006,16 @@ def test_flash_attn_paged_hd256_sm100_tma_gqa(nheads_kv):
     )
 
     out_paged, _ = flash_attn_varlen_func(
-        q,
-        k_paged,
-        v_paged,
-        cu_seqlens_q=cu_seqlens_q,
-        cu_seqlens_k=None,
-        max_seqlen_q=seqlen_q,
-        max_seqlen_k=seqlen_q,
+        q, k_paged, v_paged,
+        cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=None,
+        max_seqlen_q=seqlen_q, max_seqlen_k=seqlen_q,
         page_table=page_table,
     )
 
     if is_fake_mode():
         return
 
-    print(
-        f"GQA nheads_kv={nheads_kv} paged vs non-paged max diff: {(out_paged - out_ref).abs().max().item()}"
-    )
+    print(f"GQA nheads_kv={nheads_kv} paged vs non-paged max diff: {(out_paged - out_ref).abs().max().item()}")
     assert torch.allclose(out_paged, out_ref, atol=1e-3, rtol=1e-3), (
         f"Paged GQA output does not match non-paged reference (nheads_kv={nheads_kv})"
     )
@@ -2166,19 +2046,13 @@ def test_flash_attn_paged_hd256_sm100_tma_shuffled():
     q = torch.randn(batch_size * seqlen_q, nheads, d, device=device, dtype=dtype)
     k = torch.randn(batch_size * seqlen_q, nheads_kv, d, device=device, dtype=dtype)
     v = torch.randn(batch_size * seqlen_q, nheads_kv, d, device=device, dtype=dtype)
-    cu_seqlens_q = (
-        torch.arange(0, batch_size + 1, dtype=torch.int32, device=device) * seqlen_q
-    )
+    cu_seqlens_q = torch.arange(0, batch_size + 1, dtype=torch.int32, device=device) * seqlen_q
     cu_seqlens_k = cu_seqlens_q.clone()
 
     out_ref, _ = flash_attn_varlen_func(
-        q,
-        k,
-        v,
-        cu_seqlens_q=cu_seqlens_q,
-        cu_seqlens_k=cu_seqlens_k,
-        max_seqlen_q=seqlen_q,
-        max_seqlen_k=seqlen_q,
+        q, k, v,
+        cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=cu_seqlens_k,
+        max_seqlen_q=seqlen_q, max_seqlen_k=seqlen_q,
     )
 
     # Shuffle physical pages: reverse order within each batch item.
@@ -2189,12 +2063,8 @@ def test_flash_attn_paged_hd256_sm100_tma_shuffled():
     ]
     page_table = torch.tensor(perm, dtype=torch.int32, device=device)
 
-    k_paged = torch.zeros(
-        total_pages, page_size, nheads_kv, d, device=device, dtype=dtype
-    )
-    v_paged = torch.zeros(
-        total_pages, page_size, nheads_kv, d, device=device, dtype=dtype
-    )
+    k_paged = torch.zeros(total_pages, page_size, nheads_kv, d, device=device, dtype=dtype)
+    v_paged = torch.zeros(total_pages, page_size, nheads_kv, d, device=device, dtype=dtype)
     for b in range(batch_size):
         for s in range(seqlen_q):
             phys = perm[b][s // page_size]  # Python int, safe in FakeTensorMode
@@ -2203,22 +2073,16 @@ def test_flash_attn_paged_hd256_sm100_tma_shuffled():
             v_paged[phys, po] = v[b * seqlen_q + s]
 
     out_paged, _ = flash_attn_varlen_func(
-        q,
-        k_paged,
-        v_paged,
-        cu_seqlens_q=cu_seqlens_q,
-        cu_seqlens_k=None,
-        max_seqlen_q=seqlen_q,
-        max_seqlen_k=seqlen_q,
+        q, k_paged, v_paged,
+        cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=None,
+        max_seqlen_q=seqlen_q, max_seqlen_k=seqlen_q,
         page_table=page_table,
     )
 
     if is_fake_mode():
         return
 
-    print(
-        f"Shuffled paged vs non-paged max diff: {(out_paged - out_ref).abs().max().item()}"
-    )
+    print(f"Shuffled paged vs non-paged max diff: {(out_paged - out_ref).abs().max().item()}")
     assert torch.allclose(out_paged, out_ref, atol=1e-3, rtol=1e-3), (
         "Shuffled paged output does not match non-paged reference"
     )
@@ -2234,12 +2098,7 @@ def test_flash_attn_invalid_head_dim(head_dim):
     k = torch.randn(batch_size, seqlen, nheads, head_dim, device=device, dtype=dtype)
     v = torch.randn(batch_size, seqlen, nheads, head_dim, device=device, dtype=dtype)
 
-    with pytest.raises(
-        AssertionError,
-        match=re.escape(
-            f"(head_dim, head_dim_v)=({head_dim}, {head_dim}) is not supported on SM"
-        ),
-    ):
+    with pytest.raises(AssertionError, match=re.escape(f"(head_dim, head_dim_v)=({head_dim}, {head_dim}) is not supported on SM")):
         flash_attn_func(q, k, v)
 
 
@@ -2323,18 +2182,12 @@ def test_flash_attn_mla_absorbed(
         v_ref = torch.randn(batch_size, seqlen_k, nheads_kv, hdimv, device=device, dtype=dtype).requires_grad_()
         qv_ref = torch.randn(batch_size, seqlen_q, nheads, hdimv, device=device, dtype=dtype).requires_grad_()
         if kv_sparsity:
-            gather_kv_indices = (
-                torch.rand(batch_size, seqlen_q, gather_kv_length, device=device)
-                .argsort(dim=-1)
-                .to(torch.int32)
-            )
+            gather_kv_indices = torch.rand(batch_size, seqlen_q, gather_kv_length, device=device).argsort(dim=-1).to(torch.int32)
         else:
             gather_kv_indices = None
         # Put window_size after QKV randn so that window_size changes from test to test
         window_size = (
-            (None, None)
-            if not local
-            else tuple(random.randrange(0, seqlen_k) for _ in range(2))
+            (None, None) if not local else tuple(random.randrange(0, seqlen_k) for _ in range(2))
         )
         if local_enum == 2:
             window_size = (None, -window_size[1])
@@ -2564,19 +2417,13 @@ def test_flash_attn_mla_absorbed_varlen(
         v_ref = torch.randn(batch_size, seqlen_k, nheads_kv, hdimv, device=device, dtype=dtype).requires_grad_()
         qv_ref = torch.randn(batch_size, seqlen_q, nheads, hdimv, device=device, dtype=dtype).requires_grad_()
         if kv_sparsity:
-            gather_kv_indices = (
-                torch.rand(batch_size, seqlen_q, gather_kv_length, device=device)
-                .argsort(dim=-1)
-                .to(torch.int32)
-            )
+            gather_kv_indices = torch.rand(batch_size, seqlen_q, gather_kv_length, device=device).argsort(dim=-1).to(torch.int32)
         else:
             gather_kv_indices = None
-
+            
         # Put window_size after QKV randn so that window_size changes from test to test
         window_size = (
-            (None, None)
-            if not local
-            else tuple(random.randrange(0, seqlen_k) for _ in range(2))
+            (None, None) if not local else tuple(random.randrange(0, seqlen_k) for _ in range(2))
         )
         if local_enum == 2:
             window_size = (None, window_size[1])
@@ -2604,7 +2451,6 @@ def test_flash_attn_mla_absorbed_varlen(
             zero_lengths=zero_lengths_k,
             min_seqlen=gather_kv_length if kv_sparsity else None,
         )
-
         def _gen_unused_masks(padding_mask, add_unused, max_seq_len, bs, device):
             if add_unused:
                 another_mask = generate_random_padding_mask(max_seq_len, bs, device)
@@ -2661,9 +2507,7 @@ def test_flash_attn_mla_absorbed_varlen(
             _, indices_q, _, _, _ = unpad_input(
                 q, query_padding_mask, query_unused_mask
             )
-            gather_kv_indices_unpad = rearrange(
-                gather_kv_indices, "b s ... -> (b s) ..."
-            )[indices_q]
+            gather_kv_indices_unpad = rearrange(gather_kv_indices, "b s ... -> (b s) ...")[indices_q]
         else:
             gather_kv_indices_unpad = None
         if unpad_q:
@@ -2747,9 +2591,7 @@ def test_flash_attn_mla_absorbed_varlen(
                 num_splits=num_splits,
                 pack_gqa=pack_gqa,
                 deterministic=deterministic,
-                gather_kv_indices=gather_kv_indices_unpad
-                if unpad_q
-                else gather_kv_indices,
+                gather_kv_indices=gather_kv_indices_unpad if unpad_q else gather_kv_indices,
             )
             out = output_pad_fn(out_unpad) if unpad_q else out_unpad
             if is_fake_mode():
@@ -2763,9 +2605,7 @@ def test_flash_attn_mla_absorbed_varlen(
             # before comparing.
             out_cmp, out_ref_cmp, out_pt_cmp = out, out_ref, out_pt
             if not unpad_q and seqused_q is not None:
-                seqused_mask = (
-                    torch.arange(seqlen_q, device=device)[None, :] < seqused_q[:, None]
-                )
+                seqused_mask = torch.arange(seqlen_q, device=device)[None, :] < seqused_q[:, None]
                 seqused_mask = rearrange(seqused_mask, "b s -> b s 1 1")
                 out_cmp = out.clone().masked_fill_(~seqused_mask, 0.0)
                 out_ref_cmp = out_ref.clone().masked_fill_(~seqused_mask, 0.0)
@@ -2806,9 +2646,7 @@ def test_flash_attn_mla_absorbed_varlen(
                     num_splits=num_splits,
                     pack_gqa=pack_gqa,
                     deterministic=deterministic,
-                    gather_kv_indices=gather_kv_indices_unpad
-                    if unpad_q
-                    else gather_kv_indices,
+                    gather_kv_indices=gather_kv_indices_unpad if unpad_q else gather_kv_indices,
                 )
                 out2 = output_pad_fn(out_unpad2) if unpad_q else out_unpad2
                 if query_unused_mask is not None:
@@ -2817,18 +2655,13 @@ def test_flash_attn_mla_absorbed_varlen(
                 # beyond seqused_q, so those contain uninitialized values. Mask them out
                 # before comparing.
                 if not unpad_q and seqused_q is not None:
-                    seqused_mask = (
-                        torch.arange(seqlen_q, device=device)[None, :]
-                        < seqused_q[:, None]
-                    )
+                    seqused_mask = torch.arange(seqlen_q, device=device)[None, :] < seqused_q[:, None]
                     seqused_mask = rearrange(seqused_mask, "b s -> b s 1 1")
                     out2.masked_fill_(~seqused_mask, 0.0)
                 # print(f"out2 max: {out2.abs().max().item()}, {iter=}")
                 # print(f"out vs out2 max diff: {(out_cmp - out2).abs().max().item()}, {iter=}")
                 # print(f"out vs out2 mean diff: {(out_cmp - out2).abs().mean().item()}, {iter=}")
-                assert torch.equal(out_cmp, out2), (
-                    f"non-deterministic with max diff = {(out_cmp - out2).abs().max().item()} on {iter=}"
-                )
+                assert torch.equal(out_cmp, out2), f"non-deterministic with max diff = {(out_cmp - out2).abs().max().item()} on {iter=}"
 
         if test_bwd:
             print("VARLEN BWD SPARSE MLA")
@@ -2994,100 +2827,9 @@ def test_flash_attn_mla_paged(dtype, seqlen_q, seqlen_k, page_size, causal, has_
     assert torch.equal(out, out_ref)
 
 
-@pytest.mark.parametrize("dtype", [torch.bfloat16])
-@pytest.mark.parametrize("causal", [False, True])
-@pytest.mark.parametrize("page_size", [1, 16, 64, 128])
-@pytest.mark.parametrize("has_qk", [True, False])
-@pytest.mark.parametrize(
-    "seqlen_q,seqlen_k",
-    [
-        (1, 128),
-        (4, 256),
-        (64, 512),
-        (1, 2048),
-        (2048, 2048),
-    ],
-)
-@maybe_fake_tensor_mode(USE_FAKE_TENSOR)
-def test_flash_attn_mla_paged(dtype, seqlen_q, seqlen_k, page_size, causal, has_qk):
-    if not IS_SM100:
-        pytest.skip("MLA paged KV only supported on SM100")
-    device = "cuda"
-    d, dv = 64, 512
-    nheads = 128
-    nheads_kv = 1
-    batch_size = 49 if seqlen_k <= 512 else 7
-
-    torch.random.manual_seed(0)
-
-    # Non-paged reference tensors (varlen format)
-    q = k = None
-    if has_qk:
-        q = torch.randn(batch_size * seqlen_q, nheads, d, device=device, dtype=dtype)
-        k = torch.randn(batch_size * seqlen_k, nheads_kv, d, device=device, dtype=dtype)
-    v = torch.randn(batch_size * seqlen_k, nheads_kv, dv, device=device, dtype=dtype)
-    qv = torch.randn(batch_size * seqlen_q, nheads, dv, device=device, dtype=dtype)
-
-    cu_seqlens_q = torch.tensor(
-        [i * seqlen_q for i in range(batch_size + 1)], dtype=torch.int32, device=device
-    )
-    cu_seqlens_k = torch.tensor(
-        [i * seqlen_k for i in range(batch_size + 1)], dtype=torch.int32, device=device
-    )
-
-    # Non-paged reference
-    out_ref, _ = flash_attn_varlen_func(
-        q, k, v, qv=qv,
-        cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=cu_seqlens_k,
-        max_seqlen_q=seqlen_q, max_seqlen_k=seqlen_k,
-        causal=causal,
-    )
-
-    # Create paged K/V cache
-    num_pages_per_seq = (seqlen_k + page_size - 1) // page_size
-    total_pages = num_pages_per_seq * batch_size
-    k_paged = None
-    if has_qk:
-        k_paged = torch.zeros(total_pages, page_size, nheads_kv, d, device=device, dtype=dtype)
-    v_paged = torch.zeros(total_pages, page_size, nheads_kv, dv, device=device, dtype=dtype)
-    page_table = torch.zeros(batch_size, num_pages_per_seq, dtype=torch.int32, device=device)
-
-    # Fill paged K/V from contiguous K/V (sequential page assignment)
-    for b in range(batch_size):
-        for p in range(num_pages_per_seq):
-            page_idx = b * num_pages_per_seq + p
-            start = p * page_size
-            end = min(start + page_size, seqlen_k)
-            k_offset = b * seqlen_k
-            if start < seqlen_k:
-                if has_qk:
-                    k_paged[page_idx, :end - start] = k[k_offset + start:k_offset + end]
-                v_paged[page_idx, :end - start] = v[k_offset + start:k_offset + end]
-            page_table[b, p] = page_idx
-
-    seqused_k = torch.full((batch_size,), seqlen_k, dtype=torch.int32, device=device)
-
-    # Paged output (triggers cp.async path if page_size != 128)
-    out, _ = flash_attn_varlen_func(
-        q, k_paged, v_paged, qv=qv,
-        cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=None,
-        max_seqlen_q=seqlen_q, max_seqlen_k=None,
-        seqused_k=seqused_k, page_table=page_table,
-        causal=causal,
-    )
-
-    if is_fake_mode():
-        return
-
-    print(f"Output max diff: {(out - out_ref).abs().max().item()}")
-    print(f"Output mean diff: {(out - out_ref).abs().mean().item()}")
-    assert torch.equal(out, out_ref)
-
-
 # ---------------------------------------------------------------------------
 # Regression test: seqlen_k=0 must not crash (CUDA graph padding scenario)
 # ---------------------------------------------------------------------------
-
 
 @pytest.mark.parametrize("causal", [False, True])
 @pytest.mark.parametrize("d", [128, 192])
@@ -3138,14 +2880,12 @@ def test_flash_attn_seqlen_k_zero(seqlen_q, d, causal):
 
     # No crash above already validates the fix. Below validates the contract
     # the early-return promises: zero output, -inf LSE.
-    assert out.shape == (batch_size, seqlen_q, nheads, dv), (
+    assert out.shape == (batch_size, seqlen_q, nheads, dv), \
         f"Unexpected output shape: {out.shape}"
-    )
-    assert torch.all(out == 0).item(), (
+    assert torch.all(out == 0).item(), \
         f"Expected all-zero output when seqlen_k=0, got max={out.abs().max().item():.6f}"
-    )
     if lse is not None:
-        assert torch.all(torch.isinf(lse) & (lse < 0)).item(), (
+        assert torch.all(torch.isinf(lse) & (lse < 0)).item(), \
             f"Expected all -inf LSE when seqlen_k=0, got: {lse}"
 
 

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -969,7 +969,7 @@ def test_flash_attn_varlen_output(
             and (
                 (dv == d and d <= 128)
                 or (d == 192 and dv == 128)
-                or (IS_SM100 and d == 256 and dv == 256)
+                or (IS_SM100 and d == 256 and dv == 256 and softcap == 0.0)
             )
             and not has_learnable_sink
             # and False

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -54,7 +54,6 @@ def retry_on_oom(func):
 
     return wrapper
 
-<<<<<<< HEAD
 def print_diff_stats(name, actual, ref, pt=None, verbose=True):
     if actual is None:
         return
@@ -77,8 +76,6 @@ def check_tensor_vs_ref(name, actual, ref, pt, rtol=2, atol=None):
     diff_max = (actual - ref).abs().max().item()
     diff_pt_max = (pt - ref).abs().max().item()
     assert diff_max <= rtol * diff_pt_max + atol, f"{name}: {diff_max=} too large compared to {diff_pt_max=} for {rtol=}, {atol=}"
-=======
->>>>>>> ebbdaeb6 (remove softcap != 0 limitation in test)
 
 # torch FakeTensorMode would enable fast cutedsl kernel compilation without allocating the actual GPU memory or running the kernel
 # When operating fake tensors, we cannot perform data-dependent operations (e.g., `tensor.max()`).
@@ -92,7 +89,6 @@ TEST_BWD_ONLY = False
 VERBOSE = True
 
 
-<<<<<<< HEAD
 @pytest.mark.skipif(not IS_SM120, reason="SM120-only SplitKV unsupported behavior")
 def test_flash_attn_sm120_rejects_splitkv():
     q = torch.randn(1, 16, 4, 64, device="cuda", dtype=torch.bfloat16)
@@ -102,8 +98,6 @@ def test_flash_attn_sm120_rejects_splitkv():
         flash_attn_func(q, k, v, num_splits=3)
 
 
-=======
->>>>>>> ebbdaeb6 (remove softcap != 0 limitation in test)
 # @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float8_e4m3fn])
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 @pytest.mark.parametrize("mha_type", ["mha", "mqa", "gqa"])
@@ -2431,7 +2425,6 @@ def test_flash_attn_mla_absorbed(
                     pack_gqa=pack_gqa,
                     num_splits=num_splits,
                 )
-<<<<<<< HEAD
                 assert torch.equal(out, out2), f"non-deterministic with max diff = {(out - out2).abs().max().item()} on {iter=}"
         
         if test_bwd:
@@ -2462,14 +2455,6 @@ def test_flash_attn_mla_absorbed(
             check_tensor_vs_ref("dK", dk, dk_ref, dk_pt)
             check_tensor_vs_ref("dV", dv, dv_ref, dv_pt)
             check_tensor_vs_ref("dQv", dqv, dqv_ref, dqv_pt)
-=======
-                # print(f"out max: {out.abs().max().item()}, {iter=}")
-                # print(f"out vs out2 max diff: {(out - out2).abs().max().item()}, {iter=}")
-                # print(f"out vs out2 mean diff: {(out - out2).abs().mean().item()}, {iter=}")
-                assert torch.equal(out, out2), (
-                    f"non-deterministic with max diff = {(out - out2).abs().max().item()} on {iter=}"
-                )
->>>>>>> ebbdaeb6 (remove softcap != 0 limitation in test)
 
 
 # @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -34,6 +34,7 @@ from flash_attn.cute.interface import (
     _flash_attn_bwd,
 )
 
+
 def retry_on_oom(func):
     @wraps(func)
     def wrapper(*args, **kwargs):
@@ -50,8 +51,10 @@ def retry_on_oom(func):
                 return func(*args, **kwargs)
             else:
                 raise
+
     return wrapper
 
+<<<<<<< HEAD
 def print_diff_stats(name, actual, ref, pt=None, verbose=True):
     if actual is None:
         return
@@ -74,6 +77,8 @@ def check_tensor_vs_ref(name, actual, ref, pt, rtol=2, atol=None):
     diff_max = (actual - ref).abs().max().item()
     diff_pt_max = (pt - ref).abs().max().item()
     assert diff_max <= rtol * diff_pt_max + atol, f"{name}: {diff_max=} too large compared to {diff_pt_max=} for {rtol=}, {atol=}"
+=======
+>>>>>>> ebbdaeb6 (remove softcap != 0 limitation in test)
 
 # torch FakeTensorMode would enable fast cutedsl kernel compilation without allocating the actual GPU memory or running the kernel
 # When operating fake tensors, we cannot perform data-dependent operations (e.g., `tensor.max()`).
@@ -87,6 +92,7 @@ TEST_BWD_ONLY = False
 VERBOSE = True
 
 
+<<<<<<< HEAD
 @pytest.mark.skipif(not IS_SM120, reason="SM120-only SplitKV unsupported behavior")
 def test_flash_attn_sm120_rejects_splitkv():
     q = torch.randn(1, 16, 4, 64, device="cuda", dtype=torch.bfloat16)
@@ -96,6 +102,8 @@ def test_flash_attn_sm120_rejects_splitkv():
         flash_attn_func(q, k, v, num_splits=3)
 
 
+=======
+>>>>>>> ebbdaeb6 (remove softcap != 0 limitation in test)
 # @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float8_e4m3fn])
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 @pytest.mark.parametrize("mha_type", ["mha", "mqa", "gqa"])
@@ -182,9 +190,13 @@ def test_flash_attn_output(
     # Remove these skips when support is added.
     if d == 256 and IS_SM100:
         if has_learnable_sink:
-            pytest.skip("SM100 head_dim=256 2CTA kernel does not support learnable_sink yet")
+            pytest.skip(
+                "SM100 head_dim=256 2CTA kernel does not support learnable_sink yet"
+            )
         if local:
-            pytest.skip("SM100 head_dim=256 2CTA kernel does not support local attention yet")
+            pytest.skip(
+                "SM100 head_dim=256 2CTA kernel does not support local attention yet"
+            )
         if softcap > 0.0:
             pytest.skip("SM100 head_dim=256 2CTA kernel does not support softcap yet")
         if deterministic:
@@ -250,7 +262,9 @@ def test_flash_attn_output(
             qv_ref = None
         # Put window_size after QKV randn so that window_size changes from test to test
         window_size = (
-            (None, None) if not local else tuple(random.randrange(0, seqlen_k) for _ in range(2))
+            (None, None)
+            if not local
+            else tuple(random.randrange(0, seqlen_k) for _ in range(2))
         )
         if local_enum == 2:
             window_size = (None, -window_size[1])
@@ -328,10 +342,16 @@ def test_flash_attn_output(
             print(f"Pytorch max diff: {(out_pt - out_ref).abs().max().item()}")
             print(f"Pytorch mean diff: {(out_pt - out_ref).abs().mean().item()}")
         # num_splits_vals = [1, 3]
-        pack_gqa_vals = [True] if has_qv else [False, True, None] if not TEST_BWD_ONLY else [False]
+        pack_gqa_vals = (
+            [True] if has_qv else [False, True, None] if not TEST_BWD_ONLY else [False]
+        )
         # SplitKV is not supported for hdim >= 192
         # pack_gqa_vals = [False]
-        num_splits_vals = [1, 3] if d < 192 and not DISABLE_SPLIT and not TEST_BWD_ONLY and not has_qv else [1]
+        num_splits_vals = (
+            [1, 3]
+            if d < 192 and not DISABLE_SPLIT and not TEST_BWD_ONLY and not has_qv
+            else [1]
+        )
         for pack_gqa, num_splits in itertools.product(pack_gqa_vals, num_splits_vals):
             # SplitKV not supported on SM90/SM120 - skip this iteration
             if (IS_SM90 or IS_SM120) and num_splits > 1:
@@ -437,19 +457,25 @@ def test_flash_attn_output(
                 max_idx = diff_dq.argmax()
                 coords = torch.unravel_index(max_idx, diff_dq.shape)
                 print(f"dQ max diff: {diff_dq.max().item()}")
-                print(f"  at coordinates {tuple(c.item() for c in coords)}: dQ={dq[coords].item()}, dQ_ref={dq_ref[coords].item()}")
+                print(
+                    f"  at coordinates {tuple(c.item() for c in coords)}: dQ={dq[coords].item()}, dQ_ref={dq_ref[coords].item()}"
+                )
 
                 diff_dk = (dk - dk_ref).abs()
                 max_idx = diff_dk.argmax()
                 coords = torch.unravel_index(max_idx, diff_dk.shape)
                 print(f"dK max diff: {diff_dk.max().item()}")
-                print(f"  at coordinates {tuple(c.item() for c in coords)}: dK={dk[coords].item()}, dK_ref={dk_ref[coords].item()}")
+                print(
+                    f"  at coordinates {tuple(c.item() for c in coords)}: dK={dk[coords].item()}, dK_ref={dk_ref[coords].item()}"
+                )
 
                 diff_dv = (dv - dv_ref).abs()
                 max_idx = diff_dv.argmax()
                 coords = torch.unravel_index(max_idx, diff_dv.shape)
                 print(f"dV max diff: {diff_dv.max().item()}")
-                print(f"  at coordinates {tuple(c.item() for c in coords)}: dV={dv[coords].item()}, dV_ref={dv_ref[coords].item()}")
+                print(
+                    f"  at coordinates {tuple(c.item() for c in coords)}: dV={dv[coords].item()}, dV_ref={dv_ref[coords].item()}"
+                )
 
             # breakpoint()
             dq_atol = 2 * (dq_ref + 0.3 - 0.3 - dq_ref).abs().max().item() + (
@@ -645,15 +671,21 @@ def test_flash_attn_varlen_output(
     # Remove these skips when support is added.
     if d == 256 and IS_SM100:
         if has_learnable_sink:
-            pytest.skip("SM100 head_dim=256 2CTA kernel does not support learnable_sink yet")
+            pytest.skip(
+                "SM100 head_dim=256 2CTA kernel does not support learnable_sink yet"
+            )
         if local:
-            pytest.skip("SM100 head_dim=256 2CTA kernel does not support local attention yet")
+            pytest.skip(
+                "SM100 head_dim=256 2CTA kernel does not support local attention yet"
+            )
         if softcap > 0.0:
             pytest.skip("SM100 head_dim=256 2CTA kernel does not support softcap yet")
         if deterministic:
             pytest.skip("SM100 head_dim=256 2CTA kernel does not support deterministic mode yet")
         if not unpad_q or not unpad_kv:
-            pytest.skip("SM100 head_dim=256 2CTA kernel does not support seqused_q/seqused_k mode yet (requires unpad_q=True and unpad_kv=True)")
+            pytest.skip(
+                "SM100 head_dim=256 2CTA kernel does not support seqused_q/seqused_k mode yet (requires unpad_q=True and unpad_kv=True)"
+            )
     if (
         causal or local
     ):  # Right now reference only supports causal attention with seqlen_k == seqlen_q
@@ -712,7 +744,9 @@ def test_flash_attn_varlen_output(
             qv_ref = None
         # Put window_size after QKV randn so that window_size changes from test to test
         window_size = (
-            (None, None) if not local else tuple(random.randrange(0, seqlen_k) for _ in range(2))
+            (None, None)
+            if not local
+            else tuple(random.randrange(0, seqlen_k) for _ in range(2))
         )
         if local_enum == 2:
             window_size = (None, window_size[1])
@@ -748,6 +782,7 @@ def test_flash_attn_varlen_output(
             mode=varlen_mode,
             zero_lengths=zero_lengths_k,
         )
+
         def _gen_unused_masks(padding_mask, add_unused, max_seq_len, bs, device):
             if add_unused:
                 another_mask = generate_random_padding_mask(max_seq_len, bs, device)
@@ -864,7 +899,9 @@ def test_flash_attn_varlen_output(
         # pack_gqa_vals = [False]
         # num_splits_vals = [1, 3]
         # SplitKV is not supported for hdim >= 192
-        num_splits_vals = [1, 3] if d < 192 and not DISABLE_SPLIT and not TEST_BWD_ONLY else [1]
+        num_splits_vals = (
+            [1, 3] if d < 192 and not DISABLE_SPLIT and not TEST_BWD_ONLY else [1]
+        )
         for pack_gqa, num_splits in itertools.product(pack_gqa_vals, num_splits_vals):
             # SplitKV not supported on SM90/SM120 - skip this iteration
             if (IS_SM90 or IS_SM120) and num_splits > 1:
@@ -911,7 +948,9 @@ def test_flash_attn_varlen_output(
             # before comparing.
             out_cmp, out_ref_cmp, out_pt_cmp = out, out_ref, out_pt
             if not unpad_q and seqused_q is not None:
-                seqused_mask = torch.arange(seqlen_q, device=device)[None, :] < seqused_q[:, None]
+                seqused_mask = (
+                    torch.arange(seqlen_q, device=device)[None, :] < seqused_q[:, None]
+                )
                 seqused_mask = rearrange(seqused_mask, "b s -> b s 1 1")
                 out_cmp = out.clone().masked_fill_(~seqused_mask, 0.0)
                 out_ref_cmp = out_ref.clone().masked_fill_(~seqused_mask, 0.0)
@@ -939,7 +978,6 @@ def test_flash_attn_varlen_output(
                 or (IS_SM100 and d == 256 and dv == 256)
             )
             and not has_learnable_sink
-            and softcap == 0.0 # TODO: support softcap != 0.0 in varlen bwd
             # and False
         ):
             if d > 192 and IS_SM90:
@@ -978,7 +1016,7 @@ def test_flash_attn_varlen_output(
                     k_unpad if unpad_kv else k,
                     v_unpad if unpad_kv else v,
                 ),
-                g_unpad
+                g_unpad,
             )
             if is_fake_mode():
                 # no more flash_attn cutedsl calls for the rest of the loop
@@ -1034,19 +1072,25 @@ def test_flash_attn_varlen_output(
                 max_idx = diff_dq.argmax()
                 coords = torch.unravel_index(max_idx, diff_dq.shape)
                 print(f"dQ max diff: {diff_dq.max().item()}")
-                print(f"  at coordinates {tuple(c.item() for c in coords)}: dQ={dq[coords].item()}, dQ_ref={dq_ref[coords].item()}")
+                print(
+                    f"  at coordinates {tuple(c.item() for c in coords)}: dQ={dq[coords].item()}, dQ_ref={dq_ref[coords].item()}"
+                )
 
                 diff_dk = (dk - dk_ref).abs()
                 max_idx = diff_dk.argmax()
                 coords = torch.unravel_index(max_idx, diff_dk.shape)
                 print(f"dK max diff: {diff_dk.max().item()}")
-                print(f"  at coordinates {tuple(c.item() for c in coords)}: dK={dk[coords].item()}, dK_ref={dk_ref[coords].item()}")
+                print(
+                    f"  at coordinates {tuple(c.item() for c in coords)}: dK={dk[coords].item()}, dK_ref={dk_ref[coords].item()}"
+                )
 
                 diff_dv = (dv - dv_ref).abs()
                 max_idx = diff_dv.argmax()
                 coords = torch.unravel_index(max_idx, diff_dv.shape)
                 print(f"dV max diff: {diff_dv.max().item()}")
-                print(f"  at coordinates {tuple(c.item() for c in coords)}: dV={dv[coords].item()}, dV_ref={dv_ref[coords].item()}")
+                print(
+                    f"  at coordinates {tuple(c.item() for c in coords)}: dV={dv[coords].item()}, dV_ref={dv_ref[coords].item()}"
+                )
             # breakpoint()
             dq_atol = 2 * (dq_ref + 0.3 - 0.3 - dq_ref).abs().max().item() + (
                 0 if softcap == 0 else 3e-4
@@ -1212,7 +1256,9 @@ def test_flash_attn_kvcache(
             cu_seqlens_q, max_seqlen_q = None, None
         # Put window_size after QKV randn so that window_size changes from test to test
         window_size = (
-            (None, None) if not local else tuple(random.randrange(0, seqlen_k) for _ in range(2))
+            (None, None)
+            if not local
+            else tuple(random.randrange(0, seqlen_k) for _ in range(2))
         )
         if has_learnable_sink:
             learnable_sink = torch.randn(nheads, dtype=torch.bfloat16, device=device)
@@ -1220,9 +1266,7 @@ def test_flash_attn_kvcache(
             learnable_sink = None
 
         seqlen_new = (
-            seqlen_q
-            if seqlen_new_eq_seqlen_q
-            else random.randrange(1, seqlen_q + 1)
+            seqlen_q if seqlen_new_eq_seqlen_q else random.randrange(1, seqlen_q + 1)
         )
         cu_seqlens_k_new = None
         key_new_padding_mask = None
@@ -1305,7 +1349,11 @@ def test_flash_attn_kvcache(
                 (
                     (
                         seqlen_k
-                        - (seqlen_q if (causal or local) and rotary_dim > 1 else seqlen_new)
+                        - (
+                            seqlen_q
+                            if (causal or local) and rotary_dim > 1
+                            else seqlen_new
+                        )
                         + 1
                     )
                     if new_kv
@@ -1338,7 +1386,9 @@ def test_flash_attn_kvcache(
                     ]
                 )
             else:
-                cache_leftpad = torch.zeros(batch_size, dtype=torch.int32, device=device)
+                cache_leftpad = torch.zeros(
+                    batch_size, dtype=torch.int32, device=device
+                )
         else:
             cache_leftpad = None
         if has_batch_idx:
@@ -1643,9 +1693,15 @@ def test_flash_attn_bwd_preallocated_outputs(seqlen_q, seqlen_k, d, causal, dtyp
     batch_size = 2
     nheads = 4
 
-    q = torch.randn(batch_size, seqlen_q, nheads, d, device=device, dtype=dtype, requires_grad=True)
-    k = torch.randn(batch_size, seqlen_k, nheads, d, device=device, dtype=dtype, requires_grad=True)
-    v = torch.randn(batch_size, seqlen_k, nheads, d, device=device, dtype=dtype, requires_grad=True)
+    q = torch.randn(
+        batch_size, seqlen_q, nheads, d, device=device, dtype=dtype, requires_grad=True
+    )
+    k = torch.randn(
+        batch_size, seqlen_k, nheads, d, device=device, dtype=dtype, requires_grad=True
+    )
+    v = torch.randn(
+        batch_size, seqlen_k, nheads, d, device=device, dtype=dtype, requires_grad=True
+    )
 
     out, lse, *_ = _flash_attn_fwd(q, k, v, causal=causal, return_lse=True)
     dout = torch.randn_like(out)
@@ -1681,9 +1737,15 @@ def test_flash_attn_lse_grad(seqlen_q, seqlen_k, d, causal, dtype):
     batch_size = 2
     nheads = 4
 
-    q = torch.randn(batch_size, seqlen_q, nheads, d, device=device, dtype=dtype, requires_grad=True)
-    k = torch.randn(batch_size, seqlen_k, nheads, d, device=device, dtype=dtype, requires_grad=True)
-    v = torch.randn(batch_size, seqlen_k, nheads, d, device=device, dtype=dtype, requires_grad=True)
+    q = torch.randn(
+        batch_size, seqlen_q, nheads, d, device=device, dtype=dtype, requires_grad=True
+    )
+    k = torch.randn(
+        batch_size, seqlen_k, nheads, d, device=device, dtype=dtype, requires_grad=True
+    )
+    v = torch.randn(
+        batch_size, seqlen_k, nheads, d, device=device, dtype=dtype, requires_grad=True
+    )
 
     out, lse = flash_attn_func(q, k, v, causal=causal, return_lse=True)
 
@@ -1705,9 +1767,12 @@ def test_flash_attn_lse_grad(seqlen_q, seqlen_k, d, causal, dtype):
     k_ref = k.detach().float().requires_grad_()
     v_ref = v.detach().float().requires_grad_()
     # (batch, seqlen_q, nheads, d) -> (batch, nheads, seqlen_q, d)
-    qk = torch.einsum("bshd,bthd->bhst", q_ref, k_ref) / (d ** 0.5)
+    qk = torch.einsum("bshd,bthd->bhst", q_ref, k_ref) / (d**0.5)
     if causal:
-        mask = torch.triu(torch.ones(seqlen_q, seqlen_k, device=device, dtype=torch.bool), diagonal=seqlen_k - seqlen_q + 1)
+        mask = torch.triu(
+            torch.ones(seqlen_q, seqlen_k, device=device, dtype=torch.bool),
+            diagonal=seqlen_k - seqlen_q + 1,
+        )
         qk = qk.masked_fill(mask, float("-inf"))
     lse_ref = torch.logsumexp(qk, dim=-1)  # (batch, nheads, seqlen_q)
     p = torch.softmax(qk, dim=-1)
@@ -1735,7 +1800,7 @@ def test_flash_attn_lse_grad(seqlen_q, seqlen_k, d, causal, dtype):
 
     q_ref2 = q.detach().float().requires_grad_()
     k_ref2 = k.detach().float().requires_grad_()
-    qk2 = torch.einsum("bshd,bthd->bhst", q_ref2, k_ref2) / (d ** 0.5)
+    qk2 = torch.einsum("bshd,bthd->bhst", q_ref2, k_ref2) / (d**0.5)
     if causal:
         qk2 = qk2.masked_fill(mask, float("-inf"))
     lse_ref2 = torch.logsumexp(qk2, dim=-1)
@@ -1746,7 +1811,9 @@ def test_flash_attn_lse_grad(seqlen_q, seqlen_k, d, causal, dtype):
     print(f"LSE-only dK max diff: {(dk2.float() - dk_ref2).abs().max().item()}")
     # dV should be zero when only LSE gradient flows (LSE doesn't depend on V)
     print(f"LSE-only dV max: {dv2.abs().max().item()}")
-    assert dv2.abs().max().item() == 0.0, "dV should be zero when loss depends only on LSE"
+    assert dv2.abs().max().item() == 0.0, (
+        "dV should be zero when loss depends only on LSE"
+    )
 
 
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
@@ -1766,9 +1833,15 @@ def test_flash_attn_lse_grad_unused(seqlen_q, seqlen_k, d, causal, dtype):
     batch_size = 2
     nheads = 4
 
-    q = torch.randn(batch_size, seqlen_q, nheads, d, device=device, dtype=dtype, requires_grad=True)
-    k = torch.randn(batch_size, seqlen_k, nheads, d, device=device, dtype=dtype, requires_grad=True)
-    v = torch.randn(batch_size, seqlen_k, nheads, d, device=device, dtype=dtype, requires_grad=True)
+    q = torch.randn(
+        batch_size, seqlen_q, nheads, d, device=device, dtype=dtype, requires_grad=True
+    )
+    k = torch.randn(
+        batch_size, seqlen_k, nheads, d, device=device, dtype=dtype, requires_grad=True
+    )
+    v = torch.randn(
+        batch_size, seqlen_k, nheads, d, device=device, dtype=dtype, requires_grad=True
+    )
     g = torch.randn(batch_size, seqlen_q, nheads, d, device=device, dtype=dtype)
 
     # Case 1: return_lse=False (standard path, lse marked non-differentiable)
@@ -1859,14 +1932,24 @@ def test_flash_attn_paged_deepseek(seqlen_q, page_size):
 
     # Non-paged reference
     out_ref, _ = flash_attn_varlen_func(
-        q, k, v, cu_seqlens_q=cu_seqlens, cu_seqlens_k=cu_seqlens,
-        max_seqlen_q=seqlen_q, max_seqlen_k=seqlen_q, causal=True,
+        q,
+        k,
+        v,
+        cu_seqlens_q=cu_seqlens,
+        cu_seqlens_k=cu_seqlens,
+        max_seqlen_q=seqlen_q,
+        max_seqlen_k=seqlen_q,
+        causal=True,
     )
 
     # Paged
     num_pages = (seqlen_q + page_size - 1) // page_size
-    k_cache_paged = torch.zeros(num_pages, page_size, nheads_kv, d, device=device, dtype=dtype)
-    v_cache_paged = torch.zeros(num_pages, page_size, nheads_kv, dv, device=device, dtype=dtype)
+    k_cache_paged = torch.zeros(
+        num_pages, page_size, nheads_kv, d, device=device, dtype=dtype
+    )
+    v_cache_paged = torch.zeros(
+        num_pages, page_size, nheads_kv, dv, device=device, dtype=dtype
+    )
     for i in range(seqlen_q):
         k_cache_paged[i // page_size, i % page_size] = k[i]
         v_cache_paged[i // page_size, i % page_size] = v[i]
@@ -1874,10 +1957,16 @@ def test_flash_attn_paged_deepseek(seqlen_q, page_size):
     cache_seqlens = torch.tensor([seqlen_q], dtype=torch.int32, device=device)
 
     out, _ = flash_attn_varlen_func(
-        q, k_cache_paged, v_cache_paged,
-        cu_seqlens_q=cu_seqlens, cu_seqlens_k=None,
-        max_seqlen_q=seqlen_q, max_seqlen_k=None,
-        seqused_k=cache_seqlens, page_table=page_table, causal=True,
+        q,
+        k_cache_paged,
+        v_cache_paged,
+        cu_seqlens_q=cu_seqlens,
+        cu_seqlens_k=None,
+        max_seqlen_q=seqlen_q,
+        max_seqlen_k=None,
+        seqused_k=cache_seqlens,
+        page_table=page_table,
+        causal=True,
     )
 
     if is_fake_mode():
@@ -1911,21 +2000,31 @@ def test_flash_attn_paged_hd256_sm100_tma(seqlen_q):
     q = torch.randn(batch_size * seqlen_q, nheads, d, device=device, dtype=dtype)
     k = torch.randn(batch_size * seqlen_q, nheads_kv, d, device=device, dtype=dtype)
     v = torch.randn(batch_size * seqlen_q, nheads_kv, d, device=device, dtype=dtype)
-    cu_seqlens_q = torch.arange(0, batch_size + 1, dtype=torch.int32, device=device) * seqlen_q
+    cu_seqlens_q = (
+        torch.arange(0, batch_size + 1, dtype=torch.int32, device=device) * seqlen_q
+    )
     cu_seqlens_k = cu_seqlens_q.clone()
 
     # Non-paged reference (varlen).
     out_ref, _ = flash_attn_varlen_func(
-        q, k, v,
-        cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=cu_seqlens_k,
-        max_seqlen_q=seqlen_q, max_seqlen_k=seqlen_q,
+        q,
+        k,
+        v,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        max_seqlen_q=seqlen_q,
+        max_seqlen_k=seqlen_q,
     )
 
     # Repack into paged layout: (total_pages, page_size, nheads_kv, d).
     num_pages_per_seq = seqlen_q // page_size
     total_pages = batch_size * num_pages_per_seq
-    k_paged = torch.zeros(total_pages, page_size, nheads_kv, d, device=device, dtype=dtype)
-    v_paged = torch.zeros(total_pages, page_size, nheads_kv, d, device=device, dtype=dtype)
+    k_paged = torch.zeros(
+        total_pages, page_size, nheads_kv, d, device=device, dtype=dtype
+    )
+    v_paged = torch.zeros(
+        total_pages, page_size, nheads_kv, d, device=device, dtype=dtype
+    )
     for b in range(batch_size):
         for s in range(seqlen_q):
             pi = b * num_pages_per_seq + s // page_size
@@ -1938,15 +2037,23 @@ def test_flash_attn_paged_hd256_sm100_tma(seqlen_q):
 
     # Paged via hd256 2CTA TMA paged path — run twice for determinism.
     out_paged_0, _ = flash_attn_varlen_func(
-        q, k_paged, v_paged,
-        cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=None,
-        max_seqlen_q=seqlen_q, max_seqlen_k=seqlen_q,
+        q,
+        k_paged,
+        v_paged,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=None,
+        max_seqlen_q=seqlen_q,
+        max_seqlen_k=seqlen_q,
         page_table=page_table,
     )
     out_paged_1, _ = flash_attn_varlen_func(
-        q, k_paged, v_paged,
-        cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=None,
-        max_seqlen_q=seqlen_q, max_seqlen_k=seqlen_q,
+        q,
+        k_paged,
+        v_paged,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=None,
+        max_seqlen_q=seqlen_q,
+        max_seqlen_k=seqlen_q,
         page_table=page_table,
     )
 
@@ -1955,7 +2062,9 @@ def test_flash_attn_paged_hd256_sm100_tma(seqlen_q):
 
     print(f"Paged vs non-paged max diff: {(out_paged_0 - out_ref).abs().max().item()}")
     print(f"Paged determinism diff: {(out_paged_1 - out_paged_0).abs().max().item()}")
-    assert torch.allclose(out_paged_0, out_ref, atol=1e-3, rtol=1e-3), "Paged output does not match non-paged reference"
+    assert torch.allclose(out_paged_0, out_ref, atol=1e-3, rtol=1e-3), (
+        "Paged output does not match non-paged reference"
+    )
     assert torch.equal(out_paged_1, out_paged_0), "Paged output is not deterministic"
 
 
@@ -1983,19 +2092,29 @@ def test_flash_attn_paged_hd256_sm100_tma_gqa(nheads_kv):
     q = torch.randn(batch_size * seqlen_q, nheads, d, device=device, dtype=dtype)
     k = torch.randn(batch_size * seqlen_q, nheads_kv, d, device=device, dtype=dtype)
     v = torch.randn(batch_size * seqlen_q, nheads_kv, d, device=device, dtype=dtype)
-    cu_seqlens_q = torch.arange(0, batch_size + 1, dtype=torch.int32, device=device) * seqlen_q
+    cu_seqlens_q = (
+        torch.arange(0, batch_size + 1, dtype=torch.int32, device=device) * seqlen_q
+    )
     cu_seqlens_k = cu_seqlens_q.clone()
 
     out_ref, _ = flash_attn_varlen_func(
-        q, k, v,
-        cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=cu_seqlens_k,
-        max_seqlen_q=seqlen_q, max_seqlen_k=seqlen_q,
+        q,
+        k,
+        v,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        max_seqlen_q=seqlen_q,
+        max_seqlen_k=seqlen_q,
     )
 
     num_pages_per_seq = seqlen_q // page_size
     total_pages = batch_size * num_pages_per_seq
-    k_paged = torch.zeros(total_pages, page_size, nheads_kv, d, device=device, dtype=dtype)
-    v_paged = torch.zeros(total_pages, page_size, nheads_kv, d, device=device, dtype=dtype)
+    k_paged = torch.zeros(
+        total_pages, page_size, nheads_kv, d, device=device, dtype=dtype
+    )
+    v_paged = torch.zeros(
+        total_pages, page_size, nheads_kv, d, device=device, dtype=dtype
+    )
     for b in range(batch_size):
         for s in range(seqlen_q):
             pi = b * num_pages_per_seq + s // page_size
@@ -2007,16 +2126,22 @@ def test_flash_attn_paged_hd256_sm100_tma_gqa(nheads_kv):
     )
 
     out_paged, _ = flash_attn_varlen_func(
-        q, k_paged, v_paged,
-        cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=None,
-        max_seqlen_q=seqlen_q, max_seqlen_k=seqlen_q,
+        q,
+        k_paged,
+        v_paged,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=None,
+        max_seqlen_q=seqlen_q,
+        max_seqlen_k=seqlen_q,
         page_table=page_table,
     )
 
     if is_fake_mode():
         return
 
-    print(f"GQA nheads_kv={nheads_kv} paged vs non-paged max diff: {(out_paged - out_ref).abs().max().item()}")
+    print(
+        f"GQA nheads_kv={nheads_kv} paged vs non-paged max diff: {(out_paged - out_ref).abs().max().item()}"
+    )
     assert torch.allclose(out_paged, out_ref, atol=1e-3, rtol=1e-3), (
         f"Paged GQA output does not match non-paged reference (nheads_kv={nheads_kv})"
     )
@@ -2047,13 +2172,19 @@ def test_flash_attn_paged_hd256_sm100_tma_shuffled():
     q = torch.randn(batch_size * seqlen_q, nheads, d, device=device, dtype=dtype)
     k = torch.randn(batch_size * seqlen_q, nheads_kv, d, device=device, dtype=dtype)
     v = torch.randn(batch_size * seqlen_q, nheads_kv, d, device=device, dtype=dtype)
-    cu_seqlens_q = torch.arange(0, batch_size + 1, dtype=torch.int32, device=device) * seqlen_q
+    cu_seqlens_q = (
+        torch.arange(0, batch_size + 1, dtype=torch.int32, device=device) * seqlen_q
+    )
     cu_seqlens_k = cu_seqlens_q.clone()
 
     out_ref, _ = flash_attn_varlen_func(
-        q, k, v,
-        cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=cu_seqlens_k,
-        max_seqlen_q=seqlen_q, max_seqlen_k=seqlen_q,
+        q,
+        k,
+        v,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        max_seqlen_q=seqlen_q,
+        max_seqlen_k=seqlen_q,
     )
 
     # Shuffle physical pages: reverse order within each batch item.
@@ -2064,8 +2195,12 @@ def test_flash_attn_paged_hd256_sm100_tma_shuffled():
     ]
     page_table = torch.tensor(perm, dtype=torch.int32, device=device)
 
-    k_paged = torch.zeros(total_pages, page_size, nheads_kv, d, device=device, dtype=dtype)
-    v_paged = torch.zeros(total_pages, page_size, nheads_kv, d, device=device, dtype=dtype)
+    k_paged = torch.zeros(
+        total_pages, page_size, nheads_kv, d, device=device, dtype=dtype
+    )
+    v_paged = torch.zeros(
+        total_pages, page_size, nheads_kv, d, device=device, dtype=dtype
+    )
     for b in range(batch_size):
         for s in range(seqlen_q):
             phys = perm[b][s // page_size]  # Python int, safe in FakeTensorMode
@@ -2074,16 +2209,22 @@ def test_flash_attn_paged_hd256_sm100_tma_shuffled():
             v_paged[phys, po] = v[b * seqlen_q + s]
 
     out_paged, _ = flash_attn_varlen_func(
-        q, k_paged, v_paged,
-        cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=None,
-        max_seqlen_q=seqlen_q, max_seqlen_k=seqlen_q,
+        q,
+        k_paged,
+        v_paged,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=None,
+        max_seqlen_q=seqlen_q,
+        max_seqlen_k=seqlen_q,
         page_table=page_table,
     )
 
     if is_fake_mode():
         return
 
-    print(f"Shuffled paged vs non-paged max diff: {(out_paged - out_ref).abs().max().item()}")
+    print(
+        f"Shuffled paged vs non-paged max diff: {(out_paged - out_ref).abs().max().item()}"
+    )
     assert torch.allclose(out_paged, out_ref, atol=1e-3, rtol=1e-3), (
         "Shuffled paged output does not match non-paged reference"
     )
@@ -2099,7 +2240,12 @@ def test_flash_attn_invalid_head_dim(head_dim):
     k = torch.randn(batch_size, seqlen, nheads, head_dim, device=device, dtype=dtype)
     v = torch.randn(batch_size, seqlen, nheads, head_dim, device=device, dtype=dtype)
 
-    with pytest.raises(AssertionError, match=re.escape(f"(head_dim, head_dim_v)=({head_dim}, {head_dim}) is not supported on SM")):
+    with pytest.raises(
+        AssertionError,
+        match=re.escape(
+            f"(head_dim, head_dim_v)=({head_dim}, {head_dim}) is not supported on SM"
+        ),
+    ):
         flash_attn_func(q, k, v)
 
 
@@ -2183,12 +2329,18 @@ def test_flash_attn_mla_absorbed(
         v_ref = torch.randn(batch_size, seqlen_k, nheads_kv, hdimv, device=device, dtype=dtype).requires_grad_()
         qv_ref = torch.randn(batch_size, seqlen_q, nheads, hdimv, device=device, dtype=dtype).requires_grad_()
         if kv_sparsity:
-            gather_kv_indices = torch.rand(batch_size, seqlen_q, gather_kv_length, device=device).argsort(dim=-1).to(torch.int32)
+            gather_kv_indices = (
+                torch.rand(batch_size, seqlen_q, gather_kv_length, device=device)
+                .argsort(dim=-1)
+                .to(torch.int32)
+            )
         else:
             gather_kv_indices = None
         # Put window_size after QKV randn so that window_size changes from test to test
         window_size = (
-            (None, None) if not local else tuple(random.randrange(0, seqlen_k) for _ in range(2))
+            (None, None)
+            if not local
+            else tuple(random.randrange(0, seqlen_k) for _ in range(2))
         )
         if local_enum == 2:
             window_size = (None, -window_size[1])
@@ -2279,6 +2431,7 @@ def test_flash_attn_mla_absorbed(
                     pack_gqa=pack_gqa,
                     num_splits=num_splits,
                 )
+<<<<<<< HEAD
                 assert torch.equal(out, out2), f"non-deterministic with max diff = {(out - out2).abs().max().item()} on {iter=}"
         
         if test_bwd:
@@ -2309,6 +2462,14 @@ def test_flash_attn_mla_absorbed(
             check_tensor_vs_ref("dK", dk, dk_ref, dk_pt)
             check_tensor_vs_ref("dV", dv, dv_ref, dv_pt)
             check_tensor_vs_ref("dQv", dqv, dqv_ref, dqv_pt)
+=======
+                # print(f"out max: {out.abs().max().item()}, {iter=}")
+                # print(f"out vs out2 max diff: {(out - out2).abs().max().item()}, {iter=}")
+                # print(f"out vs out2 mean diff: {(out - out2).abs().mean().item()}, {iter=}")
+                assert torch.equal(out, out2), (
+                    f"non-deterministic with max diff = {(out - out2).abs().max().item()} on {iter=}"
+                )
+>>>>>>> ebbdaeb6 (remove softcap != 0 limitation in test)
 
 
 # @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
@@ -2418,13 +2579,19 @@ def test_flash_attn_mla_absorbed_varlen(
         v_ref = torch.randn(batch_size, seqlen_k, nheads_kv, hdimv, device=device, dtype=dtype).requires_grad_()
         qv_ref = torch.randn(batch_size, seqlen_q, nheads, hdimv, device=device, dtype=dtype).requires_grad_()
         if kv_sparsity:
-            gather_kv_indices = torch.rand(batch_size, seqlen_q, gather_kv_length, device=device).argsort(dim=-1).to(torch.int32)
+            gather_kv_indices = (
+                torch.rand(batch_size, seqlen_q, gather_kv_length, device=device)
+                .argsort(dim=-1)
+                .to(torch.int32)
+            )
         else:
             gather_kv_indices = None
-            
+
         # Put window_size after QKV randn so that window_size changes from test to test
         window_size = (
-            (None, None) if not local else tuple(random.randrange(0, seqlen_k) for _ in range(2))
+            (None, None)
+            if not local
+            else tuple(random.randrange(0, seqlen_k) for _ in range(2))
         )
         if local_enum == 2:
             window_size = (None, window_size[1])
@@ -2452,6 +2619,7 @@ def test_flash_attn_mla_absorbed_varlen(
             zero_lengths=zero_lengths_k,
             min_seqlen=gather_kv_length if kv_sparsity else None,
         )
+
         def _gen_unused_masks(padding_mask, add_unused, max_seq_len, bs, device):
             if add_unused:
                 another_mask = generate_random_padding_mask(max_seq_len, bs, device)
@@ -2508,7 +2676,9 @@ def test_flash_attn_mla_absorbed_varlen(
             _, indices_q, _, _, _ = unpad_input(
                 q, query_padding_mask, query_unused_mask
             )
-            gather_kv_indices_unpad = rearrange(gather_kv_indices, "b s ... -> (b s) ...")[indices_q]
+            gather_kv_indices_unpad = rearrange(
+                gather_kv_indices, "b s ... -> (b s) ..."
+            )[indices_q]
         else:
             gather_kv_indices_unpad = None
         if unpad_q:
@@ -2592,7 +2762,9 @@ def test_flash_attn_mla_absorbed_varlen(
                 num_splits=num_splits,
                 pack_gqa=pack_gqa,
                 deterministic=deterministic,
-                gather_kv_indices=gather_kv_indices_unpad if unpad_q else gather_kv_indices,
+                gather_kv_indices=gather_kv_indices_unpad
+                if unpad_q
+                else gather_kv_indices,
             )
             out = output_pad_fn(out_unpad) if unpad_q else out_unpad
             if is_fake_mode():
@@ -2606,7 +2778,9 @@ def test_flash_attn_mla_absorbed_varlen(
             # before comparing.
             out_cmp, out_ref_cmp, out_pt_cmp = out, out_ref, out_pt
             if not unpad_q and seqused_q is not None:
-                seqused_mask = torch.arange(seqlen_q, device=device)[None, :] < seqused_q[:, None]
+                seqused_mask = (
+                    torch.arange(seqlen_q, device=device)[None, :] < seqused_q[:, None]
+                )
                 seqused_mask = rearrange(seqused_mask, "b s -> b s 1 1")
                 out_cmp = out.clone().masked_fill_(~seqused_mask, 0.0)
                 out_ref_cmp = out_ref.clone().masked_fill_(~seqused_mask, 0.0)
@@ -2647,7 +2821,9 @@ def test_flash_attn_mla_absorbed_varlen(
                     num_splits=num_splits,
                     pack_gqa=pack_gqa,
                     deterministic=deterministic,
-                    gather_kv_indices=gather_kv_indices_unpad if unpad_q else gather_kv_indices,
+                    gather_kv_indices=gather_kv_indices_unpad
+                    if unpad_q
+                    else gather_kv_indices,
                 )
                 out2 = output_pad_fn(out_unpad2) if unpad_q else out_unpad2
                 if query_unused_mask is not None:
@@ -2656,13 +2832,18 @@ def test_flash_attn_mla_absorbed_varlen(
                 # beyond seqused_q, so those contain uninitialized values. Mask them out
                 # before comparing.
                 if not unpad_q and seqused_q is not None:
-                    seqused_mask = torch.arange(seqlen_q, device=device)[None, :] < seqused_q[:, None]
+                    seqused_mask = (
+                        torch.arange(seqlen_q, device=device)[None, :]
+                        < seqused_q[:, None]
+                    )
                     seqused_mask = rearrange(seqused_mask, "b s -> b s 1 1")
                     out2.masked_fill_(~seqused_mask, 0.0)
                 # print(f"out2 max: {out2.abs().max().item()}, {iter=}")
                 # print(f"out vs out2 max diff: {(out_cmp - out2).abs().max().item()}, {iter=}")
                 # print(f"out vs out2 mean diff: {(out_cmp - out2).abs().mean().item()}, {iter=}")
-                assert torch.equal(out_cmp, out2), f"non-deterministic with max diff = {(out_cmp - out2).abs().max().item()} on {iter=}"
+                assert torch.equal(out_cmp, out2), (
+                    f"non-deterministic with max diff = {(out_cmp - out2).abs().max().item()} on {iter=}"
+                )
 
         if test_bwd:
             print("VARLEN BWD SPARSE MLA")
@@ -2832,6 +3013,7 @@ def test_flash_attn_mla_paged(dtype, seqlen_q, seqlen_k, page_size, causal, has_
 # Regression test: seqlen_k=0 must not crash (CUDA graph padding scenario)
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.parametrize("causal", [False, True])
 @pytest.mark.parametrize("d", [128, 192])
 @pytest.mark.parametrize("seqlen_q", [1, 64, 128, 256])
@@ -2881,12 +3063,14 @@ def test_flash_attn_seqlen_k_zero(seqlen_q, d, causal):
 
     # No crash above already validates the fix. Below validates the contract
     # the early-return promises: zero output, -inf LSE.
-    assert out.shape == (batch_size, seqlen_q, nheads, dv), \
+    assert out.shape == (batch_size, seqlen_q, nheads, dv), (
         f"Unexpected output shape: {out.shape}"
-    assert torch.all(out == 0).item(), \
+    )
+    assert torch.all(out == 0).item(), (
         f"Expected all-zero output when seqlen_k=0, got max={out.abs().max().item():.6f}"
+    )
     if lse is not None:
-        assert torch.all(torch.isinf(lse) & (lse < 0)).item(), \
+        assert torch.all(torch.isinf(lse) & (lse < 0)).item(), (
             f"Expected all -inf LSE when seqlen_k=0, got: {lse}"
 
 

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -2994,6 +2994,96 @@ def test_flash_attn_mla_paged(dtype, seqlen_q, seqlen_k, page_size, causal, has_
     assert torch.equal(out, out_ref)
 
 
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("page_size", [1, 16, 64, 128])
+@pytest.mark.parametrize("has_qk", [True, False])
+@pytest.mark.parametrize(
+    "seqlen_q,seqlen_k",
+    [
+        (1, 128),
+        (4, 256),
+        (64, 512),
+        (1, 2048),
+        (2048, 2048),
+    ],
+)
+@maybe_fake_tensor_mode(USE_FAKE_TENSOR)
+def test_flash_attn_mla_paged(dtype, seqlen_q, seqlen_k, page_size, causal, has_qk):
+    if not IS_SM100:
+        pytest.skip("MLA paged KV only supported on SM100")
+    device = "cuda"
+    d, dv = 64, 512
+    nheads = 128
+    nheads_kv = 1
+    batch_size = 49 if seqlen_k <= 512 else 7
+
+    torch.random.manual_seed(0)
+
+    # Non-paged reference tensors (varlen format)
+    q = k = None
+    if has_qk:
+        q = torch.randn(batch_size * seqlen_q, nheads, d, device=device, dtype=dtype)
+        k = torch.randn(batch_size * seqlen_k, nheads_kv, d, device=device, dtype=dtype)
+    v = torch.randn(batch_size * seqlen_k, nheads_kv, dv, device=device, dtype=dtype)
+    qv = torch.randn(batch_size * seqlen_q, nheads, dv, device=device, dtype=dtype)
+
+    cu_seqlens_q = torch.tensor(
+        [i * seqlen_q for i in range(batch_size + 1)], dtype=torch.int32, device=device
+    )
+    cu_seqlens_k = torch.tensor(
+        [i * seqlen_k for i in range(batch_size + 1)], dtype=torch.int32, device=device
+    )
+
+    # Non-paged reference
+    out_ref, _ = flash_attn_varlen_func(
+        q, k, v, qv=qv,
+        cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=cu_seqlens_k,
+        max_seqlen_q=seqlen_q, max_seqlen_k=seqlen_k,
+        causal=causal,
+    )
+
+    # Create paged K/V cache
+    num_pages_per_seq = (seqlen_k + page_size - 1) // page_size
+    total_pages = num_pages_per_seq * batch_size
+    k_paged = None
+    if has_qk:
+        k_paged = torch.zeros(total_pages, page_size, nheads_kv, d, device=device, dtype=dtype)
+    v_paged = torch.zeros(total_pages, page_size, nheads_kv, dv, device=device, dtype=dtype)
+    page_table = torch.zeros(batch_size, num_pages_per_seq, dtype=torch.int32, device=device)
+
+    # Fill paged K/V from contiguous K/V (sequential page assignment)
+    for b in range(batch_size):
+        for p in range(num_pages_per_seq):
+            page_idx = b * num_pages_per_seq + p
+            start = p * page_size
+            end = min(start + page_size, seqlen_k)
+            k_offset = b * seqlen_k
+            if start < seqlen_k:
+                if has_qk:
+                    k_paged[page_idx, :end - start] = k[k_offset + start:k_offset + end]
+                v_paged[page_idx, :end - start] = v[k_offset + start:k_offset + end]
+            page_table[b, p] = page_idx
+
+    seqused_k = torch.full((batch_size,), seqlen_k, dtype=torch.int32, device=device)
+
+    # Paged output (triggers cp.async path if page_size != 128)
+    out, _ = flash_attn_varlen_func(
+        q, k_paged, v_paged, qv=qv,
+        cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=None,
+        max_seqlen_q=seqlen_q, max_seqlen_k=None,
+        seqused_k=seqused_k, page_table=page_table,
+        causal=causal,
+    )
+
+    if is_fake_mode():
+        return
+
+    print(f"Output max diff: {(out - out_ref).abs().max().item()}")
+    print(f"Output mean diff: {(out - out_ref).abs().mean().item()}")
+    assert torch.equal(out, out_ref)
+
+
 # ---------------------------------------------------------------------------
 # Regression test: seqlen_k=0 must not crash (CUDA graph padding scenario)
 # ---------------------------------------------------------------------------

--- a/tests/cute/test_score_mod.py
+++ b/tests/cute/test_score_mod.py
@@ -282,7 +282,10 @@ def test_cute_score_mod_vectorized(
     for vec_size in VEC_SIZES_TO_CHECK_EQUALITY:
         cute_vectorized_score_mod.__vec_size__ = vec_size
         out = run_cute_flash(q, k, v, cute_vectorized_score_mod, pack_gqa=pack_gqa)
-        assert torch.equal(out, out_ref)
+        # Vectorized codegen reorders float ops vs the scalar path; softmax amplifies
+        # the resulting 1-ulp score differences (measured max 4e-4 fp16 / 2.9e-3 bf16 on sm103).
+        rtol, atol = (2e-3, 1e-3) if dtype == torch.float16 else (1.6e-2, 5e-3)
+        assert torch.allclose(out, out_ref, rtol=rtol, atol=atol)
 
 
 @pytest.mark.parametrize("seqlen_q,seqlen_kv", SEQLEN_CONFIGS)
@@ -405,7 +408,10 @@ def test_cute_score_mod_with_aux_tensors_vectorized(
             aux_tensors=aux_tensors,
             pack_gqa=pack_gqa,
         )
-        assert torch.equal(out, out_ref)
+        # Vectorized codegen reorders float ops vs the scalar path; softmax amplifies
+        # the resulting 1-ulp score differences (measured max 4e-4 fp16 / 2.9e-3 bf16 on sm103).
+        rtol, atol = (2e-3, 1e-3) if dtype == torch.float16 else (1.6e-2, 5e-3)
+        assert torch.allclose(out, out_ref, rtol=rtol, atol=atol)
 
 
 def _generate_block_kvcache(seqlen_k, page_size, batch_size, nheads_k, d, device, dtype):

--- a/tests/cute/test_score_mod.py
+++ b/tests/cute/test_score_mod.py
@@ -52,6 +52,16 @@ from score_mod_definitions import (
     causal_v2_eager as causal_mask_v2_eager,
     batch_bias_factory as batch_bias,
     dual_buffer_factory as dual_buffer_bias,
+    squared_eager as score_squared_eager,
+)  # isort: split
+from score_mod_definitions import (
+    # Backward score mods
+    score_mod_squared,
+    score_mod_bwd_identity,
+    score_mod_bwd_times_two as score_mod_bwd_5,
+    score_mod_bwd_rel_bias as score_mod_bwd_3,
+    score_mod_bwd_causal,
+    score_mod_bwd_squared,
 )
 
 COMPUTE_CAPABILITY = torch.cuda.get_device_capability()[0]
@@ -735,49 +745,6 @@ def test_score_mod_with_paged_kvcache_aux_tensors(
     assert cute_error <= rtol * pt_error + fwd_atol, (
         f"CuTE error {cute_error:.2e} exceeds {rtol}x PyTorch error {pt_error:.2e} + {fwd_atol:.2e}"
     )
-
-
-@cute.jit
-def score_mod_bwd_5(grad, score, b_idx, h_idx, q_idx, kv_idx, seqlen_info, aux_tensors):
-    """Backward for score_mod_5 (times_two): d(score*2)/d(score) = 2."""
-    return grad * cute.full_like(grad, 2.0)
-
-
-@cute.jit
-def score_mod_bwd_3(grad, score, b_idx, h_idx, q_idx, kv_idx, seqlen_info, aux_tensors):
-    """Backward for score_mod_3 (relative_bias): d(score + |q-kv|)/d(score) = 1."""
-    return grad
-
-
-@cute.jit
-def score_mod_bwd_identity(grad, score, b_idx, h_idx, q_idx, kv_idx, seqlen_info, aux_tensors):
-    return grad
-
-
-@cute.jit
-def score_mod_bwd_causal(grad, score, b_idx, h_idx, q_idx, kv_idx, seqlen_info, aux_tensors):
-    """Backward for causal masking: d(where(mask, score, -inf))/d(score) = where(mask, 1, 0).
-
-    At unmasked positions (q_idx >= kv_idx), grad passes through.
-    At masked positions (q_idx < kv_idx), the kernel already zeros grad because P=0.
-    """
-    return grad
-
-
-@cute.jit
-def score_mod_squared(tSrS_ssa, b_idx, h_idx, q_idx, kv_idx, seqlen_info, aux_tensors):
-    """Forward: score ** 2."""
-    return tSrS_ssa * tSrS_ssa
-
-
-@cute.jit
-def score_mod_bwd_squared(grad, score, b_idx, h_idx, q_idx, kv_idx, seqlen_info, aux_tensors):
-    """Backward for score**2: d(score**2)/d(score) = 2*score."""
-    return grad * cute.full_like(grad, 2.0) * score
-
-
-def score_squared_eager(score, b, h, q_idx, kv_idx):
-    return score * score
 
 
 BWD_TEST_PAIRS = [

--- a/tests/cute/test_score_mod_varlen.py
+++ b/tests/cute/test_score_mod_varlen.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 from torch.nn.attention.flex_attention import flex_attention
-from flash_attn.cute.interface import _flash_attn_fwd
+from flash_attn.cute.interface import _flash_attn_fwd, _flash_attn_bwd
 from test_score_mod import _generate_block_kvcache
 from score_mod_definitions import (
     # TensorSSA-based score mods
@@ -62,6 +62,22 @@ from score_mod_definitions import (
     stress_global_offset_factory,
     stress_xor_pattern_factory,
     debug_global_idx_factory,
+)  # isort: split
+from score_mod_definitions import (
+    # Forward + backward score mods used in bwd tests
+    score_mod_squared,
+    score_mod_scaled_squared,
+    score_mod_rel_bias_clamped,
+    score_mod_bwd_identity,
+    score_mod_bwd_times_two,
+    score_mod_bwd_rel_bias_clamped,
+    score_mod_bwd_causal,
+    score_mod_bwd_squared,
+    score_mod_bwd_dual_buffer,
+    score_mod_bwd_scaled_squared,
+    squared_eager,
+    rel_bias_clamped_eager,
+    scaled_squared_factory,
 )
 
 IS_SM90 = torch.cuda.get_device_capability()[0] == 9
@@ -512,6 +528,7 @@ def test_varlen_with_score_mod(
         cu_seqlens_q=cu_seqlens_q if varlen_q else None,
     )
 
+
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
 @pytest.mark.parametrize("varlen_q", [True, False])
 @pytest.mark.parametrize("varlen_k", [True, False])
@@ -592,6 +609,7 @@ def test_varlen_with_score_mod_vectorized(
             cu_seqlens_k=cu_seqlens_k,
         )
         assert torch.equal(out, out_ref)
+
 
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
 @pytest.mark.parametrize("varlen_q", [True, False])
@@ -1154,6 +1172,313 @@ def test_varlen_score_mod_with_paged_kvcache_global(
         seqlens_q=seqlens_q,
         cu_seqlens_q=cu_seqlens_q,
     )
+
+
+# =============================================================================
+# Backward tests
+# =============================================================================
+
+# (cute_fwd, cute_bwd, eager_ref_or_factory, aux_type)
+# aux_type: None or "dual_buffer"
+BWD_TEST_PAIRS = [
+    (score_mod_times_two, score_mod_bwd_times_two, times_two_eager, None),
+    (score_mod_rel_bias_clamped, score_mod_bwd_rel_bias_clamped, rel_bias_clamped_eager, None),
+    (score_mod_squared, score_mod_bwd_squared, squared_eager, None),
+    (score_mod_causal, score_mod_bwd_causal, causal_eager, None),
+    (
+        score_mod_dual_buffer,
+        score_mod_bwd_dual_buffer,
+        dual_buffer_factory,
+        "dual_buffer",
+    ),
+]
+
+# (cute_fwd, cute_bwd, eager_factory, aux_type, requires_global)
+BWD_TEST_PAIRS_WITH_GLOBAL = [
+    (
+        score_mod_scaled_squared,
+        score_mod_bwd_scaled_squared,
+        scaled_squared_factory,
+        "kv",
+        "kv",
+    ),
+]
+
+BWD_SEQLEN_CONFIGS = SEQLEN_CONFIGS
+
+
+def run_cute_flash_bwd_varlen(
+    q,
+    k,
+    v,
+    cute_score_mod,
+    cute_score_mod_bwd,
+    cu_seqlens_q,
+    cu_seqlens_k,
+    aux_tensors=None,
+    pack_gqa=False,
+):
+    """Forward + backward via _flash_attn_fwd / _flash_attn_bwd directly (no autograd).
+
+    Mirrors run_cute_flash_bwd(use_autograd=False) in test_score_mod.py. Inputs are
+    already in packed varlen layout (total, num_heads, head_dim) so no transpose.
+    """
+    out, lse = _flash_attn_fwd(
+        q,
+        k,
+        v,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        return_lse=True,
+        score_mod=cute_score_mod,
+        aux_tensors=aux_tensors,
+        pack_gqa=pack_gqa,
+    )
+    grad_out = torch.randn_like(out)
+    dq, dk, dv = _flash_attn_bwd(
+        q,
+        k,
+        v,
+        out,
+        grad_out,
+        lse,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        score_mod=cute_score_mod,
+        score_mod_bwd=cute_score_mod_bwd,
+        aux_tensors=aux_tensors,
+        pack_gqa=pack_gqa,
+    )
+    return out, grad_out, dq, dk, dv
+
+
+def run_flex_varlen_ref_bwd(
+    q, k, v, cu_seqlens_q, cu_seqlens_k, eager_score_mod, grad_out, dtype=None
+):
+    """Per-sequence flex_attention fwd+bwd; concatenates results in packed layout.
+
+    Uses eager flex_attention (not torch.compile). The compiled path caches
+    artifacts globally and silently produces wrong fp32 gradients across calls
+    with different seqlens, so the reference must stay uncompiled.
+    """
+    num_batches = len(cu_seqlens_q) - 1
+    out_chunks, dq_chunks, dk_chunks, dv_chunks = [], [], [], []
+
+    for i in range(num_batches):
+        q_slice = q[cu_seqlens_q[i] : cu_seqlens_q[i + 1]].unsqueeze(0).transpose(1, 2)
+        k_slice = k[cu_seqlens_k[i] : cu_seqlens_k[i + 1]].unsqueeze(0).transpose(1, 2)
+        v_slice = v[cu_seqlens_k[i] : cu_seqlens_k[i + 1]].unsqueeze(0).transpose(1, 2)
+        go_slice = (
+            grad_out[cu_seqlens_q[i] : cu_seqlens_q[i + 1]].unsqueeze(0).transpose(1, 2)
+        )
+
+        if dtype is not None:
+            q_slice = q_slice.to(dtype)
+            k_slice = k_slice.to(dtype)
+            v_slice = v_slice.to(dtype)
+            go_slice = go_slice.to(dtype)
+
+        q_slice = q_slice.detach().requires_grad_(True)
+        k_slice = k_slice.detach().requires_grad_(True)
+        v_slice = v_slice.detach().requires_grad_(True)
+
+        def wrapped_mod(score, b, h, q_idx, kv_idx, _i=i):
+            return eager_score_mod(score, _i, h, q_idx, kv_idx)
+
+        out = flex_attention(
+            q_slice,
+            k_slice,
+            v_slice,
+            score_mod=wrapped_mod,
+            enable_gqa=q_slice.shape[1] != k_slice.shape[1],
+        )
+        dq, dk, dv = torch.autograd.grad(out, (q_slice, k_slice, v_slice), go_slice)
+
+        out_chunks.append(out.transpose(1, 2).squeeze(0))
+        dq_chunks.append(dq.transpose(1, 2).squeeze(0))
+        dk_chunks.append(dk.transpose(1, 2).squeeze(0))
+        dv_chunks.append(dv.transpose(1, 2).squeeze(0))
+
+    return (
+        torch.cat(out_chunks, dim=0),
+        torch.cat(dq_chunks, dim=0),
+        torch.cat(dk_chunks, dim=0),
+        torch.cat(dv_chunks, dim=0),
+    )
+
+
+def _check_grad(name, cute_grad, ref_fp32, pt_grad, dtype, rtol=3, extra=1e-3):
+    import os
+    if os.environ.get("DUMP_GRADS"):
+        torch.save({"cute": cute_grad.detach().cpu(), "ref_fp32": ref_fp32.detach().cpu(),
+                    "pt": pt_grad.detach().cpu()}, f"/tmp/grads_{name}.pt")
+    assert not torch.isnan(cute_grad).any(), f"{name} contains NaN"
+    atol = 2 * (ref_fp32 + 0.3 - 0.3 - ref_fp32).abs().max().item() + extra
+    ref = ref_fp32.to(dtype)
+    pt_err = (pt_grad - ref).abs().max().item()
+    cute_err = (cute_grad - ref).abs().max().item()
+    print(f"  {name}: PT err={pt_err:.2e}, CuTE err={cute_err:.2e}, atol={atol:.2e}")
+    assert cute_err <= rtol * pt_err + atol, (
+        f"{name} CuTE err {cute_err:.2e} exceeds {rtol}*PT err {pt_err:.2e} + {atol:.2e}"
+    )
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("dim", [64, 128])
+@pytest.mark.parametrize("seqlens_q,seqlens_k", BWD_SEQLEN_CONFIGS)
+@pytest.mark.parametrize("score_mod_tuple", BWD_TEST_PAIRS)
+def test_varlen_score_mod_backward(seqlens_q, seqlens_k, dim, dtype, score_mod_tuple):
+    """Varlen backward with score_mod (no global indices in bwd)."""
+    if IS_SM90 and dim == 64:
+        pytest.skip("head_dim=64 not supported on SM90 for backward")
+
+    torch.random.manual_seed(42)
+    cute_fwd, cute_bwd, eager_factory, aux_type = score_mod_tuple
+
+    num_heads = 4
+    batch_size = len(seqlens_q)
+    total_q = sum(seqlens_q)
+    total_k = sum(seqlens_k)
+
+    q = torch.randn(total_q, num_heads, dim, device="cuda", dtype=dtype)
+    k = torch.randn(total_k, num_heads, dim, device="cuda", dtype=dtype)
+    v = torch.randn(total_k, num_heads, dim, device="cuda", dtype=dtype)
+    cu_seqlens_q = torch.tensor(
+        [0] + list(torch.tensor(seqlens_q).cumsum(0).tolist()),
+        device="cuda",
+        dtype=torch.int32,
+    )
+    cu_seqlens_k = torch.tensor(
+        [0] + list(torch.tensor(seqlens_k).cumsum(0).tolist()),
+        device="cuda",
+        dtype=torch.int32,
+    )
+
+    aux_tensors = None
+    if aux_type == "dual_buffer":
+        max_seqlen_q = max(seqlens_q)
+        head_bias = torch.randn(num_heads, device="cuda", dtype=dtype) * 0.2
+        pos_bias = torch.arange(max_seqlen_q, device="cuda", dtype=dtype) * 0.01
+        aux_tensors = [head_bias, pos_bias]
+        eager_score_mod = eager_factory(head_bias, pos_bias)
+    else:
+        eager_score_mod = eager_factory
+
+    out_cute, grad_out, dq_cute, dk_cute, dv_cute = run_cute_flash_bwd_varlen(
+        q,
+        k,
+        v,
+        cute_fwd,
+        cute_bwd,
+        cu_seqlens_q,
+        cu_seqlens_k,
+        aux_tensors=aux_tensors,
+    )
+
+    _, dq_ref_fp32, dk_ref_fp32, dv_ref_fp32 = run_flex_varlen_ref_bwd(
+        q,
+        k,
+        v,
+        cu_seqlens_q,
+        cu_seqlens_k,
+        eager_score_mod,
+        grad_out,
+        dtype=torch.float32,
+    )
+    _, dq_pt, dk_pt, dv_pt = run_flex_varlen_ref_bwd(
+        q,
+        k,
+        v,
+        cu_seqlens_q,
+        cu_seqlens_k,
+        eager_score_mod,
+        grad_out,
+        dtype=dtype,
+    )
+
+    print(f"\nVarlen backward for {cute_fwd.__name__} ({batch_size=} {dtype=} {dim=}):")
+    _check_grad("dQ", dq_cute, dq_ref_fp32, dq_pt, dtype)
+    _check_grad("dK", dk_cute, dk_ref_fp32, dk_pt, dtype)
+    _check_grad("dV", dv_cute, dv_ref_fp32, dv_pt, dtype)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("dim", [64, 128])
+@pytest.mark.parametrize("seqlens_q,seqlens_k", BWD_SEQLEN_CONFIGS)
+@pytest.mark.parametrize("score_mod_tuple", BWD_TEST_PAIRS_WITH_GLOBAL)
+def test_varlen_score_mod_backward_with_global(
+    seqlens_q, seqlens_k, dim, dtype, score_mod_tuple
+):
+    """Varlen backward with a score_mod whose bwd reads aux at global indices.
+
+    Forward: scale[global_kv] * score**2.
+    Backward: 2 * scale[global_kv] * score * grad — needs all of grad, score, and
+    a global-indexed aux read.
+    """
+    if IS_SM90 and dim == 64:
+        pytest.skip("head_dim=64 not supported on SM90 for backward")
+
+    torch.random.manual_seed(42)
+    cute_fwd, cute_bwd, eager_factory, aux_type, requires_global = score_mod_tuple
+
+    num_heads = 4
+    total_q = sum(seqlens_q)
+    total_k = sum(seqlens_k)
+
+    q = torch.randn(total_q, num_heads, dim, device="cuda", dtype=dtype)
+    k = torch.randn(total_k, num_heads, dim, device="cuda", dtype=dtype)
+    v = torch.randn(total_k, num_heads, dim, device="cuda", dtype=dtype)
+    cu_seqlens_q = torch.tensor(
+        [0] + list(torch.tensor(seqlens_q).cumsum(0).tolist()),
+        device="cuda",
+        dtype=torch.int32,
+    )
+    cu_seqlens_k = torch.tensor(
+        [0] + list(torch.tensor(seqlens_k).cumsum(0).tolist()),
+        device="cuda",
+        dtype=torch.int32,
+    )
+
+    scale_tensor = torch.randn(total_k, device="cuda", dtype=dtype) * 0.1 + 1.0
+    aux_tensors = [scale_tensor]
+    eager_score_mod = eager_factory(scale_tensor, cu_seqlens_k)
+
+    out_cute, grad_out, dq_cute, dk_cute, dv_cute = run_cute_flash_bwd_varlen(
+        q,
+        k,
+        v,
+        cute_fwd,
+        cute_bwd,
+        cu_seqlens_q,
+        cu_seqlens_k,
+        aux_tensors=aux_tensors,
+    )
+
+    _, dq_ref_fp32, dk_ref_fp32, dv_ref_fp32 = run_flex_varlen_ref_bwd(
+        q,
+        k,
+        v,
+        cu_seqlens_q,
+        cu_seqlens_k,
+        eager_score_mod,
+        grad_out,
+        dtype=torch.float32,
+    )
+    _, dq_pt, dk_pt, dv_pt = run_flex_varlen_ref_bwd(
+        q,
+        k,
+        v,
+        cu_seqlens_q,
+        cu_seqlens_k,
+        eager_score_mod,
+        grad_out,
+        dtype=dtype,
+    )
+
+    print(f"\nVarlen backward (global) for {cute_fwd.__name__} ({dtype=} {dim=}):")
+    _check_grad("dQ", dq_cute, dq_ref_fp32, dq_pt, dtype)
+    _check_grad("dK", dk_cute, dk_ref_fp32, dk_pt, dtype)
+    _check_grad("dV", dv_cute, dv_ref_fp32, dv_pt, dtype)
 
 
 if __name__ == "__main__":

--- a/tests/cute/test_score_mod_varlen.py
+++ b/tests/cute/test_score_mod_varlen.py
@@ -1,7 +1,11 @@
 import pytest
 import torch
 from torch.nn.attention.flex_attention import flex_attention
-from flash_attn.cute.interface import _flash_attn_fwd, _flash_attn_bwd
+from flash_attn.cute.interface import (
+    _flash_attn_fwd,
+    _flash_attn_bwd,
+    flash_attn_varlen_func,
+)
 from test_score_mod import _generate_block_kvcache
 from score_mod_definitions import (
     # TensorSSA-based score mods
@@ -1217,12 +1221,34 @@ def run_cute_flash_bwd_varlen(
     cu_seqlens_k,
     aux_tensors=None,
     pack_gqa=False,
+    use_autograd=True,
 ):
-    """Forward + backward via _flash_attn_fwd / _flash_attn_bwd directly (no autograd).
+    """Forward + backward with score_mod for packed varlen inputs.
 
-    Mirrors run_cute_flash_bwd(use_autograd=False) in test_score_mod.py. Inputs are
-    already in packed varlen layout (total, num_heads, head_dim) so no transpose.
+    Mirrors run_cute_flash_bwd in test_score_mod.py. use_autograd=True drives
+    flash_attn_varlen_func + torch.autograd.grad; False calls the fwd/bwd entry
+    points directly.
     """
+    if use_autograd:
+        q = q.detach().requires_grad_(True)
+        k = k.detach().requires_grad_(True)
+        v = v.detach().requires_grad_(True)
+        out, lse = flash_attn_varlen_func(
+            q,
+            k,
+            v,
+            cu_seqlens_q=cu_seqlens_q,
+            cu_seqlens_k=cu_seqlens_k,
+            score_mod=cute_score_mod,
+            score_mod_bwd=cute_score_mod_bwd,
+            aux_tensors=aux_tensors,
+            pack_gqa=pack_gqa,
+            return_lse=True,
+        )
+        grad_out = torch.randn_like(out)
+        dq, dk, dv = torch.autograd.grad(out, (q, k, v), grad_out)
+        return out, grad_out, dq, dk, dv
+
     out, lse = _flash_attn_fwd(
         q,
         k,
@@ -1327,7 +1353,10 @@ def _check_grad(name, cute_grad, ref_fp32, pt_grad, dtype, rtol=3, extra=1e-3):
 @pytest.mark.parametrize("dim", [64, 128])
 @pytest.mark.parametrize("seqlens_q,seqlens_k", BWD_SEQLEN_CONFIGS)
 @pytest.mark.parametrize("score_mod_tuple", BWD_TEST_PAIRS)
-def test_varlen_score_mod_backward(seqlens_q, seqlens_k, dim, dtype, score_mod_tuple):
+@pytest.mark.parametrize("use_autograd", [True, False])
+def test_varlen_score_mod_backward(
+    seqlens_q, seqlens_k, dim, dtype, score_mod_tuple, use_autograd
+):
     """Varlen backward with score_mod (no global indices in bwd)."""
     if IS_SM90 and dim == 64:
         pytest.skip("head_dim=64 not supported on SM90 for backward")
@@ -1373,6 +1402,7 @@ def test_varlen_score_mod_backward(seqlens_q, seqlens_k, dim, dtype, score_mod_t
         cu_seqlens_q,
         cu_seqlens_k,
         aux_tensors=aux_tensors,
+        use_autograd=use_autograd,
     )
 
     _, dq_ref_fp32, dk_ref_fp32, dv_ref_fp32 = run_flex_varlen_ref_bwd(
@@ -1406,8 +1436,9 @@ def test_varlen_score_mod_backward(seqlens_q, seqlens_k, dim, dtype, score_mod_t
 @pytest.mark.parametrize("dim", [64, 128])
 @pytest.mark.parametrize("seqlens_q,seqlens_k", BWD_SEQLEN_CONFIGS)
 @pytest.mark.parametrize("score_mod_tuple", BWD_TEST_PAIRS_WITH_GLOBAL)
+@pytest.mark.parametrize("use_autograd", [True, False])
 def test_varlen_score_mod_backward_with_global(
-    seqlens_q, seqlens_k, dim, dtype, score_mod_tuple
+    seqlens_q, seqlens_k, dim, dtype, score_mod_tuple, use_autograd
 ):
     """Varlen backward with a score_mod whose bwd reads aux at global indices.
 
@@ -1452,6 +1483,7 @@ def test_varlen_score_mod_backward_with_global(
         cu_seqlens_q,
         cu_seqlens_k,
         aux_tensors=aux_tensors,
+        use_autograd=use_autograd,
     )
 
     _, dq_ref_fp32, dk_ref_fp32, dv_ref_fp32 = run_flex_varlen_ref_bwd(

--- a/tests/cute/test_score_mod_varlen.py
+++ b/tests/cute/test_score_mod_varlen.py
@@ -1249,7 +1249,7 @@ def run_cute_flash_bwd_varlen(
         dq, dk, dv = torch.autograd.grad(out, (q, k, v), grad_out)
         return out, grad_out, dq, dk, dv
 
-    out, lse = _flash_attn_fwd(
+    out, lse, *_ = _flash_attn_fwd(
         q,
         k,
         v,
@@ -1261,7 +1261,7 @@ def run_cute_flash_bwd_varlen(
         pack_gqa=pack_gqa,
     )
     grad_out = torch.randn_like(out)
-    dq, dk, dv = _flash_attn_bwd(
+    dq, dk, dv, *_ = _flash_attn_bwd(
         q,
         k,
         v,

--- a/tests/cute/test_score_mod_varlen.py
+++ b/tests/cute/test_score_mod_varlen.py
@@ -612,7 +612,10 @@ def test_varlen_with_score_mod_vectorized(
             cu_seqlens_q=cu_seqlens_q,
             cu_seqlens_k=cu_seqlens_k,
         )
-        assert torch.equal(out, out_ref)
+        # Vectorized codegen reorders float ops vs the scalar path; softmax amplifies
+        # the resulting 1-ulp score differences (measured max 4e-4 fp16 / 2.9e-3 bf16 on sm103).
+        rtol, atol = (2e-3, 1e-3) if dtype == torch.float16 else (1.6e-2, 5e-3)
+        assert torch.allclose(out, out_ref, rtol=rtol, atol=atol)
 
 
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])


### PR DESCRIPTION
Lifts the current restriction on `score_mod` being used in FA-4 backward with variable sequence length. Supersedes PR #2544. 

I added some examples of backwards score mods that use globally-indexed aux tensors to showcase the API. 

cc @drisspg @v0i0 