### PR TITLE
Add aux-scalars to interface to enable dynamic ints and floats in expressions

### DIFF
--- a/flash_attn/cute/block_sparse_utils.py
+++ b/flash_attn/cute/block_sparse_utils.py
@@ -18,6 +18,7 @@ from quack import copy_utils
 from flash_attn.cute.block_sparsity import BlockSparseTensors
 from flash_attn.cute.named_barrier import NamedBarrierBwd
 from flash_attn.cute.seqlen_info import SeqlenInfoQK
+from flash_attn.cute.utils import AuxData
 
 
 @cute.jit
@@ -1363,7 +1364,7 @@ def consume_block_sparse_mma_bwd_sm90(
     score_mod_bwd_fn=None,
     subtile_factor: cutlass.Constexpr = 1,
     m_block_max: int = 0,
-    aux_tensors=None,
+    aux_data: AuxData = AuxData(),
     fastdiv_mods=(None, None),
 ):
     """SM90 backward block sparse MMA consumption with separate partial/full loops.
@@ -1396,7 +1397,7 @@ def consume_block_sparse_mma_bwd_sm90(
         mask_causal=is_causal,
         mask_local=is_local,
         mask_mod=mask_mod,
-        aux_tensors=aux_tensors,
+        aux_data=aux_data,
         fastdiv_mods=fastdiv_mods,
     )
 
@@ -1409,7 +1410,7 @@ def consume_block_sparse_mma_bwd_sm90(
         mask_seqlen=True,
         mask_causal=is_causal,
         mask_local=is_local,
-        aux_tensors=aux_tensors,
+        aux_data=aux_data,
         fastdiv_mods=fastdiv_mods,
     )
 

--- a/flash_attn/cute/compute_block_sparsity.py
+++ b/flash_attn/cute/compute_block_sparsity.py
@@ -14,17 +14,19 @@ from flash_attn.cute.block_sparsity import (
 from flash_attn.cute.block_sparse_utils import get_curr_blocksparse_tensors
 from flash_attn.cute.testing import is_fake_mode
 from flash_attn.cute.cute_dsl_utils import (
-    to_cute_tensor,
     get_aux_tensor_metadata,
     to_cute_aux_tensor,
+    to_cute_tensor,
 )
 from flash_attn.cute.utils import (
+    get_batch_from_cu_tensor,
     hash_callable,
     scalar_to_ssa,
     ssa_to_scalar,
-    get_batch_from_cu_tensor,
 )
+from flash_attn.cute.mask import call_mask_mod
 from flash_attn.cute.seqlen_info import SeqlenInfoQK
+from flash_attn.cute.utils import AuxData
 
 
 class BlockSparsityKernel:
@@ -67,7 +69,7 @@ class BlockSparsityKernel:
         mCuSeqlensK: Optional[cute.Tensor] = None,
         mSeqUsedQ: Optional[cute.Tensor] = None,
         mSeqUsedK: Optional[cute.Tensor] = None,
-        aux_tensors: Optional[list] = None,
+        aux_data: AuxData = AuxData(),
     ):
         mask_cnt, mask_idx, full_cnt, full_idx, mCuTotalMBlocks, mCuBlockIdxOffsets, *_ = (
             blocksparse_tensors
@@ -112,7 +114,7 @@ class BlockSparsityKernel:
             mSeqUsedK,
             mCuTotalMBlocks,
             mCuBlockIdxOffsets,
-            aux_tensors,
+            aux_data,
         ).launch(grid=grid, block=[num_threads, 1, 1])
 
     @cute.kernel
@@ -128,7 +130,7 @@ class BlockSparsityKernel:
         mSeqUsedK: Optional[cute.Tensor] = None,
         mCuTotalMBlocks: Optional[cute.Tensor] = None,
         mCuBlockIdxOffsets: Optional[cute.Tensor] = None,
-        aux_tensors: Optional[list] = None,
+        aux_data: AuxData = AuxData(),
     ):
         tidx, _, _ = cute.arch.thread_idx()
         warp_idx = cute.arch.warp_idx()
@@ -224,13 +226,14 @@ class BlockSparsityKernel:
                 if tidx < 5:
                     thread_is_valid = Boolean(True)
                     thread_result = ssa_to_scalar(
-                        self.mask_mod(
+                        call_mask_mod(
+                            self.mask_mod,
                             ssa(batch_idx),
                             ssa(head_idx),
                             ssa(q_idx_sample),
                             ssa(kv_idx),
                             seqlen,
-                            aux_tensors,
+                            aux_data,
                         )
                     )
 
@@ -249,13 +252,14 @@ class BlockSparsityKernel:
                     if thread_in_bounds:
                         for c in cutlass.range(self.tile_mn[1], unroll_full=True):
                             mask_val = ssa_to_scalar(
-                                self.mask_mod(
+                                call_mask_mod(
+                                    self.mask_mod,
                                     ssa(batch_idx),
                                     ssa(head_idx),
                                     ssa(q_idx_thread),
                                     ssa(n_base + c),
                                     seqlen,
-                                    aux_tensors,
+                                    aux_data,
                                 )
                             )
                             thread_has_unmasked |= Boolean(mask_val)
@@ -266,13 +270,14 @@ class BlockSparsityKernel:
                             kv_idx = n_base + c
                             if kv_idx < seqlen_k:
                                 mask_val = ssa_to_scalar(
-                                    self.mask_mod(
+                                    call_mask_mod(
+                                        self.mask_mod,
                                         ssa(batch_idx),
                                         ssa(head_idx),
                                         ssa(q_idx_thread),
                                         ssa(kv_idx),
                                         seqlen,
-                                        aux_tensors,
+                                        aux_data,
                                     )
                                 )
                                 thread_has_unmasked |= Boolean(mask_val)
@@ -336,6 +341,7 @@ def compute_block_sparsity(
     mask_mod: Callable,
     aux_tensors: Optional[list],
     device,
+    aux_scalars: Optional[tuple] = None,
     cu_seqlens_q: Optional[torch.Tensor] = None,
     cu_seqlens_k: Optional[torch.Tensor] = None,
     seqused_q: Optional[torch.Tensor] = None,
@@ -371,6 +377,8 @@ def compute_block_sparsity(
     Returns:
         BlockSparseTensorsTorch
     """
+    aux_scalars = tuple(aux_scalars) if aux_scalars else None
+
     # Check if mask_mod is marked as suitable for 5-point sampling
     use_fast_sampling = getattr(mask_mod, "use_fast_sampling", use_fast_sampling)
 
@@ -457,12 +465,14 @@ def compute_block_sparsity(
         aux_tensor_metadata = get_aux_tensor_metadata(aux_tensors)
     else:
         aux_tensor_metadata = None
+    aux_scalar_metadata = tuple(type(s) for s in aux_scalars) if aux_scalars is not None else None
 
     compile_key = (
         tile_m,
         tile_n,
         mask_mod_hash,
         aux_tensor_metadata,
+        aux_scalar_metadata,
         compute_full_blocks,
         cu_seqlens_q is None,
         cu_seqlens_k is None,
@@ -510,7 +520,7 @@ def compute_block_sparsity(
             cu_seqlens_k_tensor,
             seqused_q_tensor,
             seqused_k_tensor,
-            cute_aux_tensors,
+            AuxData(cute_aux_tensors, aux_scalars),
             options="--enable-tvm-ffi",
         )
 
@@ -532,7 +542,7 @@ def compute_block_sparsity(
             cu_seqlens_k,
             seqused_q,
             seqused_k,
-            aux_tensors,
+            AuxData(aux_tensors, aux_scalars),
         )
 
     return blocksparse_tensors_torch

--- a/flash_attn/cute/flash_bwd.py
+++ b/flash_attn/cute/flash_bwd.py
@@ -19,10 +19,12 @@ from flash_attn.cute import ampere_helpers as sm80_utils
 from flash_attn.cute.cute_dsl_utils import assume_tensor_aligned
 from flash_attn.cute import utils
 from flash_attn.cute.mask import AttentionMask
+from flash_attn.cute.softmax import call_score_mod, call_score_mod_bwd
 from flash_attn.cute.seqlen_info import SeqlenInfoQK
 from quack.cute_dsl_utils import ParamsBase
 from flash_attn.cute.tile_scheduler import SingleTileScheduler, SingleTileVarlenScheduler, TileSchedulerArguments
 from flash_attn.cute.block_sparsity import BlockSparseTensors
+from flash_attn.cute.utils import AuxData
 
 
 class FlashAttentionBackwardSm80:
@@ -387,7 +389,7 @@ class FlashAttentionBackwardSm80:
         mdQ_semaphore: Optional[cute.Tensor] = None,
         mdK_semaphore: Optional[cute.Tensor] = None,
         mdV_semaphore: Optional[cute.Tensor] = None,
-        aux_tensors: Optional[list] = None,
+        aux_data: AuxData = AuxData(),
         blocksparse_tensors: Optional[BlockSparseTensors] = None,
         # Always keep stream as the last parameter (EnvStream: obtained implicitly via TVM FFI).
         stream: cuda.CUstream = None,
@@ -470,6 +472,7 @@ class FlashAttentionBackwardSm80:
             SharedStorage,
             tile_sched_params,
             TileScheduler,
+            aux_data,
         ).launch(
             grid=grid_dim,
             block=[self.num_threads, 1, 1],
@@ -514,6 +517,7 @@ class FlashAttentionBackwardSm80:
         SharedStorage: cutlass.Constexpr,
         tile_sched_params: ParamsBase,
         TileScheduler: cutlass.Constexpr[Callable],
+        aux_data: AuxData = AuxData(),
     ):
         # Thread index, block index
         tidx, _, _ = cute.arch.thread_idx()
@@ -779,6 +783,7 @@ class FlashAttentionBackwardSm80:
                 m_block_max=m_block_max,
                 softmax_scale=softmax_scale,
                 softmax_scale_log2=softmax_scale_log2,
+                aux_data=aux_data,
             )
 
             # ///////////////////////////////////////////////////////////////////////////////
@@ -868,6 +873,7 @@ class FlashAttentionBackwardSm80:
         m_block_max: cutlass.Int32,
         softmax_scale: cutlass.Float32,
         softmax_scale_log2: cutlass.Float32,
+        aux_data: AuxData = AuxData(),
         mask_fn: Optional[Callable] = None,
     ):
         def load_Q_next():
