### PR TITLE
[CuTe,Bwd,Sm90] fix: add missing griddepcontrol_wait in block-sparse producer

### DIFF
--- a/flash_attn/cute/block_sparse_utils.py
+++ b/flash_attn/cute/block_sparse_utils.py
@@ -1290,6 +1290,14 @@ def produce_block_sparse_q_loads_bwd_sm90(
         curr_full_cnt = Int32(0)
         curr_full_idx = None
 
+    # Wait for bwd preprocess to finish writing LSE / dPsum and zeroing dQaccum
+    # before issuing any TMA loads of those outputs. The dense producer path in
+    # flash_bwd_sm90 does this via griddepcontrol_wait() before load_LSE; without
+    # it, under PDL the bwd kernel can read un-written LSE/dPsum and reduce-add
+    # into an un-zeroed dQaccum. The block-sparse metadata reads above are
+    # host-provided inputs, safe before the wait.
+    cute.arch.griddepcontrol_wait()
+
     kv_loaded = False
 
     for iter_idx in cutlass.range(curr_q_cnt * subtile_factor, unroll=1):


### PR DESCRIPTION
## Summary

The SM90 backward kernel is launched with `use_pdl=True` (`flash_bwd_sm90.py`). Under PDL, the bwd kernel can start before the bwd preprocess kernel has finished, so producers must call `cute.arch.griddepcontrol_wait()` before reading anything preprocess writes.

The dense producer path already does this — it waits right before `load_LSE` in `flash_bwd_sm90.py`. But the block-sparse producer path (`produce_block_sparse_q_loads_bwd_sm90` in `flash_attn/cute/block_sparse_utils.py`) issues TMA loads of LSE/dPsum without any wait. As a result, with block sparsity enabled the bwd kernel can:

- read LSE/dPsum before preprocess has written them, and
- reduce-add dQ partials into a `dQaccum` buffer that preprocess hasn't zeroed yet,

which intermittently produces NaNs in dQ/dK/dV.

## Fix

Add `cute.arch.griddepcontrol_wait()` in `produce_block_sparse_q_loads_bwd_sm90` before the load loops, mirroring the dense path. It's placed before the loops (rather than immediately before the LSE load) because the loop body interleaves K/V/Q/LSE/dPsum loads per block. The block-sparse metadata reads above the wait are host-provided kernel inputs and are safe to read before it.

The SM100 block-sparse bwd path is unaffected since the SM100 bwd kernel doesn't use PDL.
