### PR TITLE
[CuTe,Sm100] fix: decode/prefill exp2 emulation consistency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,10 @@ permissions:
 
 env:
   CI_WORK_DIR: ${{ vars.CI_WORK_DIR || format('/scratch/user/{0}', github.actor) }}
-  FA4_TEST_FILTER: "1024-1024-128-True-0-0.0-False-False-False-mha-dtype0 or 1024-1024-128-False-0-0.0-False-False-False-mha-dtype0"
+  FA4_TEST_FILTER: >-
+    1024-1024-128-True-0-0.0-False-False-False-mha-dtype0
+    or 1024-1024-128-False-0-0.0-False-False-False-mha-dtype0
+    or test_flash_attn_ex2_emu_decode_prefill_consistency
 
 jobs:
   lint:

--- a/flash_attn/cute/flash_fwd_sm100.py
+++ b/flash_attn/cute/flash_fwd_sm100.py
@@ -2327,7 +2327,7 @@ class FlashAttentionForwardSm100:
         softmax.apply_exp2_convert(
             tSrS_t2r,
             tSrP_r2t,
-            ex2_emu_freq=self.ex2_emu_freq if const_expr(mask_fn is None) else 0,
+            ex2_emu_freq=self.ex2_emu_freq,
             ex2_emu_start_frg=self.ex2_emu_start_frg,
         )
         # Sequence barrier arrive

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -2838,3 +2838,64 @@ def test_flash_attn_empty_q_varlen(causal):
     assert out.numel() == 0
     if lse is not None:
         assert lse.numel() == 0
