### PR TITLE
[CuTe,Bwd,Sm100] support non-native head dims via store predication

### DIFF
--- a/flash_attn/cute/flash_bwd_preprocess.py
+++ b/flash_attn/cute/flash_bwd_preprocess.py
@@ -59,12 +59,7 @@ class FlashAttentionBackwardPreprocess:
         self.use_pdl = BaseDSL._get_dsl().get_arch_enum() >= Arch.sm_90a
         self.dtype = dtype
         self.tile_m = tile_m
-        # head_dim_padded sizes the dQaccum zeroing -> must match the main kernel's tile_hdim
-        # and interface's head_dim_rounded (multiple of 32).
         self.head_dim_padded = int(math.ceil(head_dim / 32) * 32)
-        # head_dim_v_padded sizes the O*dO reduction tile. Pad to a multiple of 16 (like the
-        # forward) so the head-dim predicate over the true-width O/dO tile stays tidy; padding
-        # to 32 makes the wrapped tile's K-layout non-tidy and predicate_k mis-shapes it.
         self.head_dim_v_padded = int(math.ceil(head_dim_v / 16) * 16)
         self.check_hdim_v_oob = head_dim_v != self.head_dim_v_padded
         self.num_threads = num_threads
@@ -104,10 +99,6 @@ class FlashAttentionBackwardPreprocess:
         # We want kBlockKGmem to be a power of 2 so that when we do the summing,
         # it's just between threads in the same warp
         if self.check_hdim_v_oob:
