### PR TITLE
fix(fa4): enable persistent JIT cache by default and serialize cold-start compiles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,14 +39,15 @@ Compilation dominates test time. The fast workflow separates compilation (parall
 
 ```bash
 # Pass 1: compile all kernels in parallel using FakeTensorMode (no GPU memory allocation)
-FLASH_ATTENTION_FAKE_TENSOR=1 FLASH_ATTENTION_CUTE_DSL_CACHE_ENABLED=1 pytest -n 64 -x tests/cute/test_flash_attn.py
+FLASH_ATTENTION_FAKE_TENSOR=1 pytest -n 64 -x tests/cute/test_flash_attn.py
 
 # Pass 2: run tests using cached compiled kernels
-FLASH_ATTENTION_FAKE_TENSOR=0 FLASH_ATTENTION_CUTE_DSL_CACHE_ENABLED=1 pytest -x tests/cute/test_flash_attn.py
+FLASH_ATTENTION_FAKE_TENSOR=0 pytest -x tests/cute/test_flash_attn.py
 ```
 
 - `FLASH_ATTENTION_FAKE_TENSOR=1` — uses PyTorch FakeTensorMode to compile kernels without allocating GPU memory or running them.
-- `FLASH_ATTENTION_CUTE_DSL_CACHE_ENABLED=1` — enables persistent disk cache at `/tmp/${USER}/flash_attention_cute_dsl_cache/`.
+- `FLASH_ATTENTION_CUTE_DSL_CACHE_ENABLED=0` — disables the persistent disk cache, which is enabled by default at `/tmp/${USER}/flash_attention_cute_dsl_cache/`.
+- `FLASH_ATTENTION_CUTE_DSL_CACHE_DIR=/path` — changes the persistent cache directory; use a fast shared path for distributed training.
 - `-n 256` — pytest-xdist parallel workers (only useful in the compilation pass).
 
 Tests are parametrized over dtype (fp16/bf16), head dimension (64, 96, 128), sequence length, causal/non-causal, and MHA/GQA/MQA.

--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ from flash_attn.cute import flash_attn_func
 out = flash_attn_func(q, k, v, causal=True)
 ```
 
+FA4 kernels are JIT-compiled and use a persistent on-disk cache by default at
+`/tmp/${USER}/flash_attention_cute_dsl_cache/`. For distributed training, set
+`FLASH_ATTENTION_CUTE_DSL_CACHE_DIR` to a fast shared path so ranks and restarts
+reuse compiled kernels. Set `FLASH_ATTENTION_CUTE_DSL_CACHE_ENABLED=0` to force
+in-process-only caching.
+
 ## Installation and features
 **Requirements:**
 - CUDA toolkit or ROCm toolkit

--- a/flash_attn/cute/cache_utils.py
+++ b/flash_attn/cute/cache_utils.py
@@ -9,7 +9,7 @@ import time
 from functools import lru_cache
 from getpass import getuser
 from pathlib import Path
-from typing import Hashable, TypeAlias
+from typing import Callable, Hashable, TypeAlias
 
 import ctypes
 
@@ -30,13 +30,22 @@ for _lib_path in cute.runtime.find_runtime_libraries(enable_tvm_ffi=False):
 CompileKeyType: TypeAlias = tuple[Hashable, ...]
 CallableFunction: TypeAlias = JitCompiledFunction | tvm_ffi.Function
 
-# Enable cache via `FLASH_ATTENTION_CUTE_DSL_CACHE_ENABLED=1`
-CUTE_DSL_CACHE_ENABLED: bool = os.getenv("FLASH_ATTENTION_CUTE_DSL_CACHE_ENABLED", "0") == "1"
+
+def _env_flag(name: str, default: str) -> bool:
+    return os.getenv(name, default).strip().lower() in {"1", "true", "yes", "on"}
+
+
+# Persistent cache is enabled by default. Set
+# `FLASH_ATTENTION_CUTE_DSL_CACHE_ENABLED=0` to force in-process-only caching.
+CUTE_DSL_CACHE_ENABLED: bool = _env_flag("FLASH_ATTENTION_CUTE_DSL_CACHE_ENABLED", "1")
 
 
 # Customize cache dir via `FLASH_ATTENTION_CUTE_DSL_CACHE_DIR`, default is
 # `/tmp/${USER}/flash_attention_cute_dsl_cache``
 CUTE_DSL_CACHE_DIR: str | None = os.getenv("FLASH_ATTENTION_CUTE_DSL_CACHE_DIR", None)
+CUTE_DSL_CACHE_LOCK_TIMEOUT_SECONDS: float = float(
+    os.getenv("FLASH_ATTENTION_CUTE_DSL_CACHE_LOCK_TIMEOUT_SECONDS", "1800")
+)
 
 
 def get_cache_path() -> Path:
@@ -163,6 +172,13 @@ class JITCache:
     def __contains__(self, key: CompileKeyType) -> bool:
         return key in self.cache
 
+    def get_or_compile(
+        self, key: CompileKeyType, compile_fn: Callable[[], JitCompiledFunction]
+    ) -> CallableFunction:
+        if key not in self.cache:
+            self.cache[key] = compile_fn()
+        return self.cache[key]
+
     def clear(self) -> None:
         """
         Clear in-memory cache of compiled functions
@@ -177,7 +193,7 @@ class JITPersistentCache(JITCache):
     """
 
     EXPORT_FUNCTION_PREFIX = "func"
-    LOCK_TIMEOUT_SECONDS = 15
+    LOCK_TIMEOUT_SECONDS = CUTE_DSL_CACHE_LOCK_TIMEOUT_SECONDS
 
     def __init__(self, cache_path: Path):
         super().__init__()
@@ -215,14 +231,17 @@ class JITPersistentCache(JITCache):
             label=sha256_hex,
         ):
             if obj_path.exists():
-                fa_log(1, f"Loading compiled function from disk: {obj_path}")
-                m = cute.runtime.load_module(str(obj_path), enable_tvm_ffi=True)
-                fn = getattr(m, self.EXPORT_FUNCTION_PREFIX)
-                JITCache.__setitem__(self, key, fn)
+                self._load_from_storage_unlocked(key, obj_path)
                 return True
             else:
                 fa_log(1, f"Cache miss on disk for key hash {sha256_hex}")
         return False
+
+    def _load_from_storage_unlocked(self, key: CompileKeyType, obj_path: Path) -> None:
+        fa_log(1, f"Loading compiled function from disk: {obj_path}")
+        m = cute.runtime.load_module(str(obj_path), enable_tvm_ffi=True)
+        fn = getattr(m, self.EXPORT_FUNCTION_PREFIX)
+        JITCache.__setitem__(self, key, fn)
 
     def _try_export_to_storage(self, key: CompileKeyType, fn: JitCompiledFunction) -> None:
         """Export a compiled function to persistent storage under exclusive lock."""
@@ -238,12 +257,40 @@ class JITPersistentCache(JITCache):
                 # Another process already exported.
                 fa_log(1, f"Skipping export, already on disk: {obj_path}")
                 return
-            fa_log(1, f"Exporting compiled function to disk: {obj_path}")
-            fn.export_to_c(
-                object_file_path=str(obj_path),
-                function_name=self.EXPORT_FUNCTION_PREFIX,
-            )
-            fa_log(1, f"Successfully exported compiled function to disk: {obj_path}")
+            self._export_to_storage_unlocked(obj_path, fn)
+
+    def _export_to_storage_unlocked(self, obj_path: Path, fn: JitCompiledFunction) -> None:
+        fa_log(1, f"Exporting compiled function to disk: {obj_path}")
+        fn.export_to_c(
+            object_file_path=str(obj_path),
+            function_name=self.EXPORT_FUNCTION_PREFIX,
+        )
+        fa_log(1, f"Successfully exported compiled function to disk: {obj_path}")
+
+    def get_or_compile(
+        self, key: CompileKeyType, compile_fn: Callable[[], JitCompiledFunction]
+    ) -> CallableFunction:
+        if JITCache.__contains__(self, key):
+            return JITCache.__getitem__(self, key)
+
+        sha256_hex = self._key_to_hash(key)
+        obj_path = self.cache_path / f"{sha256_hex}.o"
+        with FileLock(
+            self._lock_path(sha256_hex),
+            exclusive=True,
+            timeout=self.LOCK_TIMEOUT_SECONDS,
+            label=sha256_hex,
+        ):
+            if JITCache.__contains__(self, key):
+                return JITCache.__getitem__(self, key)
+            if obj_path.exists():
+                self._load_from_storage_unlocked(key, obj_path)
+                return JITCache.__getitem__(self, key)
+
+            fn = compile_fn()
+            JITCache.__setitem__(self, key, fn)
+            self._export_to_storage_unlocked(obj_path, fn)
+            return fn
 
     def _key_to_hash(self, key: CompileKeyType) -> str:
         return hashlib.sha256(pickle.dumps(key)).hexdigest()

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -752,7 +752,7 @@ def _flash_attn_fwd(
         fa_logging.get_fa_log_level(),
     )
 
-    if compile_key not in _flash_attn_fwd.compile_cache:
+    def _compile_fwd():
         (
             cu_seqlens_q_tensor,
             cu_seqlens_k_tensor,
@@ -970,7 +970,7 @@ def _flash_attn_fwd(
             )
         # TODO: check @can_implement
         if qv is not None:
-            _flash_attn_fwd.compile_cache[compile_key] = cute.compile(
+            return cute.compile(
                 fa_fwd,
                 q_tensor,
                 qv_tensor,
@@ -1017,9 +1017,11 @@ def _flash_attn_fwd(
                 AuxData(cute_aux_tensors, aux_scalars),
             ])
             compile_args.append(current_stream)
-            _flash_attn_fwd.compile_cache[compile_key] = cute.compile(
+            return cute.compile(
                 *compile_args, options="--enable-tvm-ffi"
             )
+
+    compiled_fwd = _flash_attn_fwd.compile_cache.get_or_compile(compile_key, _compile_fwd)
 
     if not is_fake_mode():
         q_call, k_call, v_call, qv_call = [
@@ -1038,7 +1040,7 @@ def _flash_attn_fwd(
             else None
         )
         if qv is not None:
-            _flash_attn_fwd.compile_cache[compile_key](
+            compiled_fwd(
                 q_call,
                 qv_call,
                 k_call,
@@ -1091,7 +1093,7 @@ def _flash_attn_fwd(
                 else None,
                 AuxData(aux_tensors, aux_scalars),
             ])
-            _flash_attn_fwd.compile_cache[compile_key](*call_args)
+            compiled_fwd(*call_args)
     if is_split_kv:
         _flash_attn_fwd_combine(
             out_partial,
@@ -1187,10 +1189,11 @@ def _bwd_preprocess(
         dtype, head_dim, head_dim_v, m_block_size, is_varlen, seqused_q is not None, dlse is not None, dq_accum is not None,
         use_padded_offsets,
     )
-    if compile_key not in _bwd_preprocess.compile_cache:
-        _bwd_preprocess.compile_cache[compile_key] = _compile_bwd_preprocess(*compile_key)
+    compiled = _bwd_preprocess.compile_cache.get_or_compile(
+        compile_key, lambda: _compile_bwd_preprocess(*compile_key)
+    )
     if not is_fake_mode():
-        _bwd_preprocess.compile_cache[compile_key](
+        compiled(
             out, dout, dpsum, lse, lse_log2, dq_accum, cu_seqlens_q, seqused_q, dlse
         )
 
@@ -1236,10 +1239,11 @@ def _bwd_postprocess_convert(
         cu_seqlens is not None, seqused is not None,
         use_2cta_instrs, cluster_size, arch,
     )
-    if compile_key not in _bwd_postprocess_convert.compile_cache:
-        _bwd_postprocess_convert.compile_cache[compile_key] = _compile_bwd_postprocess(*compile_key)
+    compiled = _bwd_postprocess_convert.compile_cache.get_or_compile(
+        compile_key, lambda: _compile_bwd_postprocess(*compile_key)
+    )
     if not is_fake_mode():
-        _bwd_postprocess_convert.compile_cache[compile_key](
+        compiled(
             accum, output, scale, cu_seqlens, seqused,
         )
 
@@ -1723,7 +1727,7 @@ def _flash_attn_bwd(
             (seqlen_k_rounded // n_block_size == 1),
         )
 
-    if compile_key not in _flash_attn_bwd.compile_cache:
+    def _compile_bwd():
         q_tensor, k_tensor, v_tensor, do_tensor, dq_tensor, dk_tensor, dv_tensor = [
             to_cute_tensor(t) for t in (q, k, v, dout, dq, dk, dv)
         ]
@@ -1854,7 +1858,7 @@ def _flash_attn_bwd(
         dq_accum_tensor = dq_tensor if use_dedicated_hd256_kernel else dq_accum_tensor
 
         # TODO: check @can_implement
-        _flash_attn_bwd.compile_cache[compile_key] = cute.compile(
+        return cute.compile(
             fa_bwd_obj,
             q_tensor,
             k_tensor,
@@ -1880,9 +1884,12 @@ def _flash_attn_bwd(
             current_stream,
             options="--enable-tvm-ffi",
         )
+
+    compiled_bwd = _flash_attn_bwd.compile_cache.get_or_compile(compile_key, _compile_bwd)
+
     if not is_fake_mode():
         dq_accum = dq if use_dedicated_hd256_kernel else dq_accum
-        _flash_attn_bwd.compile_cache[compile_key](
+        compiled_bwd(
             q.detach(),
             k.detach(),
             v.detach(),
@@ -2473,12 +2480,11 @@ def _flash_attn_fwd_combine(
         lse is not None,
         varlen_batch_idx is not None,
     )
-    if compile_key not in _flash_attn_fwd_combine.compile_cache:
-        _flash_attn_fwd_combine.compile_cache[compile_key] = _compile_fwd_combine(
-            *compile_key
-        )
+    compiled = _flash_attn_fwd_combine.compile_cache.get_or_compile(
+        compile_key, lambda: _compile_fwd_combine(*compile_key)
+    )
     if not is_fake_mode():
-        _flash_attn_fwd_combine.compile_cache[compile_key](
+        compiled(
             out_partial, lse_partial, out, lse,
             cu_seqlens, seqused, num_splits_dynamic_ptr, varlen_batch_idx,
             semaphore_to_reset,

--- a/tests/cute/test_cache_utils.py
+++ b/tests/cute/test_cache_utils.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import logging
 from types import SimpleNamespace
 
@@ -28,3 +29,53 @@ def test_persistent_cache_hit_logs_at_host_level_only(tmp_path, monkeypatch, cap
         assert "Loading compiled function from disk" in caplog.text
     finally:
         monkeypatch.setattr(fa_logging, "_fa_log_level", original_level)
+
+
+class DummyCompiledFunction:
+    def __init__(self):
+        self.exports = 0
+
+    def export_to_c(self, object_file_path, function_name):
+        self.exports += 1
+        Path(object_file_path).write_bytes(function_name.encode())
+
+
+def test_in_memory_get_or_compile_runs_factory_once():
+    cache = cache_utils.JITCache()
+    compiled = object()
+    calls = {"n": 0}
+
+    def compile_fn():
+        calls["n"] += 1
+        return compiled
+
+    assert cache.get_or_compile(("key",), compile_fn) is compiled
+    assert cache.get_or_compile(("key",), compile_fn) is compiled
+    assert calls["n"] == 1
+
+
+def test_persistent_get_or_compile_exports_then_loads(tmp_path, monkeypatch):
+    key = ("persistent-key",)
+    compiled = DummyCompiledFunction()
+    calls = {"n": 0}
+    cache = cache_utils.JITPersistentCache(tmp_path)
+
+    def compile_fn():
+        calls["n"] += 1
+        return compiled
+
+    assert cache.get_or_compile(key, compile_fn) is compiled
+    assert calls["n"] == 1
+    assert compiled.exports == 1
+
+    loaded = object()
+    monkeypatch.setattr(
+        cache_utils.cute.runtime,
+        "load_module",
+        lambda *_args, **_kwargs: SimpleNamespace(func=loaded),
+    )
+
+    def fail_compile():
+        raise AssertionError("compile factory should not run on persistent cache hit")
+
+    assert cache_utils.JITPersistentCache(tmp_path).get_or_compile(key, fail_compile) is loaded


### PR DESCRIPTION
Fixes the JIT-recompile stalls in #2635. The cache logic was correct, but nothing persisted across processes by default, so every rank and every restart recompiled from scratch — and on a cold multi-rank start all ranks raced to compile the same keys at once. Two independent changes, reviewable separately.

## Part 1 — persistent cache on by default

The on-disk cache was opt-in (`FLASH_ATTENTION_CUTE_DSL_CACHE_ENABLED` defaulted to `"0"`), so each rank compiled its own copy and nothing survived a restart. This flips the default to enabled, with `=0` as the opt-out. Cache dir still defaults to `/tmp/${USER}/flash_attention_cute_dsl_cache/` and is overridable via `FLASH_ATTENTION_CUTE_DSL_CACHE_DIR` — point it at a shared path for distributed training. README/CLAUDE.md updated. Pure default change, no logic risk.

## Part 2 — serialize cold-start compiles via `get_or_compile`

Even with the cache on, the old `if key not in cache: cache[key] = compile()` held no lock across the gap, so a cold multi-rank start compiled the same key N times redundantly. Adds `get_or_compile(key, compile_fn)` holding one exclusive lock across check → compile → export (double-checked), so exactly one rank compiles per key and the rest load from disk. All five FA4 compile sites switched over. Lock timeout raised 15s → 1800s (configurable via `FLASH_ATTENTION_CUTE_DSL_CACHE_LOCK_TIMEOUT_SECONDS`) since the lock now spans the full compile. Degrades safely: a rank dying mid-compile releases its `flock` on fd close (no deadlock); where `flock` is unreliable the worst case is the old redundant-compile behavior, never wrong output. Perf optimization, not a bug fix.

## Testing

`pytest tests/cute/test_cache_utils.py -q` passes (incl. two new `get_or_compile` tests); `py_compile` and `git diff --check` clean.

## Out of scope

The follow-up `head_dim=256 does not support aux_tensors` error is a separate, unrelated kernel limitation (the dedicated SM100 hd256 kernel doesn't implement `aux_tensors`/`score_mod`), not a cache issue. We could not reproduce the reported "None at the API but non-empty in the kernel" path on `main`; tracked separately pending the reporter's config.
