### PR TITLE
Enable pack_gqa backward on SM100/SM110

### DIFF
--- a/flash_attn/cute/block_info.py
+++ b/flash_attn/cute/block_info.py
@@ -56,7 +56,15 @@ class BlockInfo:
 
     @cute.jit
     def get_m_block_min_max(self, seqlen_info: SeqlenInfoQK, n_block: Int32) -> Tuple[Int32, Int32]:
-        m_block_max = cute.ceil_div(seqlen_info.seqlen_q, self.tile_m)
+        # With PackGQA the backward iterates over the packed Q dimension
+        # (qhead_per_kvhead_packgqa * seqlen_q rows per kv-head), so the number of
+        # m_blocks scales by the packing factor. seqlen_info.seqlen_q stays the
+        # logical (unpacked) sequence length so masking/score_mod can recover the
+        # per-head query position.
+        seqlen_q_packed = seqlen_info.seqlen_q
+        if const_expr(self.qhead_per_kvhead_packgqa > 1):
+            seqlen_q_packed = seqlen_info.seqlen_q * self.qhead_per_kvhead_packgqa
+        m_block_max = cute.ceil_div(seqlen_q_packed, self.tile_m)
         m_block_min = 0
         if const_expr(self.is_causal or (self.is_local and self.window_size_right is not None)):
             n_idx_min = n_block * self.tile_n

--- a/flash_attn/cute/flash_bwd_sm100.py
+++ b/flash_attn/cute/flash_bwd_sm100.py
@@ -22,6 +22,7 @@ from flash_attn.cute import copy_utils
 from flash_attn.cute import pipeline
 from flash_attn.cute.blackwell_helpers import gemm_w_idx, gemm_ptx_w_idx  # noqa
 from flash_attn.cute.mask import AttentionMask
+from flash_attn.cute.pack_gqa import pack_gqa_layout
 from flash_attn.cute.seqlen_info import SeqlenInfoQK
 from flash_attn.cute.block_info import BlockInfo
 from quack.cute_dsl_utils import ParamsBase
@@ -55,6 +56,7 @@ class FlashAttentionBackwardSm100:
         is_causal: bool = False,
         is_local: bool = False,
         qhead_per_kvhead: cutlass.Constexpr[int] = 1,
+        pack_gqa: cutlass.Constexpr[bool] = False,
         tile_m: int = 128,
         tile_n: int = 128,
         is_persistent: bool = False,
@@ -110,7 +112,11 @@ class FlashAttentionBackwardSm100:
         self.is_causal = is_causal
         self.is_local = is_local
         self.qhead_per_kvhead = qhead_per_kvhead
-        self.pack_gqa = False
+        # PackGQA folds the qhead_per_kvhead query heads of a kv-group into the seqlen_q
+        # dimension so a single kv-head tile processes all of its query heads. This is only
+        # enabled by the interface for SM100/SM110 on the supported (dense, non-causal/local,
+        # non-2CTA-hd256) configs; every other path passes pack_gqa=False.
+        self.pack_gqa = pack_gqa
         self.deterministic = deterministic
         self.spt_override = spt
 
@@ -479,7 +485,10 @@ class FlashAttentionBackwardSm100:
         self.is_varlen_q = mCuSeqlensQ is not None or mSeqUsedQ is not None
         self.use_tma_store = not (self.qhead_per_kvhead == 1 and mCuSeqlensK is not None)
         # self.use_tma_store = not self.qhead_per_kvhead == 1
-        self.dKV_postprocess = self.qhead_per_kvhead > 1
+        # With PackGQA all query heads of a kv-group are processed within a single kv-head
+        # tile, so dK/dV accumulate directly in TMEM across the packed m-loop and no longer
+        # need the float32 accum + postprocess reduction across separate query-head tiles.
+        self.dKV_postprocess = self.qhead_per_kvhead > 1 and not self.pack_gqa
 
         if const_expr(self.dKV_postprocess):
             assert self.dk_dtype.width == 32, "Must accumulate dK in float precision for GQA"
@@ -491,6 +500,16 @@ class FlashAttentionBackwardSm100:
         QO_layout_transpose = [1, 3, 2, 0] if const_expr(mCuSeqlensQ is None) else [0, 2, 1]
         mQ, mdO = [layout_utils.select(t, mode=QO_layout_transpose) for t in (mQ, mdO)]
 
