### PR TITLE
ci: bump Jimver/cuda-toolkit to v0.2.35 for CUDA 13.2 support

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Install CUDA ${{ inputs.cuda-version }}
         if: ${{ inputs.cuda-version != 'cpu' }}
-        uses: Jimver/cuda-toolkit@v0.2.30
+        uses: Jimver/cuda-toolkit@v0.2.35
         id: cuda-toolkit
         with:
           cuda: ${{ inputs.cuda-version }}


### PR DESCRIPTION
<details><summary>Claude summary</summary>

## Background

Dispatching `build.yml` with `cuda-version=13.2.0` fails at `Install CUDA`:

```
##[error]Error: Version not available: 13.2.0
```

`Jimver/cuda-toolkit@v0.2.30` (current pin) only ships URLs up to CUDA `13.1.0` in its hardcoded version map.

## What changed

- `.github/workflows/_build.yml`: bump `Jimver/cuda-toolkit` `v0.2.30 → v0.2.35`.

## Details

- `v0.2.35` adds `13.1.1`, `13.2.0` to `LinuxLinks.cudaVersionToURL`.
- aarch64 is covered: `getLocalURLFromCudaVersion` rewrites `_linux.run → _linux_sbsa.run` for `arm64`, so x86 + arm both work from the same map.

## Tested

- Reproduced the failure on https://github.com/Dao-AILab/flash-attention/actions/runs/26804183296 (x86, `cuda=13.2.0`).
- Verified the v0.2.35 source map includes `13.2.0`:

  ```
  curl -sL https://raw.githubusercontent.com/Jimver/cuda-toolkit/v0.2.35/src/links/linux-links.ts \
    | grep -oE "'13\.[0-9]+\.[0-9]+'" | sort -u
  # 13.0.0 13.0.1 13.0.2 13.1.0 13.1.1 13.2.0
  ```

- Will re-dispatch x86 + arm `cuda=13.2.0 / torch=2.9.0` against this branch after the PR is open.

</details>
