### PR TITLE
Include sm_110 in Blackwell-family arch gating (follow-up to #2572)

### DIFF
--- a/flash_attn/cute/flash_bwd_postprocess.py
+++ b/flash_attn/cute/flash_bwd_postprocess.py
@@ -63,7 +63,7 @@ class FlashAttentionBackwardPostprocess:
         self.num_threads = num_threads
         self.AtomLayoutMdQ = AtomLayoutMdQ
         self.dQ_swapAB = dQ_swapAB
-        self.use_2cta_instrs = use_2cta_instrs and arch // 10 == 10 and head_dim != 64
+        self.use_2cta_instrs = use_2cta_instrs and arch // 10 in [10, 11] and head_dim != 64
         self.cluster_size = cluster_size
 
     @staticmethod
@@ -373,7 +373,7 @@ class FlashAttentionBackwardPostprocess:
             seqlen_q = seqlen.seqlen_q
             seqlen_q_rounded = cute.round_up(seqlen_q, self.tile_m)
 
-            if const_expr(self.arch // 10 == 10 and self.use_2cta_instrs):
+            if const_expr(self.arch // 10 in [10, 11] and self.use_2cta_instrs):
                 # 2-CTA: remap dQaccum layout into TMEM view before writing sdQ
                 num_reduce_threads = self.num_threads
                 thr_mma_dsk = tiled_mma.get_slice(tidx)

--- a/flash_attn/cute/flash_bwd_sm100.py
+++ b/flash_attn/cute/flash_bwd_sm100.py
@@ -1423,9 +1423,7 @@ class FlashAttentionBackwardSm100:
         )
         TileSchedulerCls = partial(self.tile_scheduler_cls.create, tile_sched_params)
 
-        AttentionMaskCls = self._generate_attention_mask_cls(
-            window_size_left, window_size_right
-        )
+        AttentionMaskCls = self._generate_attention_mask_cls(window_size_left, window_size_right)
         #  EMPTY
         # (15)
         if warp_idx == self.empty_warp_id:

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -530,7 +530,7 @@ def _flash_attn_fwd(
     if cu_seqlens_k is None and seqused_k is None:
         min_seqlen_k = seqlen_k 
     seqlen_q_packgqa = max_seqlen_q * qhead_per_kvhead
-    if arch // 10 == 10:
+    if arch // 10 in [10, 11]:
         q_stage = 2 if seqlen_q_packgqa > tile_m else 1
     else:
         q_stage = 1
@@ -575,8 +575,8 @@ def _flash_attn_fwd(
         and (tile_m % qhead_per_kvhead == 0 or not pack_gqa)
     )
 
-    # hd=256 2CTA forward uses dedicated kernel (SM100 only)
-    use_dedicated_hd256_kernel = arch // 10 == 10 and head_dim == 256 and head_dim_v == 256
+    # hd=256 2CTA forward uses dedicated kernel (Blackwell family)
+    use_dedicated_hd256_kernel = arch // 10 in [10, 11] and head_dim == 256 and head_dim_v == 256
     use_2cta_instrs = use_2cta_instrs or use_dedicated_hd256_kernel
 
     if softcap is not None:
@@ -1332,7 +1332,7 @@ def _flash_attn_bwd(
         cluster_size = 2 if head_dim >= 128 and not disable_2cta else 1
         use_2cta_instrs = cluster_size==2
 
-    use_dedicated_hd256_kernel = arch // 10 == 10 and head_dim == 256 and head_dim_v == 256
+    use_dedicated_hd256_kernel = arch // 10 in [10, 11] and head_dim == 256 and head_dim_v == 256
     use_2cta_instrs = use_2cta_instrs or use_dedicated_hd256_kernel
 
     q, k, v, out, dout, lse, cu_seqlens_q, cu_seqlens_k, seqused_q, seqused_k = [


### PR DESCRIPTION
Follow-up to #2572: align remaining `arch // 10 == 10` checks with the codebase’s Blackwell-family convention (`arch // 10 in [10, 11]`) so `sm_110` (Thor) is not unintentionally excluded.

`flash_fwd_sm100.py` already accepts both `sm_10x` and `sm_11x`, and `interface.py` dispatches both through the same `FlashAttentionForwardSm100` / MLA paths. However, several remaining `== 10` checks still cause `sm_110` to silently miss optimized paths.

Split into two commits for easier review.

### Commit 1 — `flash_bwd_postprocess.py`

Updates two 2CTA gating sites:

* `use_2cta_instrs`
* 2CTA TMEM remap branch

Previously, `sm_110` could not enter the 2CTA postprocess path even when the rest of the backward pipeline was already using 2CTA. This aligns the logic with the existing Blackwell-family convention used elsewhere in the codebase.

### Commit 2 — `interface.py`

Updates three inconsistent gating sites:

* `q_stage` heuristic
* `use_dedicated_hd256_kernel` (fwd)
* `use_dedicated_hd256_kernel` (bwd)

Currently, `sm_110` falls back to less optimized paths (`q_stage=1` and generic hd=256 kernels). Nearby logic in the same file already uses `arch // 10 in [10, 11]`, so these appear to be oversights rather than intentional restrictions.

If any of these paths are intentionally `sm_100`-only (e.g. unvalidated on `sm_110`), happy to revert individual hunks.

Also updates one stale `# SM100 only` comment to `# Blackwell family` for consistency.

### Intentionally unchanged

`interface.py:480` still keeps the FP8 assertion:

```python id="lqj7wu"
arch // 10 == 10
```

with the message:

> "FP8 is only supported on SM100 (compute capability 10.x) for FA4 CuTe."

This appears intentional, so FP8 gating was left unchanged.

### Note on implementation style

#2572 used `is_family_of` because that file operates on the `Arch` enum. These files use `arch: int`, so this PR follows the existing local convention:

```python id="4njlwm"
arch // 10 in [10, 11]
```

rather than introducing a broader `Arch` enum refactor.
