### PR TITLE
[Sm120] Route hd=128 forward through sm_8x small-SMEM tile

### DIFF
--- a/csrc/flash_attn/src/flash_fwd_launch_template.h
+++ b/csrc/flash_attn/src/flash_fwd_launch_template.h
@@ -234,11 +234,14 @@ void run_mha_fwd_hdim128(Flash_fwd_params &params, cudaStream_t stream) {
     constexpr static int Headdim = 128;
     auto [cc_major, cc_minor] = get_compute_capability(get_current_device());
     bool is_sm8x = cc_major == 8 && cc_minor > 0;
+    bool is_sm12x = cc_major == 12 && cc_minor == 0;
     DROPOUT_SWITCH(params.p_dropout < 1.f, Is_dropout, [&] {
         if constexpr(!Is_dropout) {
             // For sm86 or sm89, 64 x 64 is the fastest for causal (because it's square),
             // and 128 x 32 (48 KB smem) is the fastest for non-causal since we get 2 CTAs per SM.
-            if (is_sm8x) {
+            // sm_120 (RTX 50-series consumer Blackwell): same ~100 KB SMEM/SM, joins
+            // the sm_8x small-SMEM tile to get 2 blocks/SM (16.67% theoretical occupancy).
+            if (is_sm8x || is_sm12x) {
                 if constexpr(!Is_causal) {
                     run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 128, 32, 4, false, false, T>, Is_dropout, Is_causal>(params, stream);
                 } else {


### PR DESCRIPTION
## Summary

RTX 50-series consumer Blackwell (sm_120, GB202) shares the ~100 KB
shared-memory-per-SM budget of sm_86/89, not the larger H100/A100 budget.
The default H100/A100 hdim=128 forward tile `<128, 128, 64, 4>` allocates
64 KB dynamic SMEM/block, capping sm_120 at 1 block/SM (8.33% theoretical
occupancy).

This PR routes sm_120 through the existing sm_8x dispatch in
`run_mha_fwd_hdim128`, which uses the smaller `<128, 128, 32, 4>` tile
(48 KB SMEM/block, 2 blocks/SM, 16.67% theoretical occupancy).

Forward dispatch only. No changes to kernel source, softmax, mma,
backward, or `run_mha_fwd_splitkv_dispatch` (KV-cache / paged attention
path). Other arches are gated by a runtime `cc_major == 8 && cc_minor > 0`
/ `cc_major == 12 && cc_minor == 0` check; binary unchanged for them.

Step toward #1638 (RTX 5090 support; fwd hd=128 only). Does not address
#2307 (FA4 sm_120, blocked on tcgen05/UMMA absence on consumer Blackwell —
orthogonal track).

Builds on the sm_120 enablement track started in #2329 (forward pass),
#2330 (backward pass), and #2333 (varlen attention); this PR addresses the
forward hd=128 dispatch tile not covered by those — `run_mha_fwd_hdim128`
still routed sm_120 through the H100/A100 large-SMEM path.

## Bench (RTX 5090, CUDA 12.8, torch 2.11+cu130)

Base: `upstream/main @ 8a8b2f1` (now rebased onto current main).
Vanilla `.so` md5 `2682b22b5b205d30b8c1847a2089ce1e`,
patched `.so` md5 `01e6f6f3711a5d901ec576aeaefe7d99` — distinct, logged.

5-cycle paired interleaved bench (vanilla ↔ patched alternating), 30
repeats per measurement, 24 configs from `benchmarks/benchmark_flash_attention.py`.
Reproduced on two consecutive days:

| Day  | dtype | overall mean Δ | 95% CI               | hd=128 mean Δ | hd=64 (sm_8x path, unchanged) |
|------|-------|----------------|----------------------|---------------|-------------------------------|
| 5/20 | fp16  | **+3.73%**     | [+2.83%, +4.63%]     | **+7.41%**    | +0.05% (noise)                |
| 5/21 | fp16  | **+3.64%**     | [+2.86%, +4.42%]     | **+7.24%**    | +0.03% (noise)                |
| 5/21 | bf16  | +3.24%         | [+2.70%, +3.78%]     | +6.48%        | +0.04% (noise)                |

95% CIs overlap across days; effect is dtype-consistent. BF16 measurement
stabilized after 10 cycles (N=240) — earlier 5-cycle runs showed high
per-cycle variance during thermal warmup, so reported figures are from
the 10-cycle run.

Paired interleaved (vs single-pass) is used because single-pass measurements
on shared dev GPUs drift by up to ~6 %p between batches taken 30 min
apart (production traffic + clock auto-boost). Interleaving converges
the paired Δ within ±0.5 %p 95% CI.

### hd=128 detail (5/20, 12 configs, sorted by Δ)

| causal | bs  | seqlen | vanilla TFLOPS | patched TFLOPS | Δ%       | std% |
|--------|-----|--------|----------------|----------------|----------|------|
| T      | 32  | 512    | 144.20         | 169.37         | **+17.45** | 0.41 |
| T      | 16  | 1024   | 163.78         | 186.58         | **+13.92** | 0.57 |
| F      | 16  | 1024   | 188.07         | 205.33         | +9.21    | 2.10 |
| F      | 32  | 512    | 187.72         | 204.42         | +8.90    | 0.55 |
| T      | 8   | 2048   | 183.38         | 199.22         | +8.68    | 2.61 |
| F      | 8   | 2048   | 203.35         | 216.07         | +6.27    | 1.49 |
| T      | 4   | 4096   | 198.33         | 209.61         | +5.69    | 0.66 |
| F      | 4   | 4096   | 211.76         | 222.17         | +4.92    | 0.25 |
| F      | 2   | 8192   | 214.03         | 223.59         | +4.47    | 0.10 |
| F      | 1   | 16384  | 214.10         | 222.80         | +4.06    | 0.19 |
| T      | 2   | 8192   | 205.00         | 212.58         | +3.69    | 0.36 |
| T      | 1   | 16384  | 207.75         | 211.27         | +1.70    | 0.08 |

All 12 hd=128 configs improved; min +1.70%, max +17.45%, std < 3%.

## ncu evidence (RTX 5090, hd=128 fp16, bs=1 seqlen=4096)

```
                          Vanilla  Patched    Δ
Compute (SM) Throughput    41.41%   44.05%   +2.6 %p
Theoretical Occupancy       8.33%   16.67%   2x  (1 → 2 blocks/SM)
No Eligible                88.02%   85.09%   -2.9 %p
Dynamic SMEM/block          64 KB    48 KB   -25%
Registers/thread             255      244   nvcc auto-relaxes under smaller tile
```

Static per-kernel max from `cuobjdump --dump-resource-usage` is 255
(compile-time `maxnreg` cap); ncu-measured per-launch allocation is 244
after the tile shrink — both are consistent, just different metrics.

No Eligible remains 85% — most of the wall-clock headroom is still
scheduler-stall and is left for future warp-specialized forward (separate
PR scope). The 1 → 2 blocks/SM bump captures the tail-effect / wave
quantization portion of that headroom, which is the +3.7%.

## Correctness

- **cos sim vs SDPA-MATH (fp32 ref)**: `1.000000` (mean and min) across
  24 configs. Same `mma.sync.aligned.m16n8k16` instruction is emitted;
  output is bit-exact.
- **pytest** on RTX 5090 (fp16 + bf16):
  - `test_flash_attn_qkvpacked` d ∈ {32,40,59,64,80,96,111,128,160,192,
    224,256} × {causal,non-causal} × seqlen ∈ {384,768,1024}: **216/216 pass**
  - Active options on top of qkvpacked (dropout=0.17, alibi=T, local=T,
    deterministic=T): **12/12 pass**
  - `test_flash_attn_varlen_output` d=128 × mha/gqa/mqa (Qwen3/LFM2
    prefill path): **48/48 pass**
  - `softcap=50` d=128 (Gemma path): **80/80 pass**

## Files changed

`csrc/flash_attn/src/flash_fwd_launch_template.h` — `run_mha_fwd_hdim128`
adds `bool is_sm12x = cc_major == 12 && cc_minor == 0;` and joins it into
the existing `is_sm8x` dispatch branch. **1 file, +4 / −1 lines.**

No other paths touched: `run_mha_fwd_hdim{32,64,96,192,256}`, backward
launch templates, `run_mha_fwd_splitkv_dispatch`, and the
`compute_120/code=sm_120` gencode at `setup.py:128-132` are unchanged.

## Scope and future work

This PR: forward, hd=128, dense (non-varlen, non-splitkv), sm_120 only.

Out of scope (deferred to follow-up PRs):
- Backward `run_mha_bwd_hdim128` sm_120 dispatch
- `run_mha_fwd_splitkv_dispatch` (KV-cache / paged attention) — likely
  has its own sm_120 occupancy story; not benchmarked here
- hd ∈ {32, 96, 192, 256} sm_120 tuning (we tested hd=96 sm_8x branch
  join — −1.27% mean regression, abandoned; SMEM/M tradeoffs differ per hd)
- Warp-specialized forward addressing the remaining No-Eligible 85%

#2361 (bwd nvcc segfault) was not reproduced on this toolchain (CUDA 12.8
+ torch 2.11+cu130); bwd kernels compile and link unchanged. May still
warrant investigation on the original reporter's toolchain.

## Tested on

RTX 5090 (sm_120) only. sm_121/12x variants are gated out by the
`cc_minor == 0` check; behavior on those parts is untested. Other arches
(sm_80/86/89/90/100) are unaffected by the runtime branch (`is_sm8x`
exclusion of sm_80 preserved; A100 stays on the H100 tile path it
already used).