### PR TITLE
Harden NVIDIA toolchain extraction in hopper/setup.py against local attack

### DIFF
--- a/hopper/setup.py
+++ b/hopper/setup.py
@@ -415,12 +415,24 @@ def download_and_copy(name, src_func, dst_path, version, url_func):
     src_path = src_func(supported[system], arch, version)
     tmp_path = os.path.join(flashattn_cache_path, "nvidia", name)  # path to cache the download
     dst_path = os.path.join(base_dir, os.pardir, "third_party", "nvidia", "backend", dst_path)  # final binary path
+    # Refuse to extract into a symlinked cache directory. The cache path
+    # (~/.flashattn/nvidia/<name>) is predictable, so a local attacker could
+    # pre-plant a symlink there and have extractall() write the downloaded
+    # toolchain through it to an attacker-chosen location.
+    if os.path.islink(tmp_path):
+        raise RuntimeError(f"Refusing to extract into symlinked cache path: {tmp_path}")
+    os.makedirs(tmp_path, exist_ok=True)
     src_path = os.path.join(tmp_path, src_path)
     download = not os.path.exists(src_path)
     if download:
         print(f'downloading and extracting {url} ...')
         file = tarfile.open(fileobj=open_url(url), mode="r|*")
-        file.extractall(path=tmp_path)
+        # Use the 'data' extraction filter (Python 3.12+) to block path
+        # traversal and unsafe symlink/device members inside the archive.
+        if hasattr(tarfile, "data_filter"):
+            file.extractall(path=tmp_path, filter="data")
+        else:
+            file.extractall(path=tmp_path)
     os.makedirs(os.path.split(dst_path)[0], exist_ok=True)
     print(f'copy {src_path} to {dst_path} ...')
     if os.path.isdir(src_path):


### PR DESCRIPTION
download_and_copy() extracts downloaded NVIDIA toolchain archives with a bare tarfile.extractall() into a predictable, user-home-rooted cache directory (~/.flashattn/nvidia/<name>) with no symlink check and no member filtering.

On a shared build host (multi-user GPU box, CI with a persistent home), a local attacker can pre-plant a symlink at that predictable path before the victim runs `pip install flash-attn` from source, causing extractall() to write toolchain binaries through the symlink to an attacker-chosen location (arbitrary file write with the victim's privileges at build time). Malicious members inside the archive (path traversal, symlinks) are likewise unfiltered.

Fix:
- Refuse to extract when the cache path is a symlink.
- Create the cache dir explicitly before extraction.
- Use tarfile's 'data' extraction filter on Python 3.12+ to reject path traversal and unsafe symlink/device members.