### PR TITLE
fix: add weights_only=True to all torch.load call sites

### DIFF
--- a/flash_attn/models/llama.py
+++ b/flash_attn/models/llama.py
@@ -385,7 +385,7 @@ def state_dicts_from_checkpoint(
 ) -> List[dict]:
     # Need to sort, otherwise we mess up the ordering and the weights are wrong
     return [
-        torch.load(path, map_location="cpu")
+        torch.load(path, map_location="cpu", weights_only=True)
         for path in sorted((Path(checkpoint_path) / model_name).glob("consolidated.*.pth"))
     ]
 

--- a/flash_attn/utils/pretrained.py
+++ b/flash_attn/utils/pretrained.py
@@ -59,7 +59,7 @@ def state_dict_from_pretrained(model_name, device=None, dtype=None):
     if load_safe:
         loader = partial(safe_load_file, device=mapped_device)
     else:
-        loader = partial(torch.load, map_location=mapped_device)
+        loader = partial(torch.load, map_location=mapped_device, weights_only=True)
 
     if is_sharded:
         # resolved_archive_file becomes a list of files that point to the different

--- a/training/src/eval.py
+++ b/training/src/eval.py
@@ -31,7 +31,7 @@ def load_checkpoint(path, device='cpu'):
         path /= 'last.ckpt'
     # dst = f'cuda:{torch.cuda.current_device()}'
     log.info(f'Loading checkpoint from {str(path)}')
-    state_dict = torch.load(path, map_location=device)
+    state_dict = torch.load(path, map_location=device, weights_only=True)
     # T2T-ViT checkpoint is nested in the key 'state_dict_ema'
     if state_dict.keys() == {'state_dict_ema'}:
         state_dict = state_dict['state_dict_ema']

--- a/training/src/utils/checkpoint.py
+++ b/training/src/utils/checkpoint.py
@@ -17,7 +17,7 @@ def load_checkpoint(path, device='cpu'):
         else:
             raise ValueError(f"Unable to find 'latest' file at {latest_path}")
         path /= f'{tag}/mp_rank_00_model_states.pt'
-    state_dict = torch.load(path, map_location=device)
+    state_dict = torch.load(path, map_location=device, weights_only=True)
     if is_deepspeed:
         state_dict = state_dict['module']
 


### PR DESCRIPTION
## Summary

Adds `weights_only=True` to all four `torch.load` call sites in the repository, addressing the unsafe deserialization vector reported in #2583.

**Why this matters:** `torch.load` without `weights_only=True` uses Python's `pickle` protocol for deserialization. A malicious checkpoint file can execute arbitrary Python code on the machine that loads it — CWE-502 / CVE-class issue. Passing `weights_only=True` restricts deserialization to tensors, primitive types, dicts, lists, and tuples only.

## Sites fixed

| File | Function |
|---|---|
| `training/src/utils/checkpoint.py` | `load_checkpoint()` |
| `training/src/eval.py` | eval checkpoint loader |
| `flash_attn/utils/pretrained.py` | `partial(torch.load, ...)` loader |
| `flash_attn/models/llama.py` | `state_dicts_from_checkpoint()` |

## Compatibility

`weights_only=True` was introduced in PyTorch 1.13 and is the default in PyTorch ≥ 2.4. FA4's CuTeDSL dependency already requires a modern PyTorch 2.x build, so there is no compatibility regression. All four sites load model state dicts, which are always `weights_only`-safe (tensors + primitive containers only).

Fixes #2583