### PR TITLE
Fix SM100 FP8 fwd with cutlass-dsl >=4.5.2 (MmaF8F6F4Op)

### DIFF
--- a/flash_attn/cute/blackwell_helpers.py
+++ b/flash_attn/cute/blackwell_helpers.py
@@ -17,7 +17,9 @@ def _tcgen05_mma_kind(op: cute.nvgpu.tcgen05.mma.MmaOp) -> str:
         return "tf32"
     if isinstance(op, tcgen05.mma.MmaI8Op):
         return "i8"
-    if isinstance(op, tcgen05.mma.MmaFP8Op):
+    # cutlass-dsl >=4.5.2 builds plain FP8 MMAs as MmaF8F6F4Op (make_trivial_tiled_mma's
+    # _F8F6F4_TYPES branch); <4.4.x returned the now-legacy MmaFP8Op. Both map to kind::f8f6f4.
+    if isinstance(op, (tcgen05.mma.MmaFP8Op, tcgen05.mma.MmaF8F6F4Op)):
         return "f8f6f4"
     if isinstance(op, tcgen05.mma.MmaMXF8Op):
         return "mxf8f6f4"


### PR DESCRIPTION
Fixes #2639

### Problem

Running `python -m flash_attn.cute.benchmark_flash_attention_fp8` on Blackwell (SM100) fails on every FP8 config with:

```
TypeError: Unsupported tcgen05 MMA op kind: MmaF8F6F4Op
```

It works on `nvidia-cutlass-dsl==4.4.2` and breaks on `>=4.5.2` (which is the floor we pin). BF16 is unaffected.

### Root cause

The error is raised by FA4's own `_tcgen05_mma_kind()` in `flash_attn/cute/blackwell_helpers.py`, not by cutlass-dsl.

In cutlass-dsl `>=4.5.2`, `make_trivial_tiled_mma` builds plain FP8 MMAs through its `_F8F6F4_TYPES` branch, returning a **`MmaF8F6F4Op`** instance. Earlier versions returned the now-legacy **`MmaFP8Op`**. The two classes are *siblings* under `MmaOp` (neither subclasses the other), so the existing `isinstance(op, MmaFP8Op)` check no longer matches and the function falls through to its `raise TypeError(...)`. The FP8 forward never reaches the kernel.

### Fix

Accept both op types in the `f8f6f4` branch — both map to the same PTX `tcgen05.mma...kind::f8f6f4`:

```python
if isinstance(op, (tcgen05.mma.MmaFP8Op, tcgen05.mma.MmaF8F6F4Op)):
    return "f8f6f4"
```

`mma_op_to_idesc` only reads generic op attributes (`a_dtype`, `b_dtype`, `acc_dtype`, `shape_mnk`, `*_major_mode`), all present on `MmaF8F6F4Op`, so it needs no change. One-line, backward-compatible with 4.4.x.

### Validation (B200, SM100, cutlass-dsl 4.5.2)

Ran the exact reporter script — `benchmark_flash_attention_fp8.py --check` (FP8 output checked against the BF16 PyTorch baseline). All **24/24** configs pass; 0 skipped, 0 failed (was "FP8 failures: 24" before the fix).

FP8 vs FA4-BF16 forward, selected non-causal configs:

| Config (non-causal)     | BF16 TFLOPs/s | FP8 TFLOPs/s | Speedup |
|-------------------------|--------------:|-------------:|--------:|
| hd=128, b=1, s=16384    |          1536 |     **1870** |   1.22× |
| hd=128, b=2, s=8192     |          1522 |     **1830** |   1.20× |
| hd=128, b=4, s=4096     |          1463 |     **1754** |   1.20× |
| hd=64,  b=1, s=16384    |           761 |      **967** |   1.27× |
| hd=64,  b=2, s=8192     |           756 |      **956** |   1.27× |

- hd=128 / hd=64 non-causal: FP8 ~1.2–1.27× over BF16.
- Causal cases: FP8 ≈ BF16 (within ±2%) — these small/triangular tiles are overhead/memory-bound rather than MMA-bound, so FP8 gives little there. Expected.

Correctness spot-check vs a BF16 reference: mean abs error ~0.002–0.01 across hd=64 and hd=128, causal and non-causal (consistent with FP8 quantization).
