### PR TITLE
[FA4] Add fused split_size prefill path for SM100

### DIFF
--- a/flash_attn/cute/block_info.py
+++ b/flash_attn/cute/block_info.py
@@ -53,15 +53,13 @@ class BlockInfo:
                 # Fixed-size mode: each split covers exactly n_blocks_per_split blocks.
                 num_n_blocks_per_split = self.n_blocks_per_split
             else:
-                # Regular even-division mode (unchanged behavior).
                 num_n_blocks_per_split = (
                     Int32(0)
                     if n_block_max <= n_block_min
                     else (n_block_max - n_block_min + num_splits - 1) // num_splits
                 )
-            split_start = n_block_min + split_idx * num_n_blocks_per_split
-            n_block_max = cutlass.min(split_start + num_n_blocks_per_split, n_block_max)
-            n_block_min = split_start
+            n_block_min = n_block_min + split_idx * num_n_blocks_per_split
+            n_block_max = cutlass.min(n_block_min + num_n_blocks_per_split, n_block_max)
         return n_block_min, n_block_max
 
     @cute.jit

--- a/flash_attn/cute/block_info.py
+++ b/flash_attn/cute/block_info.py
@@ -19,6 +19,10 @@ class BlockInfo:
     window_size_left: Optional[Int32] = None
     window_size_right: Optional[Int32] = None
     qhead_per_kvhead_packgqa: cutlass.Constexpr[int] = 1
+    # Fixed split size in KV tile-blocks. None => regular even-division by num_splits.
+    # When set, every split covers exactly this many tile_n blocks (last split takes
+    # the remainder), giving seqlen-invariant, tile-aligned split boundaries.
+    n_blocks_per_split: Optional[Int32] = None
 
     @cute.jit
     def get_n_block_min_max(
@@ -45,13 +49,19 @@ class BlockInfo:
             n_idx_left = n_idx - self.window_size_left
             n_block_min = cutlass.max(n_idx_left // self.tile_n, 0)
         if cutlass.const_expr(self.is_split_kv):
-            num_n_blocks_per_split = (
-                Int32(0)
-                if n_block_max <= n_block_min
-                else (n_block_max - n_block_min + num_splits - 1) // num_splits
-            )
-            n_block_min = n_block_min + split_idx * num_n_blocks_per_split
-            n_block_max = cutlass.min(n_block_min + num_n_blocks_per_split, n_block_max)
+            if cutlass.const_expr(self.n_blocks_per_split is not None):
+                # Fixed-size mode: each split covers exactly n_blocks_per_split blocks.
+                num_n_blocks_per_split = self.n_blocks_per_split
+            else:
+                # Regular even-division mode (unchanged behavior).
+                num_n_blocks_per_split = (
+                    Int32(0)
+                    if n_block_max <= n_block_min
+                    else (n_block_max - n_block_min + num_splits - 1) // num_splits
+                )
+            split_start = n_block_min + split_idx * num_n_blocks_per_split
+            n_block_max = cutlass.min(split_start + num_n_blocks_per_split, n_block_max)
+            n_block_min = split_start
         return n_block_min, n_block_max
 
     @cute.jit

--- a/flash_attn/cute/flash_fwd_combine.py
+++ b/flash_attn/cute/flash_fwd_combine.py
@@ -587,10 +587,16 @@ class FlashAttentionForwardCombine:
                         m_new = max(m_run[m], lse_s[m])
                         a = cute.math.exp2((m_run[m] - m_new) * LOG2_E, fastmath=True)
                         b = cute.math.exp2((lse_s[m] - m_new) * LOG2_E, fastmath=True)
-                        tOrO[None, m, None].store(
-                            tOrO[None, m, None].load() * a
-                            + tOrO_partial[None, m, None].load().to(Float32) * b
-                        )
+                        # Per-element acc*a + seg*b via separate f32 muls + add. The fused
+                        # in-kernel merge (correction_merge in flash_fwd_sm100.py) uses the
+                        # IDENTICAL op sequence so prefill (fused) == decode (gmem) bitwise.
+                        acc_row = tOrO[None, m, None]
+                        seg_row = cute.make_rmem_tensor_like(acc_row, Float32)
+                        seg_row.store(tOrO_partial[None, m, None].load().to(Float32))
+                        for k in cutlass.range(0, cute.size(acc_row), 2, unroll_full=True):
+                            pa0, pa1 = cute.arch.mul_packed_f32x2((acc_row[k], acc_row[k + 1]), (a, a))
+                            ps0, ps1 = cute.arch.mul_packed_f32x2((seg_row[k], seg_row[k + 1]), (b, b))
+                            acc_row[k], acc_row[k + 1] = pa0 + ps0, pa1 + ps1
                         s_run[m] = s_run[m] * a + b
                         m_run[m] = m_new
 

--- a/flash_attn/cute/flash_fwd_combine.py
+++ b/flash_attn/cute/flash_fwd_combine.py
@@ -597,7 +597,10 @@ class FlashAttentionForwardCombine:
                             pa0, pa1 = cute.arch.mul_packed_f32x2((acc_row[k], acc_row[k + 1]), (a, a))
                             ps0, ps1 = cute.arch.mul_packed_f32x2((seg_row[k], seg_row[k + 1]), (b, b))
                             acc_row[k], acc_row[k + 1] = pa0 + ps0, pa1 + ps1
-                        s_run[m] = s_run[m] * a + b
+                        # Explicit non-FMA mul (mul_packed) + add, matching the fused in-kernel
+                        # merge's s_run accumulation exactly (bitwise inv_sum).
+                        _sa, _ = cute.arch.mul_packed_f32x2((s_run[m], Float32(0.0)), (a, a))
+                        s_run[m] = _sa + b
                         m_run[m] = m_new
 
             # Normalize: O = tOrO / s_run

--- a/flash_attn/cute/flash_fwd_combine.py
+++ b/flash_attn/cute/flash_fwd_combine.py
@@ -510,59 +510,25 @@ class FlashAttentionForwardCombine:
             cute.copy(s2r_tiled_copy_LSE, ts2rsLSE, ts2rrLSE)
 
             # ===============================
-            # Step 4: Compute final LSE along split dimension
+            # Step 4: Per-row max valid split. sLSE keeps the RAW per-split LSE values;
+            # the actual combine is a single-pass streaming online-merge in Step 6, which
+            # matches the in-kernel fused-prefill merge order (split index ascending).
             # ===============================
 
-            lse_sum = cute.make_rmem_tensor(cute.size(ts2rrLSE, mode=[2]), Float32)
             ts2rcLSE = s2r_thr_copy_LSE.partition_D(cLSE)
-            # We compute the max valid split for each row to short-circuit the computation later
             max_valid_split = cute.make_rmem_tensor(cute.size(ts2rrLSE, mode=[2]), Int32)
             assert cute.size(ts2rrLSE, mode=[0]) == 1
-            # Compute max, scales, and final LSE for each row
+            threads_per_col = const_expr(self.smem_threads_per_col_lse)
             for m in cutlass.range(cute.size(ts2rrLSE, mode=[2]), unroll_full=True):
-                # Find max LSE value across splits
-                threads_per_col = const_expr(self.smem_threads_per_col_lse)
-                lse_max = cute.arch.warp_reduction_max(
-                    ts2rrLSE[None, None, m]
-                    .load()
-                    .reduce(cute.ReductionOp.MAX, init_val=-Float32.inf, reduction_profile=0),
-                    threads_in_group=threads_per_col,
-                )
-                # if cute.arch.thread_idx()[0] == 0: cute.printf(lse_max)
-                # Find max valid split index
+                # Highest split index with a finite LSE (short-circuits the merge loop)
                 max_valid_idx = -1
                 for s in cutlass.range(cute.size(ts2rrLSE, mode=[1]), unroll_full=True):
                     if ts2rrLSE[0, s, m] != -Float32.inf:
-                        max_valid_idx = ts2rcLSE[0, s, 0][0]  # Get split coordinate
-                # if cute.arch.thread_idx()[0] < 32: cute.printf(max_valid_idx)
+                        max_valid_idx = ts2rcLSE[0, s, 0][0]
                 max_valid_split[m] = cute.arch.warp_reduction_max(
                     max_valid_idx, threads_in_group=threads_per_col
                 )
-                # Compute exp scales and sum
-                lse_max_cur = (
-                    0.0 if lse_max == -Float32.inf else lse_max
-                )  # In case all local LSEs are -inf
-                LOG2_E = math.log2(math.e)
-                lse_sum_cur = 0.0
-                for s in cutlass.range(cute.size(ts2rrLSE, mode=[1]), unroll_full=True):
-                    scale = cute.math.exp2(
-                        ts2rrLSE[0, s, m] * LOG2_E - (lse_max_cur * LOG2_E), fastmath=True
-                    )
-                    lse_sum_cur += scale
-                    ts2rrLSE[0, s, m] = scale  # Store scale for later use
-                lse_sum_cur = cute.arch.warp_reduction_sum(
-                    lse_sum_cur, threads_in_group=threads_per_col
-                )
-                lse_sum[m] = cute.math.log(lse_sum_cur, fastmath=True) + lse_max
-                # Normalize scales
-                inv_sum = (
-                    0.0 if (lse_sum_cur == 0.0 or lse_sum_cur != lse_sum_cur) else 1.0 / lse_sum_cur
-                )
-                ts2rrLSE[None, None, m].store(ts2rrLSE[None, None, m].load() * inv_sum)
-            # Store the scales exp(lse - lse_logsum) back to smem
-            cute.copy(s2r_tiled_copy_LSE, ts2rrLSE, ts2rsLSE)
-
-            # Store max valid split to smem
+            # sLSE is left holding the raw LSE (no scale write-back).
             for m in cutlass.range(cute.size(ts2rrLSE, mode=[2]), unroll_full=True):
                 if ts2rcLSE[0, 0, m][0] == 0:  # Only thread responsible for s=0 writes
                     mi = ts2rcLSE[0, 0, m][1]
@@ -570,29 +536,10 @@ class FlashAttentionForwardCombine:
                         sMaxValidSplit[mi] = max_valid_split[m]
 
             # ===============================
-            # Step 5: Store final LSE to gmem
-            # ===============================
-
-            if const_expr(mLSE is not None):
-                if const_expr(cu_seqlens is None):
-                    mLSE_cur = mLSE[None, None, batch_idx]
-                else:
-                    mLSE_cur = cute.domain_offset((offset, 0), mLSE)
-                if k_block == 0:  # Only first k_block writes LSE when mLSE is provided
-                    for m in cutlass.range(cute.size(ts2rrLSE, mode=[2]), unroll_full=True):
-                        if ts2rcLSE[0, 0, m][0] == 0:  # Only thread responsible for s=0 writes
-                            mi = ts2rcLSE[0, 0, m][1]
-                            idx = m_block * self.tile_m + mi
-                            if idx < max_idx:
-                                if const_expr(not varlen):
-                                    head_idx, m_idx = divmod(idx, seqlen_divmod)
-                                else:
-                                    head_idx = idx // seqlen
-                                    m_idx = idx - head_idx * seqlen
-                                mLSE_cur[m_idx, head_idx] = lse_sum[m]
-
-            # ===============================
-            # Step 6: Read O_partial and accumulate final O
+            # Step 6: Streaming online-merge of O_partial across splits (single pass).
+            # Per row keep running (m_run = max lse, s_run = running denom, tOrO = running
+            # un-normalized weighted O). For each split: a = exp2(m_run-m_new), b =
+            # exp2(lse_s-m_new); tOrO = tOrO*a + O_s*b; s_run = s_run*a + b. Final O = tOrO/s_run.
             # ===============================
 
             cute.arch.sync_threads()
@@ -605,16 +552,21 @@ class FlashAttentionForwardCombine:
             tOrO_partial = cute.make_rmem_tensor_like(tOsO_partial[None, None, None, 0])
             tOrO = cute.make_rmem_tensor_like(tOrO_partial, Float32)
             tOrO.fill(0.0)
+            m_run = cute.make_rmem_tensor(num_rows, Float32)
+            s_run = cute.make_rmem_tensor(num_rows, Float32)
+            for m in cutlass.range(num_rows, unroll_full=True):
+                m_run[m] = -Float32.inf
+                s_run[m] = 0.0
 
+            LOG2_E = math.log2(math.e)
             stage_load = self.stages - 1
             stage_compute = 0
 
-            # Main accumulation loop
+            # Streaming merge loop (split index ascending)
             for s in cutlass.range(thr_max_valid_split + 1, unroll=4):
-                # Get scales for this split
-                scale = cute.make_rmem_tensor(num_rows, Float32)
+                lse_s = cute.make_rmem_tensor(num_rows, Float32)
                 for m in cutlass.range(num_rows, unroll_full=True):
-                    scale[m] = sLSE[s, tOcO[0, m, 0][0]]  # Get scale from smem
+                    lse_s[m] = sLSE[s, tOcO[0, m, 0][0]]  # raw per-split LSE
 
                 # Load next stage if needed
                 split_to_load = s + self.stages - 1
@@ -625,22 +577,50 @@ class FlashAttentionForwardCombine:
 
                 # Wait for the current stage to be ready
                 cute.arch.cp_async_wait_group(self.stages - 1)
-                # We don't need __syncthreads() because each thread is just reading its own data from smem
-                # Copy from smem to registers
                 cute.autovec_copy(tOsO_partial[None, None, None, stage_compute], tOrO_partial)
                 stage_compute = 0 if stage_compute == self.stages - 1 else stage_compute + 1
 
-                # Accumulate scaled partial results
+                # Online merge of this split's partial. -inf init handled by exp2(-inf)=0:
+                # first finite split gives a=exp2(-inf)=0 (tOrO was 0) and b=exp2(0)=1.
                 for m in cutlass.range(num_rows, unroll_full=True):
-                    if tOhidx[m] >= 0 and scale[m] > 0.0:
+                    if tOhidx[m] >= 0 and lse_s[m] != -Float32.inf:
+                        m_new = max(m_run[m], lse_s[m])
+                        a = cute.math.exp2((m_run[m] - m_new) * LOG2_E, fastmath=True)
+                        b = cute.math.exp2((lse_s[m] - m_new) * LOG2_E, fastmath=True)
                         tOrO[None, m, None].store(
-                            tOrO[None, m, None].load()
-                            + scale[m] * tOrO_partial[None, m, None].load().to(Float32)
+                            tOrO[None, m, None].load() * a
+                            + tOrO_partial[None, m, None].load().to(Float32) * b
                         )
+                        s_run[m] = s_run[m] * a + b
+                        m_run[m] = m_new
+
+            # Normalize: O = tOrO / s_run
+            for m in cutlass.range(num_rows, unroll_full=True):
+                inv_sum = (
+                    0.0 if (s_run[m] == 0.0 or s_run[m] != s_run[m]) else 1.0 / s_run[m]
+                )
+                tOrO[None, m, None].store(tOrO[None, m, None].load() * inv_sum)
 
             # ===============================
-            # Step 7: Write final O to gmem
+            # Step 7: Write final LSE + O to gmem
             # ===============================
+
+            # Final LSE = log(s_run) + m_run (logsumexp). Written once per row, by the thread
+            # owning the k=0 column, only on the first k_block.
+            if const_expr(mLSE is not None):
+                if const_expr(cu_seqlens is None):
+                    mLSE_cur = mLSE[None, None, batch_idx]
+                else:
+                    mLSE_cur = cute.domain_offset((offset, 0), mLSE)
+                if k_block == 0 and tOcO[0, 0, 0][1] == 0:
+                    for m in cutlass.range(num_rows, unroll_full=True):
+                        if tOhidx[m] >= 0:
+                            lse_final = (
+                                -Float32.inf
+                                if s_run[m] == 0.0
+                                else cute.math.log(s_run[m], fastmath=True) + m_run[m]
+                            )
+                            mLSE_cur[tOmidx[m], tOhidx[m]] = lse_final
 
             rO = cute.make_rmem_tensor_like(tOrO, self.dtype)
             rO.store(tOrO.load().to(self.dtype))

--- a/flash_attn/cute/flash_fwd_sm100.py
+++ b/flash_attn/cute/flash_fwd_sm100.py
@@ -2666,7 +2666,12 @@ class FlashAttentionForwardSm100:
                             thr_mma_pv, tOacc[None, None, None, 0], tOtO[None, None, None, stage],
                             tidx, a, b, seg == 0,
                         )
-                        s_run = s_run * a + b
+                        # Explicit non-FMA mul (mul_packed) + add, matching the combine's
+                        # s_run accumulation exactly so inv_sum=1/s_run is bitwise-identical
+                        # (a scalar FMA-contraction mismatch here flips a bf16 element on
+                        # boundary-value rows).
+                        _sa, _ = cute.arch.mul_packed_f32x2((s_run, Float32(0.0)), (a, a))
+                        s_run = _sa + b
                         m_run = m_new
                         pipeline_s_p_o.consumer_release_w_index(stage)
                         if _is_last_seg:

--- a/flash_attn/cute/flash_fwd_sm100.py
+++ b/flash_attn/cute/flash_fwd_sm100.py
@@ -1059,6 +1059,11 @@ class FlashAttentionForwardSm100:
         pv_acc_shape = thr_mma_pv.partition_shape_C(self.mma_tiler_pv[:2])
         tOtO = thr_mma_pv.make_fragment_C(cute.append(pv_acc_shape, self.q_stage))
         tOtO = cute.make_tensor(tOtO.iterator + self.tmem_o_offset[0], tOtO.layout)
+        # Fused prefill: running merged-output accumulator in the free tmem columns.
+        tOacc = None
+        if const_expr(self.fused_split):
+            tOacc = thr_mma_pv.make_fragment_C(cute.append(pv_acc_shape, 1))
+            tOacc = cute.make_tensor(tOacc.iterator + self.tmem_oacc_offset, tOacc.layout)
         tP = cute.make_tensor(tStS.iterator, tP_layout.outer)
         tOrP = thr_mma_pv.make_fragment_A(tP)[None, None, None, 0]
         # Need to multiply by width ratio bc tP is in v_dtype but tmem offsets are in FP32
@@ -1076,7 +1081,9 @@ class FlashAttentionForwardSm100:
             self.cta_tiler[1],
             self.is_causal,
             self.is_local,
-            self.is_split_kv,
+            # Fused prefill uses the same fixed-size split-range math to carve segments;
+            # the kernel's self.is_split_kv stays False (normal output, no gmem partials).
+            self.is_split_kv or self.fused_split,
             window_size_left,
             window_size_right,
             qhead_per_kvhead_packgqa=self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
@@ -1311,6 +1318,7 @@ class FlashAttentionForwardSm100:
                 thr_mma_pv,
                 tStS,
                 tOtO,
+                tOacc,
                 sScale,
                 mO,
                 mLSE,
@@ -2384,6 +2392,7 @@ class FlashAttentionForwardSm100:
         thr_mma_pv: cute.ThrMma,
         tStS: cute.Tensor,
         tOtO: cute.Tensor,
+        tOacc: Optional[cute.Tensor],
         sScale: cute.Tensor,
         mO: cute.Tensor,
         mLSE: cute.Tensor,
@@ -2735,6 +2744,54 @@ class FlashAttentionForwardSm100:
                 )
             tOtO_r2t_i = cute.make_tensor(tOtO_r2t.iterator + i * corr_tile_size, tOtO_r2t.layout)
             cute.copy(thr_tmem_store, tOrO_frg, tOtO_r2t_i)
