### PR TITLE
[Cute,Fwd,Sm100] Fix FP8 precision loss at tile boundaries

### DIFF
--- a/flash_attn/cute/flash_fwd_sm100.py
+++ b/flash_attn/cute/flash_fwd_sm100.py
@@ -2001,7 +2001,6 @@ class FlashAttentionForwardSm100:
 
             rescale_threshold = (
                 8.0 if const_expr(self.q_dtype.width == 16) else
-                4.0 if const_expr(self.q_dtype.width == 8) else
                 0.0
             )
             softmax = SoftmaxSm100.create(


### PR DESCRIPTION
Fixes #2577 

## Problem

FP8 forward pass uses `rescale_threshold=4.0`, which combined with `max_offset=8` allows intermediate P values up to 2^12 = 4096, exceeding FP8 e4m3 max (448). This causes severe precision loss (cosine similarity drops to ~0.86) at KV tile boundaries (multiples of 128).

## Fix

Set `rescale_threshold=0.0` for FP8 (always rescale O-accumulator). The BF16 path retains `rescale_threshold=8.0` as before.

## Test

Paged decode GQA with kv_seqlen=1~1023. Before/after:
<img width="1800" height="750" alt="Clipboard_Screenshot_1779337869" src="https://github.com/user-attachments/assets/3ae98c92-7613-4697-985a-7a177cc075a9" />
<img width="1800" height="750" alt="Clipboard_Screenshot_1779337877" src="https://github.com/user-attachments/assets/c0160c2e-62ec-4c9c-9312-743c20019b92" />
