### PR TITLE
[CuTe, SM103] Update architecture assertion for SM 10.x and 11.x

### DIFF
--- a/flash_attn/cute/flash_fwd_sm100.py
+++ b/flash_attn/cute/flash_fwd_sm100.py
@@ -159,7 +159,8 @@ class FlashAttentionForwardSm100:
         assert self.split_P_arrive % 32 == 0
         assert self.split_P_arrive < self.n_block_size
         self.arch = BaseDSL._get_dsl().get_arch_enum()
-        assert self.arch >= Arch.sm_100 and self.arch <= Arch.sm_110f, "Only SM 10.x and 11.x are supported"
+        assert self.arch.is_family_of(Arch.sm_100f) or self.arch.is_family_of(Arch.sm_110f), \
+            "Only SM 10.x and 11.x are supported"
 
         self.cta_group_size = 2 if self.use_2cta_instrs else 1
         # cta_tiler M includes only 1 CTA, the scheduler will take into account the cluster shape


### PR DESCRIPTION
Fix the architecture check in `flash_fwd_sm100.py`. This keeps the intended support scope for SM 10.x and SM 11.x while avoiding incorrect behavior caused by different `Arch` enum mappings between cu13 and non-cu13 CuteDSL.

When using B300(sm103) with non-cu13 cutedsl, current [assertion](https://github.com/Dao-AILab/flash-attention/blame/8a8b2f10ddca88fd46db406c3e143e1ab0af977f/flash_attn/cute/flash_fwd_sm100.py#L162) introduced in 463623e will     narrow the effective supported range as the [arch class in cutedsl](https://github.com/NVIDIA/cutlass/blob/e406c186f510a15091cce01f782020ceb7ba8eb5/python/CuTeDSL/cutlass/base_dsl/arch.py#L28) will do:

 - For non-cu13 cutedsl: map `Arch.sm_110` and `Arch.sm_101` to `SM101`
 - For cu13 cutedsl: map `Arch.sm_101` and `Arch.sm_110` to `SM110`
 
As a result when using non-cu13 cutedsl, the current the effective range check will be `sm100<= and <=sm101` which unintentionally exclude SM103