+        cute.arch.fence_view_async_tmem_store()
+
+    @cute.jit
+    def correction_merge(
+        self,
+        thr_mma: cute.ThrMma,
+        tOacc: cute.Tensor,
+        tOseg: cute.Tensor,
+        tidx: Int32,
+        a: Float32,
+        scale_seg: Float32,
+    ):
+        """Online streaming merge of a segment partial into the running accumulator (fused
+        prefill SplitKV). Computes Oacc = Oacc * a + Oseg * scale_seg in tmem, where `a`
+        rescales the running accumulator to the new global max and `scale_seg` = (1/row_sum_seg)
+        * exp2(lse_seg - max_new) folds the segment's own normalization with its merge weight.
+        Mirrors correction_rescale's tmem load/store machinery; per-thread (per-row) scalars."""
+        tOcO = thr_mma.partition_C(cute.make_identity_tensor(self.mma_tiler_pv[:2]))
+        corr_tile_size = 16
+        tmem_load_atom = cute.make_copy_atom(
+            tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(corr_tile_size)), self.pv_acc_dtype
+        )
+        tmem_store_atom = cute.make_copy_atom(
+            tcgen05.copy.St32x32bOp(tcgen05.copy.Repetition(corr_tile_size)), self.pv_acc_dtype
+        )
+        tOacc_i = cute.composition(tOacc, cute.make_layout((self.m_block_size, corr_tile_size)))
+        tOseg_i = cute.composition(tOseg, cute.make_layout((self.m_block_size, corr_tile_size)))
+        tOcO_i = cute.composition(tOcO, cute.make_layout((self.m_block_size, corr_tile_size)))
+        thr_tmem_load = tcgen05.make_tmem_copy(tmem_load_atom, tOacc_i).get_slice(tidx)
+        thr_tmem_store = tcgen05.make_tmem_copy(tmem_store_atom, tOacc_i).get_slice(tidx)
+        tOacc_t2r = thr_tmem_load.partition_S(tOacc_i)
+        tOseg_t2r = thr_tmem_load.partition_S(tOseg_i)
+        tOrO_t2r_shape = thr_tmem_load.partition_D(tOcO_i).shape
+        tOacc_r2t = thr_tmem_store.partition_D(tOacc_i)
+        frg_count = self.head_dim_v_padded // corr_tile_size
+        for i in cutlass.range_constexpr(frg_count):
+            acc_frg = cute.make_rmem_tensor(tOrO_t2r_shape, self.pv_acc_dtype)
+            seg_frg = cute.make_rmem_tensor(tOrO_t2r_shape, self.pv_acc_dtype)
+            tOacc_t2r_i = cute.make_tensor(tOacc_t2r.iterator + i * corr_tile_size, tOacc_t2r.layout)
+            tOseg_t2r_i = cute.make_tensor(tOseg_t2r.iterator + i * corr_tile_size, tOseg_t2r.layout)
+            cute.copy(thr_tmem_load, tOacc_t2r_i, acc_frg)
+            cute.copy(thr_tmem_load, tOseg_t2r_i, seg_frg)
+            for j in cutlass.range(0, cute.size(acc_frg), 2, unroll_full=True):
+                a0, a1 = cute.arch.mul_packed_f32x2((acc_frg[j], acc_frg[j + 1]), (a, a))
+                s0, s1 = cute.arch.mul_packed_f32x2((seg_frg[j], seg_frg[j + 1]), (scale_seg, scale_seg))
+                acc_frg[j], acc_frg[j + 1] = a0 + s0, a1 + s1
+            tOacc_r2t_i = cute.make_tensor(tOacc_r2t.iterator + i * corr_tile_size, tOacc_r2t.layout)
+            cute.copy(thr_tmem_store, acc_frg, tOacc_r2t_i)
         cute.arch.fence_view_async_tmem_store()
 
     @cute.jit

--- a/flash_attn/cute/flash_fwd_sm100.py
+++ b/flash_attn/cute/flash_fwd_sm100.py
@@ -1388,15 +1388,9 @@ class FlashAttentionForwardSm100:
         while work_tile.is_valid_tile:
             m_block, head_idx, batch_idx, split_idx = work_tile.tile_idx
             seqlen = SeqlenInfoCls(batch_idx)
-            if const_expr(self.fused_split):
-                _n_seg = cute.ceil_div(
-                    block_info.get_n_block_max_for_m_block(seqlen, m_block),
-                    block_info.n_blocks_per_split,
-                )
-                split_idx_eff, num_splits_eff = seg, _n_seg
-            else:
-                _n_seg = Int32(1)
-                split_idx_eff, num_splits_eff = split_idx, num_splits
+            _n_seg, split_idx_eff, num_splits_eff = self._seg_split_range(
+                block_info, seqlen, m_block, seg, split_idx, num_splits
+            )
             mQ_cur = seqlen.offset_batch_Q(mQ, batch_idx, dim=3)[None, None, head_idx]
 
             head_idx_kv = (
@@ -1701,15 +1695,9 @@ class FlashAttentionForwardSm100:
         while work_tile.is_valid_tile:
             m_block, head_idx, batch_idx, split_idx = work_tile.tile_idx
             seqlen = SeqlenInfoCls(batch_idx)
-            if const_expr(self.fused_split):
-                _n_seg = cute.ceil_div(
-                    block_info.get_n_block_max_for_m_block(seqlen, m_block),
-                    block_info.n_blocks_per_split,
-                )
-                split_idx_eff, num_splits_eff = seg, _n_seg
-            else:
-                _n_seg = Int32(1)
-                split_idx_eff, num_splits_eff = split_idx, num_splits
+            _n_seg, split_idx_eff, num_splits_eff = self._seg_split_range(
+                block_info, seqlen, m_block, seg, split_idx, num_splits
+            )
 
             block_iter_count = Int32(0)
             process_tile = False
@@ -1878,7 +1866,7 @@ class FlashAttentionForwardSm100:
                 mma_kv_consumer_state.advance()
                 # End of GEMM_PV1(i_end) (P1 * Vi_end -> O1)
 
-            # Advance to next tile (fused: stay on the tile until all segments are processed)
+            # Advance to next tile
             if const_expr(self.fused_split):
                 seg = seg + 1
                 _do_adv = seg >= _n_seg
@@ -2016,15 +2004,9 @@ class FlashAttentionForwardSm100:
             m_block, head_idx, batch_idx, split_idx = work_tile.tile_idx
             kv_head_idx = self._kv_head_idx(head_idx)
             seqlen = SeqlenInfoCls(batch_idx)
-            if const_expr(self.fused_split):
-                _n_seg = cute.ceil_div(
-                    block_info.get_n_block_max_for_m_block(seqlen, m_block),
-                    block_info.n_blocks_per_split,
-                )
-                split_idx_eff, num_splits_eff = seg, _n_seg
-            else:
-                _n_seg = Int32(1)
-                split_idx_eff, num_splits_eff = split_idx, num_splits
+            _n_seg, split_idx_eff, num_splits_eff = self._seg_split_range(
+                block_info, seqlen, m_block, seg, split_idx, num_splits
+            )
             n_block_min, n_block_max = block_info.get_n_block_min_max(seqlen, m_block, split_idx_eff, num_splits_eff)
 
             mask = AttentionMaskCls(seqlen)
@@ -2284,7 +2266,7 @@ class FlashAttentionForwardSm100:
             #     if tidx < seqlen.seqlen_q - (m_block * 2 + stage) * self.m_block_size:
             #         gLSE[tidx] = lse
 
-            # Advance to next tile (fused: stay on the tile until all segments are processed)
+            # Advance to next tile
             if const_expr(self.fused_split):
                 seg = seg + 1
                 _do_adv = seg >= _n_seg
@@ -2515,20 +2497,13 @@ class FlashAttentionForwardSm100:
                 Float32(256.0) if cutlass.const_expr(self.q_dtype.width == 8) else Float32(1.0)
             )
             seqlen = SeqlenInfoCls(batch_idx)
-            if const_expr(self.fused_split):
-                _n_seg = cute.ceil_div(
-                    block_info.get_n_block_max_for_m_block(seqlen, m_block),
-                    block_info.n_blocks_per_split,
-                )
-                split_idx_eff, num_splits_eff = seg, _n_seg
-                _is_last_seg = seg + 1 >= _n_seg
-                if seg == 0:
-                    m_run = -Float32.inf
-                    s_run = Float32(0.0)
-            else:
-                _n_seg = Int32(1)
-                split_idx_eff, num_splits_eff = split_idx, num_splits
-                _is_last_seg = True
+            _n_seg, split_idx_eff, num_splits_eff = self._seg_split_range(
+                block_info, seqlen, m_block, seg, split_idx, num_splits
+            )
+            _is_last_seg = seg + 1 >= _n_seg
+            if const_expr(self.fused_split) and seg == 0:
+                m_run = -Float32.inf  # reset running merge state at the first segment
+                s_run = Float32(0.0)
             n_block_min, n_block_max = block_info.get_n_block_min_max(seqlen, m_block, split_idx_eff, num_splits_eff)
 
             if const_expr(self.is_split_kv):
@@ -2808,7 +2783,7 @@ class FlashAttentionForwardSm100:
                             )
                             cute.make_tensor(lse_gmem_ptr, (1,))[0] = lse
 