-            # When the head-dim is padded, O/dO are loaded with a per-column predicate over the
-            # true-width (wrapped) tile. predicate_k only stays tidy when the gmem K-block is 16;
-            # a larger block (32/64/128) makes the wrapped tile's K-mode hierarchical and the
-            # predicate comes out the wrong shape. Force 16 (still a power of 2 -> warp reduce ok).
             gmem_k_block_size = 16
         else:
             gmem_k_block_size = (

--- a/flash_attn/cute/flash_bwd_preprocess.py
+++ b/flash_attn/cute/flash_bwd_preprocess.py
@@ -59,10 +59,13 @@ class FlashAttentionBackwardPreprocess:
         self.use_pdl = BaseDSL._get_dsl().get_arch_enum() >= Arch.sm_90a
         self.dtype = dtype
         self.tile_m = tile_m
-        # padding head_dim to a multiple of 32 as k_block_size
-        hdim_multiple_of = 32
-        self.head_dim_padded = int(math.ceil(head_dim / hdim_multiple_of) * hdim_multiple_of)
-        self.head_dim_v_padded = int(math.ceil(head_dim_v / hdim_multiple_of) * hdim_multiple_of)
+        # head_dim_padded sizes the dQaccum zeroing -> must match the main kernel's tile_hdim
+        # and interface's head_dim_rounded (multiple of 32).
+        self.head_dim_padded = int(math.ceil(head_dim / 32) * 32)
+        # head_dim_v_padded sizes the O*dO reduction tile. Pad to a multiple of 16 (like the
+        # forward) so the head-dim predicate over the true-width O/dO tile stays tidy; padding
+        # to 32 makes the wrapped tile's K-layout non-tidy and predicate_k mis-shapes it.
+        self.head_dim_v_padded = int(math.ceil(head_dim_v / 16) * 16)
         self.check_hdim_v_oob = head_dim_v != self.head_dim_v_padded
         self.num_threads = num_threads
         self.use_padded_offsets = use_padded_offsets
@@ -100,15 +103,22 @@ class FlashAttentionBackwardPreprocess:
         # Thread layouts for copies
         # We want kBlockKGmem to be a power of 2 so that when we do the summing,
         # it's just between threads in the same warp
-        gmem_k_block_size = (
-            128
-            if self.head_dim_v_padded % 128 == 0
-            else (
-                64
-                if self.head_dim_v_padded % 64 == 0
-                else (32 if self.head_dim_v_padded % 32 == 0 else 16)
+        if self.check_hdim_v_oob:
+            # When the head-dim is padded, O/dO are loaded with a per-column predicate over the
+            # true-width (wrapped) tile. predicate_k only stays tidy when the gmem K-block is 16;
+            # a larger block (32/64/128) makes the wrapped tile's K-mode hierarchical and the
+            # predicate comes out the wrong shape. Force 16 (still a power of 2 -> warp reduce ok).
+            gmem_k_block_size = 16
+        else:
+            gmem_k_block_size = (
+                128
+                if self.head_dim_v_padded % 128 == 0
+                else (
+                    64
+                    if self.head_dim_v_padded % 64 == 0
+                    else (32 if self.head_dim_v_padded % 32 == 0 else 16)
+                )
             )
-        )
         num_copy_elems = 128 // self.dtype.width
         threads_per_row = gmem_k_block_size // num_copy_elems
         self.gmem_tiled_copy_O = copy_utils.tiled_copy_2d(

--- a/flash_attn/cute/flash_bwd_sm100.py
+++ b/flash_attn/cute/flash_bwd_sm100.py
@@ -69,15 +69,8 @@ class FlashAttentionBackwardSm100:
         subtile_factor: cutlass.Constexpr[int] = 1,
     ):
         head_dim_v = head_dim_v if head_dim_v is not None else head_dim
-        # Keep the true (unpadded) head dims for head-dim predication in the epilogue stores.
         self.head_dim = head_dim
         self.head_dim_v = head_dim_v
-        # Two different padding rules, because dQ and dK/dV drain TMEM differently:
-        #   - dQ  : tcgen05.ld.32x32b(Rep=32) + 128B TMA-reduce into fp32 dQaccum
-        #           => tile_hdim must be a multiple of 32 (see dQ_reduce_ncol assert below).
-        #   - dK/V: tcgen05.ld.32x32b(Rep=16) + direct 128b store to gmem
-        #           => tile_hdimv only needs a multiple of 16.
-        # Padding to the smaller multiple where allowed saves dK/dV MMA/SMEM work.
         self.tile_hdim = int(math.ceil(head_dim / 32) * 32)
         self.same_hdim_kv = head_dim == head_dim_v
         self.tile_hdimv = int(math.ceil(head_dim_v / 16) * 16)
@@ -3747,11 +3740,6 @@ class FlashAttentionBackwardSm100:
         mdV_cur = seqlen.offset_batch_K(mdV, batch_idx, dim=3)[None, None, head_idx]
         mdK_cur = seqlen.offset_batch_K(mdK, batch_idx, dim=3)[None, None, head_idx]
 
-        # When the head-dim is padded (not a multiple of the native tile width), the gmem
-        # store must mask the padding columns. The store predicate granularity equals this
-        # repetition, so it must divide the true head-dim boundary. head_dim % 8 == 0 always,
-        # so a repetition of 8 lets the predicate land exactly on the boundary; otherwise the
-        # 16-wide group would straddle (e.g. head_dim=72 falls inside the [64,80) group).
         tmem_ld_rep = 8 if const_expr(self.check_hdim_oob or self.check_hdim_v_oob) else 16
         tmem_load_atom = cute.make_copy_atom(
             tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(tmem_ld_rep)), Float32
@@ -3800,10 +3788,6 @@ class FlashAttentionBackwardSm100:
         tdVgdV_r2g_p = thr_tmem_ld_dV.partition_D(tdVgdV)
         tdVgdV_r2g = self.split_wg(tdVgdV_r2g_p, wg_idx, num_wg)
 
-        # Head-dim predicate: mdV_cur is the true (unpadded) head_dim_v wide, but we tile it
-        # with the padded tile_hdimv, so columns d >= head_dim_v would spill into the next row.
-        # One predicate bit per value-group (mode[0] collapsed to 1); the group is `tmem_ld_rep`
-        # (=8) columns wide and head_dim_v % 8 == 0, so a group never straddles the boundary.
         tdVpdV = None
         if const_expr(self.check_hdim_v_oob):
             pred_shape = (1,) + tuple(tdVcdV_t2r.shape[1:])
@@ -3867,10 +3851,6 @@ class FlashAttentionBackwardSm100:
         tdKgdK_r2g_p = thr_tmem_ld_dK.partition_D(tdKgdK)
         tdKgdK_r2g = self.split_wg(tdKgdK_r2g_p, wg_idx, num_wg)
 
-        # Head-dim predicate: mdK_cur is the true (unpadded) head_dim wide, but we tile it
-        # with the padded tile_hdim, so columns d >= head_dim would spill into the next row.
-        # One predicate bit per value-group (mode[0] collapsed to 1); the group is `tmem_ld_rep`
-        # (=8) columns wide and head_dim % 8 == 0, so a group never straddles the boundary.
         tdKpdK = None
         if const_expr(self.check_hdim_oob):
             pred_shape = (1,) + tuple(tdKcdK_t2r.shape[1:])

--- a/flash_attn/cute/flash_bwd_sm100.py
+++ b/flash_attn/cute/flash_bwd_sm100.py
@@ -68,12 +68,19 @@ class FlashAttentionBackwardSm100:
         has_aux_tensors: cutlass.Constexpr = False,
         subtile_factor: cutlass.Constexpr[int] = 1,
     ):
-        # padding head_dim to a multiple of 16 as k_block_size
-        hdim_multiple_of = 16
-        self.tile_hdim = int(math.ceil(head_dim / hdim_multiple_of) * hdim_multiple_of)
         head_dim_v = head_dim_v if head_dim_v is not None else head_dim
+        # Keep the true (unpadded) head dims for head-dim predication in the epilogue stores.
+        self.head_dim = head_dim
+        self.head_dim_v = head_dim_v
+        # Two different padding rules, because dQ and dK/dV drain TMEM differently:
+        #   - dQ  : tcgen05.ld.32x32b(Rep=32) + 128B TMA-reduce into fp32 dQaccum
+        #           => tile_hdim must be a multiple of 32 (see dQ_reduce_ncol assert below).
+        #   - dK/V: tcgen05.ld.32x32b(Rep=16) + direct 128b store to gmem
+        #           => tile_hdimv only needs a multiple of 16.
+        # Padding to the smaller multiple where allowed saves dK/dV MMA/SMEM work.
+        self.tile_hdim = int(math.ceil(head_dim / 32) * 32)
         self.same_hdim_kv = head_dim == head_dim_v
-        self.tile_hdimv = int(math.ceil(head_dim_v / hdim_multiple_of) * hdim_multiple_of)
+        self.tile_hdimv = int(math.ceil(head_dim_v / 16) * 16)
         self.check_hdim_oob = head_dim != self.tile_hdim
         self.check_hdim_v_oob = head_dim_v != self.tile_hdimv
 
@@ -3740,8 +3747,14 @@ class FlashAttentionBackwardSm100:
         mdV_cur = seqlen.offset_batch_K(mdV, batch_idx, dim=3)[None, None, head_idx]
         mdK_cur = seqlen.offset_batch_K(mdK, batch_idx, dim=3)[None, None, head_idx]
 
+        # When the head-dim is padded (not a multiple of the native tile width), the gmem
+        # store must mask the padding columns. The store predicate granularity equals this
+        # repetition, so it must divide the true head-dim boundary. head_dim % 8 == 0 always,
+        # so a repetition of 8 lets the predicate land exactly on the boundary; otherwise the
+        # 16-wide group would straddle (e.g. head_dim=72 falls inside the [64,80) group).
+        tmem_ld_rep = 8 if const_expr(self.check_hdim_oob or self.check_hdim_v_oob) else 16
         tmem_load_atom = cute.make_copy_atom(
-            tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(16)), Float32
+            tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(tmem_ld_rep)), Float32
         )
         # dV
         pipeline_dKV.consumer_wait(consumer_state_dKV)
