### PR TITLE
Guard Hopper FA3 path against SM120 devices

### DIFF
--- a/hopper/flash_attn_interface.py
+++ b/hopper/flash_attn_interface.py
@@ -56,6 +56,15 @@ def round_up_headdim(head_size: int) -> int:
     return 256
 
 
+def _check_hopper_device(device: Union[str, torch.device]) -> None:
+    major, minor = torch.cuda.get_device_capability(device)
+    if (major, minor) != (9, 0):
+        raise RuntimeError(
+            "flash_attn.hopper only supports Hopper GPUs (SM90). "
+            f"Got SM{major}{minor}."
+        )
+
+
 @torch.library.custom_op("flash_attn_3::_flash_attn_forward", mutates_args=(), device_types="cuda")
 def _flash_attn_forward(
     q: torch.Tensor,
@@ -791,6 +800,7 @@ def flash_attn_qkvpacked_func(
             The output of softmax (possibly with different scaling). It also encodes the dropout
             pattern (negative means that location was dropped, nonnegative means it was kept).
     """
+    _check_hopper_device(qkv.device)
     return FlashAttnQKVPackedFunc.apply(
         qkv,
         softmax_scale,
@@ -868,6 +878,7 @@ def flash_attn_func(
             logsumexp of each row of the matrix QK^T * scaling (e.g., log of the softmax
             normalization factor).
     """
+    _check_hopper_device(q.device)
     return FlashAttnFunc.apply(
         q,
         k,
@@ -910,6 +921,7 @@ def flash_attn_varlen_func(
     sm_margin=0,
     return_attn_probs=False,
 ):
+    _check_hopper_device(q.device)
     return FlashAttnVarlenFunc.apply(
         q,
         k,
@@ -1056,6 +1068,7 @@ def flash_attn_with_kvcache(
             logsumexp of each row of the matrix QK^T * scaling (e.g., log of the softmax
             normalization factor).
     """
+    _check_hopper_device(q.device)
     assert k_cache.stride(-1) == 1, "k_cache must have contiguous last dimension"
     assert v_cache.stride(-1) == 1, "v_cache must have contiguous last dimension"
     if softmax_scale is None:

--- a/hopper/flash_attn_interface.py
+++ b/hopper/flash_attn_interface.py
@@ -1134,6 +1134,7 @@ def get_scheduler_metadata(
     pack_gqa=None,   # Can be tuned for speed
     sm_margin=0,     # Can be tuned if some SMs are used for communication
 ):
+    _check_hopper_device(cache_seqlens.device)
     cache_seqlens = maybe_contiguous(cache_seqlens)
     if headdim_v is None:
         headdim_v = headdim

--- a/hopper/test_blackwell_guard.py
+++ b/hopper/test_blackwell_guard.py
@@ -1,0 +1,63 @@
+import sys
+import types
+
+import pytest
+import torch
+
+sys.modules.setdefault("flash_attn_3", types.SimpleNamespace(_C=object()))
+sys.modules.setdefault("flash_attn_3._C", object())
+
+from hopper import flash_attn_interface as hopper_interface
+
+
+class _FakeTensor:
+    def __init__(self, device="cuda"):
+        self.device = device
+
+
+def _make_qkv():
+    q = _FakeTensor()
+    k = _FakeTensor()
+    v = _FakeTensor()
+    return q, k, v
+
+
+def test_hopper_guard_rejects_sm120(monkeypatch):
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda device=None: (12, 0))
+
+    q, k, v = _make_qkv()
+    with pytest.raises(RuntimeError, match=r"only supports Hopper GPUs \(SM90\)\. Got SM120\."):
+        hopper_interface.flash_attn_func(q, k, v)
+
+
+def test_hopper_qkvpacked_guard_rejects_sm120(monkeypatch):
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda device=None: (12, 0))
+
+    qkv = _FakeTensor()
+    with pytest.raises(RuntimeError, match=r"only supports Hopper GPUs \(SM90\)\. Got SM120\."):
+        hopper_interface.flash_attn_qkvpacked_func(qkv)
+
+
+def test_hopper_varlen_guard_rejects_sm120(monkeypatch):
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda device=None: (12, 0))
+
+    q, k, v = _make_qkv()
+    cu = _FakeTensor()
+    with pytest.raises(RuntimeError, match=r"only supports Hopper GPUs \(SM90\)\. Got SM120\."):
+        hopper_interface.flash_attn_varlen_func(
+            q,
+            k,
+            v,
+            cu,
+            cu,
+            max_seqlen_q=1,
+            max_seqlen_k=1,
+        )
+
+
+def test_hopper_kvcache_guard_rejects_sm120(monkeypatch):
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda device=None: (12, 0))
+
+    q, k_cache, v_cache = _make_qkv()
+    with pytest.raises(RuntimeError, match=r"only supports Hopper GPUs \(SM90\)\. Got SM120\."):
+        hopper_interface.flash_attn_with_kvcache(q, k_cache, v_cache)

--- a/hopper/test_blackwell_guard.py
+++ b/hopper/test_blackwell_guard.py
@@ -61,3 +61,19 @@ def test_hopper_kvcache_guard_rejects_sm120(monkeypatch):
     q, k_cache, v_cache = _make_qkv()
     with pytest.raises(RuntimeError, match=r"only supports Hopper GPUs \(SM90\)\. Got SM120\."):
         hopper_interface.flash_attn_with_kvcache(q, k_cache, v_cache)
+
+
+def test_hopper_scheduler_metadata_guard_rejects_sm120(monkeypatch):
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda device=None: (12, 0))
+
+    cache_seqlens = _FakeTensor()
+    with pytest.raises(RuntimeError, match=r"only supports Hopper GPUs \(SM90\)\. Got SM120\."):
+        hopper_interface.get_scheduler_metadata(
+            batch_size=1,
+            max_seqlen_q=1,
+            max_seqlen_k=1,
+            num_heads_q=1,
+            num_heads_kv=1,
+            headdim=64,
+            cache_seqlens=cache_seqlens,
+        )


### PR DESCRIPTION
## Purpose

On RTX 5090 / SM120, the legacy Hopper FA3 entrypoints currently allow Blackwell devices to enter the Hopper-only path and then fail late at kernel launch with:

`CUDA error ... no kernel image is available for execution on the device`

This change makes the failure mode explicit and early instead of letting SM120 fall through to a Hopper-only kernel path.

## What changed

- add `_check_hopper_device(...)` in `hopper/flash_attn_interface.py`
- call it from the five public Hopper entrypoints:
  - `flash_attn_qkvpacked_func`
  - `flash_attn_func`
  - `flash_attn_varlen_func`
  - `flash_attn_with_kvcache`
  - `get_scheduler_metadata`
- reject non-Hopper devices with a clear error:
  - `flash_attn.hopper only supports Hopper GPUs (SM90). Got SM120.`

## Why this scope

This does not claim FA3 Hopper kernels support RTX 5090 / SM120.
It only prevents unsupported Blackwell devices from reaching a misleading late kernel-launch failure in the old Hopper path.

## Preserved behavior

- Hopper (`SM90`) behavior is unchanged
- no kernel codepaths or public APIs are changed
- this only tightens device gating for the Hopper-specific interface layer

## Verification

- `python -m py_compile hopper/flash_attn_interface.py hopper/test_blackwell_guard.py`
- `python -m pytest hopper/test_blackwell_guard.py -q`
  - result: `5 passed`

## Notes

I initially screened `sglang` and `vllm` for a 5090 / WSL2 quick-merge fix, but both cleaner slices were already closed or occupied by broader SM12x work. `flash-attention#2168` remained the cleanest open path for a small correctness fix in the current upstream state.

Refs: #2168
