### PR TITLE
Fix `seqlen_k_loaded` treating a window bound of 0 as unbounded (sliding window)

### DIFF
--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -558,7 +558,13 @@ def _flash_attn_fwd(
         q_stage = 1
 
     m_block_size_effective = q_stage * tile_m
-    seqlen_k_loaded = max_seqlen_k if not local else max(0, min(max_seqlen_k, (window_size_right or max_seqlen_k) + (window_size_left or max_seqlen_k) + 1 + tile_m))
+    # A window bound of 0 is legitimate (e.g. window_size_right == 0 for any causal
+    # sliding window), so only fall back to max_seqlen_k when the bound is None
+    # (unbounded). Using `or` here treats a real 0 as falsy and over-estimates the
+    # loaded KV range, defeating the purpose of seqlen_k_loaded for sliding windows.
+    window_right_loaded = max_seqlen_k if window_size_right is None else window_size_right
+    window_left_loaded = max_seqlen_k if window_size_left is None else window_size_left
+    seqlen_k_loaded = max_seqlen_k if not local else max(0, min(max_seqlen_k, window_right_loaded + window_left_loaded + 1 + tile_m))
     num_m_blocks = (seqlen_q_packgqa + m_block_size_effective - 1) // m_block_size_effective
     total_mblocks = batch_size * num_head_kv * num_m_blocks
     num_n_blocks = (seqlen_k_loaded + tile_n - 1) // tile_n

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -346,6 +346,9 @@ def _get_fwd_config(
         q_stage = 1
 
     m_block_size_effective = q_stage * tile_m
+    # Only None is unbounded; preserve 0 (e.g. the right bound of a causal window).
+    window_right_loaded = max_seqlen_k if window_size_right is None else window_size_right
+    window_left_loaded = max_seqlen_k if window_size_left is None else window_size_left
     seqlen_k_loaded = (
         max_seqlen_k
         if not local
@@ -353,8 +356,8 @@ def _get_fwd_config(
             0,
             min(
                 max_seqlen_k,
-                (window_size_right or max_seqlen_k)
-                + (window_size_left or max_seqlen_k)
+                window_right_loaded
+                + window_left_loaded
                 + 1
                 + tile_m,
             ),


### PR DESCRIPTION
### Problem

`_flash_attn_fwd` computes `seqlen_k_loaded` (the KV length the scheduler plans to load, which feeds `num_n_blocks` → `num_splits_heuristic`) as:

```python
seqlen_k_loaded = max_seqlen_k if not local else max(0, min(max_seqlen_k,
    (window_size_right or max_seqlen_k) + (window_size_left or max_seqlen_k) + 1 + tile_m))
```

`(window_size_right or max_seqlen_k)` was written so that a `None` (unbounded) window falls back to `max_seqlen_k`. But it also catches a **legitimate `0`**, because `0` is falsy. This matters because `_resolve_causal_local_window` sets `window_size_right = 0` for **every causal sliding window**, so for the standard causal-SWA case the right bound is *always* swallowed and `seqlen_k_loaded` collapses to the full `max_seqlen_k` — defeating the purpose of the window estimate. Same trap for `window_size_left == 0`.

This is what #2574 reports.

### Effect

Output is unaffected — masking still applies, so results stay correct. This only makes the scheduler **over-estimate** the loaded KV range, so it plans for more `n_blocks` / a different `num_splits` than the window actually needs.

### Fix

Fall back to `max_seqlen_k` only when the bound is `None` (genuinely unbounded), and respect an explicit `0`:

```python
window_right_loaded = max_seqlen_k if window_size_right is None else window_size_right
window_left_loaded  = max_seqlen_k if window_size_left  is None else window_size_left
```

### Verification (host-side, no GPU)

The change is pure scheduler arithmetic, so it's verifiable by evaluating the expression directly:

| case | old | new | effect |
|---|---:|---:|---|
| causal SWA (left=128, right=0) | 8192 | 257 | over-loads full KV → fixed |
| right-only window (left=0, right=64) | 8192 | 193 | over-loads full KV → fixed |
| symmetric window (left=256, right=256) | 641 | 641 | unchanged |
| left-only, unbounded right (left=128, right=None) | 8192 | 8192 | unchanged |
| non-local / full attention | 8192 | 8192 | unchanged |

`None` (unbounded) and non-zero windows are untouched; only the falsy-`0` cases are corrected.

Scoped narrowly to the `seqlen_k_loaded` line so it doesn't overlap with #2490 (which fixes a different issue in `_resolve_causal_local_window`).

Fixes #2574
