### PR TITLE
fix: build and select cu13.2 prebuilt wheels

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -168,7 +168,7 @@ jobs:
           # Limit MAX_JOBS otherwise the github runner goes OOM
           # nvcc 11.8 can compile with 2 jobs, but nvcc 12.3 goes OOM
 
-          export MAX_JOBS=$([ "$MATRIX_CUDA_VERSION" == "129" ] || [ "$MATRIX_CUDA_VERSION" == "130" ] && echo 1 || echo 2)
+          export MAX_JOBS=$([ "$MATRIX_CUDA_VERSION" == "129" ] || [ "$MATRIX_CUDA_VERSION" == "130" ] || [ "$MATRIX_CUDA_VERSION" == "132" ] && echo 1 || echo 2)
           export NVCC_THREADS=2
           export FLASH_ATTENTION_FORCE_BUILD="TRUE"
           export FLASH_ATTENTION_FORCE_CXX11_ABI=${{ inputs.cxx11_abi }}

--- a/setup.py
+++ b/setup.py
@@ -562,9 +562,14 @@ def get_wheel_url():
         # We're using the CUDA version used to build torch, not the one currently installed
         # _, cuda_version_raw = get_cuda_bare_metal_version(CUDA_HOME)
         torch_cuda_version = parse(torch.version.cuda)
-        # For CUDA 11, we only compile for CUDA 11.8, and for CUDA 12 we only compile for CUDA 12.3
+        # For CUDA 11 we compile for 11.8, for CUDA 12 for 12.3, and for CUDA 13 for 13.0
         # to save CI time. Minor versions should be compatible.
-        torch_cuda_version = parse("11.8") if torch_cuda_version.major == 11 else parse("12.3")
+        if torch_cuda_version.major == 11:
+            torch_cuda_version = parse("11.8")
+        elif torch_cuda_version.major == 12:
+            torch_cuda_version = parse("12.3")
+        else:
+            torch_cuda_version = parse("13.0")
         # cuda_version = f"{cuda_version_raw.major}{cuda_version_raw.minor}"
         cuda_version = f"{torch_cuda_version.major}"
 


### PR DESCRIPTION
<details><summary>Claude summary</summary>

### Background

Two separate cu13.2 wheel problems — one at **build** time, one at **install** time:

- **Build (OOM):** arm wheel build for `v2.8.3 / py3.12 / cu13.2.0 / torch2.9.0 / cxx11=TRUE` lost the runner mid-build (~1h17m in) with the classic `The hosted runner lost communication with the server … starves it for CPU/Memory` annotation — the OOM-killer reaping the runner agent while `ptxas` / `cc1plus` are resident. `_build.yml` already gates `MAX_JOBS=1` on `MATRIX_CUDA_VERSION == "129" || == "130"` (added in #2195); cu13.2 was missing, so it defaulted to `MAX_JOBS=2`.
- **Install (source fallback):** `get_wheel_url()` in `setup.py` binned every CUDA `>= 12` to major `"12"`, so under a CUDA 13 torch it guessed a `cu12torch…` wheel name and never matched the published `cu13` artifacts — falling back to a multi-hour source build even when a compatible prebuilt wheel exists on the release.

### What changed

- Extend the `MAX_JOBS=1` gate to also cover `MATRIX_CUDA_VERSION == "132"`.
- Add a CUDA 13 branch in `get_wheel_url()` so the guessed wheel name uses `cu13`, matching `WHEEL_CUDA_VERSION` (`awk -F . '{print $1}'`) in `_build.yml`.

### Details

- `.github/workflows/_build.yml` — append `|| [ "$MATRIX_CUDA_VERSION" == "132" ]` to the existing `MAX_JOBS` selector. No behavior change for cu11.x / cu12.x / cu13.0.

  ```yaml
  export MAX_JOBS=$([ "$MATRIX_CUDA_VERSION" == "129" ] || [ "$MATRIX_CUDA_VERSION" == "130" ] || [ "$MATRIX_CUDA_VERSION" == "132" ] && echo 1 || echo 2)
  ```

- `setup.py` — `get_wheel_url()` now maps the torch CUDA major to `11.8` / `12.3` / `13.0` instead of binning everything non-11 to `12.3`. Filename major (`cu{major}`) is unchanged for cu11/cu12, and becomes `cu13` for CUDA 13.x.

  ```python
  if torch_cuda_version.major == 11:
      torch_cuda_version = parse("11.8")
  elif torch_cuda_version.major == 12:
      torch_cuda_version = parse("12.3")
  else:
      torch_cuda_version = parse("13.0")
  cuda_version = f"{torch_cuda_version.major}"
  ```

### Tested

- Failing build run reproducing the OOM: https://github.com/Dao-AILab/flash-attention/actions/runs/26804748567/job/79039519136
- Install-side symptom: a CUDA 13.2 / torch consumer pulled the `flash_attn-2.8.3.tar.gz` sdist and compiled from source (`Building wheel for flash-attn …`) instead of using the published `cu13torch2.9` wheel, because `get_wheel_url()` requested `cu12…`.
- Validation: workflow_dispatch on this branch with the same cu13.2 / torch2.9 / py3.12 / arm matrix entry (to follow).

</details>