+        # PackGQA: fold the query heads of each kv-group into seqlen_q (mode 0, which holds
+        # seqlen and has head at mode 2 after the transpose above). After packing, mode 2 is
+        # nheads_kv and the kernel iterates one tile per kv-head over the packed Q rows.
+        # mdQaccum is allocated by the interface already in packed (per-kv-head) form, so its
+        # view is left untouched here.
+        if const_expr(self.pack_gqa):
+            nheads_kv = mK.shape[2]
+            mQ = pack_gqa_layout(mQ, self.qhead_per_kvhead, nheads_kv, head_idx=2)
+            mdO = pack_gqa_layout(mdO, self.qhead_per_kvhead, nheads_kv, head_idx=2)
+
         KV_layout_transpose = [1, 3, 2, 0] if const_expr(mCuSeqlensK is None) else [0, 2, 1]
         mK, mV = [layout_utils.select(t, mode=KV_layout_transpose) for t in (mK, mV)]
 
@@ -500,6 +519,12 @@ class FlashAttentionBackwardSm100:
             layout_utils.select(t, mode=LSE_dPsum_dQaccum_transpose)
             for t in (mLSE, mdPsum, mdQaccum)
         ]
+        # PackGQA: LSE/dPsum keep a separate seqlen mode (mode 0) and head (mode 1), so the
+        # head folds cleanly into seqlen. mdQaccum is physically packed already, so skip it.
+        if const_expr(self.pack_gqa):
+            nheads_kv = mK.shape[2]
+            mLSE = pack_gqa_layout(mLSE, self.qhead_per_kvhead, nheads_kv, head_idx=1)
+            mdPsum = pack_gqa_layout(mdPsum, self.qhead_per_kvhead, nheads_kv, head_idx=1)
 
         if const_expr(not self.dKV_postprocess):
             layout_dKV_transpose = KV_layout_transpose
@@ -724,7 +749,7 @@ class FlashAttentionBackwardSm100:
             cluster_shape_mn=self.cluster_shape_mnk[:2],
             mCuSeqlensQ=mCuSeqlensK,
             mSeqUsedQ=mSeqUsedK,
-            qhead_per_kvhead_packgqa=1,  # pack_gqa disabled for bwd
+            qhead_per_kvhead_packgqa=self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
             element_size=self.k_dtype.width // 8,
             is_persistent=self.is_persistent,  # persistent mode not tested
             lpt=self.spt,
@@ -1013,6 +1038,7 @@ class FlashAttentionBackwardSm100:
             swap_AB=True,
             window_size_left=window_size_left,
             window_size_right=window_size_right,
+            qhead_per_kvhead_packgqa=self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
         )
 
     @cute.kernel
@@ -1403,11 +1429,14 @@ class FlashAttentionBackwardSm100:
             False,  # is_split_kv
             window_size_left,
             window_size_right,
