### PR TITLE
Add split_size control for bitwise-consistent prefill/decode SplitKV

### DIFF
--- a/flash_attn/cute/block_info.py
+++ b/flash_attn/cute/block_info.py
@@ -19,6 +19,10 @@ class BlockInfo:
     window_size_left: Optional[Int32] = None
     window_size_right: Optional[Int32] = None
     qhead_per_kvhead_packgqa: cutlass.Constexpr[int] = 1
+    # Fixed split size in KV tile-blocks. None => regular even-division by num_splits.
+    # When set, every split covers exactly this many tile_n blocks (last split takes
+    # the remainder), giving seqlen-invariant, tile-aligned split boundaries.
+    n_blocks_per_split: Optional[Int32] = None
 
     @cute.jit
     def get_n_block_min_max(
@@ -45,13 +49,19 @@ class BlockInfo:
             n_idx_left = n_idx - self.window_size_left
             n_block_min = cutlass.max(n_idx_left // self.tile_n, 0)
         if cutlass.const_expr(self.is_split_kv):
-            num_n_blocks_per_split = (
-                Int32(0)
-                if n_block_max <= n_block_min
-                else (n_block_max - n_block_min + num_splits - 1) // num_splits
-            )
-            n_block_min = n_block_min + split_idx * num_n_blocks_per_split
-            n_block_max = cutlass.min(n_block_min + num_n_blocks_per_split, n_block_max)
+            if cutlass.const_expr(self.n_blocks_per_split is not None):
+                # Fixed-size mode: each split covers exactly n_blocks_per_split blocks.
+                num_n_blocks_per_split = self.n_blocks_per_split
+            else:
+                # Regular even-division mode (unchanged behavior).
+                num_n_blocks_per_split = (
+                    Int32(0)
+                    if n_block_max <= n_block_min
+                    else (n_block_max - n_block_min + num_splits - 1) // num_splits
+                )
+            split_start = n_block_min + split_idx * num_n_blocks_per_split
+            n_block_max = cutlass.min(split_start + num_n_blocks_per_split, n_block_max)
+            n_block_min = split_start
         return n_block_min, n_block_max
 
     @cute.jit

--- a/flash_attn/cute/flash_fwd_sm100.py
+++ b/flash_attn/cute/flash_fwd_sm100.py
@@ -381,6 +381,7 @@ class FlashAttentionForwardSm100:
         window_size_right: Int32 | int | None = None,
         learnable_sink: Optional[cute.Tensor] = None,
         descale_tensors: Optional[DescaleTensors] = None,
+        n_blocks_per_split: Int32 | int | None = None,
         blocksparse_tensors: Optional[BlockSparseTensors] = None,
         aux_tensors: Optional[list] = None,
         # Always keep stream as the last parameter (EnvStream: obtained implicitly via TVM FFI).
@@ -722,6 +723,7 @@ class FlashAttentionForwardSm100:
         softmax_scale_log2, softmax_scale = utils.compute_softmax_scale_log2(softmax_scale, self.score_mod)
         window_size_left = Int32(window_size_left) if window_size_left is not None else None
         window_size_right = Int32(window_size_right) if window_size_right is not None else None
+        n_blocks_per_split = Int32(n_blocks_per_split) if n_blocks_per_split is not None else None
         fastdiv_mods = utils.compute_fastdiv_mods(mQ, mK, self.qhead_per_kvhead, self.pack_gqa, aux_tensors, mPageTable)
 
         head_divmod = None
@@ -770,6 +772,7 @@ class FlashAttentionForwardSm100:
             tiled_mma_pv,
             tile_sched_params,
             num_splits,
+            n_blocks_per_split,
             aux_tensors,
             fastdiv_mods,
             head_divmod,
@@ -829,6 +832,7 @@ class FlashAttentionForwardSm100:
         tiled_mma_pv: cute.TiledMma,
         tile_sched_params: ParamsBase,
         num_splits: Int32,
+        n_blocks_per_split: Optional[Int32] = None,
         aux_tensors: Optional[list] = None,
         fastdiv_mods=(None, None),
         head_divmod=None,
@@ -1063,6 +1067,7 @@ class FlashAttentionForwardSm100:
             window_size_left,
             window_size_right,
             qhead_per_kvhead_packgqa=self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
+            n_blocks_per_split=n_blocks_per_split,
         )
         SeqlenInfoCls = partial(
             SeqlenInfoQK.create,

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -3,6 +3,7 @@
 
 import os
 import math
+import warnings
 from dataclasses import dataclass
 from functools import lru_cache
 from typing import Optional, Tuple, Callable
@@ -267,6 +268,37 @@ def num_splits_heuristic(total_mblocks, num_SMs, num_n_blocks, max_splits):
     return min(num_SMs // total_mblocks, max_splits, num_n_blocks)
 
 
+def split_size_to_num_splits(split_size, tile_n, num_n_blocks, max_splits=256):
+    """Convert a fixed split_size (in KV tokens) into (num_splits, n_blocks_per_split).
+
+    Each split covers exactly ``n_blocks_per_split`` tile_n-blocks (the last in-range
+    split takes the remainder), giving seqlen-invariant, tile-aligned split boundaries.
+    Because the boundaries are absolute KV positions (0, S, 2S, ...), prefill (len L) and
+    a later decode step (len L+t) partition the shared prefix [0, L) identically -- this
+    is what makes prefill<->decode bitwise consistent when both pass the same split_size.
+
+    If the implied split count exceeds ``max_splits`` (the combine-kernel cap), clamp
+    num_splits and fall back to even-division (n_blocks_per_split=None) so that the KV
+    tail beyond the last split is still covered (otherwise output would be silently wrong).
+    Returns n_blocks_per_split=None whenever splitting collapses to a single split.
+    """
+    n_blocks_per_split = max((split_size + tile_n - 1) // tile_n, 1)
+    derived = (num_n_blocks + n_blocks_per_split - 1) // n_blocks_per_split
+    num_splits = max(1, min(derived, max_splits))
+    if derived > max_splits:
+        warnings.warn(
+            f"split_size={split_size} (={n_blocks_per_split} KV blocks of {tile_n}) implies "
+            f"{derived} splits, exceeding the {max_splits} cap; clamping num_splits to "
+            f"{max_splits} and falling back to even-division (KV tail still covered, but "
+            f"splits are no longer exactly split_size).",
+            stacklevel=2,
+        )
+        n_blocks_per_split = None
+    if num_splits <= 1:
+        n_blocks_per_split = None
+    return num_splits, n_blocks_per_split
+
+
 def _resolve_causal_local_window(causal, window_size_left, window_size_right, mask_mod=None):
     """Resolve causal/local/window settings into canonical form.
 
@@ -313,6 +345,7 @@ def _flash_attn_fwd(
     intra_wg_overlap: Optional[bool] = None,
     num_threads: int = 384,
     num_splits: int = 1,
+    split_size: Optional[int] = None,
     pack_gqa: Optional[bool] = None,
     _arch: Optional[int] = None,
     score_mod: Optional[Callable] = None,
@@ -523,6 +556,24 @@ def _flash_attn_fwd(
     if pack_gqa and qv is not None and 128 % qhead_per_kvhead != 0:
         pack_gqa = False
 
+    # split_size: user-controlled, seqlen-invariant, tile-aligned KV split size (in tokens),
+    # mutually exclusive with an explicit num_splits>1. Only the SM100/110 SplitKV path
+    # supports it. The num_splits count is derived from split_size below, once tile_n and
+    # num_n_blocks are known.
+    if split_size is not None:
+        assert num_splits == 1, (
+            "Pass either num_splits or split_size, not both; split_size derives num_splits."
+        )
+        assert split_size > 0, "split_size must be a positive number of KV tokens"
+        if arch // 10 not in (10, 11):
+            raise NotImplementedError("split_size (SplitKV) is only supported on SM100/110")
+        if qv is not None:
+            raise NotImplementedError("split_size is not supported with qv")
+        if head_dim == 256 and head_dim_v == 256:
+            raise NotImplementedError("split_size is not supported with the head_dim=256 kernel")
+        if head_dim != head_dim_v and head_dim_v == 512:
+            raise NotImplementedError("split_size is not supported for diff-headdim with head_dim_v=512")
+
     if max_seqlen_q is None:
         max_seqlen_q = seqlen_q if cu_seqlens_q is None else total_q
     if max_seqlen_k is None:
@@ -544,9 +595,29 @@ def _flash_attn_fwd(
     if num_splits < 1:
         num_splits = num_splits_heuristic(total_mblocks, num_SMs, num_n_blocks, 128)
 
-    # SplitKV uses float32 partial output, which doubles the O buffer size
-    # in shared memory, causing OOM for diff-headdim (192, 128)
-    if arch // 10 in [10, 11] and head_dim != head_dim_v and num_splits > 1:
+    # Derive num_splits from a fixed split_size. n_blocks_per_split=None means the kernel
+    # uses regular even-division by num_splits; a non-None value pins each split to exactly
+    # that many tile_n-blocks. This is what enables prefill (seqlen_q>1) to split KV with
+    # the same boundaries as decode, so the two are bitwise consistent.
+    n_blocks_per_split = None
+    if split_size is not None:
+        # SplitKV's fp32 partial-O doubles SMEM and OOMs at tile_n=128 for diff-headdim
+        # shapes (e.g. MLA 192/128), so the kernel must use tile_n=64. Unlike the regular
+        # num_splits guard below -- which only shrinks tile_n once seqlen is large enough
+        # to split -- we pin tile_n for ALL sequence lengths here. Otherwise a short decode
+        # (tile_n=128) and a long prefill (tile_n=64) would tile the same token's KV
+        # differently and break bitwise decode<->prefill consistency across lengths.
+        if arch // 10 in [10, 11] and head_dim != head_dim_v and head_dim_v != 512:
+            tile_n = 64
+            num_n_blocks = (seqlen_k_loaded + tile_n - 1) // tile_n
+        num_splits, n_blocks_per_split = split_size_to_num_splits(split_size, tile_n, num_n_blocks)
+        # TODO: fix GQA + SplitKV + non-varlen (mirror of the guard above for the derived count)
+        if pack_gqa and num_splits != 1 and cu_seqlens_q is None:
+            pack_gqa = False
+    elif arch // 10 in [10, 11] and head_dim != head_dim_v and num_splits > 1:
+        # Regular num_splits path: shrink tile_n only once there are enough blocks to split,
+        # otherwise disable splitting. (split_size is handled above with a seqlen-invariant
+        # tile_n so it is intentionally excluded here.)
         if num_n_blocks >= 64 and head_dim_v != 512:
             tile_n = 64
             num_n_blocks = (seqlen_k_loaded + tile_n - 1) // tile_n
@@ -705,6 +776,7 @@ def _flash_attn_fwd(
         q_stage,
         num_threads,
         is_split_kv,
+        n_blocks_per_split is not None,  # fixed-size vs even-division split mode (compile-time branch)
         pack_gqa,
         arch,
         page_size not in [None, tile_n],  # paged KV non-TMA
@@ -973,6 +1045,8 @@ def _flash_attn_fwd(
             ]
             if arch // 10 in [10, 11]:
                 compile_args.append(descale_tensors_tensor)
+                if not use_dedicated_hd256_kernel:
+                    compile_args.append(n_blocks_per_split)
             compile_args.extend([
                 sparse_tensors,
                 cute_aux_tensors,
@@ -1034,6 +1108,8 @@ def _flash_attn_fwd(
             ]
             if arch // 10 in [10, 11]:
                 call_args.append(descale_tensors)
+                if not use_dedicated_hd256_kernel:
+                    call_args.append(n_blocks_per_split)
             call_args.extend([
                 (
                     normalized_block_sparse_tensors.mask_block_cnt,
@@ -1930,6 +2006,7 @@ class FlashAttnFunc(torch.autograd.Function):
         learnable_sink: Optional[torch.Tensor] = None,
         softcap: float = 0.0,
         num_splits: int = 1,
+        split_size: Optional[int] = None,
         pack_gqa: Optional[bool] = None,
         deterministic: bool = False,
         score_mod: Optional[Callable] = None,
@@ -1952,6 +2029,7 @@ class FlashAttnFunc(torch.autograd.Function):
             learnable_sink=learnable_sink,
             softcap=softcap,
             num_splits=num_splits,
+            split_size=split_size,
             pack_gqa=pack_gqa,
             score_mod=score_mod,
             mask_mod=mask_mod,
@@ -2028,6 +2106,7 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
         learnable_sink: Optional[torch.Tensor] = None,
         softcap: float = 0.0,
         num_splits: int = 1,
+        split_size: Optional[int] = None,
         pack_gqa: Optional[bool] = None,
         deterministic: bool = False,
         score_mod: Optional[Callable] = None,
@@ -2057,6 +2136,7 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
             learnable_sink=learnable_sink,
             softcap=softcap,
             num_splits=num_splits,
+            split_size=split_size,
             pack_gqa=pack_gqa,
             score_mod=score_mod,
             mask_mod=mask_mod,
@@ -2138,6 +2218,7 @@ def flash_attn_func(
     learnable_sink: Optional[torch.Tensor] = None,
     softcap: float = 0.0,
     num_splits: int = 1,
+    split_size: Optional[int] = None,
     pack_gqa: Optional[bool] = None,
     deterministic: bool = False,
     score_mod: Optional[Callable] = None,
@@ -2160,6 +2241,7 @@ def flash_attn_func(
         learnable_sink,
         softcap,
         num_splits,
+        split_size,
         pack_gqa,
         deterministic,
         score_mod,
@@ -2192,6 +2274,7 @@ def flash_attn_varlen_func(
     learnable_sink: Optional[torch.Tensor] = None,
     softcap: float = 0.0,
     num_splits: int = 1,
+    split_size: Optional[int] = None,
     pack_gqa: Optional[bool] = None,
     deterministic: bool = False,
     score_mod: Optional[Callable] = None,
@@ -2235,6 +2318,7 @@ def flash_attn_varlen_func(
         learnable_sink,
         softcap,
         num_splits,
+        split_size,
         pack_gqa,
         deterministic,
         score_mod,

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -565,6 +565,14 @@ def _flash_attn_fwd(
             "Pass either num_splits or split_size, not both; split_size derives num_splits."
         )
         assert split_size > 0, "split_size must be a positive number of KV tokens"
+        if use_block_sparsity:
+            # split_size promises absolute, seqlen-invariant KV boundaries (0, S, 2S, ...).
+            # The SM100 block-sparse path partitions the *block list* by count
+            # (ceil_div(block_count, num_splits) in split_block_range), not by KV position,
+            # so it cannot honor those fixed boundaries and the prefill<->decode bitwise
+            # guarantee would not hold. Reject the combination rather than silently giving a
+            # derived split count with the wrong semantics.
+            raise NotImplementedError("split_size is not supported with block sparsity")
         if arch // 10 not in (10, 11):
             raise NotImplementedError("split_size (SplitKV) is only supported on SM100/110")
         if qv is not None:
@@ -2006,7 +2014,6 @@ class FlashAttnFunc(torch.autograd.Function):
         learnable_sink: Optional[torch.Tensor] = None,
         softcap: float = 0.0,
         num_splits: int = 1,
-        split_size: Optional[int] = None,
         pack_gqa: Optional[bool] = None,
         deterministic: bool = False,
         score_mod: Optional[Callable] = None,
@@ -2016,6 +2023,9 @@ class FlashAttnFunc(torch.autograd.Function):
         block_sparse_tensors: Optional[BlockSparseTensorsTorch] = None,
         block_sparse_tensors_bwd: Optional[BlockSparseTensorsTorch] = None,
         return_lse: bool = False,
+        # NB: split_size is appended at the end to preserve positional-argument
+        # compatibility for existing callers (num_splits -> pack_gqa -> ...).
+        split_size: Optional[int] = None,
     ):
         out, lse = _flash_attn_fwd(
             q,
@@ -2106,7 +2116,6 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
         learnable_sink: Optional[torch.Tensor] = None,
         softcap: float = 0.0,
         num_splits: int = 1,
-        split_size: Optional[int] = None,
         pack_gqa: Optional[bool] = None,
         deterministic: bool = False,
         score_mod: Optional[Callable] = None,
@@ -2115,6 +2124,9 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
         block_sparse_tensors: Optional[list] = None,
         aux_tensors: Optional[list] = None,
         return_lse: bool = False,
+        # NB: split_size is appended at the end to preserve positional-argument
+        # compatibility for existing callers (num_splits -> pack_gqa -> ...).
+        split_size: Optional[int] = None,
     ):
         out, lse = _flash_attn_fwd(
             q,
@@ -2218,7 +2230,6 @@ def flash_attn_func(
     learnable_sink: Optional[torch.Tensor] = None,
     softcap: float = 0.0,
     num_splits: int = 1,
-    split_size: Optional[int] = None,
     pack_gqa: Optional[bool] = None,
     deterministic: bool = False,
     score_mod: Optional[Callable] = None,
@@ -2228,6 +2239,9 @@ def flash_attn_func(
     block_sparse_tensors: Optional[BlockSparseTensorsTorch] = None,
     block_sparse_tensors_bwd: Optional[BlockSparseTensorsTorch] = None,
     return_lse: bool = False,
+    # Keyword-only and last so it cannot shift the meaning of existing positional args.
+    *,
+    split_size: Optional[int] = None,
 ):
     return FlashAttnFunc.apply(
         q,
@@ -2241,7 +2255,6 @@ def flash_attn_func(
         learnable_sink,
         softcap,
         num_splits,
-        split_size,
         pack_gqa,
         deterministic,
         score_mod,
@@ -2251,6 +2264,7 @@ def flash_attn_func(
         block_sparse_tensors,
         block_sparse_tensors_bwd,
         return_lse,
+        split_size,
     )
 
 
@@ -2274,7 +2288,6 @@ def flash_attn_varlen_func(
     learnable_sink: Optional[torch.Tensor] = None,
     softcap: float = 0.0,
     num_splits: int = 1,
-    split_size: Optional[int] = None,
     pack_gqa: Optional[bool] = None,
     deterministic: bool = False,
     score_mod: Optional[Callable] = None,
@@ -2283,6 +2296,9 @@ def flash_attn_varlen_func(
     block_sparse_tensors: Optional[BlockSparseTensorsTorch] = None,
     aux_tensors: Optional[list] = None,
     return_lse: bool = False,
+    # Keyword-only and last so it cannot shift the meaning of existing positional args.
+    *,
+    split_size: Optional[int] = None,
 ):
     """
     Explanation of some optional arguments:
@@ -2318,7 +2334,6 @@ def flash_attn_varlen_func(
         learnable_sink,
         softcap,
         num_splits,
-        split_size,
         pack_gqa,
         deterministic,
         score_mod,
@@ -2327,6 +2342,7 @@ def flash_attn_varlen_func(
         block_sparse_tensors,
         aux_tensors,
         return_lse,
+        split_size,
     )
 
 

--- a/flash_attn/cute/paged_kv.py
+++ b/flash_attn/cute/paged_kv.py
@@ -86,7 +86,11 @@ class PagedKVManager(ParamsBase):
         val_layout = cute.make_layout((1, async_copy_elems))
         gmem_tiled_copy_KV = cute.make_tiled_copy_tv(atom_async_copy, thr_layout, val_layout)
         gmem_thr_copy_KV = gmem_tiled_copy_KV.get_slice(thread_idx)
-        page_entry_per_thread = n_block_size // num_threads
+        # ceil_div (not floor): when n_block_size < num_threads (e.g. tile_n=64 for
+        # diff-headdim SplitKV with 128 load threads), floor would give 0 and create a
+        # zero-size page tensor. ceil_div yields >=1; threads with row >= n_block_size are
+        # masked by the is_valid guard in load_page_table.
+        page_entry_per_thread = cute.ceil_div(n_block_size, num_threads)
 
         tPrPage = cute.make_rmem_tensor((page_entry_per_thread,), Int32)
         tPrPageOffset = cute.make_rmem_tensor((page_entry_per_thread,), Int32)

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -2884,21 +2884,34 @@ def test_flash_attn_empty_q_varlen(causal):
         assert lse.numel() == 0
 
 
-@pytest.mark.parametrize("seqlen_k", [512, 1024])
+# (d, dv): MLA (192,128) and a regular same-head-dim (128,128) shape.
+@pytest.mark.parametrize("d, dv", [(192, 128), (128, 128)])
+# split_size=None exercises the regular num_splits=1 path; a concrete value enables
+# flash decoding (SplitKV) on BOTH prefill and decode. For MLA (192,128) the
+# diff-headdim SMEM guard only lets splitting engage at larger seqlen, so we include
+# a large seqlen_k. Boundaries are seqlen-invariant, so prefill and decode partition
+# the shared KV identically and must stay bitwise equal.
+# seqlen capped at 16384 and split_size >= 256 here: prefill SplitKV allocates an
+# fp32 out_partial of (num_splits, total_q, nheads, dv), so num_splits*seqlen must
+# stay bounded to avoid OOM (smaller split_size at long seqlen is exercised by the
+# batch=1 correctness test instead).
+@pytest.mark.parametrize("split_size", [None, 256, 512, 1024])
+@pytest.mark.parametrize("seqlen_k", [1024, 8192, 16384])
 @maybe_fake_tensor_mode(USE_FAKE_TENSOR)
-def test_flash_attn_ex2_emu_decode_prefill_consistency(seqlen_k):
-    """Decode↔prefill must be bitwise consistent for MLA (192,128).
+def test_flash_attn_ex2_emu_decode_prefill_consistency(seqlen_k, split_size, d, dv):
+    """Decode↔prefill must be bitwise consistent, including under flash decoding.
 
-    Regression test: paged decode (seqlen_q=1) vs non-paged prefill
-    (seqlen_q=full) for MLA shapes must produce identical outputs for the
-    last query position.
+    Paged decode (seqlen_q=1) vs non-paged prefill (seqlen_q=full), causal, must
+    produce identical outputs for the last query position. When ``split_size`` is set,
+    SplitKV (flash decoding) is enabled on both sides with the same, seqlen-invariant
+    split boundaries -- so the two execute an identical float-op sequence and stay
+    bitwise equal.
     """
     if IS_SM90:
         pytest.skip("ex2_emu is SM100+ only")
 
     device = "cuda"
     dtype = torch.bfloat16
-    d, dv = 192, 128
     nheads = nheads_kv = 16
 
     torch.random.manual_seed(0)
@@ -2913,6 +2926,7 @@ def test_flash_attn_ex2_emu_decode_prefill_consistency(seqlen_k):
         cu_seqlens_q=cu, cu_seqlens_k=cu,
         max_seqlen_q=seqlen_k, max_seqlen_k=seqlen_k,
         causal=True,
+        split_size=split_size,
     )
 
     # Decode: seqlen_q=1 at last position, paged KV, causal
@@ -2920,9 +2934,8 @@ def test_flash_attn_ex2_emu_decode_prefill_consistency(seqlen_k):
     num_pages = (seqlen_k + page_size - 1) // page_size
     k_cache = torch.zeros(num_pages, page_size, nheads_kv, d, device=device, dtype=dtype)
     v_cache = torch.zeros(num_pages, page_size, nheads_kv, dv, device=device, dtype=dtype)
-    for i in range(seqlen_k):
-        k_cache[i // page_size, i % page_size] = k[i]
-        v_cache[i // page_size, i % page_size] = v[i]
+    k_cache.view(num_pages * page_size, nheads_kv, d)[:seqlen_k] = k
+    v_cache.view(num_pages * page_size, nheads_kv, dv)[:seqlen_k] = v
     page_table = torch.arange(num_pages, dtype=torch.int32, device=device).unsqueeze(0)
     cache_seqlens = torch.tensor([seqlen_k], dtype=torch.int32, device=device)
 
@@ -2933,13 +2946,163 @@ def test_flash_attn_ex2_emu_decode_prefill_consistency(seqlen_k):
         max_seqlen_q=1, max_seqlen_k=None,
         seqused_k=cache_seqlens, page_table=page_table,
         causal=True,
+        split_size=split_size,
     )
 
     if is_fake_mode():
         return
 
     max_diff = (out_prefill[-1] - out_decode[0]).abs().max().item()
-    print(f"decode↔prefill max diff: {max_diff}")
+    print(f"decode↔prefill max diff (d={d}, dv={dv}, seqlen_k={seqlen_k}, split_size={split_size}): {max_diff}")
     assert torch.equal(out_prefill[-1], out_decode[0]), (
-        f"decode↔prefill diverged: max_diff={max_diff}."
+        f"decode↔prefill diverged: max_diff={max_diff} "
+        f"(d={d}, dv={dv}, seqlen_k={seqlen_k}, split_size={split_size})."
+    )
+
+
+# (d, dv, seqlen): seqlen chosen so that SplitKV actually engages for each shape,
+# including longer sequences. Regular (128,128) splits at any seqlen > split_size;
+# MLA (192,128) only engages past the diff-headdim SMEM guard (tile_n pinned to 64).
+@pytest.mark.parametrize(
+    "d, dv, seqlen",
+    [(128, 128, 2048), (128, 128, 16384), (192, 128, 8192), (192, 128, 16384)],
+)
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("split_size", [128, 256, 512, 1024])
+@maybe_fake_tensor_mode(USE_FAKE_TENSOR)
+def test_flash_attn_split_size_correctness(seqlen, split_size, causal, d, dv):
+    """A fixed split_size must produce the same answer as num_splits=1 (within tol)."""
+    if IS_SM90:
+        pytest.skip("SplitKV is SM100+ only")
+
+    device = "cuda"
+    dtype = torch.bfloat16
+    batch, nheads = 1, 8
+
+    torch.random.manual_seed(0)
+    q = torch.randn(batch, seqlen, nheads, d, device=device, dtype=dtype)
+    k = torch.randn(batch, seqlen, nheads, d, device=device, dtype=dtype)
+    v = torch.randn(batch, seqlen, nheads, dv, device=device, dtype=dtype)
+
+    out_split, _ = flash_attn_func(q, k, v, causal=causal, split_size=split_size)
+    out_ref, _ = flash_attn_func(q, k, v, causal=causal, num_splits=1)
+
+    if is_fake_mode():
+        return
+
+    max_diff = (out_split - out_ref).abs().max().item()
+    print(f"split_size={split_size} vs num_splits=1 max diff "
+          f"(d={d}, dv={dv}, seqlen={seqlen}, causal={causal}): {max_diff}")
+    assert torch.allclose(out_split, out_ref, atol=2e-2, rtol=1e-2), (
+        f"split_size output diverged from num_splits=1: max_diff={max_diff}."
+    )
+
+
+@maybe_fake_tensor_mode(USE_FAKE_TENSOR)
+def test_flash_attn_split_size_too_small_warns():
+    """split_size smaller than seqlen/256 must clamp to 256 splits, warn, and stay correct."""
+    if IS_SM90:
+        pytest.skip("SplitKV is SM100+ only")
+
+    device = "cuda"
+    dtype = torch.bfloat16
+    batch, nheads, d = 1, 4, 128
+    seqlen = 256 * 128 + 256  # > 256 blocks at tile_n=128 -> implied splits exceed the 256 cap
+
+    torch.random.manual_seed(0)
+    q = torch.randn(batch, seqlen, nheads, d, device=device, dtype=dtype)
+    k = torch.randn(batch, seqlen, nheads, d, device=device, dtype=dtype)
+    v = torch.randn(batch, seqlen, nheads, d, device=device, dtype=dtype)
+
+    with pytest.warns(UserWarning, match="clamping num_splits"):
+        out_split, _ = flash_attn_func(q, k, v, causal=False, split_size=128)
+    out_ref, _ = flash_attn_func(q, k, v, causal=False, num_splits=1)
+
+    if is_fake_mode():
+        return
+
+    # Output must not be silently truncated despite the clamp.
+    max_diff = (out_split - out_ref).abs().max().item()
+    assert torch.allclose(out_split, out_ref, atol=2e-2, rtol=1e-2), (
+        f"clamped split_size dropped KV tail or diverged: max_diff={max_diff}."
+    )
+
+
+# (d, dv): MLA (192,128) and regular (128,128). With a fixed split_size and the
+# diff-headdim tile_n pin, both engage SplitKV at this seqlen.
+@pytest.mark.parametrize("d, dv", [(192, 128), (128, 128)])
+@pytest.mark.parametrize("split_size", [128, 256, 512])
+@pytest.mark.parametrize("seqlen_k", [1024, 4096])
+@maybe_fake_tensor_mode(USE_FAKE_TENSOR)
+def test_flash_attn_split_size_autoregressive_consistency(seqlen_k, split_size, d, dv):
+    """Cross-length decode↔prefill: token p decoded at length p+1 must be bitwise
+    identical to token p in a full-length prefill, when both use the same split_size.
+
+    This is the autoregressive scenario: KV grows token-by-token during generation,
+    then a full prefill over the generated sequence must reproduce each token's hidden
+    state exactly. A fixed split_size makes split boundaries absolute KV positions, so
+    token p's causal range is partitioned identically at length p+1 and at length N.
+    """
+    if IS_SM90:
+        pytest.skip("SplitKV is SM100+ only")
+
+    device = "cuda"
+    dtype = torch.bfloat16
+    nheads = nheads_kv = 8
+    page_size = 128
+
+    torch.random.manual_seed(0)
+    q = torch.randn(seqlen_k, nheads, d, device=device, dtype=dtype)
+    k = torch.randn(seqlen_k, nheads_kv, d, device=device, dtype=dtype)
+    v = torch.randn(seqlen_k, nheads_kv, dv, device=device, dtype=dtype)
+
+    # Full-length causal prefill (varlen), SplitKV enabled via split_size.
+    cu = torch.tensor([0, seqlen_k], dtype=torch.int32, device=device)
+    out_prefill, _ = flash_attn_varlen_func(
+        q, k, v,
+        cu_seqlens_q=cu, cu_seqlens_k=cu,
+        max_seqlen_q=seqlen_k, max_seqlen_k=seqlen_k,
+        causal=True,
+        split_size=split_size,
+    )
+
+    # Paged KV cache holding the whole sequence; each decode step bounds it via seqused_k.
+    num_pages = (seqlen_k + page_size - 1) // page_size
+    k_cache = torch.zeros(num_pages, page_size, nheads_kv, d, device=device, dtype=dtype)
+    v_cache = torch.zeros(num_pages, page_size, nheads_kv, dv, device=device, dtype=dtype)
+    k_cache.view(num_pages * page_size, nheads_kv, d)[:seqlen_k] = k
+    v_cache.view(num_pages * page_size, nheads_kv, dv)[:seqlen_k] = v
+    page_table = torch.arange(num_pages, dtype=torch.int32, device=device).unsqueeze(0)
+
+    if is_fake_mode():
+        return
+
+    # Positions chosen to span: single-split (p+1 <= split_size), exact split
+    # boundaries (split_size multiples +/- 1), multi-split, and the last token.
+    positions = sorted({
+        1, 100,
+        split_size - 1, split_size, split_size + 1,
+        2 * split_size, 2 * split_size + 1,
+        seqlen_k // 2, seqlen_k - 1,
+    })
+    positions = [p for p in positions if 0 <= p < seqlen_k]
+    failures = []
+    for p in positions:
+        cache_seqlens = torch.tensor([p + 1], dtype=torch.int32, device=device)
+        out_decode, _ = flash_attn_varlen_func(
+            q[p:p + 1], k_cache, v_cache,
+            cu_seqlens_q=torch.tensor([0, 1], dtype=torch.int32, device=device),
+            cu_seqlens_k=None,
+            max_seqlen_q=1, max_seqlen_k=None,
+            seqused_k=cache_seqlens, page_table=page_table,
+            causal=True,
+            split_size=split_size,
+        )
+        if not torch.equal(out_prefill[p], out_decode[0]):
+            md = (out_prefill[p] - out_decode[0]).abs().max().item()
+            failures.append((p, md))
+
+    assert not failures, (
+        f"autoregressive decode↔prefill diverged (d={d}, dv={dv}, seqlen_k={seqlen_k}, "
+        f"split_size={split_size}) at positions [p, max_diff]: {failures}"
     )


### PR DESCRIPTION
## Summary

Adds a user-controlled **`split_size`** (in KV tokens) to the FA4 forward kernels, complementing the existing `num_splits` count. With `num_splits`, the per-split size is `ceil(n_blocks / num_splits)`, which **varies with sequence length** — so prefill (length `L`) and a later decode step (length `L+t`) partition the shared KV prefix differently. `split_size` instead pins each split to a fixed, tile-aligned number of KV blocks, making split boundaries **absolute KV positions** (`0, S, 2S, …`), independent of total length.

This delivers **bitwise-equal prefill↔decode under flash decoding**. Routing both prefill and decode through the same split+combine path with the same `split_size` makes them execute an identical float-op sequence for any shared token: a token's causal KV prefix is partitioned identically whether decoded incrementally at length `p+1` or prefilled in full at length `N`, and trailing out-of-range splits contribute exactly zero (LSE = −∞ → combine weight 0). No two-pass global-max redesign was required.

## Motivation

Today prefill runs `num_splits=1` while decode enables SplitKV (`num_splits>1`), so the two diverge numerically once flash decoding is on. The existing `test_flash_attn_ex2_emu_decode_prefill_consistency` only exercised `num_splits=1` on both sides. This PR makes prefill and decode bitwise-consistent **with flash decoding enabled**, including the autoregressive case (decode token `p` at length `p+1` must equal token `p` in a full-length prefill).

## API

```python
flash_attn_func(q, k, v, ..., split_size=256)          # KV tokens per split
flash_attn_varlen_func(q, k, v, ..., split_size=256)
```

- Mutually exclusive with an explicit `num_splits>1` (raises).
- Rounded up to a `tile_n` multiple; each split is exactly that many blocks (last split = remainder).
- SM100/110 only (SplitKV is not supported on SM80/90/120; `split_size` raises `NotImplementedError` there).
- For end-to-end bitwise determinism across a generation run, pass the **same fixed `split_size`** to both decode and prefill, chosen so the derived split count stays ≤ 256.

## Changes

- **`block_info.py`** — `n_blocks_per_split` field + exact fixed-size split branch in `get_n_block_min_max`. Regular even-division is preserved unchanged when `n_blocks_per_split is None`.
- **`flash_fwd_sm100.py`** — thread `n_blocks_per_split` as a runtime scalar through `__call__` → `kernel` → `BlockInfo`.
- **`interface.py`** — `split_size` parameter + `split_size_to_num_splits()` helper (tokens→blocks→count, with a 256-split cap that clamps and falls back to even-division so the KV tail is never dropped). Validation: mutually exclusive with `num_splits>1`, SM100/110-only, rejects qv / head_dim=256 / diff-headdim-with-head_dim_v=512. Pins `tile_n=64` for diff-headdim (MLA) `split_size` so boundaries are seqlen-invariant across lengths. Adds a compile-key bit for the fixed-vs-even mode; plumbs the arg (excluded for the hd256 kernel). Exposed on all four public entry points.
- **`paged_kv.py`** — fix a latent bug: `page_entry_per_thread` `floor`→`ceil_div`, so `tile_n < num_load_threads` (e.g. `tile_n=64` for diff-headdim SplitKV) no longer creates a zero-size page tensor; out-of-range rows are masked by the existing `is_valid` guard. (This is what made MLA SplitKV + paged decode crash.)
- **tests** — extend the decode↔prefill consistency test (MLA + regular hdim × with/without `split_size` × seqlens 1024/8192); add a cross-length autoregressive consistency test, a `split_size` correctness test (vs `num_splits=1`), and a too-small-`split_size` clamp/warning test.

## Verification (NVIDIA B200 / SM100)

**Split-size consistency & correctness — 69/69 pass.** Every prefill↔decode consistency case is `torch.equal` (max diff `0.0`):

| test | coverage | result |
|---|---|---|
| same-length decode↔prefill | MLA (192,128) + regular (128,128), `split_size` ∈ {None, 256, 512, 1024}, seqlen ∈ {1024, 8192, 16384} | all `max diff = 0.0` |
| autoregressive cross-length (decode@`p+1` vs prefill@`N`, per token) | MLA + regular, `split_size` ∈ {128, 256, 512}, seqlen ∈ {1024, 4096}, positions spanning split boundaries | all `torch.equal` |
| `split_size` vs `num_splits=1` correctness | MLA + regular, causal both, `split_size` ∈ {128, 256, 512, 1024}, seqlen up to 16384 | max diff ≤ 0.0078 (bf16 tol) |
| too-small `split_size` (256-cap clamp + warning) | regular | passes, output not truncated |

**Regression suite — real GPU run (`FAKE_TENSOR=0`): 6522 passed, 1944 skipped, 0 failed.** Covers `test_flash_attn_fast.py` (forward incl. `num_splits`), `test_flash_attn_varlen.py` (incl. paged KV), and `test_flash_attn_combine.py` (the SplitKV reduction kernel). Legacy even-division `num_splits ∈ {2,4,8}` for MLA + regular also matches `num_splits=1` within tol.

**SM90 (H100):** `split_size` raises `NotImplementedError`; the `num_splits=1` path matches SDPA.

**Performance — no regression** (FA4 forward, branch vs `main`, within run-to-run noise):

| hdim | causal | seqlen | main TFLOPS | branch TFLOPS |
|---|---|---|---|---|
| 128 | False | 2048 / 8192 / 16384 | 1182 / 1288 / 1308 | 1177 / 1292 / 1314 |
| 128 | True  | 2048 / 8192 / 16384 | 1042 / 1416 / 1455 | 1041 / 1417 / 1504 |
| 192-128 | False | 2048 / 8192 / 16384 | 1497 / 1703 / 1676 | 1496 / 1705 / 1630 |
| 192-128 | True  | 2048 / 8192 / 16384 | 1130 / 1507 / 1595 | 1130 / 1509 / 1542 |

The default (non-split, non-paged) forward codegen is byte-identical (the split branch is `const_expr`-skipped and `ceil_div == floor` when `tile_n == page_size`), so no perf impact is expected on existing paths.

## Memory cost of prefill splitting

Enabling `split_size` on a **prefill** call allocates fp32 partial buffers that the `num_splits=1` path does not: `out_partial` of shape `(num_splits, total_q, num_head, head_dim_v)` (plus a much smaller `lse_partial`). Peak extra memory is roughly `2 × num_splits ×` the normal bf16 output, scaling with `num_splits × total_q`. It is negligible for decode (`total_q=1`) but substantial for long prefill (e.g. ~8.6 GB at seqlen 16384, 16 heads, 64 splits). The buffers are transient (freed after the combine). Guidance: only enable prefill `split_size` when you need bitwise prefill↔decode parity; pick the largest `split_size` that still gives decode the parallelism it needs to keep `num_splits` (and prefill memory) down; keep `num_splits ≤ 256`. The default (`split_size=None`) prefill path is unchanged and allocates nothing extra.

## Notes / follow-ups

- **SM90 SplitKV is not included.** Hopper currently has no SplitKV path (the host asserts it). Adding it is a moderate, well-scoped follow-up — the schedulers, combine kernel, `block_info`, and host plumbing are already arch-agnostic; the main work is the fp32 partial-O epilogue in the SM90 forward.