@@ -907,9 +913,15 @@ class FlashAttentionBackwardSm80:
         if cutlass.const_expr(self.score_mod is not None):
             for r in cutlass.range(cute.size(acc_S_mn, mode=[0]), unroll_full=True):
                 acc_S_mn[r, None].store(
-                    self.score_mod(
+                    call_score_mod(
+                        self.score_mod,
                         acc_S_mn[r, None].load() * softmax_scale,
-                        0, 0, 0, 0, None, [],
+                        0,
+                        0,
+                        0,
+                        0,
+                        None,
+                        aux_data,
                     )
                 )
         if cutlass.const_expr(mask_fn is not None):
@@ -945,10 +957,16 @@ class FlashAttentionBackwardSm80:
         for r in cutlass.range(cute.size(acc_dP_mn, mode=[0]), unroll_full=True):
             grad_val = acc_S_mn[r, None].load() * (acc_dP_mn[r, None].load() - tLSErdPsum[r])
             if cutlass.const_expr(self.score_mod_bwd is not None):
-                grad_val = self.score_mod_bwd(
+                grad_val = call_score_mod_bwd(
+                    self.score_mod_bwd,
                     grad_val,
                     acc_S_pre_mn[r, None].load() * softmax_scale,
-                    0, 0, 0, 0, None, [],
+                    0,
+                    0,
+                    0,
+                    0,
+                    None,
+                    aux_data,
                 )
             acc_dP_mn[r, None].store(grad_val)
         # if cute.arch.thread_idx()[0] == 0 and cute.arch.block_idx()[0] == bidx: cute.print_tensor(acc_dP_mn)

--- a/flash_attn/cute/flash_bwd_sm100.py
+++ b/flash_attn/cute/flash_bwd_sm100.py
@@ -36,6 +36,7 @@ from flash_attn.cute import barrier
 from flash_attn.cute.named_barrier import NamedBarrierBwdSm100
 from flash_attn.cute.softmax import apply_score_mod_inner, apply_score_mod_bwd_inner
 from flash_attn.cute.block_sparsity import BlockSparseTensors
+from flash_attn.cute.utils import AuxData
 from flash_attn.cute.block_sparse_utils import (
     get_total_q_block_count_bwd,
     get_block_sparse_iteration_info_bwd,
@@ -463,7 +464,7 @@ class FlashAttentionBackwardSm100:
         mdQ_semaphore: Optional[cute.Tensor] = None,
         mdK_semaphore: Optional[cute.Tensor] = None,
         mdV_semaphore: Optional[cute.Tensor] = None,
-        aux_tensors: Optional[list] = None,
+        aux_data: AuxData = AuxData(),
         # Block-sparse tensors (Q direction - for iterating m_blocks per n_block):
         blocksparse_tensors: Optional[BlockSparseTensors] = None,
         # Always keep stream as the last parameter (EnvStream: obtained implicitly via TVM FFI).
@@ -917,7 +918,7 @@ class FlashAttentionBackwardSm100:
             window_size_right = Int32(window_size_right)
 
         fastdiv_mods = None
-        if const_expr(aux_tensors is not None):
+        if const_expr(aux_data.tensors is not None):
             seqlen_q = cute.size(mQ.shape[0]) // (
                 self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1
             )
@@ -934,7 +935,7 @@ class FlashAttentionBackwardSm100:
             )
         # 2-CTA: 231424 and 1-CTA: 232448
         # print("SMEM: ", self.shared_storage.size_in_bytes())
-        if const_expr(self.use_block_sparsity or aux_tensors is not None):
+        if const_expr(self.use_block_sparsity or aux_data.tensors is not None):
             assert all(x is None for x in (mCuSeqlensQ, mCuSeqlensK, mSeqUsedQ, mSeqUsedK)), (
                 "Variable sequence length is not supported yet for blocksparse or aux tensors in bwd"
             )
@@ -998,7 +999,7 @@ class FlashAttentionBackwardSm100:
             window_size_left,
             window_size_right,
             tile_sched_params,
-            aux_tensors,
+            aux_data,
             fastdiv_mods,
             blocksparse_tensors,
         ).launch(
@@ -1081,7 +1082,7 @@ class FlashAttentionBackwardSm100:
         window_size_left: Optional[Int32],
         window_size_right: Optional[Int32],
         tile_sched_params: ParamsBase,
-        aux_tensors: Optional[list] = None,
+        aux_data: AuxData = AuxData(),
         fastdiv_mods=(None, None),
         blocksparse_tensors: Optional[BlockSparseTensors] = None,
     ):
@@ -1596,7 +1597,7 @@ class FlashAttentionBackwardSm100:
                 tiled_copy_r2s_dKV,
                 mdK_semaphore,
                 mdV_semaphore,
-                aux_tensors,
+                aux_data,
                 fastdiv_mods,
                 blocksparse_tensors,
             )
@@ -2757,7 +2758,7 @@ class FlashAttentionBackwardSm100:
         n_block,
         softmax_scale,
         seqlen_info,
-        aux_tensors=None,
+        aux_data: AuxData = AuxData(),
         fastdiv_mods=(None, None),
     ):
         """Apply forward score modification for SM100 backward pass."""
@@ -2776,7 +2777,7 @@ class FlashAttentionBackwardSm100:
             softmax_scale,
             self.vec_size,
             self.qk_acc_dtype,
-            aux_tensors,
+            aux_data,
             fastdiv_mods,
             seqlen_info,
             constant_q_idx=None,
@@ -2794,7 +2795,7 @@ class FlashAttentionBackwardSm100:
         head_idx,
         softmax_scale,
         seqlen_info,
-        aux_tensors=None,
+        aux_data: AuxData = AuxData(),
         fastdiv_mods=(None, None),
     ):
         """Apply backward score modification (joint graph) for SM100."""
@@ -2808,7 +2809,7 @@ class FlashAttentionBackwardSm100:
             softmax_scale,
             self.vec_size,
             self.qk_acc_dtype,
-            aux_tensors,
+            aux_data,
             fastdiv_mods,
             seqlen_info,
             constant_q_idx=None,
@@ -2857,7 +2858,7 @@ class FlashAttentionBackwardSm100:
         tiled_copy_r2s_dKV: Optional[cute.TiledCopy],
         mdK_semaphore: Optional[cute.Tensor],
         mdV_semaphore: Optional[cute.Tensor],
-        aux_tensors: Optional[list] = None,
+        aux_data: AuxData = AuxData(),
         fastdiv_mods=(None, None),
         blocksparse_tensors: Optional[BlockSparseTensors] = None,
     ):
@@ -2992,7 +2993,7 @@ class FlashAttentionBackwardSm100:
                 mask_mod=self.mask_mod,
                 batch_idx=batch_idx,
                 head_idx=head_idx,
-                aux_tensors=aux_tensors,
+                aux_data=aux_data,
                 fastdiv_mods=fastdiv_mods,
             )
 
@@ -3086,7 +3087,7 @@ class FlashAttentionBackwardSm100:
                         n_block,
                         softmax_scale,
                         seqlen,
-                        aux_tensors,
+                        aux_data,
                         fastdiv_mods,
                     )
 
@@ -3212,7 +3213,7 @@ class FlashAttentionBackwardSm100:
                             head_idx,
                             softmax_scale,
                             seqlen,
-                            aux_tensors,
+                            aux_data,
                             fastdiv_mods,
                         )
                         # Zero out OOB positions (kv_idx >= seqlen_k) after score_mod_bwd

--- a/flash_attn/cute/flash_bwd_sm90.py
+++ b/flash_attn/cute/flash_bwd_sm90.py
@@ -34,6 +34,7 @@ from flash_attn.cute import barrier
 from flash_attn.cute.named_barrier import NamedBarrierBwd
 from flash_attn.cute.softmax import apply_score_mod_inner, apply_score_mod_bwd_inner
 from flash_attn.cute.block_sparsity import BlockSparseTensors
+from flash_attn.cute.utils import AuxData
 from flash_attn.cute.block_sparse_utils import (
     get_total_q_block_count_bwd,
     produce_block_sparse_q_loads_bwd_sm90,
@@ -355,7 +356,7 @@ class FlashAttentionBackwardSm90:
         mdQ_semaphore: Optional[cute.Tensor] = None,
         mdK_semaphore: Optional[cute.Tensor] = None,
         mdV_semaphore: Optional[cute.Tensor] = None,
-        aux_tensors: Optional[list] = None,
+        aux_data: AuxData = AuxData(),
         blocksparse_tensors: Optional[BlockSparseTensors] = None,
         # Always keep stream as the last parameter (EnvStream: obtained implicitly via TVM FFI).
         stream: cuda.CUstream = None,
@@ -548,7 +549,7 @@ class FlashAttentionBackwardSm90:
             softmax_scale_log2 = LOG2_E
 
         fastdiv_mods = None
-        if const_expr(aux_tensors is not None):
+        if const_expr(aux_data.tensors is not None):
             seqlen_q = cute.size(mQ.shape[0])
             seqlen_k = cute.size(mK.shape[0])
             seqlen_q_divmod = FastDivmodDivisor(seqlen_q)
@@ -602,7 +603,7 @@ class FlashAttentionBackwardSm90:
             tile_sched_params,
             TileScheduler,
             SharedStorage,
-            aux_tensors,
+            aux_data,
             fastdiv_mods,
             blocksparse_tensors,
             qhead_per_kvhead_divmod,
@@ -657,7 +658,7 @@ class FlashAttentionBackwardSm90:
         tile_sched_params: ParamsBase,
         TileScheduler: cutlass.Constexpr[Callable],
         SharedStorage: cutlass.Constexpr[Callable],
-        aux_tensors: Optional[list] = None,
+        aux_data: AuxData = AuxData(),
         fastdiv_mods=(None, None),
         blocksparse_tensors: Optional[BlockSparseTensors] = None,
         qhead_per_kvhead_divmod: Optional[FastDivmodDivisor] = None,
@@ -824,7 +825,7 @@ class FlashAttentionBackwardSm90:
                 SeqlenInfoCls,
                 AttentionMaskCls,
                 TileSchedulerCls,
-                aux_tensors,
+                aux_data,
                 fastdiv_mods,
                 blocksparse_tensors,
                 qhead_per_kvhead_divmod,
@@ -1022,7 +1023,7 @@ class FlashAttentionBackwardSm90:
         n_block,
         softmax_scale,
         seqlen_info: SeqlenInfoQK,
-        aux_tensors=None,
+        aux_data: AuxData = AuxData(),
         fastdiv_mods=(None, None),
     ):
         # [NOTE] SdP_swapAB: swapAB transposes the tile, so use (n, m) indexing
@@ -1046,7 +1047,7 @@ class FlashAttentionBackwardSm90:
             softmax_scale,
             self.vec_size,
             self.qk_acc_dtype,
