### PR TITLE
Apply data filter to tarfile.extractall in hopper setup

### DIFF
--- a/hopper/setup.py
+++ b/hopper/setup.py
@@ -403,7 +403,7 @@ def download_and_copy(name, src_func, dst_path, version, url_func):
     if download:
         print(f'downloading and extracting {url} ...')
         file = tarfile.open(fileobj=open_url(url), mode="r|*")
-        file.extractall(path=tmp_path)
+        file.extractall(path=tmp_path, filter="data")
     os.makedirs(os.path.split(dst_path)[0], exist_ok=True)
     print(f'copy {src_path} to {dst_path} ...')
     if os.path.isdir(src_path):


### PR DESCRIPTION
## Summary

Pretty minor change to remove PEP706 warnings.
Pass `filter="data"` to `TarFile.extractall` in `hopper/setup.py`'s `download_and_copy()`.

## Motivation

Python 3.14 makes `filter="data"` the default for `TarFile.extractall` (PEP 706), and Python 3.12 / 3.13 emit a `DeprecationWarning` when no filter is passed. Setting it explicitly keeps the call-site behavior stable across Python versions and silences the warning during builds and code scans.

## Verification

Tested against the pinned upstream archive `cuda_nvcc-linux-x86_64-12.6.85-archive.tar.xz` (the one `download_and_copy()` actually downloads). Extracted twice on Python 3.12 mirroring the streaming pattern in `setup.py` (`tarfile.open(fileobj=..., mode="r|*")`): once with the existing `extractall(path=tmp_path)`, once with the proposed `extractall(path=tmp_path, filter="data")`. Compared the two output trees by type, size, mode, symlink target, and SHA-256.
