### PR TITLE
fix(sm100): make arch check robust against CUTLASS DSL Arch enum changes

### DIFF
--- a/flash_attn/cute/flash_fwd_sm100.py
+++ b/flash_attn/cute/flash_fwd_sm100.py
@@ -159,7 +159,7 @@ class FlashAttentionForwardSm100:
         assert self.split_P_arrive % 32 == 0
         assert self.split_P_arrive < self.n_block_size
         self.arch = BaseDSL._get_dsl().get_arch_enum()
-        assert self.arch >= Arch.sm_100 and self.arch <= Arch.sm_110f, "Only SM 10.x and 11.x are supported"
+        assert self.arch.value[0] in [10, 11], "Only SM 10.x and 11.x are supported" 
 
         self.cta_group_size = 2 if self.use_2cta_instrs else 1
         # cta_tiler M includes only 1 CTA, the scheduler will take into account the cluster shape


### PR DESCRIPTION
## Summary

  The current SM100 forward kernel uses a range-based comparison for the architecture
  check:

  ```python
  assert self.arch >= Arch.sm_100 and self.arch <= Arch.sm_110f, \
      "Only SM 10.x and 11.x are supported"
```
  This relies on the ordering of Arch enum values, which is fragile. Specifically, in
  nvidia-cutlass-dsl 4.5.0, certain Arch enum entries have unexpected .value tuples,
  which can cause this assertion to misbehave on valid SM 10.x architectures (e.g.
  SM 10.3a / B300).

  ## Fix
fix: #25564 
  Replace the range comparison with a major-version check, which is independent of how
  the suffix variants (a, f, etc.) are ordered in the enum:
```
  arch_major = self.arch.value[0]
  assert arch_major in [10, 11], "Only SM 10.x and 11.x are supported"
```
  This continues to gate the kernel to SM 10.x and 11.x as intended, but no longer
  depends on the relative ordering of Arch.sm_10* / Arch.sm_11* variants in the
  upstream CUTLASS DSL package.

  ## Test

  Verified on B300 (SM 10.3a) with nvidia-cutlass-dsl==4.5.0:
```
  import torch
  from flash_attn.cute import flash_attn_func

  q = torch.randn(1, 128, 4, 128, dtype=torch.bfloat16, device='cuda')
  k = torch.randn(1, 128, 4, 128, dtype=torch.bfloat16, device='cuda')
  v = torch.randn(1, 128, 4, 128, dtype=torch.bfloat16, device='cuda')
  out, lse = flash_attn_func(q, k, v, causal=False)
  # torch.Size([1, 128, 4, 128])
```