### PR TITLE
fix: add weights_only=True to torch.load calls (CVE-2026-31253)

### DIFF
--- a/flash_attn/models/llama.py
+++ b/flash_attn/models/llama.py
@@ -385,7 +385,7 @@ def state_dicts_from_checkpoint(
 ) -> List[dict]:
     # Need to sort, otherwise we mess up the ordering and the weights are wrong
     return [
-        torch.load(path, map_location="cpu")
+        torch.load(path, map_location="cpu", weights_only=True)
         for path in sorted((Path(checkpoint_path) / model_name).glob("consolidated.*.pth"))
     ]
 

--- a/flash_attn/utils/pretrained.py
+++ b/flash_attn/utils/pretrained.py
@@ -59,7 +59,7 @@ def state_dict_from_pretrained(model_name, device=None, dtype=None):
     if load_safe:
         loader = partial(safe_load_file, device=mapped_device)
     else:
-        loader = partial(torch.load, map_location=mapped_device)
+        loader = partial(torch.load, map_location=mapped_device, weights_only=True)
 
     if is_sharded:
         # resolved_archive_file becomes a list of files that point to the different

--- a/training/src/eval.py
+++ b/training/src/eval.py
@@ -31,7 +31,7 @@ def load_checkpoint(path, device='cpu'):
         path /= 'last.ckpt'
     # dst = f'cuda:{torch.cuda.current_device()}'
     log.info(f'Loading checkpoint from {str(path)}')
-    state_dict = torch.load(path, map_location=device)
+    state_dict = torch.load(path, map_location=device, weights_only=True)
     # T2T-ViT checkpoint is nested in the key 'state_dict_ema'
     if state_dict.keys() == {'state_dict_ema'}:
         state_dict = state_dict['state_dict_ema']

--- a/training/src/utils/checkpoint.py
+++ b/training/src/utils/checkpoint.py
@@ -17,7 +17,7 @@ def load_checkpoint(path, device='cpu'):
         else:
             raise ValueError(f"Unable to find 'latest' file at {latest_path}")
         path /= f'{tag}/mp_rank_00_model_states.pt'
-    state_dict = torch.load(path, map_location=device)
+    state_dict = torch.load(path, map_location=device, weights_only=True)
     if is_deepspeed:
         state_dict = state_dict['module']
 


### PR DESCRIPTION
## Summary

`torch.load` without `weights_only=True` allows arbitrary code execution via crafted pickle payloads. This adds `weights_only=True` to all four `torch.load` call sites flagged by CVE-2026-31253:

- `training/src/utils/checkpoint.py`
- `training/src/eval.py`
- `flash_attn/utils/pretrained.py`
- `flash_attn/models/llama.py`

All four sites load model state dicts (nested `dict[str, Tensor]` structures), which are fully supported by the safe unpickler.

Fixes #2583