-            aux_tensors,
+            aux_data,
             fastdiv_mods,
             seqlen_info,
             constant_q_idx=None,
@@ -1066,7 +1067,7 @@ class FlashAttentionBackwardSm90:
         n_block,
         softmax_scale,
         seqlen_info: SeqlenInfoQK,
-        aux_tensors=None,
+        aux_data: AuxData = AuxData(),
         fastdiv_mods=(None, None),
     ):
         cS = cute.make_identity_tensor(
@@ -1090,7 +1091,7 @@ class FlashAttentionBackwardSm90:
             softmax_scale,
             self.vec_size,
             self.qk_acc_dtype,
-            aux_tensors,
+            aux_data,
             fastdiv_mods,
             seqlen_info,
             constant_q_idx=None,
@@ -1131,7 +1132,7 @@ class FlashAttentionBackwardSm90:
         SeqlenInfoCls: Callable,
         AttentionMaskCls: Callable,
         TileSchedulerCls: Callable,
-        aux_tensors: Optional[list] = None,
+        aux_data: AuxData = AuxData(),
         fastdiv_mods=(None, None),
         blocksparse_tensors: Optional[BlockSparseTensors] = None,
         qhead_per_kvhead_divmod: Optional[FastDivmodDivisor] = None,
@@ -1260,14 +1261,14 @@ class FlashAttentionBackwardSm90:
             self.apply_score_mod,
             thr_mma_SdP=thr_mma_SdP,
             softmax_scale=softmax_scale,
-            aux_tensors=aux_tensors,
+            aux_data=aux_data,
             fastdiv_mods=fastdiv_mods,
         )
         score_mod_bwd_fn = partial(
             self.apply_score_mod_bwd,
             thr_mma_SdP=thr_mma_SdP,
             softmax_scale=softmax_scale,
-            aux_tensors=aux_tensors,
+            aux_data=aux_data,
             fastdiv_mods=fastdiv_mods,
         )
 
@@ -1349,7 +1350,7 @@ class FlashAttentionBackwardSm90:
                         mask_causal=self.is_causal,
                         mask_local=self.is_local,
                         mask_mod=self.mask_mod,
-                        aux_tensors=aux_tensors,
+                        aux_data=aux_data,
                         fastdiv_mods=fastdiv_mods,
                     )
                     dKV_accumulate = False
@@ -1382,7 +1383,7 @@ class FlashAttentionBackwardSm90:
                         score_mod_bwd_fn=score_mod_bwd_fn_cur,
                         subtile_factor=self.subtile_factor,
                         m_block_max=m_block_max,
-                        aux_tensors=aux_tensors,
+                        aux_data=aux_data,
                         fastdiv_mods=fastdiv_mods,
                     )
 

--- a/flash_attn/cute/flash_fwd.py
+++ b/flash_attn/cute/flash_fwd.py
@@ -34,6 +34,7 @@ from flash_attn.cute.pack_gqa import PackGQA
 from flash_attn.cute.named_barrier import NamedBarrierFwd
 from flash_attn.cute.block_sparsity import BlockSparseTensors
 from flash_attn.cute.tile_scheduler import SingleTileScheduler, SingleTileVarlenScheduler, TileSchedulerArguments
+from flash_attn.cute.utils import AuxData
 
 
 class FlashAttentionForwardBase:
@@ -636,7 +637,7 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
         window_size_right: Optional[Int32] = None,
         learnable_sink: Optional[cute.Tensor] = None,
         blocksparse_tensors: Optional[BlockSparseTensors] = None,
-        aux_tensors=None,
+        aux_data: AuxData = AuxData(),
         # Always keep stream as the last parameter (EnvStream: obtained implicitly via TVM FFI).
         stream: cuda.CUstream = None,
     ):
@@ -702,7 +703,7 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
         tile_sched_params = TileScheduler.to_underlying_arguments(tile_sched_args)
         grid_dim = TileScheduler.get_grid_shape(tile_sched_params)
         softmax_scale_log2, softmax_scale = utils.compute_softmax_scale_log2(softmax_scale, self.score_mod)
-        fastdiv_mods = utils.compute_fastdiv_mods(mQ, mK, self.qhead_per_kvhead, self.pack_gqa, aux_tensors)
+        fastdiv_mods = utils.compute_fastdiv_mods(mQ, mK, self.qhead_per_kvhead, self.pack_gqa, aux_data.tensors)
 
         self.kernel(
             mQ,
@@ -732,7 +733,7 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
             SharedStorage,
             tile_sched_params,
             TileScheduler,
-            aux_tensors,
+            aux_data,
             fastdiv_mods,
         ).launch(
             grid=grid_dim,
@@ -771,7 +772,7 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
         SharedStorage: cutlass.Constexpr,
         tile_sched_params,
         TileScheduler: cutlass.Constexpr[Callable],
-        aux_tensors=None,
+        aux_data: AuxData = AuxData(),
         fastdiv_mods=None,
     ):
         # Thread index, block index
@@ -947,7 +948,7 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
             batch_idx=batch_size,
             head_idx=num_head,
             m_block=m_block,
-            aux_tensors=aux_tensors,
+            aux_data=aux_data,
             fastdiv_mods=fastdiv_mods,
         )
 
@@ -1011,7 +1012,7 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
             thr_mma=thr_mma_qk,
             mask_causal=self.is_causal,
             mask_local=self.is_local,
-            aux_tensors=aux_tensors,
+            aux_data=aux_data,
             fastdiv_mods=fastdiv_mods if const_expr(self.mask_mod is not None) else None,
         )
 
@@ -1096,7 +1097,7 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
         head_idx: cutlass.Int32,
         m_block: cutlass.Int32,
         seqlen: SeqlenInfoQK,
-        aux_tensors=None,
+        aux_data: AuxData = AuxData(),
         fastdiv_mods=None,
         mask_fn: Optional[Callable] = None,
         is_first_n_block: cutlass.Constexpr = False,
@@ -1153,7 +1154,7 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
                 n_block,
                 softmax_scale=softmax.softmax_scale,
                 seqlen=seqlen,
-                aux_tensors=aux_tensors,
+                aux_data=aux_data,
                 fastdiv_mods=fastdiv_mods,
             )
 
@@ -1202,7 +1203,7 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
         n_block,
         softmax_scale,
         seqlen,
-        aux_tensors: Optional[list] = None,
+        aux_data: AuxData = AuxData(),
         fastdiv_mods=None,
     ):
         # Prepare index tensor
@@ -1219,7 +1220,7 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
             softmax_scale,
             self.score_vec_size,
             self.qk_acc_dtype,
-            aux_tensors,
+            aux_data,
             fastdiv_mods,
             seqlen_info=seqlen,
             constant_q_idx=None,

--- a/flash_attn/cute/flash_fwd_sm100.py
+++ b/flash_attn/cute/flash_fwd_sm100.py
@@ -67,6 +67,7 @@ from flash_attn.cute.tile_scheduler import (
 )
 from flash_attn.cute.fa_logging import fa_log, fa_printf
 from flash_attn.cute.utils import smid
+from flash_attn.cute.utils import AuxData
 
 # === TUNING KNOBS (agent-editable) ===
 # Keys: (use_2cta_instrs: bool, is_causal: bool, head_dim_padded: int, is_sm103: bool)
@@ -382,7 +383,7 @@ class FlashAttentionForwardSm100:
         learnable_sink: Optional[cute.Tensor] = None,
         descale_tensors: Optional[DescaleTensors] = None,
         blocksparse_tensors: Optional[BlockSparseTensors] = None,
-        aux_tensors: Optional[list] = None,
+        aux_data: AuxData = AuxData(),
         # Always keep stream as the last parameter (EnvStream: obtained implicitly via TVM FFI).
         stream: cuda.CUstream = None,
     ):
@@ -722,7 +723,7 @@ class FlashAttentionForwardSm100:
         softmax_scale_log2, softmax_scale = utils.compute_softmax_scale_log2(softmax_scale, self.score_mod)
         window_size_left = Int32(window_size_left) if window_size_left is not None else None
         window_size_right = Int32(window_size_right) if window_size_right is not None else None
-        fastdiv_mods = utils.compute_fastdiv_mods(mQ, mK, self.qhead_per_kvhead, self.pack_gqa, aux_tensors, mPageTable)
+        fastdiv_mods = utils.compute_fastdiv_mods(mQ, mK, self.qhead_per_kvhead, self.pack_gqa, aux_data.tensors, mPageTable)
 
         head_divmod = None
         if cutlass.const_expr(self.pack_gqa):
@@ -770,7 +771,7 @@ class FlashAttentionForwardSm100:
             tiled_mma_pv,
             tile_sched_params,
             num_splits,
-            aux_tensors,
+            aux_data,
             fastdiv_mods,
             head_divmod,
         ).launch(
@@ -829,7 +830,7 @@ class FlashAttentionForwardSm100:
         tiled_mma_pv: cute.TiledMma,
         tile_sched_params: ParamsBase,
         num_splits: Int32,
-        aux_tensors: Optional[list] = None,
+        aux_data: AuxData = AuxData(),
         fastdiv_mods=(None, None),
         head_divmod=None,
     ):
@@ -1261,7 +1262,7 @@ class FlashAttentionForwardSm100:
                 num_splits=num_splits,
                 SeqlenInfoCls=SeqlenInfoCls,
                 AttentionMaskCls=AttentionMaskCls,
-                aux_tensors=aux_tensors,
+                aux_data=aux_data,
                 fastdiv_mods=fastdiv_mods,
                 head_divmod=head_divmod,
                 blocksparse_tensors=blocksparse_tensors,
@@ -1880,7 +1881,7 @@ class FlashAttentionForwardSm100:
         num_splits: Int32,
         SeqlenInfoCls: Callable,
         AttentionMaskCls: Callable,
-        aux_tensors: Optional[list] = None,
+        aux_data: AuxData = AuxData(),
         fastdiv_mods=(None, None),
         head_divmod=None,
         blocksparse_tensors: Optional[BlockSparseTensors] = None,
@@ -1903,6 +1904,7 @@ class FlashAttentionForwardSm100:
             * (len(self.softmax0_warp_ids))
         )
         warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx()) % 4
+        aux_tensors = aux_data.tensors
 
         cta_qk_tiler = (self.mma_tiler_qk[0] // thr_mma_qk.thr_id.shape, self.mma_tiler_qk[1])
         tSAcc = tStS[(None, None), 0, 0, stage]  # (128, 128)
@@ -1963,7 +1965,7 @@ class FlashAttentionForwardSm100:
                 mask_local=self.is_local,
                 batch_idx=batch_idx,
                 head_idx=head_idx,
-                aux_tensors=aux_tensors,
+                aux_data=aux_data,
                 vec_size=self.mask_vec_size,
             )
 
