### PR TITLE
Wire can_implement checks before JIT compile in interface.py

### DIFF
--- a/flash_attn/cute/flash_bwd_sm90.py
+++ b/flash_attn/cute/flash_bwd_sm90.py
@@ -161,9 +161,11 @@ class FlashAttentionBackwardSm90:
             return False
         if tile_n % 16 != 0:
             return False
-        if num_threads % 32 != 0:
-            return False
-        if (tile_m * 2) % num_threads != 0:
+        # num_threads includes one 128-thread producer warp group in addition to the
+        # MMA warp groups. The tuned SM90 configs use 384 total threads with tile_m
+        # values such as 64, 80, and 128, so the SM80-style tile_m divisibility check
+        # does not apply here. Require only a structurally valid warp-group count.
+        if num_threads < 256 or num_threads % 128 != 0:
             return False
         return True
 

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -979,7 +979,20 @@ def _flash_attn_fwd(
             raise ValueError(
                 f"Unsupported compute capability: {arch}. Supported: 8.x, 9.x, 10.x, 11.x, 12.x"
             )
-        # TODO: check @can_implement
+        # Validate the kernel configuration before JIT compilation so invalid tile /
+        # head-dim / SMEM configs fail with a clear error instead of an opaque CuTeDSL
+        # compile error. Only the SM80 and SM120 forward kernels expose can_implement;
+        # the SM90 and SM100 forward kernels do not define it, so they are skipped here.
+        if arch // 10 in [8, 12]:
+            if not fa_fwd.can_implement(
+                dtype, head_dim, head_dim_v, tile_m, tile_n, 1, num_threads, causal,
+            ):
+                raise RuntimeError(
+                    f"FlashAttention forward kernel ({type(fa_fwd).__name__}) cannot be "
+                    f"implemented with given parameters: dtype={dtype}, head_dim={head_dim}, "
+                    f"head_dim_v={head_dim_v}, tile_m={tile_m}, tile_n={tile_n}, "
+                    f"num_threads={num_threads}, causal={causal}"
+                )
         if qv is not None:
             _flash_attn_fwd.compile_cache[compile_key] = cute.compile(
                 fa_fwd,
@@ -1956,7 +1969,34 @@ def _flash_attn_bwd(
             sparse_tensors_compile = to_cute_block_sparse_tensors(normalized_block_sparse_tensors)
         dq_accum_tensor = dq_tensor if use_dedicated_hd256_kernel else dq_accum_tensor
 
-        # TODO: check @can_implement
+        # Validate the kernel configuration before JIT compilation so invalid tile /
+        # head-dim / SMEM configs fail with a clear error instead of an opaque CuTeDSL
+        # compile error. The reachable SM120 and SM90 backward kernels expose
+        # can_implement (with differing signatures); the SM100 backward kernel does
+        # not define it, so it is skipped here.
+        if arch // 10 == 12:
+            if not fa_bwd_obj.can_implement(
+                dtype, head_dim, head_dim_v, m_block_size, n_block_size,
+                num_stages_Q, num_stages_dO, num_threads, causal, V_in_regs=V_in_regs,
+            ):
+                raise RuntimeError(
+                    f"FlashAttention backward kernel ({type(fa_bwd_obj).__name__}) cannot be "
+                    f"implemented with given parameters: dtype={dtype}, head_dim={head_dim}, "
+                    f"head_dim_v={head_dim_v}, m_block_size={m_block_size}, "
+                    f"n_block_size={n_block_size}, num_stages_Q={num_stages_Q}, "
+                    f"num_stages_dO={num_stages_dO}, num_threads={num_threads}, causal={causal}"
+                )
+        elif arch // 10 == 9:
+            if not fa_bwd_obj.can_implement(
+                dtype, head_dim, head_dim_v, m_block_size, n_block_size,
+                num_stages_Q, num_threads, V_in_regs=V_in_regs,
+            ):
+                raise RuntimeError(
+                    f"FlashAttention backward kernel ({type(fa_bwd_obj).__name__}) cannot be "
+                    f"implemented with given parameters: dtype={dtype}, head_dim={head_dim}, "
+                    f"head_dim_v={head_dim_v}, tile_m={m_block_size}, tile_n={n_block_size}, "
+                    f"Q_stage={num_stages_Q}, num_threads={num_threads}"
+                )
         _flash_attn_bwd.compile_cache[compile_key] = cute.compile(
             fa_bwd_obj,
             q_tensor,

--- a/tests/cute/test_can_implement.py
+++ b/tests/cute/test_can_implement.py
@@ -1,0 +1,214 @@
+# Copyright (c) 2025, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+# Tests for the `can_implement` pre-compile guards wired into interface.py.
+#
+# These tests do NOT require a GPU. They cover two layers:
+#   1. The `can_implement` static methods themselves (the exact predicate each guard
+#      evaluates), with deliberately invalid configs that must be rejected and valid
+#      configs that must be accepted.
+#   2. The interface guards in `_flash_attn_fwd` / `_flash_attn_bwd`, asserting that an
+#      invalid config raises a clear `RuntimeError` *before* `cute.compile` is reached,
+#      and that a valid config passes the guard (reaching compilation).
+#
+# Only reachable architectures whose selected kernel class exposes `can_implement`
+# are guarded: forward = SM80 / SM120, backward = SM90 / SM120. The SM90 and SM100
+# forward kernels and the SM100 backward kernel do not define `can_implement`, so they
+# are not exercised here. SM80 backward is not supported by the interface.
+
+import cutlass
+import pytest
+import torch
+from torch._subclasses.fake_tensor import FakeTensorMode
+
+from flash_attn.cute import interface
+from flash_attn.cute.interface import _flash_attn_bwd, _flash_attn_fwd
+from flash_attn.cute.flash_bwd_sm90 import FlashAttentionBackwardSm90
+from flash_attn.cute.flash_bwd_sm120 import FlashAttentionBackwardSm120
+from flash_attn.cute.flash_fwd import FlashAttentionForwardSm80
+from flash_attn.cute.flash_fwd_sm120 import FlashAttentionForwardSm120
+
+FP16 = cutlass.Float16
+FP32 = cutlass.Float32
+
+
+# ---------------------------------------------------------------------------
+# Layer 1: `can_implement` static methods (pure, no GPU, no compile).
+# ---------------------------------------------------------------------------
+
+
+def test_fwd_sm80_can_implement_rejects_invalid_and_accepts_valid():
+    # Unsupported dtype.
+    assert not FlashAttentionForwardSm80.can_implement(
+        FP32, 64, 64, 128, 128, 1, 128, False
+    )
+    # head_dim not a multiple of 8.
+    assert not FlashAttentionForwardSm80.can_implement(
+        FP16, 100, 64, 128, 128, 1, 128, False
+    )
+    # tile_n not a multiple of 16.
+    assert not FlashAttentionForwardSm80.can_implement(
+        FP16, 64, 64, 128, 100, 1, 128, False
+    )
+    # Valid config.
+    assert FlashAttentionForwardSm80.can_implement(
+        FP16, 64, 64, 128, 128, 1, 128, False
+    )
+
+
+def test_fwd_sm120_can_implement_enforces_99kb_smem_budget():
+    # head_dim=256 with tile 128x64 needs ~131 KB of SMEM, exceeding SM120's 99 KB
+    # budget, so it must be rejected (this is the config interface.py selects for SM120
+    # head_dim>64).
+    assert not FlashAttentionForwardSm120.can_implement(
+        FP16, 256, 256, 128, 64, 1, 128, False
+    )
+    # The very same config fits within SM80's larger 163 KB budget: confirms the
+    # rejection above is specifically the tighter SM120 capacity, not generic logic.
+    assert FlashAttentionForwardSm80.can_implement(
+        FP16, 256, 256, 128, 64, 1, 128, False
+    )
+    # Valid SM120 config (head_dim=64, tile 128x128 -> ~48 KB).
+    assert FlashAttentionForwardSm120.can_implement(
+        FP16, 64, 64, 128, 128, 1, 128, False
+    )
+
+
+def test_bwd_sm90_can_implement_rejects_invalid_and_accepts_valid():
+    # Unsupported dtype.
+    assert not FlashAttentionBackwardSm90.can_implement(
+        FP32, 64, 64, 128, 64, 2, 256, False
+    )
+    # tile_n not a multiple of 16.
+    assert not FlashAttentionBackwardSm90.can_implement(
+        FP16, 64, 64, 128, 60, 2, 256, False
+    )
+    # num_threads does not include complete producer + MMA warp groups.
+    assert not FlashAttentionBackwardSm90.can_implement(
+        FP16, 64, 64, 128, 64, 2, 100, False
+    )
+    # Current interface configs use 384 total threads: one producer warp group plus
+    # two MMA warp groups. Both tile sizes below are selected by _tile_size_bwd_sm90.
+    assert FlashAttentionBackwardSm90.can_implement(
+        FP16, 64, 64, 128, 128, 2, 384, False
+    )
+    assert FlashAttentionBackwardSm90.can_implement(
+        FP16, 96, 96, 64, 128, 2, 384, False
+    )
+
+
+def test_bwd_sm120_can_implement_enforces_99kb_smem_budget():
+    # head_dim=256 with tile 64x64 needs ~128 KB of SMEM, exceeding SM120's 99 KB budget.
+    assert not FlashAttentionBackwardSm120.can_implement(
+        FP16, 256, 256, 64, 64, 1, 1, 128, False
+    )
+    # Valid SM120 config (head_dim=64).
+    assert FlashAttentionBackwardSm120.can_implement(
+        FP16, 64, 64, 64, 64, 2, 2, 128, False
+    )
+
+
+# ---------------------------------------------------------------------------
+# Layer 2: interface guards raise RuntimeError before cute.compile.
+#
+# We force the SM120 path (tight 99 KB SMEM budget) via the `_arch` override (forward)
+# or patch `_get_device_arch` for the SM90/SM120 backward paths. FakeTensorMode keeps
+# everything off the GPU; the guards run before `cute.compile`, so no kernel is built.
+# ---------------------------------------------------------------------------
+
+
+class _CompileReached(Exception):
+    """Sentinel raised in place of cute.compile to prove the guard let the flow pass."""
+
+
+def _raise_compile_reached(*args, **kwargs):
+    raise _CompileReached()
+
+
+def _skip_kernel_init(*args, **kwargs):
+    """Avoid querying the physical GPU architecture before a fake-mode guard test."""
+
+
+def _fake_qkv(head_dim, *, dtype=torch.float16, seqlen=128):
+    q = torch.randn(1, seqlen, 1, head_dim, dtype=dtype, device="cuda")
+    k = torch.randn(1, seqlen, 1, head_dim, dtype=dtype, device="cuda")
+    v = torch.randn(1, seqlen, 1, head_dim, dtype=dtype, device="cuda")
+    return q, k, v
+
+
+def test_fwd_guard_raises_runtime_error_before_compile_sm120(monkeypatch):
+    monkeypatch.setattr(
+        interface.FlashAttentionForwardSm120, "__init__", _skip_kernel_init
+    )
+    with FakeTensorMode():
+        q, k, v = _fake_qkv(256)
+        with pytest.raises(RuntimeError, match="forward kernel"):
+            _flash_attn_fwd(q, k, v, causal=False, _arch=120)
+
+
+def test_fwd_guard_passes_for_valid_config_sm120(monkeypatch):
+    monkeypatch.setattr(
+        interface.FlashAttentionForwardSm120, "__init__", _skip_kernel_init
+    )
+    monkeypatch.setattr(interface.cute, "compile", _raise_compile_reached)
+    with FakeTensorMode():
+        q, k, v = _fake_qkv(64)
+        # Valid config: the guard must not raise, so the flow reaches our patched compile.
+        with pytest.raises(_CompileReached):
+            _flash_attn_fwd(q, k, v, causal=False, _arch=120)
+
+
+def test_bwd_guard_raises_runtime_error_before_compile_sm120(monkeypatch):
+    monkeypatch.setattr(interface, "_get_device_arch", lambda: 120)
+    # The preprocess kernel compiles before the main guard; stub it out so the test
+    # stays fast and isolates the can_implement guard.
+    monkeypatch.setattr(interface, "_bwd_preprocess", lambda *a, **k: None)
+    with FakeTensorMode():
+        q, k, v = _fake_qkv(256)
+        out = torch.randn(1, 128, 1, 256, dtype=torch.float16, device="cuda")
+        dout = torch.randn(1, 128, 1, 256, dtype=torch.float16, device="cuda")
+        lse = torch.randn(1, 1, 128, dtype=torch.float32, device="cuda")
+        with pytest.raises(RuntimeError, match="backward kernel"):
+            _flash_attn_bwd(q, k, v, out, dout, lse, causal=False)
+
+
+def test_bwd_guard_passes_for_valid_config_sm120(monkeypatch):
+    monkeypatch.setattr(interface, "_get_device_arch", lambda: 120)
+    monkeypatch.setattr(interface, "_bwd_preprocess", lambda *a, **k: None)
+    monkeypatch.setattr(interface.cute, "compile", _raise_compile_reached)
+    with FakeTensorMode():
+        q, k, v = _fake_qkv(64)
+        out = torch.randn(1, 128, 1, 64, dtype=torch.float16, device="cuda")
+        dout = torch.randn(1, 128, 1, 64, dtype=torch.float16, device="cuda")
+        lse = torch.randn(1, 1, 128, dtype=torch.float32, device="cuda")
+        with pytest.raises(_CompileReached):
+            _flash_attn_bwd(q, k, v, out, dout, lse, causal=False)
+
+
+def test_bwd_guard_raises_runtime_error_before_compile_sm90(monkeypatch):
+    monkeypatch.setattr(interface, "_get_device_arch", lambda: 90)
+    monkeypatch.setattr(interface, "_bwd_preprocess", lambda *a, **k: None)
+    monkeypatch.setattr(
+        interface.FlashAttentionBackwardSm90,
+        "can_implement",
+        staticmethod(lambda *args, **kwargs: False),
+    )
+    with FakeTensorMode():
+        q, k, v = _fake_qkv(64)
+        out = torch.randn(1, 128, 1, 64, dtype=torch.float16, device="cuda")
+        dout = torch.randn(1, 128, 1, 64, dtype=torch.float16, device="cuda")
+        lse = torch.randn(1, 1, 128, dtype=torch.float32, device="cuda")
+        with pytest.raises(RuntimeError, match="backward kernel"):
+            _flash_attn_bwd(q, k, v, out, dout, lse, causal=False)
+
+
+def test_bwd_guard_passes_for_valid_config_sm90(monkeypatch):
+    monkeypatch.setattr(interface, "_get_device_arch", lambda: 90)
+    monkeypatch.setattr(interface, "_bwd_preprocess", lambda *a, **k: None)
+    monkeypatch.setattr(interface.cute, "compile", _raise_compile_reached)
+    with FakeTensorMode():
+        q, k, v = _fake_qkv(64)
+        out = torch.randn(1, 128, 1, 64, dtype=torch.float16, device="cuda")
+        dout = torch.randn(1, 128, 1, 64, dtype=torch.float16, device="cuda")
+        lse = torch.randn(1, 1, 128, dtype=torch.float32, device="cuda")
+        # Valid config: the guard must not raise, so the flow reaches our patched compile.
+        with pytest.raises(_CompileReached):
+            _flash_attn_bwd(q, k, v, out, dout, lse, causal=False)


### PR DESCRIPTION
## Summary

Adds early `can_implement()` guards before `cute.compile()` so invalid tile, head-dimension, or shared-memory configurations fail with a descriptive `RuntimeError` instead of an opaque CuTeDSL error.

Reachable guarded paths:

- Forward: `FlashAttentionForwardSm80`, `FlashAttentionForwardSm120`
- Backward: `FlashAttentionBackwardSm90`, `FlashAttentionBackwardSm120`

SM90/SM100 forward and SM100 backward do not expose compatible predicates and remain unchanged. SM80 backward is not supported by the current interface, so this PR no longer claims or tests that interface path.

The rebase exposed a stale SM90 backward predicate: `num_threads` includes a 128-thread producer warp group, while the old SM80-style divisibility rule rejected the dispatcher's valid 384-thread configurations. The predicate now validates complete producer/MMA warp groups and is tested against current SM90 tiles.

## Merge dependency

#2751 owns the SM80 forward tile heuristic and architecture-aware SMEM-capacity parameter. This PR intentionally does not duplicate it. Once #2751 lands, the SM8x forward guard here must pass `smem_capacity_arch=f"sm_{arch}"` only for SM8x and add the `_arch=89`, `head_dim=256`, `tile_mn=(128, 64)` pre-compile rejection regression. Please do not merge #2609 before that integration is complete.

Backward SM8x capacity parameterization is left to a separate change if SM8x backward support is restored.

## Tests

- `tests/cute/test_can_implement.py`: **10 passed** with `FakeTensorMode` on a remote Python/CUDA stack.
- #2751's `tests/cute/test_sm80_head_dim256_smem.py`: **15 passed** independently against #2751; its implementation was not copied here.
- Ruff check and format check: passed.

A real FA4 CUDA execution is still required before requesting review. The available host has only V100/SM70 GPUs, while FA4 requires SM80 or newer, so no hardware execution is claimed.