### PR TITLE
Wrap mask contruction in a function for mask subclassing

### DIFF
--- a/flash_attn/cute/flash_bwd_sm100.py
+++ b/flash_attn/cute/flash_bwd_sm100.py
@@ -1010,6 +1010,16 @@ class FlashAttentionBackwardSm100:
             min_blocks_per_mp=1,
         )
 
+    def _generate_attention_mask_cls(self, window_size_left, window_size_right):
+        return partial(
+            AttentionMask,
+            self.tile_m,
+            self.tile_n * self.cta_group_size,
+            swap_AB=True,
+            window_size_left=window_size_left,
+            window_size_right=window_size_right,
+        )
+
     @cute.kernel
     def kernel(
         self,
@@ -1413,13 +1423,8 @@ class FlashAttentionBackwardSm100:
         )
         TileSchedulerCls = partial(self.tile_scheduler_cls.create, tile_sched_params)
 
-        AttentionMaskCls = partial(
-            AttentionMask,
-            self.tile_m,
-            self.tile_n * self.cta_group_size,
-            swap_AB=True,
-            window_size_left=window_size_left,
-            window_size_right=window_size_right,
+        AttentionMaskCls = self._generate_attention_mask_cls(
+            window_size_left, window_size_right
         )
         #  EMPTY
         # (15)

--- a/flash_attn/cute/flash_fwd_sm100.py
+++ b/flash_attn/cute/flash_fwd_sm100.py
@@ -772,6 +772,18 @@ class FlashAttentionForwardSm100:
             min_blocks_per_mp=1,
         )
 
+    def _generate_attention_mask_cls(self, window_size_left, window_size_right):
+        return partial(
+            AttentionMask,
+            self.m_block_size,
+            self.n_block_size,
+            window_size_left=window_size_left,
+            window_size_right=window_size_right,
+            qhead_per_kvhead_packgqa=(
+                self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1
+            ),
+        )
+
     #  GPU device kernel
     @cute.kernel
     def kernel(
@@ -1060,13 +1072,8 @@ class FlashAttentionForwardSm100:
                 blocksparse_tensors.cu_block_idx_offsets if blocksparse_tensors is not None else None
             ),
         )
-        AttentionMaskCls = partial(
-            AttentionMask,
-            self.m_block_size,
-            self.n_block_size,
-            window_size_left=window_size_left,
-            window_size_right=window_size_right,
-            qhead_per_kvhead_packgqa=self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
+        AttentionMaskCls = self._generate_attention_mask_cls(
+            window_size_left, window_size_right
         )
         # Cluster wait before tensor memory alloc
         pipeline_init_wait(cluster_shape_mn=cta_layout_vmnk)


### PR DESCRIPTION
Summary:

Extract the inline `AttentionMask` construction in `FlashAttentionForwardSm100` and `FlashAttentionBackwardSm100` into an overridable `_generate_attention_mask_cls` method. This allows subclasses to inject a custom `AttentionMask` without modifying the base kernel code.

For example, a custom attention kernel can override the mask to add a `causal_q_divisor` field for scaling the `row_idx` value.

```
class CustomAttentionMask(AttentionMask):
    causal_q_divisor: cutlass.Constexpr[int] = 1

    @cute.jit
    def apply_mask_sm100(self, acc_S, m_block, n_block, ...):
        # Custom causal logic using causal_q_divisor
        row_idx = (tScS_t2r[0][0] + m_block * self.tile_m) // self.causal_q_divisor
        ...

class CustomFlashAttentionForwardSm100(FlashAttentionForwardSm100):
    def __init__(self, *args, causal_q_divisor=1, **kwargs):
        super().__init__(*args, **kwargs)
        self.causal_q_divisor = causal_q_divisor

    def _generate_attention_mask_cls(self, window_size_left, window_size_right):
        return partial(
            CustomAttentionMask,
            self.m_block_size,
            self.n_block_size,
            window_size_left=window_size_left,
            window_size_right=window_size_right,
            bottom_right=self.is_bottom_right,
            causal_q_divisor=self.causal_q_divisor,
        )
```

Test Plan:

```
$ pytest tests/cute/test_flash_attn_fast.py -v

================ 240 passed, 4139 warnings in 984.24s (0:16:24) ================
```

Reviewers:

Subscribers:

Tasks:

Tags: