### PR TITLE
Normalize scalar tensors in CuTe JIT cache keys

### DIFF
--- a/flash_attn/cute/cache_utils.py
+++ b/flash_attn/cute/cache_utils.py
@@ -16,6 +16,7 @@ import ctypes
 import cutlass
 import cutlass.cute as cute
 import tvm_ffi
+import torch
 from cutlass.cutlass_dsl import JitCompiledFunction
 from flash_attn.cute.fa_logging import fa_log
 
@@ -29,6 +30,26 @@ for _lib_path in cute.runtime.find_runtime_libraries(enable_tvm_ffi=False):
 
 CompileKeyType: TypeAlias = tuple[Hashable, ...]
 CallableFunction: TypeAlias = JitCompiledFunction | tvm_ffi.Function
+
+
+def _normalize_compile_key(key: CompileKeyType) -> CompileKeyType:
+    """Normalize scalar tensors in compile keys.
+
+    CuTeDSL compile keys are compared and hashed on the Python side.  A scalar
+    tensor in the key would otherwise compare by object identity, so two keys
+    with the same scalar value but produced by different layers would miss the
+    in-memory and persistent JIT caches.
+    """
+
+    def normalize(x):
+        if isinstance(x, torch.Tensor) and x.ndim == 0:
+            return x.item()
+        if isinstance(x, tuple):
+            return tuple(normalize(v) for v in x)
+        return x
+
+    return tuple(normalize(v) for v in key)
+
 
 # Enable cache via `FLASH_ATTENTION_CUTE_DSL_CACHE_ENABLED=1`
 CUTE_DSL_CACHE_ENABLED: bool = os.getenv("FLASH_ATTENTION_CUTE_DSL_CACHE_ENABLED", "0") == "1"
@@ -155,13 +176,13 @@ class JITCache:
         self.cache: dict[CompileKeyType, CallableFunction] = {}
 
     def __setitem__(self, key: CompileKeyType, fn: JitCompiledFunction) -> None:
-        self.cache[key] = fn
+        self.cache[_normalize_compile_key(key)] = fn
 
     def __getitem__(self, key: CompileKeyType) -> CallableFunction:
-        return self.cache[key]
+        return self.cache[_normalize_compile_key(key)]
 
     def __contains__(self, key: CompileKeyType) -> bool:
-        return key in self.cache
+        return _normalize_compile_key(key) in self.cache
 
     def clear(self) -> None:
         """
@@ -246,7 +267,7 @@ class JITPersistentCache(JITCache):
             fa_log(1, f"Successfully exported compiled function to disk: {obj_path}")
 
     def _key_to_hash(self, key: CompileKeyType) -> str:
-        return hashlib.sha256(pickle.dumps(key)).hexdigest()
+        return hashlib.sha256(pickle.dumps(_normalize_compile_key(key))).hexdigest()
 
     def _lock_path(self, sha256_hex: str) -> Path:
         return self.cache_path / f"{sha256_hex}.lock"

--- a/tests/cute/test_cache_utils.py
+++ b/tests/cute/test_cache_utils.py
@@ -1,6 +1,8 @@
 import logging
 from types import SimpleNamespace
 
+import torch
+
 import flash_attn.cute.cache_utils as cache_utils
 from flash_attn.cute import fa_logging
 
@@ -28,3 +30,26 @@ def test_persistent_cache_hit_logs_at_host_level_only(tmp_path, monkeypatch, cap
         assert "Loading compiled function from disk" in caplog.text
     finally:
         monkeypatch.setattr(fa_logging, "_fa_log_level", original_level)
+
+
+def test_scalar_tensor_compile_keys_are_normalized():
+    cache = cache_utils.JITCache()
+    fn = object()
+
+    key0 = ("kernel", torch.tensor(128, dtype=torch.int32), (torch.tensor(False),))
+    key1 = ("kernel", torch.tensor(128, dtype=torch.int64), (torch.tensor(False),))
+
+    cache[key0] = fn
+
+    assert key1 in cache
+    assert cache[key1] is fn
+    assert list(cache.cache.keys()) == [("kernel", 128, (False,))]
+
+
+def test_persistent_cache_hash_normalizes_scalar_tensors(tmp_path):
+    cache = cache_utils.JITPersistentCache(tmp_path)
+
+    key0 = ("kernel", torch.tensor(128, dtype=torch.int32), (torch.tensor(False),))
+    key1 = ("kernel", torch.tensor(128, dtype=torch.int64), (torch.tensor(False),))
+
+    assert cache._key_to_hash(key0) == cache._key_to_hash(key1)


### PR DESCRIPTION
CuTeDSL compile keys are compared and hashed on the Python side. If a scalar tensor gets into the key, two keys with the same scalar value but produced by different layers compare by object identity and miss both the in-memory and persistent JIT caches.

This can happen in FA4 varlen backward when `max_seqlen_q/k` are scalar tensors and the backward compile key includes derived single-block predicates such as `seqlen_q_rounded // m_block_size == 1`. Each layer can produce a fresh scalar tensor, causing repeated backward JIT compilation for the same kernel shape.

This PR normalizes scalar tensors in CuTe JIT cache keys before in-memory lookup/storage and before computing the persistent cache hash.

Tests added:
- in-memory cache lookup with distinct scalar tensor objects but identical values
- persistent cache hash stability for scalar tensor keys

Local validation:
- manual CPU scalar cache normalization check passed
- manual CUDA scalar cache normalization check passed on GPU7

Could not run pytest locally because pytest is not installed in the available environment.