+
+
+@pytest.mark.parametrize("seqlen_k", [512, 1024])
+@maybe_fake_tensor_mode(USE_FAKE_TENSOR)
+def test_flash_attn_ex2_emu_decode_prefill_consistency(seqlen_k):
+    """Decode↔prefill must be bitwise consistent for MLA (192,128).
+
+    Regression test: paged decode (seqlen_q=1) vs non-paged prefill
+    (seqlen_q=full) for MLA shapes must produce identical outputs for the
+    last query position.
+    """
+    if IS_SM90:
+        pytest.skip("ex2_emu is SM100+ only")
+
+    device = "cuda"
+    dtype = torch.bfloat16
+    d, dv = 192, 128
+    nheads = nheads_kv = 16
+
+    torch.random.manual_seed(0)
+    q = torch.randn(seqlen_k, nheads, d, device=device, dtype=dtype)
+    k = torch.randn(seqlen_k, nheads_kv, d, device=device, dtype=dtype)
+    v = torch.randn(seqlen_k, nheads_kv, dv, device=device, dtype=dtype)
+
+    # Prefill: full sequence, non-paged, causal
+    cu = torch.tensor([0, seqlen_k], dtype=torch.int32, device=device)
+    out_prefill, _ = flash_attn_varlen_func(
+        q, k, v,
+        cu_seqlens_q=cu, cu_seqlens_k=cu,
+        max_seqlen_q=seqlen_k, max_seqlen_k=seqlen_k,
+        causal=True,
+    )
+
+    # Decode: seqlen_q=1 at last position, paged KV, causal
+    page_size = 128
+    num_pages = (seqlen_k + page_size - 1) // page_size
+    k_cache = torch.zeros(num_pages, page_size, nheads_kv, d, device=device, dtype=dtype)
+    v_cache = torch.zeros(num_pages, page_size, nheads_kv, dv, device=device, dtype=dtype)
+    for i in range(seqlen_k):
+        k_cache[i // page_size, i % page_size] = k[i]
+        v_cache[i // page_size, i % page_size] = v[i]
+    page_table = torch.arange(num_pages, dtype=torch.int32, device=device).unsqueeze(0)
+    cache_seqlens = torch.tensor([seqlen_k], dtype=torch.int32, device=device)
+
+    out_decode, _ = flash_attn_varlen_func(
+        q[-1:], k_cache, v_cache,
+        cu_seqlens_q=torch.tensor([0, 1], dtype=torch.int32, device=device),
+        cu_seqlens_k=None,
+        max_seqlen_q=1, max_seqlen_k=None,
+        seqused_k=cache_seqlens, page_table=page_table,
+        causal=True,
+    )
+
+    if is_fake_mode():
+        return
+
+    max_diff = (out_prefill[-1] - out_decode[0]).abs().max().item()
+    print(f"decode↔prefill max diff: {max_diff}")
+    assert torch.equal(out_prefill[-1], out_decode[0]), (
+        f"decode↔prefill diverged: max_diff={max_diff}."
+    )


### PR DESCRIPTION
#2596

## Summary

Fix the root cause of decode↔prefill numerical divergence for MLA (192,128) shapes on SM100. Keeping bitwise alignment between prefill and decode is important for downstream tasks like true on-policy RL.

`apply_exp2_convert` selected the exp2 implementation based on `mask_fn` presence: hardware `ex2.approx.ftz` for causal-masked tiles, polynomial emulation for unmasked tiles. Different `q_stage` values (1 for decode, 2 for prefill) compute different `m_block` for the same logical Q row, shifting which tiles are processed with vs without `mask_fn`. The same K tile could receive different exp2 methods across variants.

Fix: always pass `self.ex2_emu_freq` to `apply_exp2_convert` regardless of `mask_fn` presence. One line fix + regression test.

## Root cause

```python
# Before (bug): masked tiles use hardware exp2, unmasked use emulation
ex2_emu_freq=self.ex2_emu_freq if const_expr(mask_fn is None) else 0

# After (fix): always use configured emulation
ex2_emu_freq=self.ex2_emu_freq
```

The causal mask boundaries are correct in both variants — the bug is that the exp2 implementation was selected based on mask presence rather than applied uniformly.

## Why tiling and position-dependent emulation mixing are not an issue

The position-dependent emulation mixing in `apply_exp2_convert` (controlled by `ex2_emu_freq`, `ex2_emu_res`, `ex2_emu_start_frg`) is consistent across decode and prefill because:

1. Both use the same `tile_n=128` on SM100, so `frg_cnt = 128/32 = 4` is identical
2. Both use the same tuning config key `(False, True, 192, False)` for causal MLA, giving the same `ex2_emu_freq=32` and `ex2_emu_start_frg=1`
3. The fragment layout within each tile is determined by the MMA instruction (same for both variants)

The only source of inconsistency was the tile-level `mask_fn` conditional selecting different exp2 implementations, not the element-level position mixing within `apply_exp2_convert`.

## Benchmark results (B200)

Forward pass benchmark comparing `origin/main` (baseline, buggy) vs this PR (fix applied) using `benchmarks/benchmark_attn.py --backend fa4 --fwd --rep 20 --warmup 5`.

| Shape | Baseline (TFLOPS / MFU) | After Fix (TFLOPS / MFU) | Δ |
|---|---|---|---|
| 192-128, causal, 2048 | 1123 / 49.9% | 1127 / 50.1% | +0.4% |
| 128, causal, 2048 | 1029 / 45.7% | 1039 / 46.2% | +1.0% |
| 192-128, non-causal, 2048 | 1476 / 65.6% | 1479 / 65.7% | +0.2% |
| 128, non-causal, 2048 | 1174 / 52.2% | 1172 / 52.1% | -0.2% |
| 192-128, causal, 8192 | 1482 / 65.9% | 1483 / 65.9% | +0.07% |
| 128, causal, 8192 | 1391 / 61.8% | 1395 / 62.0% | +0.3% |
| 192-128, non-causal, 8192 | 1672 / 74.3% | 1673 / 74.3% | +0.06% |
| 128, non-causal, 8192 | 1280 / 56.9% | 1282 / 57.0% | +0.16% |

**Verdict: no performance regression** across hd128, hd192-128, both causal and non-causal, at seqlen 2048 and 8192. All differences are within run-to-run noise (~±1%).

The fix removes the `mask_fn is None` conditional that selected hardware exp2 for masked tiles. Causal masked tiles now use polynomial emulation, but on SM100 the FMA throughput compensates for the lost SFU shortcut, leaving end-to-end forward pass perf unchanged.

## Full test suite results (B200)

Ran the affected subset of `tests/cute/test_flash_attn.py` with filter `(192- or 128-) and mha-dtype0` to cover edge cases on hd128 and hd192 (the head dims that use ex2_emu).

| Pass | Result | Time |
|---|---|---|
| Pass 1 (parallel compile, fake tensor) | **47,356 passed**, 34,612 skipped, 0 failed | 48 min |
| Pass 2 (GPU execute, cached kernels) | **47,356 passed**, 34,612 skipped, 0 failed | 22 min |

This covers the full cross-product of:
- hd ∈ {128, 192}
- causal ∈ {True, False}
- learnable_sink, deterministic, softcap, local_enum, varlen, paged_kv, etc.

Zero regressions across ~47k test cases on B200.

## Test plan

- [x] Verified bitwise decode↔prefill equality with emulation enabled (seqlen_k=512, 1024) on B200
- [x] Isolated `q_stage` as the sole variable via 5-way comparison (paged vs non-paged: 0 diff; q_stage=1 vs q_stage=2: 116/2048 diff)
- [x] Regression test: `test_flash_attn_ex2_emu_decode_prefill_consistency`
- [ ] Performance benchmark (masked tiles now use polynomial FMA chain instead of single SFU instruction)