-            # Advance to next tile (fused: stay on the tile until all segments are merged)
+            # Advance to next tile
             if const_expr(self.fused_split):
                 seg = seg + 1
                 _do_adv = seg >= _n_seg
@@ -2874,6 +2849,20 @@ class FlashAttentionForwardSm100:
             tOtO_r2t_i = cute.make_tensor(tOtO_r2t.iterator + i * corr_tile_size, tOtO_r2t.layout)
             cute.copy(thr_tmem_store, tOrO_frg, tOtO_r2t_i)
         cute.arch.fence_view_async_tmem_store()
+
+    @cute.jit
+    def _seg_split_range(self, block_info, seqlen, m_block, seg, split_idx, num_splits):
+        """Map the current per-tile segment to the (split_idx, num_splits) the block-range
+        math expects. Fused prefill carves the KV range into ceil(n_blocks / n_blocks_per_split)
+        segments; non-fused passes the scheduler's split through unchanged. Returns
+        (n_seg, split_idx_eff, num_splits_eff)."""
+        if const_expr(self.fused_split):
+            n_seg = cute.ceil_div(
+                block_info.get_n_block_max_for_m_block(seqlen, m_block),
+                block_info.n_blocks_per_split,
+            )
+            return n_seg, seg, n_seg
+        return Int32(1), split_idx, num_splits
 
     @cute.jit
     def correction_merge(

--- a/flash_attn/cute/flash_fwd_sm100.py
+++ b/flash_attn/cute/flash_fwd_sm100.py
@@ -134,6 +134,7 @@ class FlashAttentionForwardSm100:
         is_varlen_q: bool = False,
         use_2cta_instrs: bool = False,
         use_clc_scheduler: bool = False,
+        fused_split: bool = False,
     ):
         self.use_tma_KV = not paged_kv_non_tma
         # self.dtype = dtype
@@ -179,6 +180,11 @@ class FlashAttentionForwardSm100:
         self.use_correction_warps_for_epi = is_varlen_q
         self.qhead_per_kvhead = qhead_per_kvhead
         self.is_split_kv = is_split_kv
+        # Fused prefill SplitKV: one CTA per query tile internally segments the KV loop into
+        # n_blocks_per_split chunks and online-merges the per-segment partials in-kernel, so
+        # there are no gmem partials and no separate combine kernel. Milestone 1 supports
+        # q_stage==1 only (needs a free tmem column range for the running accumulator).
+        self.fused_split = fused_split
         self.pack_gqa = pack_gqa
         self.q_subtile_factor = q_subtile_factor
         assert not (self.is_split_kv and self.head_dim_v_padded >= 192), (
@@ -288,6 +294,13 @@ class FlashAttentionForwardSm100:
             for i in range(self.q_stage)
         ]  # e.g., 256, 384
         self.tmem_total = self.tmem_o_offset[-1] + self.head_dim_v_padded
+        # Fused prefill (M1): place the running merged-output accumulator Oacc_run in the
+        # free tmem columns after tmem_total. Only fits at q_stage==1 (q_stage==2 fills tmem).
+        self.tmem_oacc_offset = None
+        if self.fused_split:
+            assert self.q_stage == 1, "fused_split milestone 1 supports q_stage==1 only"
+            self.tmem_oacc_offset = self.tmem_total
+            self.tmem_total = self.tmem_oacc_offset + self.head_dim_v_padded
         assert self.tmem_total <= self.tmem_alloc_cols
         self.tmem_s_to_p_offset = self.n_block_size // 2
         self.tmem_p_offset = [

--- a/flash_attn/cute/flash_fwd_sm100.py
+++ b/flash_attn/cute/flash_fwd_sm100.py
@@ -381,6 +381,7 @@ class FlashAttentionForwardSm100:
         window_size_right: Int32 | int | None = None,
         learnable_sink: Optional[cute.Tensor] = None,
         descale_tensors: Optional[DescaleTensors] = None,
+        n_blocks_per_split: Int32 | int | None = None,
         blocksparse_tensors: Optional[BlockSparseTensors] = None,
         aux_tensors: Optional[list] = None,
         # Always keep stream as the last parameter (EnvStream: obtained implicitly via TVM FFI).
@@ -722,6 +723,7 @@ class FlashAttentionForwardSm100:
         softmax_scale_log2, softmax_scale = utils.compute_softmax_scale_log2(softmax_scale, self.score_mod)
         window_size_left = Int32(window_size_left) if window_size_left is not None else None
         window_size_right = Int32(window_size_right) if window_size_right is not None else None
+        n_blocks_per_split = Int32(n_blocks_per_split) if n_blocks_per_split is not None else None
         fastdiv_mods = utils.compute_fastdiv_mods(mQ, mK, self.qhead_per_kvhead, self.pack_gqa, aux_tensors, mPageTable)
 
         head_divmod = None
@@ -770,6 +772,7 @@ class FlashAttentionForwardSm100:
             tiled_mma_pv,
             tile_sched_params,
             num_splits,
+            n_blocks_per_split,
             aux_tensors,
             fastdiv_mods,
             head_divmod,
@@ -829,6 +832,7 @@ class FlashAttentionForwardSm100:
         tiled_mma_pv: cute.TiledMma,
         tile_sched_params: ParamsBase,
         num_splits: Int32,
+        n_blocks_per_split: Optional[Int32] = None,
         aux_tensors: Optional[list] = None,
         fastdiv_mods=(None, None),
         head_divmod=None,
@@ -1063,6 +1067,7 @@ class FlashAttentionForwardSm100:
             window_size_left,
             window_size_right,
             qhead_per_kvhead_packgqa=self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
+            n_blocks_per_split=n_blocks_per_split,
         )
         SeqlenInfoCls = partial(
             SeqlenInfoQK.create,

--- a/flash_attn/cute/flash_fwd_sm100.py
+++ b/flash_attn/cute/flash_fwd_sm100.py
@@ -177,7 +177,7 @@ class FlashAttentionForwardSm100:
         self.is_causal = is_causal
         self.is_local = is_local
         self.is_varlen_q = is_varlen_q
-        self.use_correction_warps_for_epi = is_varlen_q
+        self.use_correction_warps_for_epi = is_varlen_q or fused_split
         self.qhead_per_kvhead = qhead_per_kvhead
         self.is_split_kv = is_split_kv
         # Fused prefill SplitKV: one CTA per query tile internally segments the KV loop into
@@ -475,6 +475,7 @@ class FlashAttentionForwardSm100:
             and mSeqUsedQ is None
             and not (self.pack_gqa and self.m_block_size % self.qhead_per_kvhead != 0)
             and not (self.pack_gqa and self.is_split_kv)
+            and not self.fused_split  # fused uses the correction-warp (non-TMA) epilogue
         )
         self.ex2_emu_freq = 0
         self.ex2_emu_start_frg = self._tune.get("ex2_emu_start_frg", 1)
@@ -1382,10 +1383,20 @@ class FlashAttentionForwardSm100:
         kv_producer_state = pipeline.make_pipeline_state(
             pipeline.PipelineUserType.Producer, self.kv_stage
         )
+        seg = Int32(0)
         work_tile = tile_scheduler.initial_work_tile_info()
         while work_tile.is_valid_tile:
             m_block, head_idx, batch_idx, split_idx = work_tile.tile_idx
             seqlen = SeqlenInfoCls(batch_idx)
+            if const_expr(self.fused_split):
+                _n_seg = cute.ceil_div(
+                    block_info.get_n_block_max_for_m_block(seqlen, m_block),
+                    block_info.n_blocks_per_split,
+                )
+                split_idx_eff, num_splits_eff = seg, _n_seg
+            else:
+                _n_seg = Int32(1)
+                split_idx_eff, num_splits_eff = split_idx, num_splits
             mQ_cur = seqlen.offset_batch_Q(mQ, batch_idx, dim=3)[None, None, head_idx]
 
             head_idx_kv = (
@@ -1495,7 +1506,7 @@ class FlashAttentionForwardSm100:
 
             if const_expr(not self.use_block_sparsity):
                 n_block_min, n_block_max = block_info.get_n_block_min_max(
-                    seqlen, m_block, split_idx, num_splits
+                    seqlen, m_block, split_idx_eff, num_splits_eff
                 )
                 if const_expr(not self.is_split_kv) or n_block_min < n_block_max:
                     n_block_first = n_block_max - 1 if n_block_max > 0 else 0
@@ -1556,7 +1567,15 @@ class FlashAttentionForwardSm100:
                 )
 
 
-            work_tile = tile_scheduler.advance_to_next_work()
+            if const_expr(self.fused_split):
+                seg = seg + 1
+                _do_adv = seg >= _n_seg
+                if _do_adv:
+                    seg = Int32(0)
+            else:
+                _do_adv = True
+            if _do_adv:
+                work_tile = tile_scheduler.advance_to_next_work()
             # End of persistent scheduler loop
 
         if issue_kv_for_this_warp:
@@ -1677,10 +1696,20 @@ class FlashAttentionForwardSm100:
         )
         P_full_O_rescaled_phase = Int32(0)
 
+        seg = Int32(0)
         work_tile = tile_scheduler.initial_work_tile_info()
         while work_tile.is_valid_tile:
             m_block, head_idx, batch_idx, split_idx = work_tile.tile_idx
             seqlen = SeqlenInfoCls(batch_idx)
+            if const_expr(self.fused_split):
+                _n_seg = cute.ceil_div(
+                    block_info.get_n_block_max_for_m_block(seqlen, m_block),
+                    block_info.n_blocks_per_split,
+                )
+                split_idx_eff, num_splits_eff = seg, _n_seg
+            else:
+                _n_seg = Int32(1)
+                split_idx_eff, num_splits_eff = split_idx, num_splits
 
             block_iter_count = Int32(0)
             process_tile = False
@@ -1699,9 +1728,9 @@ class FlashAttentionForwardSm100:
                 )
                 process_tile = block_iter_count > Int32(0)
             else:
-                n_block_min, n_block_max = block_info.get_n_block_min_max(seqlen, m_block, split_idx, num_splits)
+                n_block_min, n_block_max = block_info.get_n_block_min_max(seqlen, m_block, split_idx_eff, num_splits_eff)
                 block_iter_count = n_block_max - n_block_min
-                if const_expr(not self.is_split_kv):
+                if const_expr(not self.is_split_kv and not self.fused_split):
                     process_tile = True
                 else:
                     process_tile = n_block_min < n_block_max
@@ -1849,8 +1878,16 @@ class FlashAttentionForwardSm100:
                 mma_kv_consumer_state.advance()
                 # End of GEMM_PV1(i_end) (P1 * Vi_end -> O1)
 
-            # Advance to next tile
-            work_tile = tile_scheduler.advance_to_next_work()
+            # Advance to next tile (fused: stay on the tile until all segments are processed)
+            if const_expr(self.fused_split):
+                seg = seg + 1
+                _do_adv = seg >= _n_seg
+                if _do_adv:
+                    seg = Int32(0)
+            else:
+                _do_adv = True
+            if _do_adv:
+                work_tile = tile_scheduler.advance_to_next_work()
         # End of persistent scheduler loop
 
         # We don't need pipeline_s_p_o.producer_tail() since there's no dangling mbarrier at the end
@@ -1973,12 +2010,22 @@ class FlashAttentionForwardSm100:
 
         warp_idx_in_wg = cute.arch.make_warp_uniform(cute.arch.warp_idx()) % 4
 
+        seg = Int32(0)
         work_tile = tile_scheduler.initial_work_tile_info()
         while work_tile.is_valid_tile:
             m_block, head_idx, batch_idx, split_idx = work_tile.tile_idx
             kv_head_idx = self._kv_head_idx(head_idx)
             seqlen = SeqlenInfoCls(batch_idx)
-            n_block_min, n_block_max = block_info.get_n_block_min_max(seqlen, m_block, split_idx, num_splits)
+            if const_expr(self.fused_split):
+                _n_seg = cute.ceil_div(
+                    block_info.get_n_block_max_for_m_block(seqlen, m_block),
+                    block_info.n_blocks_per_split,
+                )
+                split_idx_eff, num_splits_eff = seg, _n_seg
+            else:
+                _n_seg = Int32(1)
+                split_idx_eff, num_splits_eff = split_idx, num_splits
+            n_block_min, n_block_max = block_info.get_n_block_min_max(seqlen, m_block, split_idx_eff, num_splits_eff)
 
             mask = AttentionMaskCls(seqlen)
             shared_mask_kwargs = dict(
@@ -2140,7 +2187,7 @@ class FlashAttentionForwardSm100:
                 )
                 if not empty_tile:
                     sScale[tidx + stage * self.m_block_size] = softmax.row_sum[0]
-                    if const_expr(mLSE is not None or learnable_sink is not None):
+                    if const_expr(mLSE is not None or learnable_sink is not None or self.fused_split):
                         sScale[
                             tidx + stage * self.m_block_size + self.q_stage * self.m_block_size
                         ] = softmax.row_max[0]
@@ -2211,7 +2258,7 @@ class FlashAttentionForwardSm100:
 
                     # Dense path always writes scale / signals
                     sScale[tidx + stage * self.m_block_size] = softmax.row_sum[0]
-                    if const_expr(mLSE is not None or learnable_sink is not None):
+                    if const_expr(mLSE is not None or learnable_sink is not None or self.fused_split):
                         sScale[
                             tidx + stage * self.m_block_size + self.q_stage * self.m_block_size
                         ] = softmax.row_max[0]
@@ -2237,8 +2284,16 @@ class FlashAttentionForwardSm100:
             #     if tidx < seqlen.seqlen_q - (m_block * 2 + stage) * self.m_block_size:
             #         gLSE[tidx] = lse
 
-            # Advance to next tile
-            work_tile = tile_scheduler.advance_to_next_work()
+            # Advance to next tile (fused: stay on the tile until all segments are processed)
+            if const_expr(self.fused_split):
+                seg = seg + 1
+                _do_adv = seg >= _n_seg
+                if _do_adv:
+                    seg = Int32(0)
+            else:
+                _do_adv = True
+            if _do_adv:
+                work_tile = tile_scheduler.advance_to_next_work()
         # End of persistent scheduler loop
 
         # This is equivalent to pipeline_sm_stats.producer_tail
@@ -2441,6 +2496,10 @@ class FlashAttentionForwardSm100:
         o_corr_consumer_phase = Int32(0)
         corr_epi_producer_phase = Int32(1)
 
