### PR TITLE
[Cute,Bwd,Sm100] fix incorrect calculation of n_block global max for bwd deterministic

### DIFF
--- a/flash_attn/cute/block_info.py
+++ b/flash_attn/cute/block_info.py
@@ -143,8 +143,8 @@ class BlockInfo:
         self,
         seqlen_info: SeqlenInfoQK,
         m_block: Int32,
-        n_block_global_max: Int32,
     ) -> Int32:
+        n_block_max = cute.ceil_div(seqlen_info.seqlen_k, self.tile_n)
         if const_expr(self.is_causal or self.window_size_right is not None):
             m_idx_max = (m_block + 1) * self.tile_m
             if const_expr(self.qhead_per_kvhead_packgqa > 1):
@@ -152,5 +152,5 @@ class BlockInfo:
             n_idx_right = m_idx_max + seqlen_info.seqlen_k - seqlen_info.seqlen_q
             if const_expr(self.window_size_right is not None):
                 n_idx_right += self.window_size_right
-            return min(n_block_global_max, cute.ceil_div(n_idx_right, self.tile_n))
-        return n_block_global_max
+            n_block_max = min(n_block_max, cute.ceil_div(n_idx_right, self.tile_n))
+        return n_block_max

--- a/flash_attn/cute/flash_bwd_sm100.py
+++ b/flash_attn/cute/flash_bwd_sm100.py
@@ -3432,13 +3432,10 @@ class FlashAttentionBackwardSm100:
         seqlen,
         m_block: Int32,
         n_block: Int32,
-        n_block_global_max: Int32,
     ) -> Int32:
         lock_value = n_block
         if const_expr(self.spt):
-            n_block_max_for_m_block = block_info.get_n_block_max_for_m_block(
-                seqlen, m_block, n_block_global_max
-            )
+            n_block_max_for_m_block = block_info.get_n_block_max_for_m_block(seqlen, m_block)
             lock_value = n_block_max_for_m_block - 1 - n_block
         if const_expr(self.use_block_sparsity):
             assert blocksparse_tensors is not None
@@ -3528,7 +3525,6 @@ class FlashAttentionBackwardSm100:
                 mdQ_semaphore_cur = mdQ_semaphore[None, None, head_idx, batch_idx]
 
             delay_semaphore_release = not self.tile_hdim == 192 and not self.use_block_sparsity
-            n_block_global_max = cute.ceil_div(seqlen.seqlen_k, self.tile_n)
 
             curr_q_cnt = Int32(0)
             curr_q_idx = None
@@ -3627,7 +3623,6 @@ class FlashAttentionBackwardSm100:
                                 seqlen,
                                 m_block,
                                 n_block_cta_group,
-                                n_block_global_max,
                             )
                             barrier.wait_eq(
                                 mdQ_semaphore_cur[(m_block, None)].iterator,


### PR DESCRIPTION
PR https://github.com/Dao-AILab/flash-attention/pull/2253 refactored the bwd dQ deterministic code by introducing a new `get_n_block_max_for_m_block` method, however this took in an incorrect calculation of `n_block_global_max` by using the cta rather than the cluster n tile (thus doubling the value), which sometimes breaks deterministic mode for 2cta backward. Note that BlockInfo's tile_n is the indeed the cluster tile_n by definition in the kernel.

This PR fixes the bug by determining `n_block_global_max` inside `get_n_block_max_for_m_block`, matching the existing logic in `get_n_block_min_max`.

@drisspg 