-            qhead_per_kvhead_packgqa=1,
+            qhead_per_kvhead_packgqa=self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
         )
         SeqlenInfoCls = partial(
             SeqlenInfoQK.create,
-            seqlen_q_static=mQ.shape[0],
+            # With PackGQA mQ.shape[0] is the nested (qhead_per_kvhead, seqlen_q) mode; pass the
+            # logical (unpacked) seqlen_q so masking/score_mod recover the per-head query index,
+            # while BlockInfo scales the m_block count by qhead_per_kvhead_packgqa.
+            seqlen_q_static=mQ.shape[0] if const_expr(not self.pack_gqa) else mQ.shape[0][1],
             seqlen_k_static=mK.shape[0],
             mCuSeqlensQ=mCuSeqlensQ,
             mCuSeqlensK=mCuSeqlensK,
@@ -1642,7 +1671,9 @@ class FlashAttentionBackwardSm100:
             m_block_min, m_block_max = block_info.get_m_block_min_max(
                 seqlen, n_block // self.cluster_shape_mnk[0]
             )
-            head_idx_kv = head_idx // self.qhead_per_kvhead
+            # PackGQA schedules one tile per kv-head (head_idx is already the kv-head index);
+            # otherwise head_idx is a query head and maps to its kv-head via integer division.
+            head_idx_kv = head_idx // (self.qhead_per_kvhead if const_expr(not self.pack_gqa) else 1)
 
             process_tile = (
                 const_expr(not self.is_local and not self.is_varlen_q) or m_block_min < m_block_max
@@ -1753,7 +1784,9 @@ class FlashAttentionBackwardSm100:
             m_block_min, m_block_max = block_info.get_m_block_min_max(
                 seqlen, n_block // self.cluster_shape_mnk[0]
             )
-            head_idx_kv = head_idx // self.qhead_per_kvhead
+            # PackGQA schedules one tile per kv-head (head_idx is already the kv-head index);
+            # otherwise head_idx is a query head and maps to its kv-head via integer division.
+            head_idx_kv = head_idx // (self.qhead_per_kvhead if const_expr(not self.pack_gqa) else 1)
             n_block_cta_group = n_block // self.cta_group_size
 
             # GMEM tensors (varlen-aware)
@@ -3892,7 +3925,7 @@ class FlashAttentionBackwardSm100:
         # (8, tile_n / 128, 64 / 8) = (8, 1, 8) or (4, tile_n * 32 / (128 * 4)) = (4, 8)
         tdKVsdKV_r2s = thr_copy_r2s_dKV.partition_D(sdKV)
 
-        head_idx_kv = head_idx // self.qhead_per_kvhead
+        head_idx_kv = head_idx // (self.qhead_per_kvhead if const_expr(not self.pack_gqa) else 1)
         if const_expr(not self.dKV_postprocess):
             assert not seqlen.has_cu_seqlens_k, "varlen uses non tma store path"
             mdKV_cur = mdKV[None, None, head_idx_kv, batch_idx]  # (seqlen, hdim)

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -1317,7 +1317,7 @@ def _flash_attn_bwd(
     m_block_size: int = 64,
     n_block_size: int = 128,
     num_threads: int = 256,
-    pack_gqa: bool = False,
+    pack_gqa: Optional[bool] = None,
     num_stages_Q: int = 2,
     num_stages_dO: int = 2,
     SdP_swapAB: bool = False,
@@ -1507,10 +1507,33 @@ def _flash_attn_bwd(
     if softmax_scale is None:
         softmax_scale = 1.0 / math.sqrt(head_dim)
     qhead_per_kvhead = num_head // num_head_kv
+    # PackGQA in the backward folds the qhead_per_kvhead query heads of a kv-group into the
+    # seqlen_q dimension (mirroring the forward) so a single kv-head tile processes all of its
+    # query heads. This is currently only implemented for the SM100/SM110 (Blackwell) kernel and
+    # only for the dense, non-causal/local path that the kernel + dQ postprocess support. SM80,
+    # SM90, SM120 and the dedicated hd=256 2CTA kernel do not implement backward packing, so they
+    # always fall back to the standard (unpacked) GQA path. When pack_gqa is None we only turn it
+    # on where it is supported; an explicit pack_gqa=True is honored only on supported configs.
+    pack_gqa_bwd_supported = (
+        arch // 10 in (10, 11)
+        and not use_dedicated_hd256_kernel
+        and qhead_per_kvhead > 1
+        and m_block_size % qhead_per_kvhead == 0
+        and not causal
+        and not local
+        and cu_seqlens_q is None
+        and cu_seqlens_k is None
+        and seqused_q is None
+        and seqused_k is None
+        and block_sparse_tensors is None
+        and aux_tensors is None
+        and not deterministic
+    )
     if pack_gqa is None:
-        pack_gqa = qhead_per_kvhead > 1
-    # pack_gqa backward not yet supported in bwd
-    pack_gqa = False
+        pack_gqa = pack_gqa_bwd_supported
+    else:
+        pack_gqa = bool(pack_gqa) and pack_gqa_bwd_supported
+
     
     if softcap != 0.0:
         assert score_mod is None and score_mod_bwd is None, (
@@ -1582,7 +1605,9 @@ def _flash_attn_bwd(
     # accumulate into the same dK/dV. SM90 varlen_k with qhead_per_kvhead==1 now uses
     # ragged TMA tensors for direct store, so no longer needs accum+postprocess.
     # hd=256 2CTA backward has its own internal postprocess for dK/dV.
-    dKV_postprocess = qhead_per_kvhead > 1 and not use_dedicated_hd256_kernel
+    # PackGQA processes all query heads of a kv-group within one kv-head tile, so dK/dV
+    # accumulate directly and the accum+postprocess reduction is not needed.
+    dKV_postprocess = qhead_per_kvhead > 1 and not use_dedicated_hd256_kernel and not pack_gqa
     if dKV_postprocess:
         head_dim_v_rounded = (head_dim_v + 32 - 1) // 32 * 32
         if cu_seqlens_k is None:
@@ -1617,6 +1642,18 @@ def _flash_attn_bwd(
                 dtype=torch.float32,
                 device=device,
             )
+
+    # PackGQA: the SM100 backward and dQ postprocess view dq_accum as one packed buffer per
+    # kv-head (qhead_per_kvhead * seqlen_q_rounded contiguous rows). The preprocess that zeros
+    # dq_accum keeps the unpacked (batch, num_head, seqlen_q_rounded * head_dim_rounded) layout,
+    # so we only reinterpret the same contiguous memory for the kernel + postprocess.
+    dq_accum_kernel = dq_accum
+    if pack_gqa and dq_accum is not None:
+        dq_accum_kernel = dq_accum.view(
+            batch_size,
+            num_head_kv,
+            qhead_per_kvhead * seqlen_q_rounded * head_dim_rounded,
+        )
 
     dtype = torch2cute_dtype_map[q.dtype]
     current_stream = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
@@ -1782,7 +1819,7 @@ def _flash_attn_bwd(
             to_cute_tensor(t) for t in (q, k, v, dout, dq, dk, dv)
         ]
         lse_log2_tensor, dpsum_tensor = [to_cute_tensor(t) for t in (lse_log2, dpsum)]
-        dq_accum_tensor = to_cute_tensor(dq_accum) if dq_accum is not None else None
+        dq_accum_tensor = to_cute_tensor(dq_accum_kernel) if dq_accum_kernel is not None else None
         if dKV_postprocess:
             dk_accum_tensor, dv_accum_tensor = [
                 to_cute_tensor(t) for t in (dk_accum, dv_accum)
@@ -1894,6 +1931,7 @@ def _flash_attn_bwd(
                     is_causal=causal,
                     is_local=local,
                     qhead_per_kvhead=qhead_per_kvhead,
+                    pack_gqa=pack_gqa,
                     tile_m=m_block_size,
                     tile_n=n_block_size,
                     cluster_size=cluster_size,
@@ -1941,7 +1979,7 @@ def _flash_attn_bwd(
             options="--enable-tvm-ffi",
         )
     if not is_fake_mode():
-        dq_accum = dq if use_dedicated_hd256_kernel else dq_accum
+        dq_accum = dq if use_dedicated_hd256_kernel else dq_accum_kernel
         _flash_attn_bwd.compile_cache[compile_key](
             q.detach(),
             k.detach(),
@@ -1987,13 +2025,47 @@ def _flash_attn_bwd(
             num_threads_post_dQ = 128
             num_threads_post_dKV = 128
 
-        _bwd_postprocess_convert(
-            dq_accum, dq, softmax_scale,
-            cu_seqlens_q, seqused_q,
-            arch, dtype, head_dim, m_block_size, num_threads_post_dQ,
-            AtomLayoutMdQ, dQ_swapAB,
-            use_2cta_instrs=use_2cta_instrs, cluster_size=1,
-        )
+        if pack_gqa:
+            # PackGQA dQ: dq_accum is packed per kv-head (qhead_per_kvhead * seqlen_q_rounded
+            # contiguous rows). Run the standard postprocess treating it as a dense problem with
+            # num_head_kv heads and packed seqlen, producing a packed dq buffer laid out as
+            # row = seqpos * qhead_per_kvhead + qhead_offset (head-fastest, matching the kernel's
+            # packed m-loop), then scatter back to the dense (batch, seqlen_q, num_head, head_dim)
+            # dq tensor with a torch view+permute. This keeps the postprocess kernel unchanged.
+            packed_seqlen_q = qhead_per_kvhead * seqlen_q_rounded
+            dq_packed = torch.empty(
+                batch_size, packed_seqlen_q, num_head_kv, head_dim,
+                dtype=dq.dtype, device=device,
+            )
+            _bwd_postprocess_convert(
+                dq_accum, dq_packed, softmax_scale,
+                cu_seqlens_q, seqused_q,
+                arch, dtype, head_dim, m_block_size, num_threads_post_dQ,
+                AtomLayoutMdQ, dQ_swapAB,
+                use_2cta_instrs=use_2cta_instrs, cluster_size=1,
+            )
+            if not is_fake_mode():
+                # row r -> (seqpos = r // qhead, qhead_offset = r % qhead): split the packed
+                # seqlen into (seqlen_q, qhead) with seqpos outermost, then interleave qhead
+                # into the head dimension as kv_head * qhead + qhead_offset == original q head.
+                # reshape (not view) since the row slice is non-contiguous when seqlen_q is not
+                # a multiple of m_block_size.
+                dq_unpacked = dq_packed[:, : seqlen_q * qhead_per_kvhead].reshape(
+                    batch_size, seqlen_q, qhead_per_kvhead, num_head_kv, head_dim
+                )
+                dq.copy_(
+                    dq_unpacked.permute(0, 1, 3, 2, 4).reshape(
+                        batch_size, seqlen_q, num_head, head_dim
+                    )
+                )
+        else:
+            _bwd_postprocess_convert(
+                dq_accum, dq, softmax_scale,
+                cu_seqlens_q, seqused_q,
+                arch, dtype, head_dim, m_block_size, num_threads_post_dQ,
+                AtomLayoutMdQ, dQ_swapAB,
+                use_2cta_instrs=use_2cta_instrs, cluster_size=1,
+            )
 
         if dKV_postprocess:
             # Postprocess: convert dk_accum from float32 to dk in bf16/fp16
@@ -2503,6 +2575,9 @@ class FlashAttnFunc(torch.autograd.Function):
         ctx.mask_mod = mask_mod
         ctx.aux_scalars = aux_scalars
         ctx.block_sparse_tensors_bwd = block_sparse_tensors_bwd
+        # Forward the user's PackGQA preference; the backward independently re-gates it to the
+        # configs the SM100 bwd kernel supports (so an unsupported request falls back cleanly).
+        ctx.pack_gqa = pack_gqa
         ctx.set_materialize_grads(False)
         return out, lse
 
@@ -2553,6 +2628,7 @@ class FlashAttnFunc(torch.autograd.Function):
                 aux_tensors=aux_tensors,
                 aux_scalars=ctx.aux_scalars,
                 block_sparse_tensors=ctx.block_sparse_tensors_bwd,
+                pack_gqa=ctx.pack_gqa,
                 dlse=dlse,
             )
             return dq, dk, dv, *((None,) * 30)  # Extra Nones is fine


### PR DESCRIPTION
## Summary

This PR enables `pack_gqa` in the SM100/SM110 (Blackwell) backward path, which was previously hardcoded off. The forward kernel already packs multiple query heads per KV head; this change mirrors that packing into the backward kernel so a single KV-head tile processes all of its query heads.

**What changed**
- Thread `pack_gqa` from the forward path through to the backward path via `FlashAttnFunc`/`ctx` and `_flash_attn_bwd`.
- Pack the `mQ`/`mdO`/`mLSE`/`mdPsum` layouts in `FlashAttentionBackwardSm100`.
- Set `qhead_per_kvhead_packgqa` in the backward tile scheduler, mask, and `SeqlenInfoQK`, and map `head_idx` to the KV head when packing.
- Scale the backward m-block count in `block_info.get_m_block_min_max` by the pack-gqa factor while keeping the logical `seqlen_q` for masking/score_mod.
- Use a packed `dq_accum` buffer for the kernel, run the (unchanged) dQ postprocess on the packed `dq` buffer, then scatter back to the dense `dq` tensor. dK/dV accumulate directly in the packed tiles, so their accum+postprocess steps are skipped.

**Scope / gating**
Packing is only enabled when all of the following hold:
- Architecture is SM100/SM110.
- Dense (non-varlen, non-block-sparse).
- Non-causal / non-local.
- Non-deterministic.
- Not head_dim 256.
- `m_block_size % qhead_per_kvhead == 0`.

SM80/SM90/SM120 still force `pack_gqa` off in the backward path. SM90 backward `pack_gqa` remains unimplemented and is still a separate xfail.

**Why**
Improves performance for GQA/MQA training on Blackwell, bringing the backward path in line with the forward path which already packs heads.

## Test plan

- `tests/cute/test_score_mod.py::test_cute_vs_flex_attention_backward_pack_gqa` now exercises the SM100 packed backward path (it remains xfail only on SM90).

## Validation caveat

This change has been implemented and statically validated (ruff reports no new errors; AST parse OK), but it has **not** yet been run on hardware — the author has no NVIDIA GPU available. It needs SM100 (Blackwell) CI/hardware validation before merge, specifically of:
- the packed `dq_accum` buffer and the dQ postprocess scatter back to dense `dq`,
- mask boundaries under packing,
- the packed TMA layouts (`mQ`/`mdO`/`mLSE`/`mdPsum`).