+        seg = Int32(0)
+        # Fused running-merge state (per correction-warp row / thread).
+        m_run = -Float32.inf
+        s_run = Float32(0.0)
         work_tile = tile_scheduler.initial_work_tile_info()
         while work_tile.is_valid_tile:
             m_block, head_idx, batch_idx, split_idx = work_tile.tile_idx
@@ -2456,7 +2515,21 @@ class FlashAttentionForwardSm100:
                 Float32(256.0) if cutlass.const_expr(self.q_dtype.width == 8) else Float32(1.0)
             )
             seqlen = SeqlenInfoCls(batch_idx)
-            n_block_min, n_block_max = block_info.get_n_block_min_max(seqlen, m_block, split_idx, num_splits)
+            if const_expr(self.fused_split):
+                _n_seg = cute.ceil_div(
+                    block_info.get_n_block_max_for_m_block(seqlen, m_block),
+                    block_info.n_blocks_per_split,
+                )
+                split_idx_eff, num_splits_eff = seg, _n_seg
+                _is_last_seg = seg + 1 >= _n_seg
+                if seg == 0:
+                    m_run = -Float32.inf
+                    s_run = Float32(0.0)
+            else:
+                _n_seg = Int32(1)
+                split_idx_eff, num_splits_eff = split_idx, num_splits
+                _is_last_seg = True
+            n_block_min, n_block_max = block_info.get_n_block_min_max(seqlen, m_block, split_idx_eff, num_splits_eff)
 
             if const_expr(self.is_split_kv):
                 mO_cur = seqlen.offset_batch_Q(mO, batch_idx, dim=3)[None, None, head_idx, split_idx]