@@ -3787,8 +3800,21 @@ class FlashAttentionBackwardSm100:
         tdVgdV_r2g_p = thr_tmem_ld_dV.partition_D(tdVgdV)
         tdVgdV_r2g = self.split_wg(tdVgdV_r2g_p, wg_idx, num_wg)
 
+        # Head-dim predicate: mdV_cur is the true (unpadded) head_dim_v wide, but we tile it
+        # with the padded tile_hdimv, so columns d >= head_dim_v would spill into the next row.
+        # One predicate bit per value-group (mode[0] collapsed to 1); the group is `tmem_ld_rep`
+        # (=8) columns wide and head_dim_v % 8 == 0, so a group never straddles the boundary.
+        tdVpdV = None
+        if const_expr(self.check_hdim_v_oob):
+            pred_shape = (1,) + tuple(tdVcdV_t2r.shape[1:])
+            tdVpdV = cute.make_rmem_tensor(pred_shape, cutlass.Boolean)
+            for i in cutlass.range_constexpr(cute.size(tdVcdV_t2r, mode=[1])):
+                tdVpdV[(0, i, 0, 0)] = cute.elem_less(
+                    tdVcdV_t2r[(0, i, 0, 0)][1], self.head_dim_v
+                )
+
         if tidx < seqlen.seqlen_k - self.tile_n * n_block:
-            cute.copy(tiled_gmem_store_dV, tdVrdV_r2s, tdVgdV_r2g)
+            cute.copy(tiled_gmem_store_dV, tdVrdV_r2s, tdVgdV_r2g, pred=tdVpdV)
 
         cute.arch.sync_warp()
         with cute.arch.elect_one():
@@ -3841,8 +3867,21 @@ class FlashAttentionBackwardSm100:
         tdKgdK_r2g_p = thr_tmem_ld_dK.partition_D(tdKgdK)
         tdKgdK_r2g = self.split_wg(tdKgdK_r2g_p, wg_idx, num_wg)
 
+        # Head-dim predicate: mdK_cur is the true (unpadded) head_dim wide, but we tile it
+        # with the padded tile_hdim, so columns d >= head_dim would spill into the next row.
+        # One predicate bit per value-group (mode[0] collapsed to 1); the group is `tmem_ld_rep`
+        # (=8) columns wide and head_dim % 8 == 0, so a group never straddles the boundary.
+        tdKpdK = None
+        if const_expr(self.check_hdim_oob):
+            pred_shape = (1,) + tuple(tdKcdK_t2r.shape[1:])
+            tdKpdK = cute.make_rmem_tensor(pred_shape, cutlass.Boolean)
+            for i in cutlass.range_constexpr(cute.size(tdKcdK_t2r, mode=[1])):
+                tdKpdK[(0, i, 0, 0)] = cute.elem_less(
+                    tdKcdK_t2r[(0, i, 0, 0)][1], self.head_dim
+                )
+
         if tidx < seqlen.seqlen_k - self.tile_n * n_block:
-            cute.copy(tiled_gmem_store_dK, tdKrdK_r2s, tdKgdK_r2g)
+            cute.copy(tiled_gmem_store_dK, tdKrdK_r2s, tdKgdK_r2g, pred=tdKpdK)
 
         cute.arch.sync_warp()
         with cute.arch.elect_one():


### PR DESCRIPTION
This PR supports non-native head dims (`head_dim % 32 != 0`), which is especially relevant to ViT models (like Siglip2 SO 400M, which has `head_dim = 72`).