### PR TITLE
docs: fix misleading comment about num_splits accumulator tensors

### DIFF
--- a/hopper/flash_attn_interface.py
+++ b/hopper/flash_attn_interface.py
@@ -248,7 +248,7 @@ def _flash_attn_forward_fake(
             out_accum = torch.empty((num_splits, batch_size, num_heads, seqlen_q, head_size_v), dtype=torch.float32, device=q.device)
             softmax_lse_accum = torch.empty((num_splits, batch_size, num_heads, seqlen_q), dtype=torch.float32, device=q.device)
     else:
-        # Tensors are not set when num_splits < 1
+        # num_splits == 1: no accumulator needed, pass empty placeholders to the kernel
         out_accum = torch.tensor([], device=out.device)
         softmax_lse_accum = torch.tensor([], device=out.device)
 


### PR DESCRIPTION
## Doc/Code Alignment Fix

Found a misleading inline comment in `hopper/flash_attn_interface.py`.

### Change

`hopper/flash_attn_interface.py:251`

**Before:**
```python
else:
    # Tensors are not set when num_splits < 1
    out_accum = torch.tensor([], device=out.device)
    softmax_lse_accum = torch.tensor([], device=out.device)
```

**After:**
```python
else:
    # num_splits == 1: no accumulator needed, pass empty placeholders to the kernel
    out_accum = torch.tensor([], device=out.device)
    softmax_lse_accum = torch.tensor([], device=out.device)
```

The original comment is wrong on two counts:
1. `num_splits < 1` is impossible at this point — the function raises `ValueError` for `num_splits <= 0` at line 241
2. The tensors **are** set in this branch (to empty placeholders), so "not set" is inaccurate

The corrected comment accurately describes the `num_splits == 1` case: no accumulator is needed, so empty tensors are passed as placeholders to the kernel.

### Verification

| Check | Result |
|-------|--------|
| Logic change | ✅ None — comment only |