### PR TITLE
[CuTe,Bwd,Sm100] allow 2cta with score mod and mask mod in bwd

### DIFF
--- a/flash_attn/cute/flash_bwd_sm100.py
+++ b/flash_attn/cute/flash_bwd_sm100.py
@@ -82,13 +82,7 @@ class FlashAttentionBackwardSm100:
         assert self.tile_hdim <= 128 or (self.tile_hdim == 192 and self.tile_hdimv == 128)
         assert self.tile_hdimv <= 128
 
-        self.use_2cta_instrs = bool(
-            use_2cta_instrs
-            and cluster_size == 2
-            and score_mod is None
-            and score_mod_bwd is None
-            and mask_mod is None
-        )
+        self.use_2cta_instrs = bool(use_2cta_instrs and cluster_size == 2)
         self.cta_group_size = 2 if self.use_2cta_instrs else 1
 
         assert self.tile_hdim != 192 or self.use_2cta_instrs, "Must use 2CTA for hdim 192"
@@ -2758,9 +2752,15 @@ class FlashAttentionBackwardSm100:
         fastdiv_mods=(None, None),
     ):
         """Apply forward score modification for SM100 backward pass."""
-        # In bwd, S is computed as K @ Q.T so dimensions are (tile_n, tile_m)
-        cS = cute.make_identity_tensor((self.tile_n, self.tile_m))
-        cS = cute.domain_offset((n_block * self.tile_n, m_block * self.tile_m), cS)
+        # In bwd, S is computed as K @ Q.T so dimensions are (tile_n, tile_m).
+        # With 2CTA, partition_C must see the full cluster tile so each CTA 
+        # gets its own half of the tile.
+        cluster_tile_n = self.tile_n * self.cta_group_size
+        cluster_n_block = n_block // self.cta_group_size
+        cS = cute.make_identity_tensor((cluster_tile_n, self.tile_m))
+        cS = cute.domain_offset(
+            (cluster_n_block * cluster_tile_n, m_block * self.tile_m), cS
+        )
         tScS = thr_mma_S.partition_C(cS)
         tScS_idx = thr_copy_t2r.partition_D(tScS)
 
@@ -2976,13 +2976,13 @@ class FlashAttentionBackwardSm100:
                 seqlen, n_block // self.cluster_shape_mnk[0]
             )
             mask = AttentionMaskCls(seqlen)
-            n_block_for_cluster = n_block // self.cta_group_size
+            cluster_n_block = n_block // self.cta_group_size
             # TODO: condition mask_seqlen
             mask_fn = partial(
                 mask.apply_mask_sm100_transposed,
                 tScS_t2r=tScS_t2r,
                 t0ScS_t2r=t0ScS_t2r,
-                n_block=n_block_for_cluster,
+                n_block=cluster_n_block,
                 mask_seqlen=True,
                 mask_causal=self.is_causal,
                 mask_local=self.is_local,
@@ -3194,9 +3194,12 @@ class FlashAttentionBackwardSm100:
 
                     if const_expr(self.score_mod_bwd is not None):
                         tSrS_pre_cur = tSrS_pre[None, stage, 0, 0]
-                        cS_bwd = cute.make_identity_tensor((self.tile_n, self.tile_m))
+                        cluster_tile_n = self.tile_n * self.cta_group_size
+                        cluster_n_block = n_block // self.cta_group_size
+                        cS_bwd = cute.make_identity_tensor((cluster_tile_n, self.tile_m))
                         cS_bwd = cute.domain_offset(
-                            (n_block * self.tile_n, m_block * self.tile_m), cS_bwd
+                            (cluster_n_block * cluster_tile_n, m_block * self.tile_m),
+                            cS_bwd,
                         )
                         tScS_bwd = thr_mma_S.partition_C(cS_bwd)
                         tScS_idx_bwd = thr_copy_t2r.partition_D(tScS_bwd)

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -1323,9 +1323,6 @@ def _flash_attn_bwd(
         requested_disable_2cta = utils._get_disable_2cta_default()
         disable_2cta = (
             requested_disable_2cta
-            or score_mod is not None
-            or score_mod_bwd is not None
-            or mask_mod is not None
             or block_sparse_tensors is not None
         )
         cluster_size = 2 if head_dim >= 128 and not disable_2cta else 1

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -349,11 +349,10 @@ def test_flash_attn_output(
             and not has_qv
             and not dv > 256
             and not attention_chunk != 0
-            and softcap == 0.0
             and (
                 (dv == d and d <= 128)
                 or (d == 192 and dv == 128)
-                or (IS_SM100 and d == 256 and dv == 256)
+                or (IS_SM100 and d == 256 and dv == 256 and softcap == 0.0)
             )
             and learnable_sink is None
             # and False


### PR DESCRIPTION
This PR enables the 2cta version of the backward kernel with `score_mod` and `mask_mod` callables. Beyond a (frequent but not consistent) perf improvement, this enables softcap with hdim 192. 

Some perf numbers:
```
2CTA bwd speedup per (b, s) — SM100, hdim=128
  (cell = bwd_1cta_ms / bwd_2cta_ms;  nc = non-causal, c = causal)

  ┌────────────┬─────────────┬─────────────┬─────────────┬─────────────┬─────────────┐
  │            │  identity   │    alibi    │ batch_bias  │ dual_buffer │  times_two  │
  │  (b,  s)   │   nc /  c   │   nc /  c   │   nc /  c   │   nc /  c   │   nc /  c   │
  ├────────────┼─────────────┼─────────────┼─────────────┼─────────────┼─────────────┤
  │ ( 8, 1024) │ 2.62 / 0.95 │ 2.48 / 2.97 │ 1.02 / 0.94 │ 1.86 / 2.32 │ 0.97 / 0.97 │
  │ ( 4, 2048) │ 0.97 / 1.15 │ 1.02 / 0.96 │ 1.01 / 1.23 │ 1.01 / 0.96 │ 1.00 / 0.91 │
  │ ( 4, 4096) │ 1.02 / 1.20 │ 0.95 / 1.04 │ 0.97 / 0.98 │ 0.85 / 0.84 │ 1.00 / 1.17 │
  │ ( 2, 8192) │ 1.04 / 1.17 │ 0.94 / 1.03 │ 1.04 / 1.02 │ 0.88 / 0.88 │ 1.02 / 1.12 │
  │ ( 1,16384) │ 1.13 / 1.22 │ 1.05 / 1.07 │ 1.02 / 1.10 │ 0.97 / 0.91 │ 1.03 / 1.16 │
  └────────────┴─────────────┴─────────────┴─────────────┴─────────────┴─────────────┘
```
We could add an optional attribute to mods `score_mod.__disable_2cta__` for those cases where it regresses. Thoughts greatly appreciated. 

Tests passing:
<img width="825" height="207" alt="Screenshot 2026-05-12 at 5 43 00 PM" src="https://github.com/user-attachments/assets/386f00b6-0bd8-4f65-ab3e-55bf1462720d" />
<img width="823" height="139" alt="Screenshot 2026-05-12 at 5 49 59 PM" src="https://github.com/user-attachments/assets/d82e22dc-4f17-42f4-a496-89ec8d829665" />
<img width="818" height="139" alt="Screenshot 2026-05-12 at 5 52 57 PM" src="https://github.com/user-attachments/assets/55041fd1-9024-4c24-b133-b8ede0681509" />
<img width="857" height="378" alt="Screenshot 2026-05-12 at 6 49 31 PM" src="https://github.com/user-attachments/assets/521a03bd-f08f-4a5a-a254-911e6c1a6f91" />

cc: @drisspg @v0i0 