### PR TITLE
[CuTe] Fix lint failure in flash_bwd_sm100.py

### DIFF
--- a/flash_attn/cute/flash_bwd_sm100.py
+++ b/flash_attn/cute/flash_bwd_sm100.py
@@ -2756,14 +2756,12 @@ class FlashAttentionBackwardSm100:
     ):
         """Apply forward score modification for SM100 backward pass."""
         # In bwd, S is computed as K @ Q.T so dimensions are (tile_n, tile_m).
-        # With 2CTA, partition_C must see the full cluster tile so each CTA 
+        # With 2CTA, partition_C must see the full cluster tile so each CTA
         # gets its own half of the tile.
         cluster_tile_n = self.tile_n * self.cta_group_size
         cluster_n_block = n_block // self.cta_group_size
         cS = cute.make_identity_tensor((cluster_tile_n, self.tile_m))
-        cS = cute.domain_offset(
-            (cluster_n_block * cluster_tile_n, m_block * self.tile_m), cS
-        )
+        cS = cute.domain_offset((cluster_n_block * cluster_tile_n, m_block * self.tile_m), cS)
         tScS = thr_mma_S.partition_C(cS)
         tScS_idx = thr_copy_t2r.partition_D(tScS)
 


### PR DESCRIPTION
# [CuTe] Fix lint failure in flash_bwd_sm100.py

`ruff format --check flash_attn/cute/` currently fails on `main` (`22a7223`) because `flash_attn/cute/flash_bwd_sm100.py` is not formatted:

```
Would reformat: flash_attn/cute/flash_bwd_sm100.py
1 file would be reformatted, 42 files already formatted
```

This file was missed by the lint sweep in #2625. Two nits, both auto-fixed by `ruff format`:

- trailing whitespace in a comment
- an over-split `cute.domain_offset(...)` call that fits on a single line

After this change `ruff format --check flash_attn/cute/` is clean (43 files already formatted).
