### PR TITLE
[Triton] Fix graph capture issues and env var

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -227,11 +227,8 @@ if IS_ROCM:
             assert os.path.isdir("third_party/aiter"), (
                 "third_party/aiter is missing, please use source distribution or git clone"
             )
-        aiter_env = os.environ.copy()
-        aiter_env.setdefault("AITER_TRITON_ONLY", "1")
         subprocess.run(
             [sys.executable, "-m", "pip", "install", "--no-build-isolation", "third_party/aiter"],
-            env=aiter_env,
             check=True,
         )
     elif ROCM_BACKEND == "ck":


### PR DESCRIPTION
Bumps aiter to pick up the graph-capture fix (ROCm/aiter#2764) and removes the `AITER_TRITON_ONLY=1` env variable in setup.py which was added in #2614. It was added to fix #2580 but replacing a full build of aiter with a slim, triton only build might cause issues for other users.