@@ -2067,7 +2069,7 @@ class FlashAttentionForwardSm100:
                 head_idx=head_idx,
                 m_block=(self.q_stage * m_block + stage) * self.cta_group_size,
                 seqlen=seqlen,
-                aux_tensors=aux_tensors,
+                aux_data=aux_data,
                 fastdiv_mods=fastdiv_mods,
                 head_divmod=head_divmod,
             )
@@ -2248,7 +2250,7 @@ class FlashAttentionForwardSm100:
         head_idx: Int32,
         m_block: Int32,
         seqlen,
-        aux_tensors: Optional[list] = None,
+        aux_data: AuxData = AuxData(),
         fastdiv_mods=(None, None),
         head_divmod=None,
         mask_fn: Optional[Callable] = None,
@@ -2294,7 +2296,7 @@ class FlashAttentionForwardSm100:
                 n_block,
                 softmax,
                 seqlen,
-                aux_tensors,
+                aux_data,
                 fastdiv_mods,
                 head_divmod,
             )
@@ -3103,7 +3105,7 @@ class FlashAttentionForwardSm100:
         n_block,
         softmax,
         seqlen: SeqlenInfoQK,
-        aux_tensors=None,
+        aux_data: AuxData = AuxData(),
         fastdiv_mods=(None, None),
         head_divmod=None,
     ):
@@ -3126,7 +3128,7 @@ class FlashAttentionForwardSm100:
             q_idx_logical, head_offset = divmod(q_physical, head_divmod)
             head_idx = head_idx * self.qhead_per_kvhead + head_offset
 
-        if cutlass.const_expr(aux_tensors is not None):
+        if cutlass.const_expr(aux_data.tensors is not None):
             seqlen_q_divmod, _ = fastdiv_mods
             _, q_idx_logical = divmod(q_idx_logical, seqlen_q_divmod)
 
@@ -3139,7 +3141,7 @@ class FlashAttentionForwardSm100:
             softmax.softmax_scale,
             self.score_vec_size,
             self.qk_acc_dtype,
-            aux_tensors,
+            aux_data,
             fastdiv_mods,
             seqlen_info=seqlen,
             constant_q_idx=q_idx_logical,

--- a/flash_attn/cute/flash_fwd_sm90.py
+++ b/flash_attn/cute/flash_fwd_sm90.py
@@ -46,6 +46,7 @@ from flash_attn.cute.tile_scheduler import (
 from cutlass.cute import FastDivmodDivisor
 
 from flash_attn.cute.flash_fwd import FlashAttentionForwardBase
+from flash_attn.cute.utils import AuxData
 
 
 class FlashAttentionForwardSm90(FlashAttentionForwardBase):
@@ -171,7 +172,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         window_size_right: Int32 | int | None = None,
         learnable_sink: Optional[cute.Tensor] = None,
         blocksparse_tensors: Optional[BlockSparseTensors] = None,
-        aux_tensors: Optional[list] = None,
+        aux_data: AuxData = AuxData(),
         # Always keep stream as the last parameter (EnvStream: obtained implicitly via TVM FFI).
         stream: cuda.CUstream = None,
     ):
@@ -350,7 +351,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         window_size_left = Int32(window_size_left) if window_size_left is not None else None
         window_size_right = Int32(window_size_right) if window_size_right is not None else None
         fastdiv_mods = utils.compute_fastdiv_mods(
-            mQ, mK, self.qhead_per_kvhead, self.pack_gqa, aux_tensors, mPageTable
+            mQ, mK, self.qhead_per_kvhead, self.pack_gqa, aux_data.tensors, mPageTable
         )
 
         self.kernel(
@@ -388,7 +389,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
             tile_sched_params,
             TileScheduler,
             SharedStorage,
-            aux_tensors,
+            aux_data,
             fastdiv_mods,
         ).launch(
             grid=grid_dim,
@@ -434,7 +435,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         tile_sched_params: ParamsBase,
         TileScheduler: cutlass.Constexpr[Callable],
         SharedStorage: cutlass.Constexpr[Callable],
-        aux_tensors=Optional[list[cute.Tensor]],
+        aux_data: AuxData = AuxData(),
         fastdiv_mods=None,
     ):
         warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
@@ -630,7 +631,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                 AttentionMaskCls,
                 TileSchedulerCls,
                 blocksparse_tensors,
-                aux_tensors,
+                aux_data,
                 fastdiv_mods,
             )
 
@@ -958,9 +959,10 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         AttentionMaskCls: Callable,
         TileSchedulerCls: Callable,
         blocksparse_tensors: Optional[BlockSparseTensors],
-        aux_tensors: Optional[list],
+        aux_data: AuxData = AuxData(),
         fastdiv_mods=None,
     ):
+        aux_tensors = aux_data.tensors
         warp_group_idx = cute.arch.make_warp_uniform(tidx // self.num_threads_per_warp_group)
         warp_group_thread_layout = cute.make_layout(
             self.num_wg_mma, stride=self.num_threads_per_warp_group
@@ -1075,7 +1077,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                 thr_mma=thr_mma_qk,
                 mask_causal=self.is_causal,
                 mask_local=self.is_local,
-                aux_tensors=aux_tensors,
+                aux_data=aux_data,
                 fastdiv_mods=fastdiv_mods,
             )
             score_mod_fn = None
@@ -1087,7 +1089,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                     head_idx,
                     m_block,
                     softmax_scale=softmax_scale,
-                    aux_tensors=aux_tensors,
+                    aux_data=aux_data,
                     fastdiv_mods=fastdiv_mods,
                 )
             mma_one_n_block = partial(
@@ -1495,7 +1497,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         n_block,
         softmax_scale,
         seqlen,
-        aux_tensors: Optional[list] = None,
+        aux_data: AuxData = AuxData(),
         fastdiv_mods=None,
     ):
         # Prepare index tensor
@@ -1512,7 +1514,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
             softmax_scale,
             self.score_vec_size,
             self.qk_acc_dtype,
-            aux_tensors,
+            aux_data,
             fastdiv_mods,
             seqlen_info=seqlen,
             constant_q_idx=None,

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -30,7 +30,10 @@ if os.environ.get("CUTE_DSL_PTXAS_PATH", None) is not None:
 from flash_attn.cute import utils
 from flash_attn.cute import fa_logging
 from flash_attn.cute.cute_dsl_utils import (
-    to_cute_tensor, to_cute_aux_tensor, get_aux_tensor_metadata, get_broadcast_dims,
+    get_aux_tensor_metadata,
+    get_broadcast_dims,
+    to_cute_aux_tensor,
+    to_cute_tensor,
 )
 from flash_attn.cute.flash_fwd import FlashAttentionForwardSm80
 from flash_attn.cute.flash_fwd_sm90 import FlashAttentionForwardSm90
@@ -49,6 +52,7 @@ from flash_attn.cute.flash_fwd_mla_sm100 import FlashAttentionMLAForwardSm100
 from flash_attn.cute.sm100_hd256_2cta_fmha_forward import BlackwellFusedMultiHeadAttentionForward
 from flash_attn.cute.sm100_hd256_2cta_fmha_backward import BlackwellFusedMultiHeadAttentionBackward
 
