### PR TITLE
Clamp kv_stage to avoid SMEM overflow for small head_dims on SM100

### DIFF
--- a/flash_attn/cute/flash_fwd_sm100.py
+++ b/flash_attn/cute/flash_fwd_sm100.py
@@ -336,7 +336,10 @@ class FlashAttentionForwardSm100:
         smem_size_k_per_stage = self.n_block_size * self.head_dim_padded * self.k_dtype.width // 8
         smem_size_v_per_stage = self.n_block_size * self.head_dim_v_padded * self.v_dtype.width // 8
         smem_size_kv_per_stage = max(smem_size_k_per_stage, smem_size_v_per_stage) // self.cta_group_size
-        kv_stage = (224 * 1024 - smem_size_q_o) // smem_size_kv_per_stage
+        # Cap small head_dim from over-staging: the 224*1024 budget undercounts
+        # per-stage state, so at hd_padded=16 the unbounded formula picks 52 stages
+        # and overflows the 227 KB SMEM cap. No-op for hd_padded >= 32 (max 26).
+        kv_stage = min((224 * 1024 - smem_size_q_o) // smem_size_kv_per_stage, 32)
         if self.head_dim_padded == 192 and self.head_dim_v_padded == 128 and kv_stage == 2:
             # For hdim 192,128, we can fit 3 stages if we use uneven_kv_smem
              kv_stage = 3

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -438,6 +438,50 @@ def test_flash_attn_output(
             ).abs().max().item() + dv_atol
 
 
+# Regression test for #2591: SMEM overflow at small head_dims on SM100. The main
+# test_flash_attn_output skips d < 64, but _validate_head_dims accepts head_dim >= 8
+# for sm_100/110, so this path needs coverage. Trigger requires
+# seqlen_q_packgqa > tile_m to push q_stage 1->2.
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("d", [8, 16, 32])
+@pytest.mark.parametrize("seqlen_q,seqlen_k", [(128, 128), (2048, 2048)])
+@retry_on_oom
+@maybe_fake_tensor_mode(USE_FAKE_TENSOR)
+def test_flash_attn_small_head_dim(seqlen_q, seqlen_k, d, causal, dtype):
+    device = "cuda"
+    seed = 0
+    random.seed(seed)
+    torch.random.manual_seed(seed)
+    torch.cuda.empty_cache()
+    torch.cuda.synchronize()
+    batch_size = 2
+    nheads = 2
+    nheads_kv = nheads
+    dtype_ref = dtype
+    q_ref = torch.randn(
+        batch_size, seqlen_q, nheads, d, device=device, dtype=dtype_ref
+    ).requires_grad_()
+    k_ref = torch.randn(
+        batch_size, seqlen_k, nheads_kv, d, device=device, dtype=dtype_ref
+    ).requires_grad_()
+    v_ref = torch.randn(
+        batch_size, seqlen_k, nheads_kv, d, device=device, dtype=dtype_ref
+    ).requires_grad_()
+    q, k, v = [x.detach().to(dtype).requires_grad_() for x in (q_ref, k_ref, v_ref)]
+    out_ref, _ = attention_ref(q_ref, k_ref, v_ref, None, None, causal=causal)
+    out_pt, _ = attention_ref(
+        q_ref, k_ref, v_ref, None, None, causal=causal, upcast=False, reorder_ops=True
+    )
+    out, _ = flash_attn_func(q, k, v, causal=causal)
+    if is_fake_mode():
+        return
+    fwd_atol = 2 * (out_ref + 0.3 - 0.3 - out_ref).abs().max().item()
+    assert (out - out_ref).abs().max().item() <= 2 * (
+        out_pt - out_ref
+    ).abs().max().item() + fwd_atol
+
+
 # @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float8_e4m3fn])
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 @pytest.mark.parametrize("mha_type", ["mha", "mqa", "gqa"])


### PR DESCRIPTION
## Summary

Fixes #2591.

`flash_fwd_sm100.py:335` computes `kv_stage` without accounting for per-stage overhead (`mbar_*`, `sScale`, pipeline counters). For `head_dim_padded=16`, the heuristic can select 52+ stages, exceeding the `sm_100a` shared memory limit by ~1 KB and causing kernel launch failure:

```text
cudaErrorInvalidValue: launch shared memory exceeds current GPU arch sm_100a allowed
Allocated: 233472 bytes. Max: 232448 bytes.
```

This affects small head dimensions (`head_dim ∈ [8,16]`) with non-trivial sequence lengths where `q_stage=2`.

## Fix

Clamp `kv_stage` to 32.

This is sufficient to avoid the SMEM overflow and does not impact performance in practice, since attention pipelining saturates well before 32 stages. Existing `head_dim_padded >= 64` configurations are unchanged because they already use ≤24 stages.

## Test plan

* Added `test_flash_attn_small_head_dim` covering:

  * `d ∈ {8,16,32}`
  * `causal ∈ {True, False}`
  * `seqlen ∈ {128, 2048}`
* Verified original #2591 repro now passes.
* Verified on B200 (`sm_100a`): all new tests pass with max error vs Torch SDPA ≤ 0.0078.
* Confirmed no behavior change for `head_dim_padded >= 64`.

## Notes

An alternative fix would incorporate per-stage overhead directly into the heuristic:

```python id="jlwmju"
(BUDGET - smem_qo) // (smem_kv + PER_STAGE_OVERHEAD)
```

but that reduces stage count across all configurations. The clamp is a smaller, lower-risk fix for this bug.

`_validate_head_dims` remains unchanged: small head dimensions are valid on `sm_100/110`; only the staging heuristic was incorrect.
