### PR TITLE
Add descriptive FlashAttention kernel names

### DIFF
--- a/flash_attn/cute/cute_dsl_utils.py
+++ b/flash_attn/cute/cute_dsl_utils.py
@@ -123,6 +123,129 @@ def get_broadcast_dims(tensor: torch.Tensor) -> Tuple[bool, ...]:
     return tuple(s == 0 for s in tensor.stride())
 
 
+_DTYPE_SHORT_NAMES = {
+    torch.float16: "f16",
+    torch.bfloat16: "bf16",
+    torch.float32: "f32",
+    torch.float8_e4m3fn: "e4m3",
+    torch.float8_e5m2: "e5m2",
+    cutlass.Float16: "f16",
+    cutlass.BFloat16: "bf16",
+    cutlass.Float32: "f32",
+    cutlass.Float8E4M3FN: "e4m3",
+    cutlass.Float8E5M2: "e5m2",
+}
+
+
+def short_dtype_name(dtype):
+    """Return a compact dtype label suitable for a kernel symbol."""
+    return _DTYPE_SHORT_NAMES.get(dtype, str(dtype).replace("torch.", "").replace(".", "_"))
+
+
+def make_kernel_name_prefix(
+    prefix,
+    *,
+    arch=None,
+    dtype=None,
+    head_dim=None,
+    head_dim_v=None,
+    qhead_per_kvhead=None,
+    tile_m=None,
+    tile_n=None,
+    q_stage=None,
+    dout_stage=None,
+    num_threads=None,
+    q_subtile_factor=None,
+    causal=False,
+    local=False,
+    varlen=False,
+    paged=False,
+    paged_non_tma=False,
+    split_kv=False,
+    pack_gqa=False,
+    use_2cta=False,
+    use_clc=False,
+    deterministic=False,
+    dq_single_wg=False,
+    spt=False,
+    cluster_size=None,
+    mma_pv_is_rs=False,
+    intra_wg_overlap=False,
+    no_lse=False,
+    has_score_mod=False,
+    has_mask_mod=False,
+    has_block_sparsity=False,
+    has_learnable_sink=False,
+    has_qv=False,
+    has_descale=False,
+    has_aux=False,
+):
+    """Build a readable prefix for CuTeDSL's normally mangled kernel symbol."""
+    parts = [prefix]
+    if arch is not None:
+        parts.append(f"sm{arch}")
+    if dtype is not None:
+        parts.append(short_dtype_name(dtype))
+    if head_dim is not None:
+        if head_dim_v in (None, head_dim):
+            parts.append(f"head_dim{head_dim}")
+        else:
+            parts.extend((f"head_dim{head_dim}", f"value_dim{head_dim_v}"))
+    if qhead_per_kvhead and qhead_per_kvhead > 1:
+        parts.append(f"gqa_ratio{qhead_per_kvhead}")
+    if tile_m and tile_n:
+        parts.append(f"tile{tile_m}x{tile_n}")
+    if q_stage is not None and q_stage != 1:
+        parts.append(f"q_stages{q_stage}")
+    if dout_stage is not None and dout_stage != 1:
+        parts.append(f"dout_stages{dout_stage}")
+    if num_threads is not None:
+        parts.append(f"threads{num_threads}")
+    if q_subtile_factor is not None and q_subtile_factor != 1:
+        parts.append(f"q_subtile{q_subtile_factor}")
+    for cond, tag in (
+        (causal, "causal"),
+        (local, "local"),
+        (varlen, "varlen"),
+        (paged, "paged"),
+        (paged_non_tma, "paged_non_tma"),
+        (split_kv, "split_kv"),
+        (pack_gqa, "pack_gqa"),
+        (use_2cta, "use_2cta"),
+        (use_clc, "clc_scheduler"),
+        (deterministic, "deterministic"),
+        (dq_single_wg, "dq_single_wg"),
+        (spt, "spt_scheduler"),
+        (cluster_size is not None and cluster_size > 1, f"cluster_size{cluster_size}"),
+        (mma_pv_is_rs, "pv_mma_rs"),
+        (intra_wg_overlap, "intra_wg_overlap"),
+        (no_lse, "no_lse"),
+        (has_score_mod, "score_mod"),
+        (has_mask_mod, "mask_mod"),
+        (has_block_sparsity, "block_sparse"),
+        (has_learnable_sink, "learnable_sink"),
+        (has_qv, "qv"),
+        (has_descale, "descale"),
+        (has_aux, "aux"),
+    ):
+        if cond:
+            parts.append(tag)
+    return "_".join(parts)
+
+
+def compile_with_kernel_name_prefix(op, *args, name_prefix, options="--enable-tvm-ffi"):
+    """Compile a CuTeDSL op with a temporary GPU kernel name prefix."""
+    kernel = type(op).kernel
+    kernel.set_name_prefix(name_prefix)
+    try:
+        return cute.compile(op, *args, options=options)
+    finally:
+        kernel.set_name_prefix(None)
+        dsl = kernel.__wrapped__.__dict__.get("_dsl_object")
+        if dsl is not None:
+            dsl._name_prefix = None
+
+
 # credit: monellz (https://github.com/NVIDIA/cutlass/issues/2658#issuecomment-3630564264)
 def dump_kernel_attributes(compiled_kernel):
     from cuda.bindings import driver

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -29,8 +29,10 @@ if os.environ.get("CUTE_DSL_PTXAS_PATH", None) is not None:
 from flash_attn.cute import utils
 from flash_attn.cute import fa_logging
 from flash_attn.cute.cute_dsl_utils import (
+    compile_with_kernel_name_prefix,
     get_aux_tensor_metadata,
     get_broadcast_dims,
+    make_kernel_name_prefix,
     to_cute_aux_tensor,
     to_cute_tensor,
 )