+from flash_attn.cute.utils import AuxData
 from flash_attn.cute.block_sparsity import (
     BlockSparseTensorsTorch,
     get_sparse_q_block_size,
@@ -322,6 +326,7 @@ def _flash_attn_fwd(
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
     aux_tensors: Optional[list[torch.Tensor]] = None,
+    aux_scalars: Optional[tuple] = None,
     q_descale: Optional[torch.Tensor] = None,
     k_descale: Optional[torch.Tensor] = None,
     v_descale: Optional[torch.Tensor] = None,
@@ -339,7 +344,9 @@ def _flash_attn_fwd(
         out: Optional pre-allocated output tensor. If None, will be allocated internally.
         lse: Optional pre-allocated log-sum-exp tensor. If None, will be allocated when needed.
         aux_tensors: Some score_mods will want to read from global aux_tensors. This is how we thread them through to the inner kernel.
+        aux_scalars: Runtime scalar captures used by score_mod or mask_mod.
     """
+    aux_scalars = tuple(aux_scalars) if aux_scalars else None
     q, k, v, qv = [maybe_contiguous(t) for t in (q, k, v, qv)]
     assert q is not None or qv is not None
     assert v is not None
@@ -658,6 +665,7 @@ def _flash_attn_fwd(
         aux_tensor_metadata = get_aux_tensor_metadata(aux_tensors)
     else:
         aux_tensor_metadata = None
+    aux_scalar_metadata = tuple(type(s) for s in aux_scalars) if aux_scalars is not None else None
 
     if qv is not None:
         assert arch // 10 in [10, 11], "only support Blackwell arch with qv"
@@ -715,6 +723,7 @@ def _flash_attn_fwd(
         use_block_sparsity,
         block_sparse_broadcast_pattern,
         aux_tensor_metadata,
+        aux_scalar_metadata,
         lse is None,
         cu_seqlens_q is None,
         cu_seqlens_k is None,
@@ -1014,7 +1023,7 @@ def _flash_attn_fwd(
                 compile_args.append(descale_tensors_tensor)
             compile_args.extend([
                 sparse_tensors,
-                cute_aux_tensors,
+                AuxData(cute_aux_tensors, aux_scalars),
             ])
             compile_args.append(current_stream)
             _flash_attn_fwd.compile_cache[compile_key] = cute.compile(
@@ -1089,7 +1098,7 @@ def _flash_attn_fwd(
                 )
                 if normalized_block_sparse_tensors is not None
                 else None,
-                aux_tensors,
+                AuxData(aux_tensors, aux_scalars),
             ])
             _flash_attn_fwd.compile_cache[compile_key](*call_args)
     if is_split_kv:
@@ -1286,9 +1295,11 @@ def _flash_attn_bwd(
     score_mod_bwd: Optional[Callable] = None,
     mask_mod: Optional[Callable] = None,
     aux_tensors: Optional[list[torch.Tensor]] = None,
+    aux_scalars: Optional[tuple] = None,
     block_sparse_tensors: Optional[BlockSparseTensorsTorch] = None,
     dlse: Optional[torch.Tensor] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    aux_scalars = tuple(aux_scalars) if aux_scalars else None
     arch = _get_device_arch()
     assert arch // 10 in [9, 10, 11, 12], "Unsupported compute capability. Supported: 9.x, 10.x, 11.x, 12.x"
     sparse_q = None
@@ -1597,6 +1608,7 @@ def _flash_attn_bwd(
     score_mod_bwd_hash = utils.hash_callable(score_mod_bwd) if score_mod_bwd else False
     mask_mod_hash = utils.hash_callable(mask_mod) if mask_mod else False
     num_aux_tensors = len(aux_tensors) if aux_tensors else 0
+    aux_scalar_metadata = tuple(type(s) for s in aux_scalars) if aux_scalars is not None else None
     cute_aux_tensors = None
     if aux_tensors is not None:
         cute_aux_tensors = [to_cute_tensor(buf, assumed_align=None, fully_dynamic=True) for buf in aux_tensors]
@@ -1674,6 +1686,7 @@ def _flash_attn_bwd(
             score_mod_bwd_hash,
             mask_mod_hash,
             num_aux_tensors,
+            aux_scalar_metadata,
             use_block_sparsity,
             block_sparse_broadcast_pattern,
             get_broadcast_dims(q),
@@ -1706,6 +1719,7 @@ def _flash_attn_bwd(
             score_mod_bwd_hash,
             mask_mod_hash,
             num_aux_tensors,
+            aux_scalar_metadata,
             use_block_sparsity,
             block_sparse_broadcast_pattern,
             cu_seqlens_q is None,
@@ -1873,7 +1887,7 @@ def _flash_attn_bwd(
             dQ_semaphore_tensor,
             dK_semaphore_tensor,
             dV_semaphore_tensor,
-            cute_aux_tensors,
+            AuxData(cute_aux_tensors, aux_scalars),
             sparse_tensors_compile,
             current_stream,
             options="--enable-tvm-ffi",
@@ -1900,7 +1914,7 @@ def _flash_attn_bwd(
             dQ_semaphore,
             dK_semaphore,
             dV_semaphore,
-            aux_tensors,
+            AuxData(aux_tensors, aux_scalars),
             (
                 normalized_block_sparse_tensors.mask_block_cnt,
                 normalized_block_sparse_tensors.mask_block_idx,
@@ -1978,10 +1992,12 @@ class FlashAttnFunc(torch.autograd.Function):
         score_mod_bwd: Optional[Callable] = None,
         mask_mod: Optional[Callable] = None,
         aux_tensors: Optional[list] = None,
+        aux_scalars: Optional[tuple] = None,
         block_sparse_tensors: Optional[BlockSparseTensorsTorch] = None,
         block_sparse_tensors_bwd: Optional[BlockSparseTensorsTorch] = None,
         return_lse: bool = False,
     ):
+        aux_scalars = tuple(aux_scalars) if aux_scalars else None
         shared_kv = k is v
         if shared_kv and v.shape[-1] == 512:
             # specialize MLA attention formula
@@ -2005,6 +2021,7 @@ class FlashAttnFunc(torch.autograd.Function):
             score_mod=score_mod,
             mask_mod=mask_mod,
             aux_tensors=aux_tensors,
+            aux_scalars=aux_scalars,
             block_sparse_tensors=block_sparse_tensors,
             return_lse=return_lse,
             gather_kv_indices=gather_kv_indices,
@@ -2019,6 +2036,7 @@ class FlashAttnFunc(torch.autograd.Function):
         ctx.score_mod = score_mod 
         ctx.score_mod_bwd = score_mod_bwd 
         ctx.mask_mod = mask_mod
+        ctx.aux_scalars = aux_scalars
         ctx.block_sparse_tensors_bwd = block_sparse_tensors_bwd
         ctx.set_materialize_grads(False)
         return out, lse
@@ -2048,10 +2066,11 @@ class FlashAttnFunc(torch.autograd.Function):
             score_mod_bwd=ctx.score_mod_bwd,
             mask_mod=ctx.mask_mod,
             aux_tensors=aux_tensors,
+            aux_scalars=ctx.aux_scalars,
             block_sparse_tensors=ctx.block_sparse_tensors_bwd,
             dlse=dlse,
         )
-        return dq, dk, dv, *((None,) * 30)  # Extra Nones is fine
+        return dq, dk, dv, *((None,) * 31)
 
 
 class FlashAttnVarlenFunc(torch.autograd.Function):
@@ -2084,8 +2103,10 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
         mask_mod: Optional[Callable] = None,
         block_sparse_tensors: Optional[list] = None,
         aux_tensors: Optional[list] = None,
+        aux_scalars: Optional[tuple] = None,
         return_lse: bool = False,
     ):
+        aux_scalars = tuple(aux_scalars) if aux_scalars else None
         shared_kv = k is v
         if shared_kv and v.shape[-1] == 512:
             # specialize MLA attention formula
@@ -2118,6 +2139,7 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
             mask_mod=mask_mod,
             block_sparse_tensors=block_sparse_tensors,
             aux_tensors=aux_tensors,
+            aux_scalars=aux_scalars,
             return_lse=return_lse,
             gather_kv_indices=gather_kv_indices,
         )
@@ -2143,6 +2165,8 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
         ctx.return_lse = return_lse
         ctx.score_mod = score_mod
         ctx.score_mod_bwd = score_mod_bwd
+        ctx.mask_mod = mask_mod
+        ctx.aux_scalars = aux_scalars
         ctx.set_materialize_grads(False)
         return out, lse
 
@@ -2176,10 +2200,12 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
             score_mod=ctx.score_mod,
             score_mod_bwd=ctx.score_mod_bwd,
             aux_tensors=aux_tensors,
+            aux_scalars=ctx.aux_scalars,
+            mask_mod=ctx.mask_mod,
             dlse=dlse,
         )
 
-        return dq, dk, dv, *((None,) * 30)
+        return dq, dk, dv, *((None,) * 31)
 
 
 def flash_attn_func(
@@ -2200,6 +2226,7 @@ def flash_attn_func(
     score_mod_bwd: Optional[Callable] = None,
     mask_mod: Optional[Callable] = None,
     aux_tensors: Optional[list] = None,
+    aux_scalars: Optional[tuple] = None,
     block_sparse_tensors: Optional[BlockSparseTensorsTorch] = None,
     block_sparse_tensors_bwd: Optional[BlockSparseTensorsTorch] = None,
     return_lse: bool = False,
@@ -2222,6 +2249,7 @@ def flash_attn_func(
         score_mod_bwd,
         mask_mod,
         aux_tensors,
+        aux_scalars,
         block_sparse_tensors,
         block_sparse_tensors_bwd,
         return_lse,
@@ -2255,6 +2283,7 @@ def flash_attn_varlen_func(
     mask_mod: Optional[Callable] = None,
     block_sparse_tensors: Optional[BlockSparseTensorsTorch] = None,
     aux_tensors: Optional[list] = None,
+    aux_scalars: Optional[tuple] = None,
     return_lse: bool = False,
 ):
     """
@@ -2315,6 +2344,7 @@ def flash_attn_varlen_func(
         mask_mod,
         block_sparse_tensors,
         aux_tensors,
+        aux_scalars,
         return_lse,
     )
 

--- a/flash_attn/cute/mask.py
+++ b/flash_attn/cute/mask.py
@@ -13,9 +13,41 @@ from quack import layout_utils
 import flash_attn.cute.utils as utils
 from flash_attn.cute.block_info import BlockInfo
 from flash_attn.cute.seqlen_info import SeqlenInfoQK
+from flash_attn.cute.utils import AuxData
 
 MaskGenFn: TypeAlias = Callable[[int], Uint32]
 MASK_R2P_CHUNK_SIZE: int = 32
+
+
+@cute.jit
+def call_mask_mod(
+    mask_mod: cutlass.Constexpr,
+    batch_idx,
+    head_idx,
+    q_idx,
+    kv_idx,
+    seqlen_info,
+    aux_data: AuxData,
+):
+    # Compatibility shim for pre-aux_scalars mask_mod callables.
+    if const_expr(aux_data.scalars is not None):
+        return mask_mod(
+            batch_idx,
+            head_idx,
+            q_idx,
+            kv_idx,
+            seqlen_info,
+            aux_data.tensors,
+            aux_data.scalars,
+        )
+    return mask_mod(
+        batch_idx,
+        head_idx,
+        q_idx,
+        kv_idx,
+        seqlen_info,
+        aux_data.tensors,
+    )
 
 
 @cute.jit
@@ -154,7 +186,7 @@ class AttentionMask:
         mask_causal: cutlass.Constexpr[bool],
         mask_local: cutlass.Constexpr[bool] = False,
         mask_mod: cutlass.Constexpr[Optional[Callable]] = None,
-        aux_tensors: Optional[list] = None,
+        aux_data: AuxData = AuxData(),
         fastdiv_mods=(None, None),
     ) -> None:
         assert not (mask_causal and mask_local), "mask_causal and mask_local cannot be both True"
@@ -200,7 +232,7 @@ class AttentionMask:
                 and fastdiv_mods[1] is not None
             )
             wrap_aux_indices = const_expr(
-                has_fastdiv and mask_seqlen and const_expr(aux_tensors is not None)
+                has_fastdiv and mask_seqlen and const_expr(aux_data.tensors is not None)
             )
 
             for r in cutlass.range_constexpr(nrow):
@@ -229,13 +261,14 @@ class AttentionMask:
                     head_idx_ssa = utils.scalar_to_ssa(head_idx_for_mod, cutlass.Int32)
                     q_idx_ssa = utils.scalar_to_ssa(row_for_mod, cutlass.Int32)
                     kv_idx_ssa = utils.scalar_to_ssa(col_for_mod, cutlass.Int32)
-                    mask_value = mask_mod(
+                    mask_value = call_mask_mod(
+                        mask_mod,
                         batch_idx_ssa,
                         head_idx_ssa,
                         q_idx_ssa,
                         kv_idx_ssa,
                         self.seqlen_info,
-                        aux_tensors,
+                        aux_data,
                     )
                     cond = cutlass.Boolean(utils.ssa_to_scalar(mask_value))
                     if const_expr(mask_seqlen):
@@ -401,7 +434,7 @@ class AttentionMask:
         mask_mod: cutlass.Constexpr[Callable],
         batch_idx: Int32,
         head_idx: Int32,
-        aux_tensors: Optional[list] = None,
+        aux_data: AuxData = AuxData(),
         fastdiv_mods=(None, None),
         head_divmod=None,
         check_q_boundary: bool = False,
@@ -434,23 +467,24 @@ class AttentionMask:
                 mask_row = global_row
 
             mask_row_for_mod = mask_row
-            if const_expr(has_fastdiv and aux_tensors is not None):
+            if const_expr(has_fastdiv and aux_data.tensors is not None):
                 if check_q_boundary:
                     _, mask_row_for_mod = divmod(mask_row, fastdiv_mods[0])
             global_col_for_mod = global_col
-            if const_expr(has_fastdiv and mask_seqlen and aux_tensors is not None):
+            if const_expr(has_fastdiv and mask_seqlen and aux_data.tensors is not None):
                 _, global_col_for_mod = divmod(global_col, fastdiv_mods[1])
 
             head_idx_ssa = utils.scalar_to_ssa(head_idx_for_mod, cutlass.Int32)
             mask_row_ssa = utils.scalar_to_ssa(mask_row_for_mod, cutlass.Int32)
             kv_idx_ssa = utils.scalar_to_ssa(global_col_for_mod, cutlass.Int32)
-            mask_value = mask_mod(
+            mask_value = call_mask_mod(
+                mask_mod,
                 batch_idx_ssa,
                 head_idx_ssa,
                 mask_row_ssa,
                 kv_idx_ssa,
                 self.seqlen_info,
-                aux_tensors,
+                aux_data,
             )
             cond = cutlass.Boolean(utils.ssa_to_scalar(mask_value))
             acc_S[i] = acc_S[i] if cond else -Float32.inf
@@ -471,7 +505,7 @@ class AttentionMask:
         batch_idx: Int32,
         head_idx: Int32,
         vec_size: cutlass.Constexpr[int],
-        aux_tensors: Optional[list] = None,
+        aux_data: AuxData = AuxData(),
         fastdiv_mods=(None, None),
         head_divmod=None,
         check_q_boundary: bool = False,
@@ -512,7 +546,7 @@ class AttentionMask:
                 head_idx_for_mod = head_idx
                 mask_row = global_row
             mask_row_for_mod = mask_row
-            if const_expr(has_fastdiv and aux_tensors is not None):
+            if const_expr(has_fastdiv and aux_data.tensors is not None):
                 if check_q_boundary:
                     _, mask_row_for_mod = divmod(mask_row, fastdiv_mods[0])
 
@@ -530,19 +564,20 @@ class AttentionMask:
                 col_j_coord = tScS_t2r[i + j][1] if not self.swap_AB else tScS_t2r[i + j][0]
                 col_j_global = col_j_coord + n_block * self.tile_n
                 col_j_for_mod = col_j_global
-                if const_expr(has_fastdiv and mask_seqlen and aux_tensors is not None):
+                if const_expr(has_fastdiv and mask_seqlen and aux_data.tensors is not None):
                     _, col_j_for_mod = divmod(col_j_global, fastdiv_mods[1])
                 kv_idx_vec[j] = col_j_for_mod
             kv_idx_ssa = kv_idx_vec.load()
 
             # mask_value is already bit-packed by the vectorized mask_mod.
-            mask_value = mask_mod(
+            mask_value = call_mask_mod(
+                mask_mod,
                 batch_idx_ssa_call,
                 head_idx_ssa,
                 mask_row_ssa,
                 kv_idx_ssa,
                 self.seqlen_info,
-                aux_tensors,
+                aux_data,
             )
 
             # For vec_size < 32, multiple mask_mod calls fill one R2P chunk.
@@ -590,7 +625,7 @@ class AttentionMask:
         mask_mod: cutlass.Constexpr[Optional[Callable]] = None,
         batch_idx: Int32 = None,
         head_idx: Int32 = None,
-        aux_tensors: Optional[list] = None,
+        aux_data: AuxData = AuxData(),
         fastdiv_mods=(None, None),
         head_divmod=None,
         vec_size: cutlass.Constexpr[int] = 1,
@@ -653,7 +688,7 @@ class AttentionMask:
                     mask_mod,
                     batch_idx,
                     head_idx,
-                    aux_tensors,
+                    aux_data,
                     fastdiv_mods,
                     head_divmod,
                     check_q_boundary,
@@ -669,7 +704,7 @@ class AttentionMask:
                     batch_idx,
                     head_idx,
                     vec_size,
-                    aux_tensors,
+                    aux_data,
                     fastdiv_mods,
                     head_divmod,
                     check_q_boundary,
@@ -752,7 +787,7 @@ class AttentionMask:
         mask_mod: cutlass.Constexpr[Optional[Callable]] = None,
         batch_idx: Int32 = None,
         head_idx: Int32 = None,
-        aux_tensors: Optional[list] = None,
+        aux_data: AuxData = AuxData(),
         fastdiv_mods=(None, None),
         is_full_block: bool = False,
         check_m_boundary: bool = True,
@@ -810,7 +845,7 @@ class AttentionMask:
                     and fastdiv_mods[1] is not None
                 )
                 wrap_aux_indices = const_expr(
-                    has_fastdiv and mask_seqlen and const_expr(aux_tensors is not None)
+                    has_fastdiv and mask_seqlen and const_expr(aux_data.tensors is not None)
                 )
                 batch_idx_ssa = utils.scalar_to_ssa(batch_idx, cutlass.Int32)
                 head_idx_ssa = utils.scalar_to_ssa(head_idx, cutlass.Int32)
@@ -831,13 +866,14 @@ class AttentionMask:
                     q_idx_ssa = utils.scalar_to_ssa(q_idx_for_mod, cutlass.Int32)
                     kv_idx_ssa = utils.scalar_to_ssa(kv_idx_for_mod, cutlass.Int32)
 
-                    mask_value = mask_mod(
+                    mask_value = call_mask_mod(
+                        mask_mod,
                         batch_idx_ssa,
                         head_idx_ssa,
                         q_idx_ssa,
                         kv_idx_ssa,
                         self.seqlen_info,
-                        aux_tensors,
+                        aux_data,
                     )
                     cond = cutlass.Boolean(utils.ssa_to_scalar(mask_value))
                     acc_S[i] = acc_S[i] if cond else -cutlass.Float32.inf

--- a/flash_attn/cute/sm100_hd256_2cta_fmha_backward.py
+++ b/flash_attn/cute/sm100_hd256_2cta_fmha_backward.py
@@ -22,6 +22,7 @@ from flash_attn.cute.sm100_hd256_2cta_fmha_backward_dkdvkernel import (
     BlackwellFusedMultiHeadAttentionBackwardDKDVKernel,
 )
 from flash_attn.cute.cute_dsl_utils import assume_tensor_aligned
+from flash_attn.cute.utils import AuxData
 
 
 def _as_bshkrd_tensor(
@@ -205,7 +206,7 @@ class BlackwellFusedMultiHeadAttentionBackward:
         dQ_semaphore: cute.Tensor | None = None,
         dK_semaphore: cute.Tensor | None = None,
         dV_semaphore: cute.Tensor | None = None,
-        aux_tensors: tuple[cute.Tensor] | None = None,
+        aux_data: AuxData = AuxData(),
         block_sparse_tensors: cute.Tensor | None = None,
         stream: cuda.CUstream = None,
     ):
@@ -222,8 +223,11 @@ class BlackwellFusedMultiHeadAttentionBackward:
         assert block_sparse_tensors is None, (
             "SM100 backward with head_dim=256 does not support block sparse tensors"
         )
-        assert aux_tensors is None or len(aux_tensors) == 0, (
+        assert aux_data.tensors is None or len(aux_data.tensors) == 0, (
             "SM100 backward with head_dim=256 does not support aux_tensors"
+        )
+        assert aux_data.scalars is None or len(aux_data.scalars) == 0, (
+            "SM100 backward with head_dim=256 does not support aux_scalars"
         )
         assert dQ_accum is not None, (
             "SM100 backward with head_dim=256 expects dQ tensor at dQ_accum slot"

--- a/flash_attn/cute/sm100_hd256_2cta_fmha_forward.py
+++ b/flash_attn/cute/sm100_hd256_2cta_fmha_forward.py
@@ -30,6 +30,7 @@ from flash_attn.cute.mask import (
 from flash_attn.cute.tile_scheduler import SM100_TMEM_CAPACITY_COLUMNS
 from flash_attn.cute.flash_fwd_sm100 import DescaleTensors, _TUNING_CONFIG
 from flash_attn.cute.utils import ex2_emulation_2
+from flash_attn.cute.utils import AuxData
 
 
 class BlackwellFusedMultiHeadAttentionForward:
@@ -179,7 +180,7 @@ class BlackwellFusedMultiHeadAttentionForward:
         learnable_sink: Optional[cute.Tensor] = None,
         descale_tensors: Optional[DescaleTensors] = None,
         blocksparse_tensors: Optional[cute.Tensor] = None,
-        aux_tensors: Optional[list] = None,
+        aux_data: AuxData = AuxData(),
         stream: cuda.CUstream = None,
     ):
         # Keep parity with FlashAttentionForwardSm100.__call__ interface.
@@ -193,7 +194,12 @@ class BlackwellFusedMultiHeadAttentionForward:
         assert blocksparse_tensors is None, (
             "SM100 forward with head_dim=256 does not support block sparsity"
         )
-        assert aux_tensors is None, "SM100 forward with head_dim=256 does not support aux_tensors"
+        assert aux_data.tensors is None, (
+            "SM100 forward with head_dim=256 does not support aux_tensors"
+        )
+        assert aux_data.scalars is None, (
+            "SM100 forward with head_dim=256 does not support aux_scalars"
+        )
         assert not self.is_local, (
             "SM100 forward with head_dim=256 does not support local attention yet"
         )

--- a/flash_attn/cute/softmax.py
+++ b/flash_attn/cute/softmax.py
@@ -13,6 +13,80 @@ from quack import layout_utils
 import flash_attn.cute.utils as utils
 from quack.cute_dsl_utils import ParamsBase
 from flash_attn.cute.seqlen_info import SeqlenInfoQK
+from flash_attn.cute.utils import AuxData
+
+
+@cute.jit
+def call_score_mod(
+    score_mod: cutlass.Constexpr,
+    score,
+    batch_idx,
+    head_idx,
+    q_idx,
+    kv_idx,
+    seqlen_info,
+    aux_data: AuxData,
+):
+    aux_tensors = aux_data.tensors if aux_data.tensors is not None else ()
+    # Compatibility shim for pre-aux_scalars score_mod callables.
+    if cutlass.const_expr(aux_data.scalars is not None):
+        return score_mod(
+            score,
+            batch_idx,
+            head_idx,
+            q_idx=q_idx,
+            kv_idx=kv_idx,
+            seqlen_info=seqlen_info,
+            aux_tensors=aux_tensors,
+            aux_scalars=aux_data.scalars,
+        )
+    return score_mod(
+        score,
+        batch_idx,
+        head_idx,
+        q_idx=q_idx,
+        kv_idx=kv_idx,
+        seqlen_info=seqlen_info,
+        aux_tensors=aux_tensors,
+    )
+
+
+@cute.jit
+def call_score_mod_bwd(
+    score_mod_bwd: cutlass.Constexpr,
+    grad,
+    score,
+    batch_idx,
+    head_idx,
+    q_idx,
+    kv_idx,
+    seqlen_info,
+    aux_data: AuxData,
+):
+    aux_tensors = aux_data.tensors if aux_data.tensors is not None else ()
+    # Compatibility shim for pre-aux_scalars score_mod_bwd callables.
+    if cutlass.const_expr(aux_data.scalars is not None):
+        return score_mod_bwd(
+            grad,
+            score,
+            batch_idx,
+            head_idx,
+            q_idx=q_idx,
+            kv_idx=kv_idx,
+            seqlen_info=seqlen_info,
+            aux_tensors=aux_tensors,
+            aux_scalars=aux_data.scalars,
+        )
+    return score_mod_bwd(
+        grad,
+        score,
+        batch_idx,
+        head_idx,
+        q_idx=q_idx,
+        kv_idx=kv_idx,
+        seqlen_info=seqlen_info,
+        aux_tensors=aux_tensors,
+    )
 
 
 @dataclass
@@ -386,7 +460,7 @@ def apply_score_mod_inner(
     softmax_scale,
     vec_size: cutlass.Constexpr,
     qk_acc_dtype: cutlass.Constexpr,
-    aux_tensors,
+    aux_data: AuxData,
     fastdiv_mods,
     seqlen_info: SeqlenInfoQK,
     constant_q_idx: cutlass.Constexpr,
@@ -405,6 +479,7 @@ def apply_score_mod_inner(
         vec_size: Vector size for processing elements
         qk_acc_dtype: Data type for accumulator
         aux_tensors: Optional aux_tensors for FlexAttention
+        aux_scalars: Optional runtime scalar captures for FlexAttention
         fastdiv_mods: Tuple of (seqlen_q_divmod, seqlen_k_divmod) for wrapping
         seqlen_info: Sequence length info
         constant_q_idx: If provided, use this constant for all q_idx values
@@ -451,7 +526,7 @@ def apply_score_mod_inner(
                 head_idx_vec[j] = head_idx * qhead_per_kvhead + head_offset
 
             # If we will do loads we mod, in order to not read OOB
-            if cutlass.const_expr(aux_tensors is not None and fastdiv_mods is not None):
+            if cutlass.const_expr(aux_data.tensors is not None and fastdiv_mods is not None):
                 if cutlass.const_expr(constant_q_idx is None):
                     seqlen_q_divmod, seqlen_k_divmod = fastdiv_mods
                     q_idx_floored = floor_if_packed(
@@ -486,18 +561,15 @@ def apply_score_mod_inner(
         else:
             head_idx_ssa = utils.scalar_to_ssa(head_idx, cutlass.Int32).broadcast_to((vec_size,))
 
-        aux_args = []
-        if cutlass.const_expr(aux_tensors is not None):
-            aux_args = aux_tensors
-
-        post_mod_scores = score_mod(
+        post_mod_scores = call_score_mod(
+            score_mod,
             score_ssa,
             batch_idx_ssa,
             head_idx_ssa,
-            q_idx=q_idx_ssa,
-            kv_idx=kv_idx_ssa,
-            seqlen_info=seqlen_info,
-            aux_tensors=aux_args,
+            q_idx_ssa,
+            kv_idx_ssa,
+            seqlen_info,
+            aux_data,
         )
 
         # Write back modified scores
@@ -517,7 +589,7 @@ def apply_score_mod_bwd_inner(
     softmax_scale,
     vec_size: cutlass.Constexpr,
     qk_acc_dtype: cutlass.Constexpr,
-    aux_tensors,
+    aux_data: AuxData,
     fastdiv_mods,
     seqlen_info,
     constant_q_idx: cutlass.Constexpr,
@@ -537,6 +609,7 @@ def apply_score_mod_bwd_inner(
         vec_size: Vector size for processing elements
         qk_acc_dtype: Data type for accumulator
         aux_tensors: Optional aux_tensors for FlexAttention
+        aux_scalars: Optional runtime scalar captures for FlexAttention
         fastdiv_mods: Tuple of (seqlen_q_divmod, seqlen_k_divmod) for wrapping
         seqlen_info: Sequence length info
         constant_q_idx: If provided, use this constant for all q_idx values
@@ -575,7 +648,7 @@ def apply_score_mod_bwd_inner(
                 head_offset = q_idx_packed - q_idx_logical * qhead_per_kvhead
                 head_idx_vec[j] = head_idx * qhead_per_kvhead + head_offset
 
-            if cutlass.const_expr(aux_tensors is not None and fastdiv_mods is not None):
+            if cutlass.const_expr(aux_data.tensors is not None and fastdiv_mods is not None):
                 if cutlass.const_expr(constant_q_idx is None):
                     seqlen_q_divmod, seqlen_k_divmod = fastdiv_mods
                     q_idx_floored = floor_if_packed(
@@ -608,19 +681,16 @@ def apply_score_mod_bwd_inner(
         else:
             head_idx_ssa = utils.scalar_to_ssa(head_idx, cutlass.Int32).broadcast_to((vec_size,))
 
-        aux_args = []
-        if cutlass.const_expr(aux_tensors is not None):
-            aux_args = aux_tensors
-
-        grad_out_ssa = score_mod_bwd(
+        grad_out_ssa = call_score_mod_bwd(
+            score_mod_bwd,
             grad_ssa,
             score_ssa,
             batch_idx_ssa,
             head_idx_ssa,
-            q_idx=q_idx_ssa,
-            kv_idx=kv_idx_ssa,
-            seqlen_info=seqlen_info,
-            aux_tensors=aux_args,
+            q_idx_ssa,
+            kv_idx_ssa,
+            seqlen_info,
+            aux_data,
         )
 
         grad_vec.store(grad_out_ssa)

--- a/flash_attn/cute/utils.py
+++ b/flash_attn/cute/utils.py
@@ -5,7 +5,7 @@ import hashlib
 import inspect
 import os
 from functools import partial
-from typing import Type, Callable, Optional, Tuple, overload
+from typing import Type, Callable, Optional, Tuple, overload, NamedTuple
 
 import cutlass
 import cutlass.cute as cute
@@ -20,6 +20,12 @@ from cutlass.cute.runtime import from_dlpack
 import quack.activation
 
 _MIXER_ATTRS = ("__vec_size__",)
+
+
+class AuxData(NamedTuple):
+    tensors: tuple | list | None = None
+    scalars: tuple | None = None
+
 
 # Obtained from sollya:
 # fpminimax(exp(x * log(2.0)), 1, [|1,24...|],[0;1],relative);

--- a/tests/cute/test_mask_mod.py
+++ b/tests/cute/test_mask_mod.py
@@ -31,6 +31,7 @@ from flash_attn.cute.block_sparsity import (
     compute_dq_write_order_from_block_mask,
 )
 from flash_attn.cute.cache_utils import get_jit_cache
+from flash_attn.cute.compute_block_sparsity import compute_block_sparsity
 from flash_attn.cute import utils
 from mask_mod_definitions import (
     get_mask_pair,
@@ -40,6 +41,18 @@ from mask_mod_definitions import (
     make_packed_mask_aux_tensor,
 )
 COMPUTE_CAPABILITY = torch.cuda.get_device_capability()[0]
+
+
+@cute.jit
+def scalar_limit_mask(batch, head, q_idx, kv_idx, seqlen_info, aux_tensors, aux_scalars):
+    return (q_idx >= kv_idx) & (kv_idx < cutlass.Int32(aux_scalars[0]))
+
+
+def flex_scalar_limit_mask(limit: int):
+    def mask_mod(b_idx, h_idx, q_idx, kv_idx):
+        return (q_idx >= kv_idx) & (kv_idx < limit)
+
+    return mask_mod
 
 
 @pytest.fixture(autouse=True)
@@ -2605,6 +2618,65 @@ def test_compact_block_sparse_indices():
         f"Compact and full block sparse outputs differ: "
         f"max diff = {(out_compact - out_full).abs().max().item():.2e}"
     )
+
+
+@pytest.mark.parametrize("limit", [64, 96])
+def test_flash_attn_fwd_mask_mod_aux_scalars_matches_flex(limit):
+    torch.manual_seed(0)
+    tensors = create_tensors(1, 128, 128, 4, 4, 64, 64, torch.bfloat16)
+    out, _ = _flash_attn_fwd(
+        tensors["q"],
+        tensors["k"],
+        tensors["v"],
+        softmax_scale=1.0 / math.sqrt(64),
+        return_lse=True,
+        mask_mod=scalar_limit_mask,
+        aux_scalars=[cutlass.Int32(limit)],
+    )
+    expected = compute_reference_flex_attn(tensors, flex_scalar_limit_mask(limit))
+    torch.testing.assert_close(out, expected, rtol=2e-2, atol=2e-2)
+
+
+def test_flash_attn_bwd_mask_mod_aux_scalars_produces_grads():
+    torch.manual_seed(1)
+    q, k, v = [
+        x.requires_grad_()
+        for x in (
+            torch.randn(1, 128, 4, 64, device="cuda", dtype=torch.bfloat16),
+            torch.randn(1, 128, 4, 64, device="cuda", dtype=torch.bfloat16),
+            torch.randn(1, 128, 4, 64, device="cuda", dtype=torch.bfloat16),
+        )
+    ]
+    out, _ = flash_attn_func(
+        q,
+        k,
+        v,
+        softmax_scale=1.0 / math.sqrt(q.shape[-1]),
+        return_lse=True,
+        mask_mod=scalar_limit_mask,
+        aux_scalars=[cutlass.Int32(64)],
+    )
+    out.float().square().mean().backward()
+    assert q.grad is not None and torch.isfinite(q.grad).all()
+    assert k.grad is not None and torch.isfinite(k.grad).all()
+    assert v.grad is not None and torch.isfinite(v.grad).all()
+
+
+def test_compute_block_sparsity_mask_mod_aux_scalars_runs():
+    blocks = compute_block_sparsity(
+        tile_m=64,
+        tile_n=128,
+        batch_size=1,
+        num_heads=1,
+        seqlen_q=128,
+        seqlen_k=128,
+        mask_mod=scalar_limit_mask,
+        aux_tensors=None,
+        device="cuda",
+        aux_scalars=[cutlass.Int32(64)],
+    )
+    assert blocks.mask_block_cnt.shape == (1, 1, 2)
+    assert blocks.mask_block_idx.shape == (1, 1, 2, 1)
 
 
 if __name__ == "__main__":

--- a/tests/cute/test_score_mod.py
+++ b/tests/cute/test_score_mod.py
@@ -116,6 +116,44 @@ SEQLEN_CONFIGS = [
 VEC_SIZES_TO_CHECK_EQUALITY = [1, 2, 4] if COMPUTE_CAPABILITY == 10 else [1, 2]
 
 
+@cute.jit
+def scalar_scale_score(score, b_idx, h_idx, q_idx, kv_idx, seqlen_info, aux_tensors, aux_scalars):
+    return score * cute.full_like(score, cutlass.Float32(aux_scalars[0]))
+
+
+@cute.jit
+def scalar_scale_score_bwd(grad, score, b_idx, h_idx, q_idx, kv_idx, seqlen_info, aux_tensors, aux_scalars):
+    return grad * cute.full_like(grad, cutlass.Float32(aux_scalars[0]))
+
+
+@cute.jit
+def tensor_bias_and_scalar_scale_score(
+    score, b_idx, h_idx, q_idx, kv_idx, seqlen_info, aux_tensors, aux_scalars
+):
+    batch_bias = aux_tensors[0]
+    b_frag = cute.make_rmem_tensor(1, cutlass.Int32)
+    b_frag.store(b_idx)
+    bias_frag = cute.make_rmem_tensor(1, batch_bias.element_type)
+    bias_frag[0] = batch_bias[b_frag[0]]
+    return score * cute.full_like(score, cutlass.Float32(aux_scalars[0])) + bias_frag.load().to(
+        cutlass.Float32
+    )
+
+
+def scalar_scale_score_eager(scale: int):
+    def score_mod(score, b_idx, h_idx, q_idx, kv_idx):
+        return score * scale
+
+    return score_mod
+
+
+def tensor_bias_and_scalar_scale_score_eager(batch_bias, scale: int):
+    def score_mod(score, b_idx, h_idx, q_idx, kv_idx):
+        return score * scale + batch_bias[b_idx]
+
+    return score_mod
+
+
 def create_tensors(
     batch_size=2, num_heads=4, seqlen_q=64, seqlen_kv=64, dim=128, dtype=torch.bfloat16
 ):
@@ -125,7 +163,9 @@ def create_tensors(
     return q, k, v
 
 
-def run_cute_flash(q, k, v, cute_score_mod, aux_tensors=None, pack_gqa=False) -> torch.Tensor:
+def run_cute_flash(
+    q, k, v, cute_score_mod, aux_tensors=None, aux_scalars=None, pack_gqa=False
+) -> torch.Tensor:
     q_transposed, k_transposed, v_transposed = map(lambda x: x.transpose(1, 2), (q, k, v))
     out = torch.empty_like(q_transposed)
     _flash_attn_fwd(
@@ -137,6 +177,7 @@ def run_cute_flash(q, k, v, cute_score_mod, aux_tensors=None, pack_gqa=False) ->
         out=out,
         lse=None,
         aux_tensors=aux_tensors,
+        aux_scalars=aux_scalars,
         pack_gqa=pack_gqa,
     )
     return out.transpose(1, 2)
@@ -758,7 +799,7 @@ BWD_TEST_PAIRS_PACK_GQA = [
 
 
 def run_cute_flash_bwd(
-    q, k, v, cute_score_mod, cute_score_mod_bwd, aux_tensors=None, pack_gqa=False, use_autograd=True,
+    q, k, v, cute_score_mod, cute_score_mod_bwd, aux_tensors=None, aux_scalars=None, pack_gqa=False, use_autograd=True,
 ):
     """Run flash attention forward + backward with score_mod."""
     q_t = q.transpose(1, 2)
@@ -776,6 +817,7 @@ def run_cute_flash_bwd(
             score_mod=cute_score_mod,
             score_mod_bwd=cute_score_mod_bwd,
             aux_tensors=aux_tensors,
+            aux_scalars=aux_scalars,
             pack_gqa=pack_gqa,
         )
 
@@ -790,6 +832,7 @@ def run_cute_flash_bwd(
             return_lse=True,
             score_mod=cute_score_mod,
             aux_tensors=aux_tensors,
+            aux_scalars=aux_scalars,
             pack_gqa=pack_gqa,
         )
 
@@ -805,6 +848,7 @@ def run_cute_flash_bwd(
             score_mod=cute_score_mod,
             score_mod_bwd=cute_score_mod_bwd,
             aux_tensors=aux_tensors,
+            aux_scalars=aux_scalars,
             pack_gqa=pack_gqa,
         )
 
@@ -1189,6 +1233,101 @@ def test_cute_vs_flex_attention_backward_pack_gqa(
     assert cute_dq_err <= rtol * pt_dq_err + dq_atol, f"dQ error too large: {cute_dq_err:.2e}"
     assert cute_dk_err <= rtol * pt_dk_err + dk_atol, f"dK error too large: {cute_dk_err:.2e}"
     assert cute_dv_err <= rtol * pt_dv_err + dv_atol, f"dV error too large: {cute_dv_err:.2e}"
+
+
+@pytest.mark.parametrize("score_scale", [2, 3])
+def test_cute_score_mod_aux_scalars_matches_flex(score_scale):
+    torch.manual_seed(0)
+    q, k, v = create_tensors(batch_size=1, num_heads=4, seqlen_q=128, seqlen_kv=128, dim=64)
+    out_ref_fp32 = run_flex_reference(
+        q, k, v, scalar_scale_score_eager(score_scale), dtype=torch.float32
+    )
+    out_pt = run_flex_reference(q, k, v, scalar_scale_score_eager(score_scale))
+    out_cute = run_cute_flash(
+        q,
+        k,
+        v,
+        scalar_scale_score,
+        aux_scalars=[cutlass.Int32(score_scale)],
+    )
+    fwd_atol = 2 * (out_ref_fp32 + 0.3 - 0.3 - out_ref_fp32).abs().max().item()
+    pt_error = (out_pt - out_ref_fp32).abs().max().item()
+    cute_error = (out_cute - out_ref_fp32).abs().max().item()
+    assert cute_error <= 2 * pt_error + fwd_atol
+
+
+def test_cute_score_mod_aux_tensors_and_scalars_match_flex():
+    torch.manual_seed(0)
+    score_scale = 2
+    batch_bias = torch.randn(2, device="cuda", dtype=torch.bfloat16) * 0.1
+    q, k, v = create_tensors(
+        batch_size=2,
+        num_heads=4,
+        seqlen_q=128,
+        seqlen_kv=128,
+        dim=64,
+        dtype=torch.bfloat16,
+    )
+    eager_score_mod = tensor_bias_and_scalar_scale_score_eager(batch_bias, score_scale)
+    out_ref_fp32 = run_flex_reference(q, k, v, eager_score_mod, dtype=torch.float32)
+    out_pt = run_flex_reference(q, k, v, eager_score_mod)
+    out_cute = run_cute_flash(
+        q,
+        k,
+        v,
+        tensor_bias_and_scalar_scale_score,
+        aux_tensors=[batch_bias],
+        aux_scalars=[cutlass.Int32(score_scale)],
+    )
+    fwd_atol = 2 * (out_ref_fp32 + 0.3 - 0.3 - out_ref_fp32).abs().max().item()
+    pt_error = (out_pt - out_ref_fp32).abs().max().item()
+    cute_error = (out_cute - out_ref_fp32).abs().max().item()
+    assert cute_error <= 2 * pt_error + fwd_atol
+
+
+@pytest.mark.parametrize("use_autograd", [True, False])
+def test_cute_score_mod_bwd_aux_scalars_matches_flex(use_autograd):
+    torch.manual_seed(0)
+    q, k, v = create_tensors(
+        batch_size=1,
+        num_heads=4,
+        seqlen_q=128,
+        seqlen_kv=128,
+        dim=128,
+        dtype=torch.bfloat16,
+    )
+    score_scale = 2
+    out_cute, grad_out, dq_cute, dk_cute, dv_cute = run_cute_flash_bwd(
+        q,
+        k,
+        v,
+        scalar_scale_score,
+        scalar_scale_score_bwd,
+        aux_scalars=[cutlass.Int32(score_scale)],
+        use_autograd=use_autograd,
+    )
+    out_ref_fp32, dq_ref_fp32, dk_ref_fp32, dv_ref_fp32 = run_flex_reference_bwd(
+        q,
+        k,
+        v,
+        scalar_scale_score_eager(score_scale),
+        grad_out,
+        dtype=torch.float32,
+    )
+    out_pt, dq_pt, dk_pt, dv_pt = run_flex_reference_bwd(
+        q, k, v, scalar_scale_score_eager(score_scale), grad_out
+    )
+
+    rtol = 2
+    for cute_out, ref_fp32, pt in (
+        (out_cute, out_ref_fp32, out_pt),
+        (dq_cute, dq_ref_fp32, dq_pt),
+        (dk_cute, dk_ref_fp32, dk_pt),
+        (dv_cute, dv_ref_fp32, dv_pt),
+    ):
+        atol = 2 * (ref_fp32 + 0.3 - 0.3 - ref_fp32).abs().max().item()
+        ref = ref_fp32.to(cute_out.dtype)
+        assert (cute_out - ref).abs().max().item() <= rtol * (pt - ref).abs().max().item() + atol
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add aux-scalars to interface to enable dynamic ints and floats in expressions

## Summary

Right now we have Aux-tensors mixin data coming from global tensors,

This pr provides the same functionality but for scalar values via  `aux_scalars`. 

With this we can write mask/score mods that are dynamic over python ints and floats instead of needing to recompute. The most common case is for decode attention. Today that is done via 1 off seq_len info but in general this could have been done via generic query and key size or a dynamic integer offset ( handy if you cant derive from input tensor sizes).

### Examples

```Python
   @cute.jit
   def shifted_causal_mask(batch, head, q_idx, kv_idx, seqlen_info, aux_tensors, aux_scalars):
       q_offset = cutlass.Int32(aux_scalars[0])
       return kv_idx <= q_idx + q_offset


   out = flash_attn_func(
       q,
       k,
       v,
       mask_mod=shifted_causal_mask,
       aux_scalars=[cutlass.Int32(cache_position)],
   )
  ```


I have the PyTorch PR here: https://github.com/pytorch/pytorch/pull/186019
This removes the largest coverage gap between triton and flex/flash :)


## Review guidance

I can merge the two in to an AuxStruct if we want to reduce the number of kwargs for internal kernel funcs -> down for whatever