@@ -2472,7 +2545,7 @@ class FlashAttentionForwardSm100:
                 gO = cute.flat_divide(gO, (self.mma_tiler_pv[0] // self.cta_group_size,))[None, mma_tile_coord_v, None, None]
 
             # Default LSE to -inf for invalid split_idx tiles
-            stats = [(0.0, -Float32.inf if const_expr(mLSE is not None or learnable_sink is not None) else None, True)] * self.q_stage
+            stats = [(0.0, -Float32.inf if const_expr(mLSE is not None or learnable_sink is not None or self.fused_split) else None, True)] * self.q_stage
 
             if const_expr(self.use_block_sparsity):
                 total_block_count = get_total_block_count(
@@ -2549,7 +2622,7 @@ class FlashAttentionForwardSm100:
                     # cute.arch.fence_view_async_tmem_load()
                     # scale = tSrScale_t2r[0]
                     row_sum = sScale[tidx + stage * self.m_block_size]
-                    if const_expr(mLSE is not None or learnable_sink is not None):
+                    if const_expr(mLSE is not None or learnable_sink is not None or self.fused_split):
                         row_max = sScale[tidx + stage * self.m_block_size + self.q_stage * self.m_block_size]
                     else:
                         row_max = None
@@ -2572,28 +2645,60 @@ class FlashAttentionForwardSm100:
                     scale = scale * v_descale
                     # Wait for the last O to be ready from the MMA warp
                     pipeline_o_acc.consumer_wait_w_index_phase(stage, o_corr_consumer_phase)
-                    if const_expr(not self.use_correction_warps_for_epi):
-                        pipeline_o_epi.producer_acquire_w_index_phase(stage, corr_epi_producer_phase)
                     gO_stage = gO[None, None, stage] if const_expr(gO is not None) else None
-                    self.correction_epilogue(
-                        thr_mma_pv,
-                        tOtO[None, None, None, stage],
-                        tidx,
-                        stage,
-                        m_block,
-                        seqlen.seqlen_q,
-                        scale,
-                        sO[None, None, stage],
-                        mO_cur,
-                        gO_stage,
-                        gmem_tiled_copy_O,
-                    )
-                    # Signal for the next work tile that O buffers in tmem are already read, so
-                    # mma warp can write to them
-                    pipeline_s_p_o.consumer_release_w_index(stage)
-                    if const_expr(not self.use_correction_warps_for_epi):
-                        pipeline_o_epi.producer_commit_w_index(stage)
-                    # if tidx == 0: cute.printf("Correction final scale for stage %d: %f\n", stage, scale)
+                    if const_expr(self.fused_split):
+                        # In-kernel streaming merge of this segment's partial into tOacc.
+                        LN2 = math.log(2.0)
+                        LOG2_E = math.log2(math.e)
+                        lse_s = (
+                            -Float32.inf
+                            if acc_O_mn_row_is_zero_or_nan
+                            else (row_max * softmax_scale_log2_eff
+                                  + (cute.math.log2(row_sum, fastmath=True) - max_offset)) * LN2
+                        )
+                        m_new = cutlass.max(m_run, lse_s)
+                        a = cute.math.exp2((m_run - m_new) * LOG2_E, fastmath=True)
+                        b = cute.math.exp2((lse_s - m_new) * LOG2_E, fastmath=True)
+                        # O_s = tOtO_seg * (rcp(row_sum)*v_descale), matching the gmem split epilogue,
+                        # then tOacc = tOacc*a + O_s*b (b folds in the merge weight).
+                        self.correction_rescale(thr_mma_pv, tOtO[None, None, None, stage], tidx, scale)
+                        self.correction_merge(
+                            thr_mma_pv, tOacc[None, None, None, 0], tOtO[None, None, None, stage],
+                            tidx, a, b, seg == 0,
+                        )
+                        s_run = s_run * a + b
+                        m_run = m_new
+                        pipeline_s_p_o.consumer_release_w_index(stage)
+                        if _is_last_seg:
+                            final_scale = (
+                                0.0 if (s_run == 0.0 or s_run != s_run) else 1.0 / s_run
+                            )
+                            self.correction_epilogue(
+                                thr_mma_pv, tOacc[None, None, None, 0], tidx, stage, m_block,
+                                seqlen.seqlen_q, final_scale, sO[None, None, stage], mO_cur,
+                                gO_stage, gmem_tiled_copy_O,
+                            )
+                    else:
+                        if const_expr(not self.use_correction_warps_for_epi):
+                            pipeline_o_epi.producer_acquire_w_index_phase(stage, corr_epi_producer_phase)
+                        self.correction_epilogue(
+                            thr_mma_pv,
+                            tOtO[None, None, None, stage],
+                            tidx,
+                            stage,
+                            m_block,
+                            seqlen.seqlen_q,
+                            scale,
+                            sO[None, None, stage],
+                            mO_cur,
+                            gO_stage,
+                            gmem_tiled_copy_O,
+                        )
+                        # Signal for the next work tile that O buffers in tmem are already read, so
+                        # mma warp can write to them
+                        pipeline_s_p_o.consumer_release_w_index(stage)
+                        if const_expr(not self.use_correction_warps_for_epi):
+                            pipeline_o_epi.producer_commit_w_index(stage)
 
                 o_corr_consumer_phase ^= 1
                 sm_stats_consumer_phase ^= 1
@@ -2661,11 +2766,19 @@ class FlashAttentionForwardSm100:
                     # if tidx == 0 and stage <= 1:
                     #     cute.printf("row_sum = {}, row_max = {}, acc_O_mn_row_is_zero_or_nan = {}\n", row_sum, row_max, acc_O_mn_row_is_zero_or_nan)
                     LN2 = math.log(2.0)
-                    lse = (
-                        (row_max * softmax_scale_log2_eff + (cute.math.log2(row_sum, fastmath=True) - max_offset)) * LN2
-                        if not acc_O_mn_row_is_zero_or_nan
-                        else -Float32.inf
-                    )
+                    if const_expr(self.fused_split):
+                        # Final LSE from the merged running state (natural log).
+                        lse = (
+                            -Float32.inf
+                            if (s_run == 0.0 or s_run != s_run)
+                            else cute.math.log(s_run, fastmath=True) + m_run
+                        )
+                    else:
+                        lse = (
+                            (row_max * softmax_scale_log2_eff + (cute.math.log2(row_sum, fastmath=True) - max_offset)) * LN2
+                            if not acc_O_mn_row_is_zero_or_nan
+                            else -Float32.inf
+                        )
                     seqlen_q = (
                         seqlen.seqlen_q
                         if const_expr(not self.pack_gqa)
@@ -2673,7 +2786,10 @@ class FlashAttentionForwardSm100:
                     )
                     if const_expr(not self.pack_gqa or self.m_block_size % self.qhead_per_kvhead == 0):
                         gLSE = cute.local_tile(mLSE_cur, (self.m_block_size,), (m_tile_idx,))
-                        if tidx < seqlen_q - m_tile_idx * self.m_block_size:
+                        # Fused: only write LSE once, on the last segment.
+                        if tidx < seqlen_q - m_tile_idx * self.m_block_size and (
+                            const_expr(not self.fused_split) or _is_last_seg
+                        ):
                             # This actually just works with PackGQA too
                             gLSE[tidx] = lse
                     else:
@@ -2687,8 +2803,16 @@ class FlashAttentionForwardSm100:
                             )
                             cute.make_tensor(lse_gmem_ptr, (1,))[0] = lse
 
-            # Advance to next tile
-            work_tile = tile_scheduler.advance_to_next_work()
+            # Advance to next tile (fused: stay on the tile until all segments are merged)
+            if const_expr(self.fused_split):
+                seg = seg + 1
+                _do_adv = seg >= _n_seg
+                if _do_adv:
+                    seg = Int32(0)
+            else:
+                _do_adv = True
+            if _do_adv:
+                work_tile = tile_scheduler.advance_to_next_work()
         # End of persistent scheduler loop
 
         # This is equivalent to pipeline_o_epi.consumer_tail() for the correction warps
@@ -2755,6 +2879,7 @@ class FlashAttentionForwardSm100:
         tidx: Int32,
         a: Float32,
         scale_seg: Float32,
+        first: Boolean,
     ):
         """Online streaming merge of a segment partial into the running accumulator (fused
         prefill SplitKV). Computes Oacc = Oacc * a + Oseg * scale_seg in tmem, where `a`
@@ -2782,16 +2907,27 @@ class FlashAttentionForwardSm100:
         for i in cutlass.range_constexpr(frg_count):
             acc_frg = cute.make_rmem_tensor(tOrO_t2r_shape, self.pv_acc_dtype)
             seg_frg = cute.make_rmem_tensor(tOrO_t2r_shape, self.pv_acc_dtype)
-            tOacc_t2r_i = cute.make_tensor(tOacc_t2r.iterator + i * corr_tile_size, tOacc_t2r.layout)
+            out_frg = cute.make_rmem_tensor(tOrO_t2r_shape, self.pv_acc_dtype)
             tOseg_t2r_i = cute.make_tensor(tOseg_t2r.iterator + i * corr_tile_size, tOseg_t2r.layout)
-            cute.copy(thr_tmem_load, tOacc_t2r_i, acc_frg)
             cute.copy(thr_tmem_load, tOseg_t2r_i, seg_frg)
-            for j in cutlass.range(0, cute.size(acc_frg), 2, unroll_full=True):
-                a0, a1 = cute.arch.mul_packed_f32x2((acc_frg[j], acc_frg[j + 1]), (a, a))
-                s0, s1 = cute.arch.mul_packed_f32x2((seg_frg[j], seg_frg[j + 1]), (scale_seg, scale_seg))
-                acc_frg[j], acc_frg[j + 1] = a0 + s0, a1 + s1
+            # Per-element acc*a + seg*scale_seg via separate f32 muls + add. The streaming
+            # combine (flash_fwd_combine.py) uses the IDENTICAL op sequence so each element
+            # is bitwise-identical between the in-kernel merge and the gmem path.
+            if first:
+                # First segment: tOacc = O_s * scale_seg (don't read uninitialized tOacc).
+                for j in cutlass.range(0, cute.size(seg_frg), 2, unroll_full=True):
+                    out_frg[j], out_frg[j + 1] = cute.arch.mul_packed_f32x2(
+                        (seg_frg[j], seg_frg[j + 1]), (scale_seg, scale_seg)
+                    )
+            else:
+                tOacc_t2r_i = cute.make_tensor(tOacc_t2r.iterator + i * corr_tile_size, tOacc_t2r.layout)
+                cute.copy(thr_tmem_load, tOacc_t2r_i, acc_frg)
+                for j in cutlass.range(0, cute.size(acc_frg), 2, unroll_full=True):
+                    pa0, pa1 = cute.arch.mul_packed_f32x2((acc_frg[j], acc_frg[j + 1]), (a, a))
+                    ps0, ps1 = cute.arch.mul_packed_f32x2((seg_frg[j], seg_frg[j + 1]), (scale_seg, scale_seg))
+                    out_frg[j], out_frg[j + 1] = pa0 + ps0, pa1 + ps1
             tOacc_r2t_i = cute.make_tensor(tOacc_r2t.iterator + i * corr_tile_size, tOacc_r2t.layout)
-            cute.copy(thr_tmem_store, acc_frg, tOacc_r2t_i)
+            cute.copy(thr_tmem_store, out_frg, tOacc_r2t_i)
         cute.arch.fence_view_async_tmem_store()
 
     @cute.jit

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -269,16 +269,12 @@ def num_splits_heuristic(total_mblocks, num_SMs, num_n_blocks, max_splits):
 def split_size_to_num_splits(split_size, tile_n, num_n_blocks, max_splits=256):
     """Convert a fixed split_size (in KV tokens) into (num_splits, n_blocks_per_split).
 
-    Each split covers exactly ``n_blocks_per_split`` tile_n-blocks (the last in-range
-    split takes the remainder), giving seqlen-invariant, tile-aligned split boundaries.
-    Because the boundaries are absolute KV positions (0, S, 2S, ...), prefill (len L) and
-    a later decode step (len L+t) partition the shared prefix [0, L) identically -- this
-    is what makes prefill<->decode bitwise consistent when both pass the same split_size.
-
-    If the implied split count exceeds ``max_splits`` (the combine-kernel cap), clamp
-    num_splits and fall back to even-division (n_blocks_per_split=None) so that the KV
-    tail beyond the last split is still covered (otherwise output would be silently wrong).
-    Returns n_blocks_per_split=None whenever splitting collapses to a single split.
+    Each split covers exactly ``n_blocks_per_split`` tile_n-blocks (last split takes the
+    remainder) -> seqlen-invariant, tile-aligned boundaries at absolute KV positions, which
+    is what makes prefill<->decode bitwise consistent under the same split_size. If the
+    implied count exceeds ``max_splits`` (combine-kernel cap), clamp and fall back to
+    even-division (n_blocks_per_split=None) so the KV tail stays covered. Returns
+    n_blocks_per_split=None whenever splitting collapses to a single split.
     """
     n_blocks_per_split = max((split_size + tile_n - 1) // tile_n, 1)
     derived = (num_n_blocks + n_blocks_per_split - 1) // n_blocks_per_split

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -3,7 +3,6 @@
 
 import os
 import math
-import warnings
 from dataclasses import dataclass
 from functools import lru_cache
 from typing import Optional, Tuple, Callable
@@ -271,23 +270,17 @@ def split_size_to_num_splits(split_size, tile_n, num_n_blocks, max_splits=256):
 
     Each split covers exactly ``n_blocks_per_split`` tile_n-blocks (last split takes the
     remainder) -> seqlen-invariant, tile-aligned boundaries at absolute KV positions, which
-    is what makes prefill<->decode bitwise consistent under the same split_size. If the
-    implied count exceeds ``max_splits`` (combine-kernel cap), clamp and fall back to
-    even-division (n_blocks_per_split=None) so the KV tail stays covered. Returns
+    is what makes prefill<->decode bitwise consistent under the same split_size. Returns
     n_blocks_per_split=None whenever splitting collapses to a single split.
     """
     n_blocks_per_split = max((split_size + tile_n - 1) // tile_n, 1)
     derived = (num_n_blocks + n_blocks_per_split - 1) // n_blocks_per_split
     num_splits = max(1, min(derived, max_splits))
     if derived > max_splits:
-        warnings.warn(
+        raise NotImplementedError(
             f"split_size={split_size} (={n_blocks_per_split} KV blocks of {tile_n}) implies "
-            f"{derived} splits, exceeding the {max_splits} cap; clamping num_splits to "
-            f"{max_splits} and falling back to even-division (KV tail still covered, but "
-            f"splits are no longer exactly split_size).",
-            stacklevel=2,
+            f"{derived} splits, exceeding the {max_splits} cap"
         )
-        n_blocks_per_split = None
     if num_splits <= 1:
         n_blocks_per_split = None
     return num_splits, n_blocks_per_split
@@ -353,6 +346,7 @@ def _flash_attn_fwd(
     k_descale: Optional[torch.Tensor] = None,
     v_descale: Optional[torch.Tensor] = None,
     gather_kv_indices: Optional[torch.Tensor] = None,
+    _disable_fused_split: bool = False,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """Forward pass for FlashAttention.
 
@@ -581,6 +575,14 @@ def _flash_attn_fwd(
             "Pass either num_splits or split_size, not both; split_size derives num_splits."
         )
         assert split_size > 0, "split_size must be a positive number of KV tokens"
+        if use_block_sparsity:
+            # split_size promises absolute, seqlen-invariant KV boundaries (0, S, 2S, ...).
+            # The SM100 block-sparse path partitions the *block list* by count
+            # (ceil_div(block_count, num_splits) in split_block_range), not by KV position,
+            # so it cannot honor those fixed boundaries and the prefill<->decode bitwise
+            # guarantee would not hold. Reject the combination rather than silently giving a
+            # derived split count with the wrong semantics.
+            raise NotImplementedError("split_size is not supported with block sparsity")
         if arch // 10 not in (10, 11):
             raise NotImplementedError("split_size (SplitKV) is only supported on SM100/110")
         if qv is not None:
@@ -594,6 +596,23 @@ def _flash_attn_fwd(
         max_seqlen_q = seqlen_q if cu_seqlens_q is None else total_q
     if max_seqlen_k is None:
         max_seqlen_k = seqlen_k
+    if split_size is not None and max_seqlen_q > 1:
+        if local:
+            raise NotImplementedError("split_size prefill is not supported with local/window attention")
+        if int(math.ceil(head_dim_v / 16) * 16) > 128:
+            raise NotImplementedError("split_size prefill is not supported with head_dim_v > 128")
+        if (cu_seqlens_q is None) != (cu_seqlens_k is None):
+            raise NotImplementedError("split_size prefill requires matching q/k varlen mode")
+        if page_table is not None:
+            raise NotImplementedError("split_size prefill is not supported with paged KV")
+        if seqused_q is not None or seqused_k is not None:
+            raise NotImplementedError("split_size prefill is not supported with seqused_q/seqused_k")
+        if learnable_sink is not None:
+            raise NotImplementedError("split_size prefill is not supported with learnable_sink")
+        if mask_mod is not None or score_mod is not None:
+            raise NotImplementedError("split_size prefill is not supported with mask_mod/score_mod")
+        if is_fp8:
+            raise NotImplementedError("split_size prefill is not supported with fp8")
     if cu_seqlens_k is None and seqused_k is None:
         min_seqlen_k = seqlen_k 
     seqlen_q_packgqa = max_seqlen_q * qhead_per_kvhead
@@ -601,20 +620,14 @@ def _flash_attn_fwd(
     # in-kernel merge keeps its running accumulator in the tmem columns that are only free
     # at q_stage=1; q_stage=1 also handles large-Q prefill and matches decode's q_stage).
     want_fused = (
-        os.environ.get("FLASH_ATTENTION_FUSED_SPLIT", "0") == "1"
+        not _disable_fused_split
         and split_size is not None
         and arch // 10 in [10, 11]
-        and not causal
         and not local
-        and head_dim == head_dim_v
-        and cu_seqlens_q is None
-        and cu_seqlens_k is None
-        and page_table is None
-        and seqused_q is None
-        and seqused_k is None
-        and mask_mod is None
-        and score_mod is None
-        and not is_fp8
+        and max_seqlen_q is not None
+        and max_seqlen_q > 1
+        and max_seqlen_k is not None
+        and ((max_seqlen_k + tile_n - 1) // tile_n) > ((split_size + tile_n - 1) // tile_n)
         and not use_block_sparsity
         and qv is None
     )
@@ -666,8 +679,8 @@ def _flash_attn_fwd(
     # the KV loop into n_blocks_per_split chunks and online-merges the per-segment partials
     # in registers/tmem -- no gmem out_partial and no separate combine kernel. Bitwise-equal
     # to the gmem split path (same streaming-merge order). Milestone 1 supports q_stage==1
-    # (free tmem for the running accumulator), dense (non-causal/non-local), same-headdim,
-    # non-varlen, non-paged, no mods/fp8/block-sparsity.
+    # (free tmem for the running accumulator), dense (causal/non-causal, non-local),
+    # batched or varlen, non-paged, no mods/fp8/block-sparsity.
     # want_fused already captured the shape eligibility (and forced q_stage=1); engage the
     # fused path only when splitting actually happens (>1 segment) and the size is fixed.
     fused_split = want_fused and n_blocks_per_split is not None and num_splits > 1
@@ -683,7 +696,7 @@ def _flash_attn_fwd(
         and not causal
         and not local
         and not is_split_kv
-        and not want_fused  # decode (split) is non-2CTA; fused must match it -> non-2CTA for bitwise
+        and not want_fused  # split decode is non-2CTA; fused prefill must match it for bitwise
         and cu_seqlens_q is None
         and seqused_q is None
         and not use_block_sparsity
@@ -2073,7 +2086,6 @@ class FlashAttnFunc(torch.autograd.Function):
         learnable_sink: Optional[torch.Tensor] = None,
         softcap: float = 0.0,
         num_splits: int = 1,
-        split_size: Optional[int] = None,
         pack_gqa: Optional[bool] = None,
         deterministic: bool = False,
         score_mod: Optional[Callable] = None,
@@ -2083,6 +2095,9 @@ class FlashAttnFunc(torch.autograd.Function):
         block_sparse_tensors: Optional[BlockSparseTensorsTorch] = None,
         block_sparse_tensors_bwd: Optional[BlockSparseTensorsTorch] = None,
         return_lse: bool = False,
+        # NB: split_size is appended at the end to preserve positional-argument
+        # compatibility for existing callers (num_splits -> pack_gqa -> ...).
+        split_size: Optional[int] = None,
     ):
         shared_kv = k is v
         if shared_kv and v.shape[-1] == 512:
@@ -2180,7 +2195,6 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
         learnable_sink: Optional[torch.Tensor] = None,
         softcap: float = 0.0,
         num_splits: int = 1,
-        split_size: Optional[int] = None,
         pack_gqa: Optional[bool] = None,
         deterministic: bool = False,
         score_mod: Optional[Callable] = None,
@@ -2189,6 +2203,9 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
         block_sparse_tensors: Optional[list] = None,
         aux_tensors: Optional[list] = None,
         return_lse: bool = False,
+        # NB: split_size is appended at the end to preserve positional-argument
+        # compatibility for existing callers (num_splits -> pack_gqa -> ...).
+        split_size: Optional[int] = None,
     ):
         shared_kv = k is v
         if shared_kv and v.shape[-1] == 512:
@@ -2299,7 +2316,6 @@ def flash_attn_func(
     learnable_sink: Optional[torch.Tensor] = None,
     softcap: float = 0.0,
     num_splits: int = 1,
-    split_size: Optional[int] = None,
     pack_gqa: Optional[bool] = None,
     deterministic: bool = False,
     score_mod: Optional[Callable] = None,
@@ -2309,6 +2325,9 @@ def flash_attn_func(
     block_sparse_tensors: Optional[BlockSparseTensorsTorch] = None,
     block_sparse_tensors_bwd: Optional[BlockSparseTensorsTorch] = None,
     return_lse: bool = False,
+    # Keyword-only and last so it cannot shift the meaning of existing positional args.
+    *,
+    split_size: Optional[int] = None,
 ):
     return FlashAttnFunc.apply(
         q,
@@ -2322,7 +2341,6 @@ def flash_attn_func(
         learnable_sink,
         softcap,
         num_splits,
-        split_size,
         pack_gqa,
         deterministic,
         score_mod,
@@ -2332,6 +2350,7 @@ def flash_attn_func(
         block_sparse_tensors,
         block_sparse_tensors_bwd,
         return_lse,
+        split_size,
     )
 
 
@@ -2355,7 +2374,6 @@ def flash_attn_varlen_func(
     learnable_sink: Optional[torch.Tensor] = None,
     softcap: float = 0.0,
     num_splits: int = 1,
-    split_size: Optional[int] = None,
     pack_gqa: Optional[bool] = None,
     deterministic: bool = False,
     score_mod: Optional[Callable] = None,
@@ -2364,6 +2382,9 @@ def flash_attn_varlen_func(
     block_sparse_tensors: Optional[BlockSparseTensorsTorch] = None,
     aux_tensors: Optional[list] = None,
     return_lse: bool = False,
+    # Keyword-only and last so it cannot shift the meaning of existing positional args.
+    *,
+    split_size: Optional[int] = None,
 ):
     """
     Tensor arguments:
@@ -2416,7 +2437,6 @@ def flash_attn_varlen_func(
         learnable_sink,
         softcap,
         num_splits,
-        split_size,
         pack_gqa,
         deterministic,
         score_mod,
@@ -2425,6 +2445,7 @@ def flash_attn_varlen_func(
         block_sparse_tensors,
         aux_tensors,
         return_lse,
+        split_size,
     )
 
 

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -601,8 +601,29 @@ def _flash_attn_fwd(
     if cu_seqlens_k is None and seqused_k is None:
         min_seqlen_k = seqlen_k 
     seqlen_q_packgqa = max_seqlen_q * qhead_per_kvhead
+    # Decide fused-prefill eligibility before q_stage so we can force q_stage=1 (the fused
+    # in-kernel merge keeps its running accumulator in the tmem columns that are only free
+    # at q_stage=1; q_stage=1 also handles large-Q prefill and matches decode's q_stage).
+    want_fused = (
+        os.environ.get("FLASH_ATTENTION_FUSED_SPLIT", "0") == "1"
+        and split_size is not None
+        and arch // 10 in [10, 11]
+        and not causal
+        and not local
+        and head_dim == head_dim_v
+        and cu_seqlens_q is None
+        and cu_seqlens_k is None
+        and page_table is None
+        and seqused_q is None
+        and seqused_k is None
+        and mask_mod is None
+        and score_mod is None
+        and not is_fp8
+        and not use_block_sparsity
+        and qv is None
+    )
     if arch // 10 in [10, 11]:
-        q_stage = 2 if seqlen_q_packgqa > tile_m else 1
+        q_stage = 1 if want_fused else (2 if seqlen_q_packgqa > tile_m else 1)
     else:
         q_stage = 1
 
@@ -651,26 +672,9 @@ def _flash_attn_fwd(
     # to the gmem split path (same streaming-merge order). Milestone 1 supports q_stage==1
     # (free tmem for the running accumulator), dense (non-causal/non-local), same-headdim,
     # non-varlen, non-paged, no mods/fp8/block-sparsity.
-    fused_split = (
-        os.environ.get("FLASH_ATTENTION_FUSED_SPLIT", "0") == "1"  # WIP: opt-in until kernel lands
-        and n_blocks_per_split is not None
-        and num_splits > 1
-        and arch // 10 in [10, 11]
-        and q_stage == 1
-        and not causal
-        and not local
-        and head_dim == head_dim_v
-        and cu_seqlens_q is None
-        and cu_seqlens_k is None
-        and page_table is None
-        and seqused_q is None
-        and seqused_k is None
-        and mask_mod is None
-        and score_mod is None
-        and not is_fp8
-        and not use_block_sparsity
-        and qv is None
-    )
+    # want_fused already captured the shape eligibility (and forced q_stage=1); engage the
+    # fused path only when splitting actually happens (>1 segment) and the size is fixed.
+    fused_split = want_fused and n_blocks_per_split is not None and num_splits > 1
 
     is_split_kv = num_splits > 1 and not fused_split
     if is_split_kv:

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -3,6 +3,7 @@
 
 import os
 import math
+import warnings
 from dataclasses import dataclass
 from functools import lru_cache
 from typing import Optional, Tuple, Callable
@@ -265,6 +266,37 @@ def num_splits_heuristic(total_mblocks, num_SMs, num_n_blocks, max_splits):
     return min(num_SMs // total_mblocks, max_splits, num_n_blocks)
 
 
+def split_size_to_num_splits(split_size, tile_n, num_n_blocks, max_splits=256):
+    """Convert a fixed split_size (in KV tokens) into (num_splits, n_blocks_per_split).
+
+    Each split covers exactly ``n_blocks_per_split`` tile_n-blocks (the last in-range
+    split takes the remainder), giving seqlen-invariant, tile-aligned split boundaries.
+    Because the boundaries are absolute KV positions (0, S, 2S, ...), prefill (len L) and
+    a later decode step (len L+t) partition the shared prefix [0, L) identically -- this
+    is what makes prefill<->decode bitwise consistent when both pass the same split_size.
+
+    If the implied split count exceeds ``max_splits`` (the combine-kernel cap), clamp
+    num_splits and fall back to even-division (n_blocks_per_split=None) so that the KV
+    tail beyond the last split is still covered (otherwise output would be silently wrong).
+    Returns n_blocks_per_split=None whenever splitting collapses to a single split.
+    """
+    n_blocks_per_split = max((split_size + tile_n - 1) // tile_n, 1)
+    derived = (num_n_blocks + n_blocks_per_split - 1) // n_blocks_per_split
+    num_splits = max(1, min(derived, max_splits))
+    if derived > max_splits:
+        warnings.warn(
+            f"split_size={split_size} (={n_blocks_per_split} KV blocks of {tile_n}) implies "
+            f"{derived} splits, exceeding the {max_splits} cap; clamping num_splits to "
+            f"{max_splits} and falling back to even-division (KV tail still covered, but "
+            f"splits are no longer exactly split_size).",
+            stacklevel=2,
+        )
+        n_blocks_per_split = None
+    if num_splits <= 1:
+        n_blocks_per_split = None
+    return num_splits, n_blocks_per_split
+
+
 def _resolve_causal_local_window(causal, window_size_left, window_size_right, mask_mod=None):
     """Resolve causal/local/window settings into canonical form.
 
@@ -311,6 +343,7 @@ def _flash_attn_fwd(
     intra_wg_overlap: Optional[bool] = None,
     num_threads: int = 384,
     num_splits: int = 1,
+    split_size: Optional[int] = None,
     pack_gqa: Optional[bool] = None,
     _arch: Optional[int] = None,
     score_mod: Optional[Callable] = None,
@@ -543,6 +576,24 @@ def _flash_attn_fwd(
     if pack_gqa and qv is not None and 128 % qhead_per_kvhead != 0:
         pack_gqa = False
 
+    # split_size: user-controlled, seqlen-invariant, tile-aligned KV split size (in tokens),
+    # mutually exclusive with an explicit num_splits>1. Only the SM100/110 SplitKV path
+    # supports it. The num_splits count is derived from split_size below, once tile_n and
+    # num_n_blocks are known.
+    if split_size is not None:
+        assert num_splits == 1, (
+            "Pass either num_splits or split_size, not both; split_size derives num_splits."
+        )
+        assert split_size > 0, "split_size must be a positive number of KV tokens"
+        if arch // 10 not in (10, 11):
+            raise NotImplementedError("split_size (SplitKV) is only supported on SM100/110")
+        if qv is not None:
+            raise NotImplementedError("split_size is not supported with qv")
+        if head_dim == 256 and head_dim_v == 256:
+            raise NotImplementedError("split_size is not supported with the head_dim=256 kernel")
+        if head_dim != head_dim_v and head_dim_v == 512:
+            raise NotImplementedError("split_size is not supported for diff-headdim with head_dim_v=512")
+
     if max_seqlen_q is None:
         max_seqlen_q = seqlen_q if cu_seqlens_q is None else total_q
     if max_seqlen_k is None:
@@ -564,9 +615,29 @@ def _flash_attn_fwd(
     if num_splits < 1:
         num_splits = num_splits_heuristic(total_mblocks, num_SMs, num_n_blocks, 128)
 
-    # SplitKV uses float32 partial output, which doubles the O buffer size
-    # in shared memory, causing OOM for diff-headdim (192, 128)
-    if arch // 10 in [10, 11] and head_dim != head_dim_v and num_splits > 1:
+    # Derive num_splits from a fixed split_size. n_blocks_per_split=None means the kernel
+    # uses regular even-division by num_splits; a non-None value pins each split to exactly
+    # that many tile_n-blocks. This is what enables prefill (seqlen_q>1) to split KV with
+    # the same boundaries as decode, so the two are bitwise consistent.
+    n_blocks_per_split = None
+    if split_size is not None:
+        # SplitKV's fp32 partial-O doubles SMEM and OOMs at tile_n=128 for diff-headdim
+        # shapes (e.g. MLA 192/128), so the kernel must use tile_n=64. Unlike the regular
+        # num_splits guard below -- which only shrinks tile_n once seqlen is large enough
+        # to split -- we pin tile_n for ALL sequence lengths here. Otherwise a short decode
+        # (tile_n=128) and a long prefill (tile_n=64) would tile the same token's KV
+        # differently and break bitwise decode<->prefill consistency across lengths.
+        if arch // 10 in [10, 11] and head_dim != head_dim_v and head_dim_v != 512:
+            tile_n = 64
+            num_n_blocks = (seqlen_k_loaded + tile_n - 1) // tile_n
+        num_splits, n_blocks_per_split = split_size_to_num_splits(split_size, tile_n, num_n_blocks)
+        # TODO: fix GQA + SplitKV + non-varlen (mirror of the guard above for the derived count)
+        if pack_gqa and num_splits != 1 and cu_seqlens_q is None:
+            pack_gqa = False
+    elif arch // 10 in [10, 11] and head_dim != head_dim_v and num_splits > 1:
+        # Regular num_splits path: shrink tile_n only once there are enough blocks to split,
+        # otherwise disable splitting. (split_size is handled above with a seqlen-invariant
+        # tile_n so it is intentionally excluded here.)
         if num_n_blocks >= 64 and head_dim_v != 512:
             tile_n = 64
             num_n_blocks = (seqlen_k_loaded + tile_n - 1) // tile_n
@@ -732,6 +803,7 @@ def _flash_attn_fwd(
         q_stage,
         num_threads,
         is_split_kv,
+        n_blocks_per_split is not None,  # fixed-size vs even-division split mode (compile-time branch)
         pack_gqa,
         arch,
         page_size not in [None, tile_n],  # paged KV non-TMA
@@ -1010,6 +1082,8 @@ def _flash_attn_fwd(
             ]
             if arch // 10 in [10, 11]:
                 compile_args.append(descale_tensors_tensor)
+                if not use_dedicated_hd256_kernel:
+                    compile_args.append(n_blocks_per_split)
             compile_args.extend([
                 sparse_tensors,
                 cute_aux_tensors,
@@ -1074,6 +1148,8 @@ def _flash_attn_fwd(
             ]
             if arch // 10 in [10, 11]:
                 call_args.append(descale_tensors)
+                if not use_dedicated_hd256_kernel:
+                    call_args.append(n_blocks_per_split)
             call_args.extend([
                 (
                     normalized_block_sparse_tensors.mask_block_cnt,
@@ -1967,6 +2043,7 @@ class FlashAttnFunc(torch.autograd.Function):
         learnable_sink: Optional[torch.Tensor] = None,
         softcap: float = 0.0,
         num_splits: int = 1,
+        split_size: Optional[int] = None,
         pack_gqa: Optional[bool] = None,
         deterministic: bool = False,
         score_mod: Optional[Callable] = None,
@@ -1996,6 +2073,7 @@ class FlashAttnFunc(torch.autograd.Function):
             learnable_sink=learnable_sink,
             softcap=softcap,
             num_splits=num_splits,
+            split_size=split_size,
             pack_gqa=pack_gqa,
             score_mod=score_mod,
             mask_mod=mask_mod,
@@ -2072,6 +2150,7 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
         learnable_sink: Optional[torch.Tensor] = None,
         softcap: float = 0.0,
         num_splits: int = 1,
+        split_size: Optional[int] = None,
         pack_gqa: Optional[bool] = None,
         deterministic: bool = False,
         score_mod: Optional[Callable] = None,
@@ -2108,6 +2187,7 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
             learnable_sink=learnable_sink,
             softcap=softcap,
             num_splits=num_splits,
+            split_size=split_size,
             pack_gqa=pack_gqa,
             score_mod=score_mod,
             mask_mod=mask_mod,
@@ -2189,6 +2269,7 @@ def flash_attn_func(
     learnable_sink: Optional[torch.Tensor] = None,
     softcap: float = 0.0,
     num_splits: int = 1,
+    split_size: Optional[int] = None,
     pack_gqa: Optional[bool] = None,
     deterministic: bool = False,
     score_mod: Optional[Callable] = None,
@@ -2211,6 +2292,7 @@ def flash_attn_func(
         learnable_sink,
         softcap,
         num_splits,
+        split_size,
         pack_gqa,
         deterministic,
         score_mod,
@@ -2243,6 +2325,7 @@ def flash_attn_varlen_func(
     learnable_sink: Optional[torch.Tensor] = None,
     softcap: float = 0.0,
     num_splits: int = 1,
+    split_size: Optional[int] = None,
     pack_gqa: Optional[bool] = None,
     deterministic: bool = False,
     score_mod: Optional[Callable] = None,
@@ -2303,6 +2386,7 @@ def flash_attn_varlen_func(
         learnable_sink,
         softcap,
         num_splits,
+        split_size,
         pack_gqa,
         deterministic,
         score_mod,

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -687,6 +687,7 @@ def _flash_attn_fwd(
         and not causal
         and not local
         and not is_split_kv
+        and not want_fused  # decode (split) is non-2CTA; fused must match it -> non-2CTA for bitwise
         and cu_seqlens_q is None
         and seqused_q is None
         and not use_block_sparsity

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -645,7 +645,34 @@ def _flash_attn_fwd(
         else:
             num_splits = 1
 
-    is_split_kv = num_splits > 1
+    # Fused prefill SplitKV (memory-efficient): one CTA per query tile internally segments
+    # the KV loop into n_blocks_per_split chunks and online-merges the per-segment partials
+    # in registers/tmem -- no gmem out_partial and no separate combine kernel. Bitwise-equal
+    # to the gmem split path (same streaming-merge order). Milestone 1 supports q_stage==1
+    # (free tmem for the running accumulator), dense (non-causal/non-local), same-headdim,
+    # non-varlen, non-paged, no mods/fp8/block-sparsity.
+    fused_split = (
+        os.environ.get("FLASH_ATTENTION_FUSED_SPLIT", "0") == "1"  # WIP: opt-in until kernel lands
+        and n_blocks_per_split is not None
+        and num_splits > 1
+        and arch // 10 in [10, 11]
+        and q_stage == 1
+        and not causal
+        and not local
+        and head_dim == head_dim_v
+        and cu_seqlens_q is None
+        and cu_seqlens_k is None
+        and page_table is None
+        and seqused_q is None
+        and seqused_k is None
+        and mask_mod is None
+        and score_mod is None
+        and not is_fp8
+        and not use_block_sparsity
+        and qv is None
+    )
+
+    is_split_kv = num_splits > 1 and not fused_split
     if is_split_kv:
         out_partial = torch.empty(num_splits, *q_batch_seqlen_shape, num_head, head_dim_v, dtype=torch.float32, device=device)
         lse_partial = torch.empty(num_splits, *lse_shape, dtype=torch.float32, device=device)
@@ -804,6 +831,7 @@ def _flash_attn_fwd(
         num_threads,
         is_split_kv,
         n_blocks_per_split is not None,  # fixed-size vs even-division split mode (compile-time branch)
+        fused_split,  # fused in-kernel segmented-combine prefill
         pack_gqa,
         arch,
         page_size not in [None, tile_n],  # paged KV non-TMA
@@ -1011,6 +1039,7 @@ def _flash_attn_fwd(
                     q_subtile_factor=q_subtile_factor,
                     use_2cta_instrs=use_2cta_instrs,
                     use_clc_scheduler=use_clc_scheduler,
+                    fused_split=fused_split,
                 )
         elif arch // 10 == 12:
             # SM120 (Blackwell GeForce / DGX Spark): uses SM80 MMA with SM120 SMEM capacity

--- a/flash_attn/cute/paged_kv.py
+++ b/flash_attn/cute/paged_kv.py
@@ -86,10 +86,8 @@ class PagedKVManager(ParamsBase):
         val_layout = cute.make_layout((1, async_copy_elems))
         gmem_tiled_copy_KV = cute.make_tiled_copy_tv(atom_async_copy, thr_layout, val_layout)
         gmem_thr_copy_KV = gmem_tiled_copy_KV.get_slice(thread_idx)
-        # ceil_div (not floor): when n_block_size < num_threads (e.g. tile_n=64 for
-        # diff-headdim SplitKV with 128 load threads), floor would give 0 and create a
-        # zero-size page tensor. ceil_div yields >=1; threads with row >= n_block_size are
-        # masked by the is_valid guard in load_page_table.
+        # ceil_div (not floor): n_block_size < num_threads (e.g. tile_n=64, 128 load threads)
+        # would floor to a zero-size tensor; out-of-range rows are masked in load_page_table.
         page_entry_per_thread = cute.ceil_div(n_block_size, num_threads)
 
         tPrPage = cute.make_rmem_tensor((page_entry_per_thread,), Int32)

--- a/flash_attn/cute/paged_kv.py
+++ b/flash_attn/cute/paged_kv.py
@@ -86,7 +86,11 @@ class PagedKVManager(ParamsBase):
         val_layout = cute.make_layout((1, async_copy_elems))
         gmem_tiled_copy_KV = cute.make_tiled_copy_tv(atom_async_copy, thr_layout, val_layout)
         gmem_thr_copy_KV = gmem_tiled_copy_KV.get_slice(thread_idx)
-        page_entry_per_thread = n_block_size // num_threads
+        # ceil_div (not floor): when n_block_size < num_threads (e.g. tile_n=64 for
+        # diff-headdim SplitKV with 128 load threads), floor would give 0 and create a
+        # zero-size page tensor. ceil_div yields >=1; threads with row >= n_block_size are
+        # masked by the is_valid guard in load_page_table.
+        page_entry_per_thread = cute.ceil_div(n_block_size, num_threads)
 
         tPrPage = cute.make_rmem_tensor((page_entry_per_thread,), Int32)
         tPrPageOffset = cute.make_rmem_tensor((page_entry_per_thread,), Int32)

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -2963,21 +2963,34 @@ def test_flash_attn_empty_q_varlen(causal):
         assert lse.numel() == 0
 
 
-@pytest.mark.parametrize("seqlen_k", [512, 1024])
+# (d, dv): MLA (192,128) and a regular same-head-dim (128,128) shape.
+@pytest.mark.parametrize("d, dv", [(192, 128), (128, 128)])
+# split_size=None exercises the regular num_splits=1 path; a concrete value enables
+# flash decoding (SplitKV) on BOTH prefill and decode. For MLA (192,128) the
+# diff-headdim SMEM guard only lets splitting engage at larger seqlen, so we include
+# a large seqlen_k. Boundaries are seqlen-invariant, so prefill and decode partition
+# the shared KV identically and must stay bitwise equal.
+# seqlen capped at 16384 and split_size >= 256 here: prefill SplitKV allocates an
+# fp32 out_partial of (num_splits, total_q, nheads, dv), so num_splits*seqlen must
+# stay bounded to avoid OOM (smaller split_size at long seqlen is exercised by the
+# batch=1 correctness test instead).
+@pytest.mark.parametrize("split_size", [None, 256, 512, 1024])
+@pytest.mark.parametrize("seqlen_k", [1024, 8192, 16384])
 @maybe_fake_tensor_mode(USE_FAKE_TENSOR)
-def test_flash_attn_ex2_emu_decode_prefill_consistency(seqlen_k):
-    """Decode↔prefill must be bitwise consistent for MLA (192,128).
+def test_flash_attn_ex2_emu_decode_prefill_consistency(seqlen_k, split_size, d, dv):
+    """Decode↔prefill must be bitwise consistent, including under flash decoding.
 
-    Regression test: paged decode (seqlen_q=1) vs non-paged prefill
-    (seqlen_q=full) for MLA shapes must produce identical outputs for the
-    last query position.
+    Paged decode (seqlen_q=1) vs non-paged prefill (seqlen_q=full), causal, must
+    produce identical outputs for the last query position. When ``split_size`` is set,
+    SplitKV (flash decoding) is enabled on both sides with the same, seqlen-invariant
+    split boundaries -- so the two execute an identical float-op sequence and stay
+    bitwise equal.
     """
     if IS_SM90:
         pytest.skip("ex2_emu is SM100+ only")
 
     device = "cuda"
     dtype = torch.bfloat16
-    d, dv = 192, 128
     nheads = nheads_kv = 16
 
     torch.random.manual_seed(0)
@@ -2992,6 +3005,7 @@ def test_flash_attn_ex2_emu_decode_prefill_consistency(seqlen_k):
         cu_seqlens_q=cu, cu_seqlens_k=cu,
         max_seqlen_q=seqlen_k, max_seqlen_k=seqlen_k,
         causal=True,
+        split_size=split_size,
     )
 
     # Decode: seqlen_q=1 at last position, paged KV, causal
@@ -2999,9 +3013,8 @@ def test_flash_attn_ex2_emu_decode_prefill_consistency(seqlen_k):
     num_pages = (seqlen_k + page_size - 1) // page_size
     k_cache = torch.zeros(num_pages, page_size, nheads_kv, d, device=device, dtype=dtype)
     v_cache = torch.zeros(num_pages, page_size, nheads_kv, dv, device=device, dtype=dtype)
-    for i in range(seqlen_k):
-        k_cache[i // page_size, i % page_size] = k[i]
-        v_cache[i // page_size, i % page_size] = v[i]
+    k_cache.view(num_pages * page_size, nheads_kv, d)[:seqlen_k] = k
+    v_cache.view(num_pages * page_size, nheads_kv, dv)[:seqlen_k] = v
     page_table = torch.arange(num_pages, dtype=torch.int32, device=device).unsqueeze(0)
     cache_seqlens = torch.tensor([seqlen_k], dtype=torch.int32, device=device)
 
@@ -3012,13 +3025,163 @@ def test_flash_attn_ex2_emu_decode_prefill_consistency(seqlen_k):
         max_seqlen_q=1, max_seqlen_k=None,
         seqused_k=cache_seqlens, page_table=page_table,
         causal=True,
+        split_size=split_size,
     )
 
     if is_fake_mode():
         return
 
     max_diff = (out_prefill[-1] - out_decode[0]).abs().max().item()
-    print(f"decode↔prefill max diff: {max_diff}")
+    print(f"decode↔prefill max diff (d={d}, dv={dv}, seqlen_k={seqlen_k}, split_size={split_size}): {max_diff}")
     assert torch.equal(out_prefill[-1], out_decode[0]), (
-        f"decode↔prefill diverged: max_diff={max_diff}."
+        f"decode↔prefill diverged: max_diff={max_diff} "
+        f"(d={d}, dv={dv}, seqlen_k={seqlen_k}, split_size={split_size})."
+    )
+
+
+# (d, dv, seqlen): seqlen chosen so that SplitKV actually engages for each shape,
+# including longer sequences. Regular (128,128) splits at any seqlen > split_size;
+# MLA (192,128) only engages past the diff-headdim SMEM guard (tile_n pinned to 64).
+@pytest.mark.parametrize(
+    "d, dv, seqlen",
+    [(128, 128, 2048), (128, 128, 16384), (192, 128, 8192), (192, 128, 16384)],
+)
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("split_size", [128, 256, 512, 1024])
+@maybe_fake_tensor_mode(USE_FAKE_TENSOR)
+def test_flash_attn_split_size_correctness(seqlen, split_size, causal, d, dv):
+    """A fixed split_size must produce the same answer as num_splits=1 (within tol)."""
+    if IS_SM90:
+        pytest.skip("SplitKV is SM100+ only")
+
+    device = "cuda"
+    dtype = torch.bfloat16
+    batch, nheads = 1, 8
+
+    torch.random.manual_seed(0)
+    q = torch.randn(batch, seqlen, nheads, d, device=device, dtype=dtype)
+    k = torch.randn(batch, seqlen, nheads, d, device=device, dtype=dtype)
+    v = torch.randn(batch, seqlen, nheads, dv, device=device, dtype=dtype)
+
+    out_split, _ = flash_attn_func(q, k, v, causal=causal, split_size=split_size)
+    out_ref, _ = flash_attn_func(q, k, v, causal=causal, num_splits=1)
+
+    if is_fake_mode():
+        return
+
+    max_diff = (out_split - out_ref).abs().max().item()
+    print(f"split_size={split_size} vs num_splits=1 max diff "
+          f"(d={d}, dv={dv}, seqlen={seqlen}, causal={causal}): {max_diff}")
+    assert torch.allclose(out_split, out_ref, atol=2e-2, rtol=1e-2), (
+        f"split_size output diverged from num_splits=1: max_diff={max_diff}."
+    )
+
+
+@maybe_fake_tensor_mode(USE_FAKE_TENSOR)
+def test_flash_attn_split_size_too_small_warns():
+    """split_size smaller than seqlen/256 must clamp to 256 splits, warn, and stay correct."""
+    if IS_SM90:
+        pytest.skip("SplitKV is SM100+ only")
+
+    device = "cuda"
+    dtype = torch.bfloat16
+    batch, nheads, d = 1, 4, 128
+    seqlen = 256 * 128 + 256  # > 256 blocks at tile_n=128 -> implied splits exceed the 256 cap
+
+    torch.random.manual_seed(0)
+    q = torch.randn(batch, seqlen, nheads, d, device=device, dtype=dtype)
+    k = torch.randn(batch, seqlen, nheads, d, device=device, dtype=dtype)
+    v = torch.randn(batch, seqlen, nheads, d, device=device, dtype=dtype)
+
+    with pytest.warns(UserWarning, match="clamping num_splits"):
+        out_split, _ = flash_attn_func(q, k, v, causal=False, split_size=128)
+    out_ref, _ = flash_attn_func(q, k, v, causal=False, num_splits=1)
+
+    if is_fake_mode():
+        return
+
+    # Output must not be silently truncated despite the clamp.
+    max_diff = (out_split - out_ref).abs().max().item()
+    assert torch.allclose(out_split, out_ref, atol=2e-2, rtol=1e-2), (
+        f"clamped split_size dropped KV tail or diverged: max_diff={max_diff}."
+    )
+
+
+# (d, dv): MLA (192,128) and regular (128,128). With a fixed split_size and the
+# diff-headdim tile_n pin, both engage SplitKV at this seqlen.
+@pytest.mark.parametrize("d, dv", [(192, 128), (128, 128)])
+@pytest.mark.parametrize("split_size", [128, 256, 512])
+@pytest.mark.parametrize("seqlen_k", [1024, 4096])
+@maybe_fake_tensor_mode(USE_FAKE_TENSOR)
+def test_flash_attn_split_size_autoregressive_consistency(seqlen_k, split_size, d, dv):
+    """Cross-length decode↔prefill: token p decoded at length p+1 must be bitwise
+    identical to token p in a full-length prefill, when both use the same split_size.
+
+    This is the autoregressive scenario: KV grows token-by-token during generation,
+    then a full prefill over the generated sequence must reproduce each token's hidden
+    state exactly. A fixed split_size makes split boundaries absolute KV positions, so
+    token p's causal range is partitioned identically at length p+1 and at length N.
+    """
+    if IS_SM90:
+        pytest.skip("SplitKV is SM100+ only")
+
+    device = "cuda"
+    dtype = torch.bfloat16
+    nheads = nheads_kv = 8
+    page_size = 128
+
+    torch.random.manual_seed(0)
+    q = torch.randn(seqlen_k, nheads, d, device=device, dtype=dtype)
+    k = torch.randn(seqlen_k, nheads_kv, d, device=device, dtype=dtype)
+    v = torch.randn(seqlen_k, nheads_kv, dv, device=device, dtype=dtype)
+
+    # Full-length causal prefill (varlen), SplitKV enabled via split_size.
+    cu = torch.tensor([0, seqlen_k], dtype=torch.int32, device=device)
+    out_prefill, _ = flash_attn_varlen_func(
+        q, k, v,
+        cu_seqlens_q=cu, cu_seqlens_k=cu,
+        max_seqlen_q=seqlen_k, max_seqlen_k=seqlen_k,
+        causal=True,
+        split_size=split_size,
+    )
+
+    # Paged KV cache holding the whole sequence; each decode step bounds it via seqused_k.
+    num_pages = (seqlen_k + page_size - 1) // page_size
+    k_cache = torch.zeros(num_pages, page_size, nheads_kv, d, device=device, dtype=dtype)
+    v_cache = torch.zeros(num_pages, page_size, nheads_kv, dv, device=device, dtype=dtype)
+    k_cache.view(num_pages * page_size, nheads_kv, d)[:seqlen_k] = k
+    v_cache.view(num_pages * page_size, nheads_kv, dv)[:seqlen_k] = v
+    page_table = torch.arange(num_pages, dtype=torch.int32, device=device).unsqueeze(0)
+
+    if is_fake_mode():
+        return
+
+    # Positions chosen to span: single-split (p+1 <= split_size), exact split
+    # boundaries (split_size multiples +/- 1), multi-split, and the last token.
+    positions = sorted({
+        1, 100,
+        split_size - 1, split_size, split_size + 1,
+        2 * split_size, 2 * split_size + 1,
+        seqlen_k // 2, seqlen_k - 1,
+    })
+    positions = [p for p in positions if 0 <= p < seqlen_k]
+    failures = []
+    for p in positions:
+        cache_seqlens = torch.tensor([p + 1], dtype=torch.int32, device=device)
+        out_decode, _ = flash_attn_varlen_func(
+            q[p:p + 1], k_cache, v_cache,
+            cu_seqlens_q=torch.tensor([0, 1], dtype=torch.int32, device=device),
+            cu_seqlens_k=None,
+            max_seqlen_q=1, max_seqlen_k=None,
+            seqused_k=cache_seqlens, page_table=page_table,
+            causal=True,
+            split_size=split_size,
+        )
+        if not torch.equal(out_prefill[p], out_decode[0]):
+            md = (out_prefill[p] - out_decode[0]).abs().max().item()
+            failures.append((p, md))
+
+    assert not failures, (
+        f"autoregressive decode↔prefill diverged (d={d}, dv={dv}, seqlen_k={seqlen_k}, "
+        f"split_size={split_size}) at positions [p, max_diff]: {failures}"
     )

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -2962,30 +2962,40 @@ def test_flash_attn_empty_q_varlen(causal):
     if lse is not None:
         assert lse.numel() == 0
 
+def _make_paged_kv(k, v, page_size=128):
+    seqlen, nheads_kv, d = k.shape
+    dv = v.shape[-1]
+    num_pages = (seqlen + page_size - 1) // page_size
+    k_cache = torch.zeros(num_pages, page_size, nheads_kv, d, device=k.device, dtype=k.dtype)
+    v_cache = torch.zeros(num_pages, page_size, nheads_kv, dv, device=v.device, dtype=v.dtype)
+    k_cache.view(num_pages * page_size, nheads_kv, d)[:seqlen] = k
+    v_cache.view(num_pages * page_size, nheads_kv, dv)[:seqlen] = v
+    page_table = torch.arange(num_pages, dtype=torch.int32, device=k.device).unsqueeze(0)
+    return k_cache, v_cache, page_table
 
-# (d, dv): MLA (192,128) and a regular same-head-dim (128,128) shape.
+
+def _decode_one(q, k_cache, v_cache, page_table, pos, split_size):
+    return flash_attn_varlen_func(
+        q[pos:pos + 1],
+        k_cache,
+        v_cache,
+        cu_seqlens_q=torch.tensor([0, 1], dtype=torch.int32, device=q.device),
+        cu_seqlens_k=None,
+        max_seqlen_q=1,
+        max_seqlen_k=None,
+        seqused_k=torch.tensor([pos + 1], dtype=torch.int32, device=q.device),
+        page_table=page_table,
+        causal=True,
+        split_size=split_size,
+    )[0]
+
+
 @pytest.mark.parametrize("d, dv", [(192, 128), (128, 128)])
-# split_size=None exercises the regular num_splits=1 path; a concrete value enables
-# flash decoding (SplitKV) on BOTH prefill and decode. For MLA (192,128) the
-# diff-headdim SMEM guard only lets splitting engage at larger seqlen, so we include
-# a large seqlen_k. Boundaries are seqlen-invariant, so prefill and decode partition
-# the shared KV identically and must stay bitwise equal.
-# seqlen capped at 16384 and split_size >= 256 here: prefill SplitKV allocates an
-# fp32 out_partial of (num_splits, total_q, nheads, dv), so num_splits*seqlen must
-# stay bounded to avoid OOM (smaller split_size at long seqlen is exercised by the
-# batch=1 correctness test instead).
 @pytest.mark.parametrize("split_size", [None, 256, 512, 1024])
 @pytest.mark.parametrize("seqlen_k", [1024, 8192, 16384])
 @maybe_fake_tensor_mode(USE_FAKE_TENSOR)
 def test_flash_attn_ex2_emu_decode_prefill_consistency(seqlen_k, split_size, d, dv):
-    """Decode↔prefill must be bitwise consistent, including under flash decoding.
-
-    Paged decode (seqlen_q=1) vs non-paged prefill (seqlen_q=full), causal, must
-    produce identical outputs for the last query position. When ``split_size`` is set,
-    SplitKV (flash decoding) is enabled on both sides with the same, seqlen-invariant
-    split boundaries -- so the two execute an identical float-op sequence and stay
-    bitwise equal.
-    """
+    """Paged decode and full causal prefill must match at the last token."""
     if IS_SM90:
         pytest.skip("ex2_emu is SM100+ only")
 
@@ -2998,7 +3008,6 @@ def test_flash_attn_ex2_emu_decode_prefill_consistency(seqlen_k, split_size, d, 
     k = torch.randn(seqlen_k, nheads_kv, d, device=device, dtype=dtype)
     v = torch.randn(seqlen_k, nheads_kv, dv, device=device, dtype=dtype)
 
-    # Prefill: full sequence, non-paged, causal
     cu = torch.tensor([0, seqlen_k], dtype=torch.int32, device=device)
     out_prefill, _ = flash_attn_varlen_func(
         q, k, v,
@@ -3008,32 +3017,15 @@ def test_flash_attn_ex2_emu_decode_prefill_consistency(seqlen_k, split_size, d, 
         split_size=split_size,
     )
 
-    # Decode: seqlen_q=1 at last position, paged KV, causal
-    page_size = 128
-    num_pages = (seqlen_k + page_size - 1) // page_size
-    k_cache = torch.zeros(num_pages, page_size, nheads_kv, d, device=device, dtype=dtype)
-    v_cache = torch.zeros(num_pages, page_size, nheads_kv, dv, device=device, dtype=dtype)
-    k_cache.view(num_pages * page_size, nheads_kv, d)[:seqlen_k] = k
-    v_cache.view(num_pages * page_size, nheads_kv, dv)[:seqlen_k] = v
-    page_table = torch.arange(num_pages, dtype=torch.int32, device=device).unsqueeze(0)
-    cache_seqlens = torch.tensor([seqlen_k], dtype=torch.int32, device=device)
-
-    out_decode, _ = flash_attn_varlen_func(
-        q[-1:], k_cache, v_cache,
-        cu_seqlens_q=torch.tensor([0, 1], dtype=torch.int32, device=device),
-        cu_seqlens_k=None,
-        max_seqlen_q=1, max_seqlen_k=None,
-        seqused_k=cache_seqlens, page_table=page_table,
-        causal=True,
-        split_size=split_size,
-    )
+    k_cache, v_cache, page_table = _make_paged_kv(k, v)
+    out_decode = _decode_one(q, k_cache, v_cache, page_table, seqlen_k - 1, split_size)
 
     if is_fake_mode():
         return
 
-    max_diff = (out_prefill[-1] - out_decode[0]).abs().max().item()
+    max_diff = (out_prefill[-1] - out_decode).abs().max().item()
     print(f"decode↔prefill max diff (d={d}, dv={dv}, seqlen_k={seqlen_k}, split_size={split_size}): {max_diff}")
-    assert torch.equal(out_prefill[-1], out_decode[0]), (
+    assert torch.equal(out_prefill[-1], out_decode), (
         f"decode↔prefill diverged: max_diff={max_diff} "
         f"(d={d}, dv={dv}, seqlen_k={seqlen_k}, split_size={split_size})."
     )
@@ -3077,33 +3069,115 @@ def test_flash_attn_split_size_correctness(seqlen, split_size, causal, d, dv):
     )
 
 
+@pytest.mark.parametrize("varlen", [False, True])
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("d, dv", [(128, 128), (192, 128)])
 @maybe_fake_tensor_mode(USE_FAKE_TENSOR)
-def test_flash_attn_split_size_too_small_warns():
-    """split_size smaller than seqlen/256 must clamp to 256 splits, warn, and stay correct."""
+def test_flash_attn_fused_split_size_prefill_matches_gmem(varlen, causal, d, dv):
+    """Fused split prefill must preserve the existing gmem SplitKV result."""
     if IS_SM90:
         pytest.skip("SplitKV is SM100+ only")
 
     device = "cuda"
     dtype = torch.bfloat16
-    batch, nheads, d = 1, 4, 128
-    seqlen = 256 * 128 + 256  # > 256 blocks at tile_n=128 -> implied splits exceed the 256 cap
+    seqlens = [1024, 768] if varlen else [1024]
+    seqlen, nheads, split_size = max(seqlens), 4, 256
 
     torch.random.manual_seed(0)
-    q = torch.randn(batch, seqlen, nheads, d, device=device, dtype=dtype)
-    k = torch.randn(batch, seqlen, nheads, d, device=device, dtype=dtype)
-    v = torch.randn(batch, seqlen, nheads, d, device=device, dtype=dtype)
+    if varlen:
+        total_q = sum(seqlens)
+        q = torch.randn(total_q, nheads, d, device=device, dtype=dtype)
+        k = torch.randn(total_q, nheads, d, device=device, dtype=dtype)
+        v = torch.randn(total_q, nheads, dv, device=device, dtype=dtype)
+        cu = torch.tensor([0, *torch.tensor(seqlens).cumsum(0).tolist()], dtype=torch.int32, device=device)
+        kwargs = dict(cu_seqlens_q=cu, cu_seqlens_k=cu, max_seqlen_q=seqlen, max_seqlen_k=seqlen)
+        fwd = flash_attn_varlen_func
+    else:
+        q = torch.randn(1, seqlen, nheads, d, device=device, dtype=dtype)
+        k = torch.randn(1, seqlen, nheads, d, device=device, dtype=dtype)
+        v = torch.randn(1, seqlen, nheads, dv, device=device, dtype=dtype)
+        kwargs = {}
+        fwd = flash_attn_func
 
-    with pytest.warns(UserWarning, match="clamping num_splits"):
-        out_split, _ = flash_attn_func(q, k, v, causal=False, split_size=128)
-    out_ref, _ = flash_attn_func(q, k, v, causal=False, num_splits=1)
+    out_gmem, lse_gmem = _flash_attn_fwd(
+        q,
+        k,
+        v,
+        **kwargs,
+        causal=causal,
+        split_size=split_size,
+        return_lse=True,
+        _disable_fused_split=True,
+    )
+    out_fused, lse_fused = fwd(q, k, v, **kwargs, causal=causal, split_size=split_size, return_lse=True)
 
     if is_fake_mode():
         return
 
-    # Output must not be silently truncated despite the clamp.
-    max_diff = (out_split - out_ref).abs().max().item()
-    assert torch.allclose(out_split, out_ref, atol=2e-2, rtol=1e-2), (
-        f"clamped split_size dropped KV tail or diverged: max_diff={max_diff}."
+    max_diff = (out_fused - out_gmem).abs().max().item()
+    max_lse_diff = (lse_fused - lse_gmem).abs().max().item()
+    assert torch.equal(out_fused, out_gmem), (
+        f"fused split prefill diverged from gmem SplitKV: max_diff={max_diff} "
+        f"(varlen={varlen}, causal={causal}, d={d}, dv={dv})."
+    )
+    assert torch.equal(lse_fused, lse_gmem), (
+        f"fused split prefill LSE diverged from gmem SplitKV: max_lse_diff={max_lse_diff} "
+        f"(varlen={varlen}, causal={causal}, d={d}, dv={dv})."
+    )
+
+
+@pytest.mark.parametrize("varlen", [False, True])
+@pytest.mark.parametrize("d, dv", [(128, 128), (192, 128)])
+@maybe_fake_tensor_mode(USE_FAKE_TENSOR)
+def test_flash_attn_fused_split_size_prefill_matches_decode(varlen, d, dv):
+    """Automatic fused split prefill must match same-split flash decoding bitwise."""
+    if IS_SM90:
+        pytest.skip("SplitKV is SM100+ only")
+
+    device = "cuda"
+    dtype = torch.bfloat16
+    seqlen, nheads, split_size = 1024, 4, 256
+
+    torch.random.manual_seed(0)
+    q = torch.randn(seqlen, nheads, d, device=device, dtype=dtype)
+    k = torch.randn(seqlen, nheads, d, device=device, dtype=dtype)
+    v = torch.randn(seqlen, nheads, dv, device=device, dtype=dtype)
+    if varlen:
+        cu = torch.tensor([0, seqlen], dtype=torch.int32, device=device)
+        out_prefill, _ = flash_attn_varlen_func(
+            q, k, v,
+            cu_seqlens_q=cu, cu_seqlens_k=cu,
+            max_seqlen_q=seqlen, max_seqlen_k=seqlen,
+            causal=True,
+            split_size=split_size,
+        )
+    else:
+        out_prefill, _ = flash_attn_func(
+            q.unsqueeze(0), k.unsqueeze(0), v.unsqueeze(0), causal=True, split_size=split_size
+        )
+        out_prefill = out_prefill[0]
+    k_cache, v_cache, page_table = _make_paged_kv(k, v)
+
+    if is_fake_mode():
+        return
+
+    positions = sorted({
+        split_size - 1,
+        split_size,
+        split_size + 1,
+        2 * split_size,
+        2 * split_size + 1,
+        seqlen - 1,
+    })
+    failures = []
+    for p in positions:
+        out_decode = _decode_one(q, k_cache, v_cache, page_table, p, split_size)
+        if not torch.equal(out_prefill[p], out_decode):
+            failures.append((p, (out_prefill[p] - out_decode).abs().max().item()))
+
+    assert not failures, (
+        f"fused split prefill diverged from same-split decode "
+        f"(varlen={varlen}, d={d}, dv={dv}, split_size={split_size}) at [p, max_diff]: {failures}"
     )
 
 
@@ -3145,13 +3219,7 @@ def test_flash_attn_split_size_autoregressive_consistency(seqlen_k, split_size, 
         split_size=split_size,
     )
 
-    # Paged KV cache holding the whole sequence; each decode step bounds it via seqused_k.
-    num_pages = (seqlen_k + page_size - 1) // page_size
-    k_cache = torch.zeros(num_pages, page_size, nheads_kv, d, device=device, dtype=dtype)
-    v_cache = torch.zeros(num_pages, page_size, nheads_kv, dv, device=device, dtype=dtype)
-    k_cache.view(num_pages * page_size, nheads_kv, d)[:seqlen_k] = k
-    v_cache.view(num_pages * page_size, nheads_kv, dv)[:seqlen_k] = v
-    page_table = torch.arange(num_pages, dtype=torch.int32, device=device).unsqueeze(0)
+    k_cache, v_cache, page_table = _make_paged_kv(k, v, page_size)
 
     if is_fake_mode():
         return
@@ -3167,18 +3235,9 @@ def test_flash_attn_split_size_autoregressive_consistency(seqlen_k, split_size, 
     positions = [p for p in positions if 0 <= p < seqlen_k]
     failures = []
     for p in positions:
-        cache_seqlens = torch.tensor([p + 1], dtype=torch.int32, device=device)
-        out_decode, _ = flash_attn_varlen_func(
-            q[p:p + 1], k_cache, v_cache,
-            cu_seqlens_q=torch.tensor([0, 1], dtype=torch.int32, device=device),
-            cu_seqlens_k=None,
-            max_seqlen_q=1, max_seqlen_k=None,
-            seqused_k=cache_seqlens, page_table=page_table,
-            causal=True,
-            split_size=split_size,
-        )
-        if not torch.equal(out_prefill[p], out_decode[0]):
-            md = (out_prefill[p] - out_decode[0]).abs().max().item()
+        out_decode = _decode_one(q, k_cache, v_cache, page_table, p, split_size)
+        if not torch.equal(out_prefill[p], out_decode):
+            md = (out_prefill[p] - out_decode).abs().max().item()
             failures.append((p, md))
 
     assert not failures, (


### PR DESCRIPTION
## Summary

This PR adds `split_size` support for FA4 SM100/SM110 and introduces a fused split-size prefill path.

`split_size` defines fixed, tile-aligned KV split boundaries in token units. This makes causal prefill and same-split decode use the same KV partitioning, preserving bitwise consistency across autoregressive decode and full prefill.

For eligible prefill cases, the SM100 forward kernel performs the split merge in-kernel, avoiding large temporary partial output/LSE buffers while preserving the same streaming merge order.

## Changes

- Add public `split_size` keyword to `flash_attn_func` and `flash_attn_varlen_func`.
- Derive `num_splits` and fixed `n_blocks_per_split` from `split_size`.
- Add fixed split-boundary support in `BlockInfo`.
- Add fused in-kernel segmented merge for dense SM100/SM110 prefill.
- Keep `split_size` prefill constrained to supported cases:
  - SM100/SM110
  - dense batched or varlen prefill
  - no paged KV, local/window attention, block sparsity, score/mask mods, fp8, qv, or learnable_sink
- Add tests for:
  - `split_size` correctness vs non-split
  - prefill/decode bitwise consistency
  - fused split prefill correctness
  - varlen fused split prefill

## Performance / Memory

Benchmarked on NVIDIA B200.

Peak memory for fused split prefill matches non-split prefill in tested cases, avoiding large temporary memory growth from materialized split partials.

Example peak memory:
- Batched 8192, d/dv=128/128:
  - non-split: 88 MiB
  - fused split: 88 MiB
- Varlen 8192, d/dv=128/128:
  - non-split: 112 MiB
  - fused split: 112 MiB

Latency remains close enough for the intended split-size correctness path while preserving the key memory behavior.

## Verification

- `git diff --check`
- `python -m py_compile` on touched FA4 files and tests
- B200 smoke:
  - fused split prefill matches reference output
  - fused split prefill last token matches same-split paged decode
- Expanded B200 pytest coverage passed before the final test refactor.