### PR TITLE
[CK_TILE] Update CK to enable RDNA backward support

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,6 @@ FlashAttention-2 ROCm CK backend currently supports:
 1. MI200x, MI250x, MI300x, MI355x, and RDNA 3/4 GPUs.
 2. Datatype fp16 and bf16
 3. Both forward's and backward's head dimensions up to 256.
-4. RDNA 3 GPUs do not currently support backward, and RDNA 4 GPUs support backward only with deterministic=False
 
 #### Triton Backend
 The Triton implementation of [Flash Attention](https://tridao.me/publications/flash2/flash2.pdf) supports AMD's CDNA (MI200, MI300) and RDNA GPUs using fp16, bf16, and fp32 datatypes. It provides forward and backward passes with causal masking, variable sequence lengths, arbitrary Q/KV sequence lengths and head sizes, MQA/GQA, dropout, rotary embeddings, ALiBi, paged attention, and FP8 (via the Flash Attention v3 interface). Sliding window attention is currently a work in progress.

--- a/csrc/flash_attn_ck/flash_common.hpp
+++ b/csrc/flash_attn_ck/flash_common.hpp
@@ -78,46 +78,4 @@ inline int num_splits_heuristic_ck(int batch_nheads_mblocks, int num_SMs, int nu
 
 int override_num_splits_if_necessary(int batch, int nhead, int max_seqlen_q, int hdim_v, float p_drop, int num_splits);
 
-inline std::string get_gcn_arch_name() {
-#ifdef USE_ROCM
-    int dev = 0;
-    if (hipGetDevice(&dev) != hipSuccess) {
-        return std::string{};
-    }
-    hipDeviceProp_t prop{};
-    if (hipGetDeviceProperties(&prop, dev) != hipSuccess) {
-        return std::string{};
-    }
-    return std::string{prop.gcnArchName};
-#else
-    return "";
-#endif
-}
-
-inline bool is_gfx11_arch() {
-    const std::string arch = get_gcn_arch_name();
-    return !arch.empty() && arch.rfind("gfx11", 0) == 0;
-}
-
-inline bool is_gfx12_arch() {
-    const std::string arch = get_gcn_arch_name();
-    return !arch.empty() && arch.rfind("gfx12", 0) == 0;
-}
-
-inline bool is_gfx1x_arch() {
-    return is_gfx11_arch() || is_gfx12_arch();
-}
-
-inline void check_gfx1x_bwd_supported(bool deterministic) {
-    if (is_gfx11_arch()) {
-        TORCH_CHECK(false, "CK backward is not supported on gfx11.");
-    }
-
-    if (is_gfx12_arch() && deterministic) {
-        TORCH_CHECK(false,
-                    "Deterministic CK backward is not supported on gfx12. "
-                    "Please rerun with deterministic=False.");
-    }
-}
-
 } // namespace flash

--- a/csrc/flash_attn_ck/mha_bwd.cpp
+++ b/csrc/flash_attn_ck/mha_bwd.cpp
@@ -54,7 +54,7 @@ fmha_bwd_args get_ck_fmha_bwd_args(const mask_info &mask,
                                    const at::Tensor out,
                                    const at::Tensor softmax_lse,
                                    const at::Tensor dout,
-                                   at::Tensor dq_acc,
+                                   void *workspace_ptr,
                                    at::Tensor d,
                                    at::Tensor dq,
                                    at::Tensor dk,
@@ -110,12 +110,6 @@ fmha_bwd_args get_ck_fmha_bwd_args(const mask_info &mask,
     ck_tile::index_t stride_dv = dv.stride(1);
     ck_tile::index_t nhead_stride_dv = dv.stride(2);
 
-    // dq_acc: (batch_size, nheads, split, seqlen_q, hdim)
-    ck_tile::long_index_t batch_stride_dq_acc = dq_acc.stride(0);
-    ck_tile::long_index_t nhead_stride_dq_acc = dq_acc.stride(1);
-    ck_tile::index_t split_stride_dq_acc = dq_acc.stride(2);
-    ck_tile::index_t stride_dq_acc = dq_acc.stride(3);
-
     float p_undrop = 1.0 - p_dropout;
 
     void *alibi_slopes_ptr = nullptr;
@@ -144,7 +138,7 @@ fmha_bwd_args get_ck_fmha_bwd_args(const mask_info &mask,
                          dk.data_ptr(),
                          dv.data_ptr(),
                          nullptr, // dbias
-                         dq_acc.data_ptr(), // dq_acc
+                         workspace_ptr,
                          nullptr, // sink_ptr
                          nullptr, // d_sink_ptr
                          nullptr, // seqstart_q_ptr
@@ -170,7 +164,6 @@ fmha_bwd_args get_ck_fmha_bwd_args(const mask_info &mask,
                          stride_o,
                          0, // stride_randval
                          stride_do,
-                         stride_dq_acc,
                          stride_dq,
                          stride_dk,
                          stride_dv,
@@ -183,7 +176,6 @@ fmha_bwd_args get_ck_fmha_bwd_args(const mask_info &mask,
                          0, // nhead_stride_randval
                          nhead_stride_do,
                          nhead_stride_lse,
-                         nhead_stride_dq_acc,
                          nhead_stride_dq,
                          nhead_stride_dk,
                          nhead_stride_dv,
@@ -196,12 +188,10 @@ fmha_bwd_args get_ck_fmha_bwd_args(const mask_info &mask,
                          0, // batch_stride_randval
                          batch_stride_do,
                          batch_stride_lse,
-                         batch_stride_dq_acc,
                          batch_stride_dq,
                          batch_stride_dk,
                          batch_stride_dv,
                          0  , // batch_stride_dbias, FA without dbias
-                         split_stride_dq_acc,
                          mask.left,
                          mask.right,
                          static_cast<ck_tile::index_t>(mask.type),
@@ -343,7 +333,6 @@ mha_bwd(const at::Tensor &dout,                   // batch_size x seqlen_q x num
         alibi_slopes_.has_value(),
         deterministic);
     fmha_bwd_launcher launcher(traits);
-    const ck_tile::index_t nsplits = launcher.dq_acc_splits;
 
     at::cuda::CUDAGuard device_guard{q.device()};
 
@@ -352,7 +341,16 @@ mha_bwd(const at::Tensor &dout,                   // batch_size x seqlen_q x num
         flash::check_gfx1x_bwd_supported(deterministic);
     }
     auto softmax_d = torch::empty({batch_size, num_heads, seqlen_q}, opts.dtype(at::kFloat));
-    at::Tensor dq_accum = torch::zeros({batch_size, num_heads, nsplits, seqlen_q, head_size}, opts.dtype(at::kFloat));
+
+    // Allocate device workspace
+    at::Tensor workspace;
+    void *workspace_ptr = nullptr;
+    if (launcher.workspace_size > 0) {
+        workspace = torch::empty({static_cast<int64_t>(launcher.workspace_size)},
+                                 opts.dtype(at::kByte));
+        workspace_ptr = workspace.data_ptr();
+        launcher.prepare_workspace(workspace_ptr);
+    }
 
     at::Tensor dk_expanded, dv_expanded;
     if (num_heads_k != num_heads) {  // MQA / GQA
@@ -402,7 +400,7 @@ mha_bwd(const at::Tensor &dout,                   // batch_size x seqlen_q x num
                 out,
                 softmax_lse,
                 dout,
-                dq_accum,
+                workspace_ptr,
                 softmax_d,
                 dq,
                 dk_expanded,
@@ -411,7 +409,7 @@ mha_bwd(const at::Tensor &dout,                   // batch_size x seqlen_q x num
                 p_dropout,
                 drop_seed_offset);
 
-        float t = fmha_bwd(traits, args, stream_config);
+        float t = launcher.run(args, stream_config);
         TORCH_CHECK(t >= 0, "invalid argument for fmha_bwd");
     } else {
         // If seqlen_q == 0, then we have an empty tensor. We need to set the output to 0.

--- a/csrc/flash_attn_ck/mha_bwd.cpp
+++ b/csrc/flash_attn_ck/mha_bwd.cpp
@@ -145,6 +145,8 @@ fmha_bwd_args get_ck_fmha_bwd_args(const mask_info &mask,
                          dv.data_ptr(),
                          nullptr, // dbias
                          dq_acc.data_ptr(), // dq_acc
+                         nullptr, // sink_ptr
+                         nullptr, // d_sink_ptr
                          nullptr, // seqstart_q_ptr
                          nullptr, // seqstart_k_ptr
                          nullptr, // seqlen_q_ptr

--- a/csrc/flash_attn_ck/mha_bwd.cpp
+++ b/csrc/flash_attn_ck/mha_bwd.cpp
@@ -349,7 +349,23 @@ mha_bwd(const at::Tensor &dout,                   // batch_size x seqlen_q x num
         workspace = torch::empty({static_cast<int64_t>(launcher.workspace_size)},
                                  opts.dtype(at::kByte));
         workspace_ptr = workspace.data_ptr();
-        launcher.prepare_workspace(workspace_ptr);
+        // Pinned host buffer allocator backed by PyTorch's CachingHostAllocator.
+        // The returned shared_ptr owns the at::Tensor; the launcher keeps it
+        // alive via a stream-tail hipLaunchHostFunc keepalive. Required when
+        // the launcher needs host-side workspace metadata (deterministic mode
+        // and/or non-trivial worker state); harmless when it doesn't.
+        auto pinned_host_alloc = [](size_t bytes) -> std::shared_ptr<void> {
+            auto t = std::make_shared<at::Tensor>(torch::empty(
+                {static_cast<int64_t>(bytes)},
+                torch::TensorOptions().dtype(at::kByte).device(at::kCPU).pinned_memory(true)));
+            return std::shared_ptr<void>(t, t->data_ptr());
+        };
+        ck_tile::stream_config prep_cfg{stream};
+        launcher.prepare_workspace_async(workspace_ptr,
+                                         /*seqstart_q_dev=*/nullptr,
+                                         /*seqstart_k_dev=*/nullptr,
+                                         prep_cfg,
+                                         pinned_host_alloc);
     }
 
     at::Tensor dk_expanded, dv_expanded;

--- a/csrc/flash_attn_ck/mha_bwd.cpp
+++ b/csrc/flash_attn_ck/mha_bwd.cpp
@@ -337,9 +337,6 @@ mha_bwd(const at::Tensor &dout,                   // batch_size x seqlen_q x num
     at::cuda::CUDAGuard device_guard{q.device()};
 
     auto opts = q.options();
-    if (flash::is_gfx1x_arch()) {
-        flash::check_gfx1x_bwd_supported(deterministic);
-    }
     auto softmax_d = torch::empty({batch_size, num_heads, seqlen_q}, opts.dtype(at::kFloat));
 
     // Allocate device workspace

--- a/csrc/flash_attn_ck/mha_varlen_bwd.cpp
+++ b/csrc/flash_attn_ck/mha_varlen_bwd.cpp
@@ -19,7 +19,9 @@ fmha_bwd_traits get_ck_fmha_varlen_bwd_traits(const mask_info &mask,
                                               int nhead_k,
                                               bool has_dropout,
                                               bool enable_alibi,
-                                              bool deterministic)
+                                              bool deterministic,
+                                              const int* seqstart_qs,
+                                              const int* seqstart_ks)
 {
     return fmha_bwd_traits{seqlen_q,
                            seqlen_k,
@@ -37,7 +39,9 @@ fmha_bwd_traits get_ck_fmha_varlen_bwd_traits(const mask_info &mask,
                            false,    // has_dbias
                            has_dropout,
                            false, // s_randval
-                           deterministic};
+                           deterministic,
+                           seqstart_qs,
+                           seqstart_ks};
 }
 fmha_bwd_args get_ck_fmha_varlen_bwd_args(const mask_info &mask,
                                           // sizes
@@ -57,7 +61,7 @@ fmha_bwd_args get_ck_fmha_varlen_bwd_args(const mask_info &mask,
                                           const at::Tensor out,
                                           const at::Tensor softmax_lse,
                                           const at::Tensor dout,
-                                          at::Tensor dq_acc,
+                                          void *workspace_ptr,
                                           at::Tensor d,
                                           at::Tensor dq,
                                           at::Tensor dk,
@@ -117,12 +121,6 @@ fmha_bwd_args get_ck_fmha_varlen_bwd_args(const mask_info &mask,
     ck_tile::index_t stride_dv = dv.stride(0);
     ck_tile::index_t nhead_stride_dv = dv.stride(1);
 
-    // dq_acc: (nheads, split, total_q, hdim)
-    ck_tile::long_index_t batch_stride_dq_acc = 0;
-    ck_tile::long_index_t nhead_stride_dq_acc = dq_acc.stride(0);
-    ck_tile::index_t split_stride_dq_acc = dq_acc.stride(1);
-    ck_tile::index_t stride_dq_acc = dq_acc.stride(2);
-
     float p_undrop = 1.0 - p_dropout;
 
     void *alibi_slopes_ptr = nullptr;
@@ -151,7 +149,7 @@ fmha_bwd_args get_ck_fmha_varlen_bwd_args(const mask_info &mask,
                          dk.data_ptr(),
                          dv.data_ptr(),
                          nullptr, // dbias
-                         dq_acc.data_ptr(), // dq_acc
+                         workspace_ptr,
                          nullptr, // sink_ptr
                          nullptr, // d_sink_ptr
                          seqlens_q.data_ptr(), // seqstart_q_ptr
@@ -177,7 +175,6 @@ fmha_bwd_args get_ck_fmha_varlen_bwd_args(const mask_info &mask,
                          stride_o,
                          0, // stride_randval
                          stride_do,
-                         stride_dq_acc,
                          stride_dq,
                          stride_dk,
                          stride_dv,
@@ -190,7 +187,6 @@ fmha_bwd_args get_ck_fmha_varlen_bwd_args(const mask_info &mask,
                          0, // nhead_stride_randval
                          nhead_stride_do,
                          nhead_stride_lse,
-                         nhead_stride_dq_acc,
                          nhead_stride_dq,
                          nhead_stride_dk,
                          nhead_stride_dv,
@@ -203,12 +199,10 @@ fmha_bwd_args get_ck_fmha_varlen_bwd_args(const mask_info &mask,
                          0, // batch_stride_randval
                          batch_stride_do,
                          batch_stride_lse,
-                         batch_stride_dq_acc,
                          batch_stride_dq,
                          batch_stride_dk,
                          batch_stride_dv,
                          0  , // batch_stride_dbias, FA without dbias
-                         split_stride_dq_acc,
                          mask.left,
                          mask.right,
                          static_cast<ck_tile::index_t>(mask.type),
@@ -345,6 +339,11 @@ mha_varlen_bwd(const at::Tensor &dout,                   // total_q x num_heads 
         dv = torch::empty_like(v);
     }
 
+    // seqstart_qs/ks are dereferenced on the HOST inside fmha_bwd_launcher constructor
+    // (to compute workspace sizes), so we must use host copies.
+    at::Tensor cu_seqlens_q_host = cu_seqlens_q.cpu();
+    at::Tensor cu_seqlens_k_host = cu_seqlens_k.cpu();
+
     const auto traits = get_ck_fmha_varlen_bwd_traits(
         mask,
         q_dtype_str,
@@ -358,9 +357,10 @@ mha_varlen_bwd(const at::Tensor &dout,                   // total_q x num_heads 
         num_heads_k,
         is_dropout,
         alibi_slopes_.has_value(),
-        deterministic);
+        deterministic,
+        reinterpret_cast<const int*>(cu_seqlens_q_host.data_ptr()),
+        reinterpret_cast<const int*>(cu_seqlens_k_host.data_ptr()));
     fmha_bwd_launcher launcher(traits);
-    const ck_tile::index_t nsplits = launcher.dq_acc_splits;
 
     at::cuda::CUDAGuard device_guard{q.device()};
 
@@ -369,7 +369,16 @@ mha_varlen_bwd(const at::Tensor &dout,                   // total_q x num_heads 
         flash::check_gfx1x_bwd_supported(deterministic);
     }
     auto softmax_d = torch::empty({batch_size, num_heads, max_seqlen_q}, opts.dtype(at::kFloat));
-    at::Tensor dq_accum  = torch::zeros({num_heads, nsplits, total_q, head_size}, opts.dtype(at::kFloat));
+
+    // Allocate device workspace
+    at::Tensor workspace;
+    void *workspace_ptr = nullptr;
+    if (launcher.workspace_size > 0) {
+        workspace = torch::empty({static_cast<int64_t>(launcher.workspace_size)},
+                                 opts.dtype(at::kByte));
+        workspace_ptr = workspace.data_ptr();
+        launcher.prepare_workspace(workspace_ptr);
+    }
 
     at::Tensor dk_expanded, dv_expanded;
     if (num_heads_k != num_heads) {  // MQA / GQA
@@ -430,7 +439,7 @@ mha_varlen_bwd(const at::Tensor &dout,                   // total_q x num_heads 
                 out,
                 softmax_lse,
                 dout,
-                dq_accum,
+                workspace_ptr,
                 softmax_d,
                 dq,
                 dk_expanded,
@@ -439,7 +448,7 @@ mha_varlen_bwd(const at::Tensor &dout,                   // total_q x num_heads 
                 p_dropout,
                 drop_seed_offset);
 
-        float t = fmha_bwd(traits, args, stream_config);
+        float t = launcher.run(args, stream_config);
         TORCH_CHECK(t >= 0, "invalid argument for fmha_bwd");
     } else {
         // If seqlen_q == 0, then we have an empty tensor. We need to set the output to 0.

--- a/csrc/flash_attn_ck/mha_varlen_bwd.cpp
+++ b/csrc/flash_attn_ck/mha_varlen_bwd.cpp
@@ -152,6 +152,8 @@ fmha_bwd_args get_ck_fmha_varlen_bwd_args(const mask_info &mask,
                          dv.data_ptr(),
                          nullptr, // dbias
                          dq_acc.data_ptr(), // dq_acc
+                         nullptr, // sink_ptr
+                         nullptr, // d_sink_ptr
                          seqlens_q.data_ptr(), // seqstart_q_ptr
                          seqlens_k.data_ptr(), // seqstart_k_ptr
                          nullptr, // seqlen_q_ptr

--- a/csrc/flash_attn_ck/mha_varlen_bwd.cpp
+++ b/csrc/flash_attn_ck/mha_varlen_bwd.cpp
@@ -354,9 +354,6 @@ mha_varlen_bwd(const at::Tensor &dout,                   // total_q x num_heads 
     at::cuda::CUDAGuard device_guard{q.device()};
 
     auto opts = q.options();
-    if (flash::is_gfx1x_arch()) {
-        flash::check_gfx1x_bwd_supported(deterministic);
-    }
     auto softmax_d = torch::empty({batch_size, num_heads, max_seqlen_q}, opts.dtype(at::kFloat));
 
     // Allocate device workspace

--- a/csrc/flash_attn_ck/mha_varlen_bwd.cpp
+++ b/csrc/flash_attn_ck/mha_varlen_bwd.cpp
@@ -19,9 +19,7 @@ fmha_bwd_traits get_ck_fmha_varlen_bwd_traits(const mask_info &mask,
                                               int nhead_k,
                                               bool has_dropout,
                                               bool enable_alibi,
-                                              bool deterministic,
-                                              const int* seqstart_qs,
-                                              const int* seqstart_ks)
+                                              bool deterministic)
 {
     return fmha_bwd_traits{seqlen_q,
                            seqlen_k,
@@ -39,9 +37,7 @@ fmha_bwd_traits get_ck_fmha_varlen_bwd_traits(const mask_info &mask,
                            false,    // has_dbias
                            has_dropout,
                            false, // s_randval
-                           deterministic,
-                           seqstart_qs,
-                           seqstart_ks};
+                           deterministic};
 }
 fmha_bwd_args get_ck_fmha_varlen_bwd_args(const mask_info &mask,
                                           // sizes
@@ -339,11 +335,6 @@ mha_varlen_bwd(const at::Tensor &dout,                   // total_q x num_heads 
         dv = torch::empty_like(v);
     }
 
-    // seqstart_qs/ks are dereferenced on the HOST inside fmha_bwd_launcher constructor
-    // (to compute workspace sizes), so we must use host copies.
-    at::Tensor cu_seqlens_q_host = cu_seqlens_q.cpu();
-    at::Tensor cu_seqlens_k_host = cu_seqlens_k.cpu();
-
     const auto traits = get_ck_fmha_varlen_bwd_traits(
         mask,
         q_dtype_str,
@@ -357,9 +348,7 @@ mha_varlen_bwd(const at::Tensor &dout,                   // total_q x num_heads 
         num_heads_k,
         is_dropout,
         alibi_slopes_.has_value(),
-        deterministic,
-        reinterpret_cast<const int*>(cu_seqlens_q_host.data_ptr()),
-        reinterpret_cast<const int*>(cu_seqlens_k_host.data_ptr()));
+        deterministic);
     fmha_bwd_launcher launcher(traits);
 
     at::cuda::CUDAGuard device_guard{q.device()};
@@ -377,7 +366,23 @@ mha_varlen_bwd(const at::Tensor &dout,                   // total_q x num_heads 
         workspace = torch::empty({static_cast<int64_t>(launcher.workspace_size)},
                                  opts.dtype(at::kByte));
         workspace_ptr = workspace.data_ptr();
-        launcher.prepare_workspace(workspace_ptr);
+        // Pinned host buffer allocator backed by PyTorch's CachingHostAllocator.
+        // The returned shared_ptr owns the at::Tensor; the launcher keeps it
+        // alive via a stream-tail hipLaunchHostFunc keepalive so the buffer
+        // is not recycled while async D2H/H2D copies are still in flight.
+        auto pinned_host_alloc = [](size_t bytes) -> std::shared_ptr<void> {
+            auto t = std::make_shared<at::Tensor>(torch::empty(
+                {static_cast<int64_t>(bytes)},
+                torch::TensorOptions().dtype(at::kByte).device(at::kCPU).pinned_memory(true)));
+            return std::shared_ptr<void>(t, t->data_ptr());
+        };
+        ck_tile::stream_config prep_cfg{stream};
+        launcher.prepare_workspace_async(
+            workspace_ptr,
+            reinterpret_cast<const int*>(cu_seqlens_q.data_ptr()),
+            reinterpret_cast<const int*>(cu_seqlens_k.data_ptr()),
+            prep_cfg,
+            pinned_host_alloc);
     }
 
     at::Tensor dk_expanded, dv_expanded;

--- a/setup.py
+++ b/setup.py
@@ -192,9 +192,23 @@ def append_nvcc_threads(nvcc_extra_args):
     return nvcc_extra_args + ["--threads", NVCC_THREADS]
 
 
-def rename_cpp_to_cu(cpp_files):
+def rename_cpp_to_cu(cpp_files, generated_rdna_bfloat16_override=None):
     for entry in cpp_files:
-        shutil.copy(entry, os.path.splitext(entry)[0] + ".cu")
+        dst = os.path.splitext(entry)[0] + ".cu"
+        if (
+            generated_rdna_bfloat16_override is not None
+            and Path(entry).parent.name == "build"
+            and Path(entry).name.startswith(("fmha_fwd", "fmha_bwd"))
+            and re.search(r"_gfx1[12][^/]*\.cpp$", Path(entry).name)
+        ):
+            with open(entry, "r", encoding="utf-8") as src, open(dst, "w", encoding="utf-8") as out:
+                out.write(
+                    "#undef CK_TILE_FLOAT_TO_BFLOAT16_DEFAULT\n"
+                    f"#define CK_TILE_FLOAT_TO_BFLOAT16_DEFAULT {generated_rdna_bfloat16_override}\n"
+                )
+                out.write(src.read())
+        else:
+            shutil.copy(entry, dst)
 
 
 def validate_and_update_archs(archs):
@@ -211,6 +225,27 @@ def validate_and_update_archs(archs):
             f"'native' cannot be combined with explicit archs: {archs}. "
             "Use either GPU_ARCHS='native' or GPU_ARCHS='gfx942;gfx950'."
         )
+
+
+def get_ck_tile_bfloat16_supported_modes(ck_dir):
+    config_path = Path(this_dir) / ck_dir / "include" / "ck_tile" / "core" / "config.hpp"
+    try:
+        config_text = config_path.read_text(encoding="utf-8")
+    except OSError:
+        # Old vendored CK revisions support up to mode 4.
+        return {"0", "1", "2", "3", "4"}
+
+    supported_modes = set(
+        re.findall(
+            r"^#define\s+CK_TILE_FLOAT_TO_BFLOAT16_[A-Z0-9_]+\s+(\d+)\s*$",
+            config_text,
+            re.MULTILINE,
+        )
+    )
+    if not supported_modes:
+        raise RuntimeError(f"Failed to detect CK tile BF16 conversion modes from {config_path}.")
+
+    return supported_modes
 
 
 cmdclass = {}
@@ -465,16 +500,6 @@ elif not SKIP_CUDA_BUILD and IS_ROCM:
         if detect_hipify_v2():
             maybe_hipify_v2_flag = ["-DHIPIFY_V2"]
 
-        rename_cpp_to_cu(sources)
-
-        renamed_sources = ["csrc/flash_attn_ck/flash_api.cu",
-                        "csrc/flash_attn_ck/flash_common.cu",
-                        "csrc/flash_attn_ck/mha_bwd.cu",
-                        "csrc/flash_attn_ck/mha_fwd_kvcache.cu",
-                        "csrc/flash_attn_ck/mha_fwd.cu",
-                        "csrc/flash_attn_ck/mha_varlen_bwd.cu",
-                        "csrc/flash_attn_ck/mha_varlen_fwd.cu"] + glob.glob(f"build/fmha_*wd*.cu")
-
         cc_flag += ["-O3","-std=c++20",
                     "-Wno-unknown-warning-option",
                     "-fbracket-depth=1024",
@@ -492,11 +517,45 @@ elif not SKIP_CUDA_BUILD and IS_ROCM:
                     # "-DFLASHATTENTION_DISABLE_BACKWARD",
                     "-D__HIP_PLATFORM_HCC__=1"]
 
+        supported_ck_tile_bfloat16_modes = get_ck_tile_bfloat16_supported_modes(ck_dir)
         ck_tile_float_to_bfloat16_default = os.environ.get("CK_TILE_FLOAT_TO_BFLOAT16_DEFAULT")
-        if ck_tile_float_to_bfloat16_default is None:
-            has_gfx11_target = any(arch.startswith("gfx11") for arch in kernel_targets)
-            ck_tile_float_to_bfloat16_default = "0" if has_gfx11_target else "3"
+        if ck_tile_float_to_bfloat16_default is not None:
+            if ck_tile_float_to_bfloat16_default not in supported_ck_tile_bfloat16_modes:
+                supported_modes_str = ",".join(sorted(supported_ck_tile_bfloat16_modes, key=int))
+                raise RuntimeError(
+                    "CK_TILE_FLOAT_TO_BFLOAT16_DEFAULT={} is not supported by {}. "
+                    "Supported modes: {}.".format(
+                        ck_tile_float_to_bfloat16_default, ck_dir, supported_modes_str
+                    )
+                )
+        else:
+            ck_tile_float_to_bfloat16_default = "3"
+
+        generated_rdna_bfloat16_override = None
+        has_gfx11_or_gfx12_target = any(
+            arch.startswith(("gfx11", "gfx12")) for arch in kernel_targets
+        )
+        if has_gfx11_or_gfx12_target:
+            generated_rdna_bfloat16_override = (
+                "5" if "5" in supported_ck_tile_bfloat16_modes else "0"
+            )
+
+            if generated_rdna_bfloat16_override != "5":
+                print(
+                    "Current composable_kernel does not support BF16 conversion mode 5; "
+                    f"falling back to mode {generated_rdna_bfloat16_override} for gfx11/gfx12 generated blobs."
+                )
         cc_flag += [f"-DCK_TILE_FLOAT_TO_BFLOAT16_DEFAULT={ck_tile_float_to_bfloat16_default}"]
+
+        rename_cpp_to_cu(sources, generated_rdna_bfloat16_override=generated_rdna_bfloat16_override)
+
+        renamed_sources = ["csrc/flash_attn_ck/flash_api.cu",
+                        "csrc/flash_attn_ck/flash_common.cu",
+                        "csrc/flash_attn_ck/mha_bwd.cu",
+                        "csrc/flash_attn_ck/mha_fwd_kvcache.cu",
+                        "csrc/flash_attn_ck/mha_fwd.cu",
+                        "csrc/flash_attn_ck/mha_varlen_bwd.cu",
+                        "csrc/flash_attn_ck/mha_varlen_fwd.cu"] + glob.glob(f"build/fmha_*wd*.cu")
 
         # Imitate https://github.com/ROCm/composable_kernel/blob/c8b6b64240e840a7decf76dfaa13c37da5294c4a/CMakeLists.txt#L190-L214
         hip_version = get_hip_version()

--- a/tests/test_flash_attn_ck.py
+++ b/tests/test_flash_attn_ck.py
@@ -28,30 +28,6 @@ from test_flash_attn import (
 from flash_attn.layers.rotary import apply_rotary_emb
 
 
-def is_gfx11(device="cuda"):
-    if not torch.cuda.is_available():
-        return False
-    props = torch.cuda.get_device_properties(device)
-    name = (getattr(props, "gcnArchName", "") or getattr(props, "name", "")).lower()
-    return "gfx11" in name
-
-
-def is_gfx12(device="cuda"):
-    if not torch.cuda.is_available():
-        return False
-    props = torch.cuda.get_device_properties(device)
-    name = (getattr(props, "gcnArchName", "") or getattr(props, "name", "")).lower()
-    return "gfx12" in name
-
-
-def is_gfx1x(device="cuda"):
-    if not torch.cuda.is_available():
-        return False
-    props = torch.cuda.get_device_properties(device)
-    name = (getattr(props, "gcnArchName", "") or getattr(props, "name", "")).lower()
-    return ("gfx11" in name) or ("gfx12" in name)
-
-
 def is_bwd_hdim_supported(d):
     return d <= 256
 
@@ -60,24 +36,12 @@ def is_bwd_supported(d, deterministic):
     if not is_bwd_hdim_supported(d):
         return False
 
-    if is_gfx11():
-        return False
-
-    if is_gfx12() and deterministic:
-        return False
-
     return True
 
 
 def get_bwd_unsupported_reason(d, deterministic):
     if is_bwd_hdim_supported(d) is False:
         return f"CK backward is not supported for head dim {d}."
-
-    if is_gfx11():
-        return "CK backward is not supported on gfx11."
-
-    if is_gfx12() and deterministic:
-        return "Deterministic CK backward is not supported on gfx12."
 
     return "CK backward is not supported on this arch/configuration."
 


### PR DESCRIPTION
## Summary
  - Update the composable_kernel submodule to pick up RDNA FMHA fixes and optimizations.
  - Enable CK backward on RDNA by removing the local gfx11/gfx12 backward guards.
  - Adjust CK build setup so generated RDNA FMHA blobs use an RDNA-compatible BF16 conversion mode.
  - Remove the old RDNA backward limitation from tests and documentation.

## Testing
  - Tested on gfx1100/gfx1201/gfx942
  - `pytest -q -s tests/test_flash_attn_ck.py`
  - Result: all passed