@@ -763,6 +765,40 @@ def _flash_attn_fwd(
         disable_sparse_kv_bitmask,
         fa_logging.get_fa_log_level(),
     )
+    kernel_name_prefix = make_kernel_name_prefix(
+        "flash_fwd",
+        arch=arch,
+        dtype=dtype,
+        head_dim=head_dim,
+        head_dim_v=head_dim_v,
+        qhead_per_kvhead=qhead_per_kvhead,
+        tile_m=tile_m,
+        tile_n=tile_n,
+        q_stage=q_stage,
+        num_threads=num_threads,
+        q_subtile_factor=q_subtile_factor,
+        causal=causal,
+        local=local,
+        varlen=any(
+            x is not None for x in (cu_seqlens_q, cu_seqlens_k, seqused_q, seqused_k)
+        ),
+        paged=page_table is not None,
+        paged_non_tma=page_size not in [None, tile_n],
+        split_kv=is_split_kv,
+        pack_gqa=pack_gqa,
+        use_2cta=use_2cta_instrs,
+        use_clc=use_clc_scheduler,
+        mma_pv_is_rs=mma_pv_is_rs,
+        intra_wg_overlap=intra_wg_overlap,
+        no_lse=lse is None,
+        has_score_mod=score_mod is not None,
+        has_mask_mod=mask_mod is not None,
+        has_block_sparsity=use_block_sparsity,
+        has_learnable_sink=learnable_sink is not None,
+        has_qv=qv is not None,
+        has_descale=any(x is not None for x in (q_descale, k_descale, v_descale)),
+        has_aux=bool(aux_tensor_metadata or aux_scalar_metadata),
+    )
 
     if compile_key not in _flash_attn_fwd.compile_cache:
         (
@@ -965,7 +1001,7 @@ def _flash_attn_fwd(
             )
         # TODO: check @can_implement
         if qv is not None:
-            _flash_attn_fwd.compile_cache[compile_key] = cute.compile(
+            compile_args = [
                 fa_fwd,
                 q_tensor,
                 qv_tensor,
@@ -985,8 +1021,7 @@ def _flash_attn_fwd(
                 window_size_left,
                 window_size_right,
                 current_stream,
-                options="--enable-tvm-ffi",
-            )
+            ]
         else:
             compile_args = [
                 fa_fwd,
@@ -1012,9 +1047,9 @@ def _flash_attn_fwd(
                 AuxData(cute_aux_tensors, aux_scalars),
             ])
             compile_args.append(current_stream)
-            _flash_attn_fwd.compile_cache[compile_key] = cute.compile(
-                *compile_args, options="--enable-tvm-ffi"
-            )
+        _flash_attn_fwd.compile_cache[compile_key] = compile_with_kernel_name_prefix(
+            *compile_args, name_prefix=kernel_name_prefix
+        )
 
     if not is_fake_mode():
         q_call, k_call, v_call, qv_call = [
@@ -1190,11 +1225,22 @@ def _compile_bwd_preprocess(
         qhead_per_kvhead=qhead_per_kvhead,
         nheads_kv=nheads_kv,
     )
-    return cute.compile(
+    kernel_name_prefix = make_kernel_name_prefix(
+        "flash_bwd_preprocess",
+        dtype=dtype,
+        head_dim=head_dim,
+        head_dim_v=head_dim_v,
+        qhead_per_kvhead=qhead_per_kvhead,
+        tile_m=m_block_size,
+        tile_n=m_block_size,
+        varlen=has_cuseqlens_q or has_seqused_q,
+        pack_gqa=pack_gqa,
+    )
+    return compile_with_kernel_name_prefix(
         fa_bwd_pre, mO, mdO, mPdPsum, mLSE, mLSElog2, mdQaccum, mCuSeqlensQ, mSequsedQ, mdLSE,
         mRowMax, mScaleP, softmax_scale,
         cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True),
-        options="--enable-tvm-ffi",
+        name_prefix=kernel_name_prefix,
     )
 
 
@@ -1258,10 +1304,22 @@ def _compile_bwd_postprocess(
         use_2cta_instrs=use_2cta_instrs,
         cluster_size=cluster_size,
     )
-    return cute.compile(
+    kernel_name_prefix = make_kernel_name_prefix(
+        "flash_bwd_postprocess",
+        arch=arch,
+        dtype=dtype,
+        head_dim=hdim,
+        tile_m=block_size,
+        tile_n=block_size,
+        num_threads=num_threads,
+        varlen=has_cuseqlens_q or has_seqused_q,
+        use_2cta=use_2cta_instrs,
+        cluster_size=cluster_size,
+    )
+    return compile_with_kernel_name_prefix(
         fa_bwd_post, mdQaccum, mdQ, Float32(0.0), mCuSeqlensQ, mSeqUsedQ,
         cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True),
-        options="--enable-tvm-ffi",
+        name_prefix=kernel_name_prefix,
     )
 
 
@@ -1346,6 +1404,7 @@ def _flash_attn_bwd(
     causal, local, window_size_left, window_size_right = _resolve_causal_local_window(
         causal, window_size_left, window_size_right
     )
+    dQ_single_wg = False
 
     if arch // 10 == 12:
         # SM120: uses SM80 MMA with 99 KB SMEM, 128 threads (4 warps).
@@ -1764,6 +1823,36 @@ def _flash_attn_bwd(
             (seqlen_k_rounded // n_block_size == 1),
         )
 
+    kernel_name_prefix = make_kernel_name_prefix(
+        "flash_bwd",
+        arch=arch,
+        dtype=dtype,
+        head_dim=head_dim,
+        head_dim_v=head_dim_v,
+        qhead_per_kvhead=qhead_per_kvhead,
+        tile_m=m_block_size,
+        tile_n=n_block_size,
+        q_stage=num_stages_Q,
+        dout_stage=num_stages_dO,
+        num_threads=num_threads,
+        q_subtile_factor=q_subtile_factor,
+        causal=causal,
+        local=local,
+        varlen=any(
+            x is not None for x in (cu_seqlens_q, cu_seqlens_k, seqused_q, seqused_k)
+        ),
+        pack_gqa=pack_gqa,
+        use_2cta=use_2cta_instrs,
+        deterministic=deterministic,
+        dq_single_wg=dQ_single_wg,
+        spt=spt,
+        cluster_size=cluster_size,
+        has_score_mod=score_mod is not None or score_mod_bwd is not None,
+        has_mask_mod=mask_mod is not None,
+        has_block_sparsity=use_block_sparsity,
+        has_aux=bool(num_aux_tensors or aux_scalar_metadata),
+    )
+
     if compile_key not in _flash_attn_bwd.compile_cache:
         q_tensor, k_tensor, v_tensor, do_tensor, dq_tensor, dk_tensor, dv_tensor = [
             to_cute_tensor(t) for t in (q, k, v, dout, dq, dk, dv)
@@ -1895,7 +1984,7 @@ def _flash_attn_bwd(
         dq_accum_tensor = dq_tensor if use_dedicated_hd256_kernel else dq_accum_tensor
 
         # TODO: check @can_implement
-        _flash_attn_bwd.compile_cache[compile_key] = cute.compile(
+        _flash_attn_bwd.compile_cache[compile_key] = compile_with_kernel_name_prefix(
             fa_bwd_obj,
             q_tensor,
             k_tensor,
@@ -1919,7 +2008,7 @@ def _flash_attn_bwd(
             AuxData(cute_aux_tensors, aux_scalars),
             sparse_tensors_compile,
             current_stream,
-            options="--enable-tvm-ffi",
+            name_prefix=kernel_name_prefix,
         )
     if not is_fake_mode():
         dq_accum = dq if use_dedicated_hd256_kernel else dq_accum
@@ -2892,12 +2981,22 @@ def _compile_fwd_combine(
     mVarlenBatchIdx = fake_tensor(Int32, (batch_for_1d,), divisibility=1) if has_varlen_batch_idx else None
     mSemaphore = None  # Not parametrized in compile_key
 
-    return cute.compile(
+    kernel_name_prefix = make_kernel_name_prefix(
+        "flash_fwd_combine",
+        dtype=dtype,
+        head_dim=head_dim,
+        tile_m=tile_m,
+        tile_n=k_block_size,
+        num_threads=256,
+        varlen=has_cu_seqlens or has_seqused,
+        split_kv=True,
+    )
+    return compile_with_kernel_name_prefix(
         fa_combine,
         mO_partial, mLSE_partial, mO, mLSE,
         mCuSeqlens, mSeqused, mNumSplitsDynamic, mVarlenBatchIdx, mSemaphore,
         cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True),
-        options="--enable-tvm-ffi",
+        name_prefix=kernel_name_prefix,
     )
 
 

--- a/tests/cute/test_cute_dsl_utils.py
+++ b/tests/cute/test_cute_dsl_utils.py
@@ -1,0 +1,83 @@
+import torch
+import cutlass
+
+from flash_attn.cute.cute_dsl_utils import make_kernel_name_prefix
+
+
+def test_make_kernel_name_prefix_dense_forward():
+    assert make_kernel_name_prefix(
+        "flash_fwd",
+        arch=100,
+        dtype=cutlass.BFloat16,
+        head_dim=128,
+        head_dim_v=128,
+        tile_m=128,
+        tile_n=128,
+        q_stage=2,
+        num_threads=384,
+        causal=True,
+        use_2cta=True,
+    ) == (
+        "flash_fwd_sm100_bf16_head_dim128_tile128x128_q_stages2_threads384_"
+        "causal_use_2cta"
+    )
+
+
+def test_make_kernel_name_prefix_backward():
+    assert make_kernel_name_prefix(
+        "flash_bwd",
+        arch=100,
+        dtype=cutlass.BFloat16,
+        head_dim=128,
+        qhead_per_kvhead=8,
+        tile_m=128,
+        tile_n=128,
+        q_stage=2,
+        dout_stage=2,
+        num_threads=384,
+        q_subtile_factor=2,
+        causal=True,
+        varlen=True,
+        pack_gqa=True,
+        use_2cta=True,
+        deterministic=True,
+        dq_single_wg=True,
+        spt=True,
+        cluster_size=2,
+        has_score_mod=True,
+        has_mask_mod=True,
+        has_block_sparsity=True,
+        has_aux=True,
+    ) == (
+        "flash_bwd_sm100_bf16_head_dim128_gqa_ratio8_tile128x128_q_stages2_"
+        "dout_stages2_threads384_q_subtile2_causal_varlen_pack_gqa_use_2cta_"
+        "deterministic_dq_single_wg_spt_scheduler_cluster_size2_score_mod_mask_mod_"
+        "block_sparse_aux"
+    )
+
+
+def test_make_kernel_name_prefix_feature_tags():
+    assert make_kernel_name_prefix(
+        "flash_fwd",
+        arch=100,
+        dtype=torch.float16,
+        head_dim=192,
+        head_dim_v=128,
+        qhead_per_kvhead=8,
+        tile_m=192,
+        tile_n=128,
+        q_subtile_factor=2,
+        varlen=True,
+        paged=True,
+        paged_non_tma=True,
+        split_kv=True,
+        pack_gqa=True,
+        use_clc=True,
+        has_score_mod=True,
+        has_block_sparsity=True,
+        has_aux=True,
+    ) == (
+        "flash_fwd_sm100_f16_head_dim192_value_dim128_gqa_ratio8_tile192x128_"
+        "q_subtile2_varlen_paged_paged_non_tma_split_kv_pack_gqa_clc_scheduler_"
+        "score_mod_block_sparse_aux"
+    )


### PR DESCRIPTION
# Summary

Give the standard FA4 attention kernels readable, configuration-aware names in profilers and PTX/SASS dumps. The readable portion comes first, while CuTeDSL’s native mangled arguments remain at the end for specialization and uniqueness.

## Before and after

### Forward

Before:

```text
kernel_cutlass_kernel_flash_attncuteflash_fwd_sm100FlashAttentionForwardSm100_object_at__tensor0000o11101213_..._0
```

After:

```text
flash_fwd_sm100_bf16_head_dim128_tile128x128_threads384_causal_pv_mma_rs_intra_wg_overlap_kernel_cutlass_kernel_flash_attncuteflash_fwd_sm100FlashAttentionForwardSm100_object_at__tensor0000o11101213_..._0
```

### Backward

Before:

```text
kernel_cutlass_kernel_flash_attncuteflash_bwd_sm100FlashAttentionBackwardSm100_object_at__tensor0000o11101213_..._0
```

After:

```text
flash_bwd_sm100_bf16_head_dim128_tile128x128_q_stages2_dout_stages2_threads384_q_subtile2_causal_use_2cta_cluster_size2_kernel_cutlass_kernel_flash_attncuteflash_bwd_sm100FlashAttentionBackwardSm100_object_at__tensor0000o11101213_..._0
```

## Named kernels

- forward attention
- SplitKV forward combine
- backward preprocess
- main backward attention
- backward postprocess

Names use explicit labels such as `head_dim128`, `gqa_ratio2`, `q_stages2`, `dout_stages2`, `threads384`, `q_subtile2`, and `cluster_size2` rather than compressed abbreviations.

Temporary CuTeDSL naming state is centralized and restored after every compile, preventing one kernel’s prefix from leaking into later compilations. Outer JIT artifact filenames are left unchanged, so PTX/IR dumping does not encounter filesystem filename-length limits.

## Testing

```text
pytest -q tests/cute/test_cute_dsl_utils.py
```

- 3 naming unit tests passed
- 400,000 seeded randomized naming cases passed across architectures, dtypes, dimensions, tiles, stages, and feature combinations
- real B200 compile/launch matrix passed for MHA, GQA, MQA, causal, non-causal, varlen, SplitKV, forward, and backward
- inspected 10 emitted PTX entries from that matrix; every entry had a readable `flash_*` prefix and retained its CuTeDSL mangled suffix
- prefix-length fuzzing compiled prefixes through 2,048 characters; real B200 execution passed through an 8,192-character prefix (8,382-character final symbol)

Representative real-GPU matrix:

```text
4 passed in 22.77s
```

Specialized sparse-MLA helper kernels are outside this PR’s scope.
