### PR TITLE
[NVIDIA][CuTe,Fwd,sm120] Implement Pack-GQA on SM120 (+ graceful SplitKV fallback)

### DIFF
--- a/flash_attn/cute/flash_fwd.py
+++ b/flash_attn/cute/flash_fwd.py
@@ -656,10 +656,6 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
         self.num_Q_load_threads = self.num_threads
         self.num_epilogue_threads = self.num_threads
         # self.use_tma_O = self.arch >= 90 and mCuSeqlensQ is None
-        # SM120 (Blackwell GeForce / RTX PRO / DGX Spark) lacks the WGMMA-era TMA-store
-        # epilogue path used here; only sm_90..sm_119 use TMA for the O store. On sm_120
-        # tma_atom_O is None, so using it crashes in tma_partition with
-        # 'NoneType' object has no attribute '_trait'. (issue #2649)
         self.use_tma_O = Arch.sm_90 <= self.arch < Arch.sm_120
         self._setup_attributes()
         SharedStorage = self._get_shared_storage_cls()
@@ -678,12 +674,6 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
         if const_expr(mLSE is not None):
             LSE_layout_transpose = [2, 1, 0] if const_expr(mCuSeqlensQ is None) else [1, 0]
             mLSE = cute.make_tensor(mLSE.iterator, cute.select(mLSE.layout, mode=LSE_layout_transpose))
-        # Pack-GQA: fold qhead_per_kvhead into the seqlen mode so the kernel iterates
-        # over (qhead * seqlen) rows against a single KV head. After the transpose above,
-        # mQ/mO are (seqlen, headdim, nheads, [batch]) (head at mode 2) and mLSE is
-        # (seqlen, nheads, [batch]) (head at mode 1). This matches the SM90 path and is
-        # what PackGQA.store_O/store_LSE/load_Q expect; without it the packed (h_idx,m_idx)
-        # gmem coordinate in store_O hits an unpacked layout and crd2idx fails.
         if const_expr(self.pack_gqa):
             nheads_kv = mK.shape[2]
             mQ = pack_gqa_layout(mQ, self.qhead_per_kvhead, nheads_kv, head_idx=2)
@@ -830,12 +820,7 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
         blkQ_shape = (self.tile_m, self.tile_hdim)
         blkK_shape = (self.tile_n, self.tile_hdim)
         blkV_shape = (self.tile_n, self.tile_hdimv)
-        # When pack_gqa, the scheduler iterates over KV heads, so num_head already
-        # indexes the KV head and mQ/mO are pre-packed (mode 2 = nheads_kv).
-        # When not pack_gqa, num_head indexes Q heads and KV heads are derived by division.
-        num_head_kv = (
-            num_head // self.qhead_per_kvhead if const_expr(not self.pack_gqa) else num_head
-        )
+        num_head_kv = num_head if const_expr(self.pack_gqa) else num_head // self.qhead_per_kvhead
         if const_expr(not seqlen.has_cu_seqlens_q):
             mQ_cur = mQ[None, None, num_head, batch_size]
         else:
@@ -846,12 +831,8 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
         else:
             mK_cur = cute.domain_offset((seqlen.offset_k, 0), mK[None, None, num_head_kv])
             mV_cur = cute.domain_offset((seqlen.offset_k, 0), mV[None, None, num_head_kv])
-        # For pack_gqa, Q rows are gathered via per-row gmem pointers in PackGQA.load_Q,
-        # so the standard contiguous local_tile gQ is not used.
         if const_expr(not self.pack_gqa):
             gQ = cute.local_tile(mQ_cur, blkQ_shape, (m_block, 0))
-        else:
-            gQ = None
         gK = cute.local_tile(mK_cur, blkK_shape, (None, 0))
         gV = cute.local_tile(mV_cur, blkV_shape, (None, 0))
 
@@ -986,13 +967,8 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
         if const_expr(not self.pack_gqa):
             self.load_Q(gmem_thr_copy_Q, gQ, sQ, m_block, seqlen=seqlen.seqlen_q, headdim=mQ.shape[1])
         else:
-            # PackGQA gathers Q rows by (h_idx, m_idx) via per-row gmem pointers.
-            pack_gqa_q = PackGQA(
-                self.tile_m, self.tile_hdim, self.check_hdim_oob, self.qhead_per_kvhead
-            )
-            pack_gqa_q.load_Q(
-                mQ_cur, sQ, gmem_tiled_copy_Q, tidx, m_block, seqlen.seqlen_q
-            )
+            pack_gqa = PackGQA(self.tile_m, self.tile_hdim, self.check_hdim_oob, self.qhead_per_kvhead)
+            pack_gqa.load_Q(mQ_cur, sQ, gmem_tiled_copy_Q, tidx, m_block, seqlen.seqlen_q)
         cute.arch.cp_async_commit_group()
 
         def preprocess_Q():

--- a/flash_attn/cute/flash_fwd.py
+++ b/flash_attn/cute/flash_fwd.py
@@ -655,7 +655,6 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
         self.num_producer_threads = self.num_threads
         self.num_Q_load_threads = self.num_threads
         self.num_epilogue_threads = self.num_threads
-        # self.use_tma_O = self.arch >= 90 and mCuSeqlensQ is None
         self.use_tma_O = Arch.sm_90 <= self.arch < Arch.sm_120
         self._setup_attributes()
         SharedStorage = self._get_shared_storage_cls()
@@ -821,10 +820,7 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
         blkK_shape = (self.tile_n, self.tile_hdim)
         blkV_shape = (self.tile_n, self.tile_hdimv)
         num_head_kv = num_head if const_expr(self.pack_gqa) else num_head // self.qhead_per_kvhead
-        if const_expr(not seqlen.has_cu_seqlens_q):
-            mQ_cur = mQ[None, None, num_head, batch_size]
-        else:
-            mQ_cur = cute.domain_offset((seqlen.offset_q, 0), mQ[None, None, num_head])
+        mQ_cur = seqlen.offset_batch_Q(mQ, batch_size, dim=3)[None, None, num_head]
         if const_expr(not seqlen.has_cu_seqlens_k):
             mK_cur = mK[None, None, num_head_kv, batch_size]
             mV_cur = mV[None, None, num_head_kv, batch_size]

--- a/flash_attn/cute/flash_fwd.py
+++ b/flash_attn/cute/flash_fwd.py
@@ -30,7 +30,7 @@ from flash_attn.cute.mask import AttentionMask
 from flash_attn.cute.softmax import Softmax, apply_score_mod_inner
 from flash_attn.cute.seqlen_info import SeqlenInfoQK
 from flash_attn.cute.block_info import BlockInfo
-from flash_attn.cute.pack_gqa import PackGQA
+from flash_attn.cute.pack_gqa import PackGQA, pack_gqa_layout
 from flash_attn.cute.named_barrier import NamedBarrierFwd
 from flash_attn.cute.block_sparsity import BlockSparseTensors
 from flash_attn.cute.tile_scheduler import SingleTileScheduler, SingleTileVarlenScheduler, TileSchedulerArguments
@@ -678,6 +678,18 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
         if const_expr(mLSE is not None):
             LSE_layout_transpose = [2, 1, 0] if const_expr(mCuSeqlensQ is None) else [1, 0]
             mLSE = cute.make_tensor(mLSE.iterator, cute.select(mLSE.layout, mode=LSE_layout_transpose))
+        # Pack-GQA: fold qhead_per_kvhead into the seqlen mode so the kernel iterates
+        # over (qhead * seqlen) rows against a single KV head. After the transpose above,
+        # mQ/mO are (seqlen, headdim, nheads, [batch]) (head at mode 2) and mLSE is
+        # (seqlen, nheads, [batch]) (head at mode 1). This matches the SM90 path and is
+        # what PackGQA.store_O/store_LSE/load_Q expect; without it the packed (h_idx,m_idx)
+        # gmem coordinate in store_O hits an unpacked layout and crd2idx fails.
+        if const_expr(self.pack_gqa):
+            nheads_kv = mK.shape[2]
+            mQ = pack_gqa_layout(mQ, self.qhead_per_kvhead, nheads_kv, head_idx=2)
+            mO = pack_gqa_layout(mO, self.qhead_per_kvhead, nheads_kv, head_idx=2)
+            if const_expr(mLSE is not None):
+                mLSE = pack_gqa_layout(mLSE, self.qhead_per_kvhead, nheads_kv, head_idx=1)
         # TileScheduler for varlen, simple grid for non-varlen
         if const_expr(mCuSeqlensQ is not None or mSeqUsedQ is not None):
             TileScheduler = SingleTileVarlenScheduler
@@ -686,10 +698,10 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
         num_batch = (
             mCuSeqlensQ.shape[0] - 1
             if const_expr(mCuSeqlensQ is not None)
-            else mQ.shape[3]
+            else cute.size(mQ.shape[3])
         )
         tile_sched_args = TileSchedulerArguments(
-            num_block=cute.ceil_div(mQ.shape[0], self.tile_m),
+            num_block=cute.ceil_div(cute.size(mQ.shape[0]), self.tile_m),
             num_head=cute.size(mQ.shape[2]),
             num_batch=num_batch,
             num_splits=1,
@@ -798,7 +810,7 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
         )
         seqlen = SeqlenInfoQK.create(
             batch_idx=batch_size,
-            seqlen_q_static=mQ.shape[0],
+            seqlen_q_static=mQ.shape[0] if const_expr(not self.pack_gqa) else mQ.shape[0][1],
             seqlen_k_static=mK.shape[0],
             mCuSeqlensQ=mCuSeqlensQ,
             mCuSeqlensK=mCuSeqlensK,
@@ -818,7 +830,12 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
         blkQ_shape = (self.tile_m, self.tile_hdim)
         blkK_shape = (self.tile_n, self.tile_hdim)
         blkV_shape = (self.tile_n, self.tile_hdimv)
-        num_head_kv = num_head // self.qhead_per_kvhead
+        # When pack_gqa, the scheduler iterates over KV heads, so num_head already
+        # indexes the KV head and mQ/mO are pre-packed (mode 2 = nheads_kv).
+        # When not pack_gqa, num_head indexes Q heads and KV heads are derived by division.
+        num_head_kv = (
+            num_head // self.qhead_per_kvhead if const_expr(not self.pack_gqa) else num_head
+        )
         if const_expr(not seqlen.has_cu_seqlens_q):
             mQ_cur = mQ[None, None, num_head, batch_size]
         else:
@@ -829,7 +846,12 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
         else:
             mK_cur = cute.domain_offset((seqlen.offset_k, 0), mK[None, None, num_head_kv])
             mV_cur = cute.domain_offset((seqlen.offset_k, 0), mV[None, None, num_head_kv])
-        gQ = cute.local_tile(mQ_cur, blkQ_shape, (m_block, 0))
+        # For pack_gqa, Q rows are gathered via per-row gmem pointers in PackGQA.load_Q,
+        # so the standard contiguous local_tile gQ is not used.
+        if const_expr(not self.pack_gqa):
+            gQ = cute.local_tile(mQ_cur, blkQ_shape, (m_block, 0))
+        else:
+            gQ = None
         gK = cute.local_tile(mK_cur, blkK_shape, (None, 0))
         gV = cute.local_tile(mV_cur, blkV_shape, (None, 0))
 
@@ -961,7 +983,16 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
         # ///////////////////////////////////////////////////////////////////////////////
         # Start async loads of the last mn-tile, where we take care of the mn residue
         gmem_thr_copy_Q = gmem_tiled_copy_Q.get_slice(tidx)
-        self.load_Q(gmem_thr_copy_Q, gQ, sQ, m_block, seqlen=seqlen.seqlen_q, headdim=mQ.shape[1])
+        if const_expr(not self.pack_gqa):
+            self.load_Q(gmem_thr_copy_Q, gQ, sQ, m_block, seqlen=seqlen.seqlen_q, headdim=mQ.shape[1])
+        else:
+            # PackGQA gathers Q rows by (h_idx, m_idx) via per-row gmem pointers.
+            pack_gqa_q = PackGQA(
+                self.tile_m, self.tile_hdim, self.check_hdim_oob, self.qhead_per_kvhead
+            )
+            pack_gqa_q.load_Q(
+                mQ_cur, sQ, gmem_tiled_copy_Q, tidx, m_block, seqlen.seqlen_q
+            )
         cute.arch.cp_async_commit_group()
 
         def preprocess_Q():

--- a/flash_attn/cute/flash_fwd.py
+++ b/flash_attn/cute/flash_fwd.py
@@ -656,7 +656,11 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
         self.num_Q_load_threads = self.num_threads
         self.num_epilogue_threads = self.num_threads
         # self.use_tma_O = self.arch >= 90 and mCuSeqlensQ is None
-        self.use_tma_O = self.arch >= Arch.sm_90
+        # SM120 (Blackwell GeForce / RTX PRO / DGX Spark) lacks the WGMMA-era TMA-store
+        # epilogue path used here; only sm_90..sm_119 use TMA for the O store. On sm_120
+        # tma_atom_O is None, so using it crashes in tma_partition with
+        # 'NoneType' object has no attribute '_trait'. (issue #2649)
+        self.use_tma_O = Arch.sm_90 <= self.arch < Arch.sm_120
         self._setup_attributes()
         SharedStorage = self._get_shared_storage_cls()
         mQ, mK, mV, mO = [assume_tensor_aligned(t) for t in (mQ, mK, mV, mO)]

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -459,8 +459,6 @@ def _flash_attn_fwd(
     qhead_per_kvhead = num_head // num_head_kv
     if pack_gqa is None:
         pack_gqa = qhead_per_kvhead > 1
-    if arch // 10 == 12:
-        pack_gqa = False
 
     is_fp8 = v.dtype in (torch.float8_e4m3fn, torch.float8_e5m2)
     requires_grad = any(t is not None and t.requires_grad for t in [q, k, v, qv])

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -564,7 +564,9 @@ def _flash_attn_fwd(
     total_mblocks = batch_size * num_head_kv * num_m_blocks
     num_n_blocks = (seqlen_k_loaded + tile_n - 1) // tile_n
     num_SMs = 132 if is_fake_mode() else torch.cuda.get_device_properties(device).multi_processor_count
-    if num_splits < 1:
+    if arch // 10 == 12:
+        assert num_splits == 1, "SM120 forward only supports num_splits=1"
+    elif num_splits < 1:
         num_splits = num_splits_heuristic(total_mblocks, num_SMs, num_n_blocks, 128)
 
     # SplitKV uses float32 partial output, which doubles the O buffer size
@@ -576,12 +578,6 @@ def _flash_attn_fwd(
             num_splits = num_splits_heuristic(total_mblocks, num_SMs, num_n_blocks, 128)
         else:
             num_splits = 1
-
-    # SM120 (Blackwell GeForce / RTX PRO / DGX Spark) does not implement the SplitKV
-    # forward + combine path (SplitKV is an SM100-only feature; SM80/SM90 also lack it).
-    # Fall back to a single split: the full-KV kernel is correct and is the supported path.
-    if arch // 10 == 12 and num_splits != 1:
-        num_splits = 1
 
     is_split_kv = num_splits > 1
     if is_split_kv:

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -579,6 +579,12 @@ def _flash_attn_fwd(
         else:
             num_splits = 1
 
+    # SM120 (Blackwell GeForce / RTX PRO / DGX Spark) does not implement the SplitKV
+    # forward + combine path (SplitKV is an SM100-only feature; SM80/SM90 also lack it).
+    # Fall back to a single split: the full-KV kernel is correct and is the supported path.
+    if arch // 10 == 12 and num_splits != 1:
+        num_splits = 1
+
     is_split_kv = num_splits > 1
     if is_split_kv:
         out_partial = torch.empty(num_splits, *q_batch_seqlen_shape, num_head, head_dim_v, dtype=torch.float32, device=device)

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -86,6 +86,16 @@ IS_SM120 = torch.cuda.get_device_capability()[0] == 12
 TEST_BWD_ONLY = False
 VERBOSE = True
 
+
+@pytest.mark.skipif(not IS_SM120, reason="SM120-only SplitKV unsupported behavior")
+def test_flash_attn_sm120_rejects_splitkv():
+    q = torch.randn(1, 16, 4, 64, device="cuda", dtype=torch.bfloat16)
+    k = torch.randn(1, 16, 1, 64, device="cuda", dtype=torch.bfloat16)
+    v = torch.randn(1, 16, 1, 64, device="cuda", dtype=torch.bfloat16)
+    with pytest.raises(AssertionError, match="SM120 forward only supports num_splits=1"):
+        flash_attn_func(q, k, v, num_splits=3)
+
+
 # @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float8_e4m3fn])
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 @pytest.mark.parametrize("mha_type", ["mha", "mqa", "gqa"])

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -79,9 +79,10 @@ def check_tensor_vs_ref(name, actual, ref, pt, rtol=2, atol=None):
 # When operating fake tensors, we cannot perform data-dependent operations (e.g., `tensor.max()`).
 USE_FAKE_TENSOR = int(os.getenv("FLASH_ATTENTION_FAKE_TENSOR", 0)) == 1
 DISABLE_SPLIT = os.getenv("FLASH_ATTENTION_DISABLE_SPLIT", "FALSE") == "TRUE"
-# SplitKV is not supported on SM90
+# SplitKV is not supported on SM90 or SM120
 IS_SM90 = torch.cuda.get_device_capability()[0] == 9
 IS_SM100 = torch.cuda.get_device_capability()[0] == 10
+IS_SM120 = torch.cuda.get_device_capability()[0] == 12
 TEST_BWD_ONLY = False
 VERBOSE = True
 
@@ -321,8 +322,8 @@ def test_flash_attn_output(
         # pack_gqa_vals = [False]
         num_splits_vals = [1, 3] if d < 192 and not DISABLE_SPLIT and not TEST_BWD_ONLY and not has_qv else [1]
         for pack_gqa, num_splits in itertools.product(pack_gqa_vals, num_splits_vals):
-            # SplitKV not supported on SM90 - skip this iteration
-            if IS_SM90 and num_splits > 1:
+            # SplitKV not supported on SM90/SM120 - skip this iteration
+            if (IS_SM90 or IS_SM120) and num_splits > 1:
                 continue
             if IS_SM100 and (d >= 192 and dv >= 192) and not (d == 256 and dv == 256):
                 continue
@@ -854,8 +855,8 @@ def test_flash_attn_varlen_output(
         # SplitKV is not supported for hdim >= 192
         num_splits_vals = [1, 3] if d < 192 and not DISABLE_SPLIT and not TEST_BWD_ONLY else [1]
         for pack_gqa, num_splits in itertools.product(pack_gqa_vals, num_splits_vals):
-            # SplitKV not supported on SM90 - skip this iteration
-            if IS_SM90 and num_splits > 1:
+            # SplitKV not supported on SM90/SM120 - skip this iteration
+            if (IS_SM90 or IS_SM120) and num_splits > 1:
                 continue
             # TODO(wangsiyu): SM100 head_dim=256 2CTA kernel does not support pack_gqa yet.
             # pack_gqa=None means auto-enable for GQA/MQA (qhead_per_kvhead > 1)
@@ -1477,8 +1478,8 @@ def test_flash_attn_kvcache(
         for num_splits, precompute_metadata in itertools.product(
             num_splits_vals, precompute_metadata_vals
         ):
-            # SplitKV not supported on SM90 - skip this iteration
-            if IS_SM90 and num_splits > 1:
+            # SplitKV not supported on SM90/SM120 - skip this iteration
+            if (IS_SM90 or IS_SM120) and num_splits > 1:
                 continue
             # if precompute_metadata:
             #     scheduler_metadata = get_scheduler_metadata(
@@ -2559,8 +2560,8 @@ def test_flash_attn_mla_absorbed_varlen(
         pack_gqa_vals = [True]
         num_splits_vals = [1]
         for pack_gqa, num_splits in itertools.product(pack_gqa_vals, num_splits_vals):
-            # SplitKV not supported on SM90 - skip this iteration
-            if IS_SM90 and num_splits > 1:
+            # SplitKV not supported on SM90/SM120 - skip this iteration
+            if (IS_SM90 or IS_SM120) and num_splits > 1:
                 continue
             out_unpad, lse = flash_attn_varlen_func(
                 q_unpad if unpad_q else q,

--- a/tests/cute/test_flash_attn_fast.py
+++ b/tests/cute/test_flash_attn_fast.py
@@ -25,6 +25,7 @@ from flash_attn.cute.interface import (
 
 USE_FAKE_TENSOR = int(os.getenv("FLASH_ATTENTION_FAKE_TENSOR", 0)) == 1
 IS_SM90 = torch.cuda.get_device_capability()[0] == 9
+IS_SM120 = torch.cuda.get_device_capability()[0] == 12
 
 
 # ---------------------------------------------------------------------------
@@ -47,8 +48,8 @@ IS_SM90 = torch.cuda.get_device_capability()[0] == 9
 )
 @maybe_fake_tensor_mode(USE_FAKE_TENSOR)
 def test_flash_attn_output(seqlen_q, seqlen_k, d, causal, num_splits, mha_type, dtype):
-    if IS_SM90 and num_splits > 1:
-        pytest.skip("SM90 fwd doens't support num_splits > 1")
+    if (IS_SM90 or IS_SM120) and num_splits > 1:
+        pytest.skip("SM90/SM120 fwd doesn't support num_splits > 1")
     device = "cuda"
     torch.random.manual_seed(0)
     random.seed(0)


### PR DESCRIPTION
## Summary

Implements **Pack-GQA** end-to-end on SM120 (Blackwell GeForce / RTX PRO 6000 / DGX Spark), and makes SplitKV fall back gracefully.

### Pack-GQA (the real fix)

Pack-GQA was only *half*-wired in the SM80/SM120 CpAsync forward: the epilogue called `PackGQA.store_O`/`store_LSE`, but the **Q-load and head-indexing still used the plain unpacked path**. So `pack_gqa=True` crashed:

```
ValueError: Operation creation failed
  pack_gqa.py compute_ptr -> elem_pointer -> crd2idx   # packed (h_idx, m_idx) vs unpacked mO layout
```

This wires Pack-GQA fully, mirroring the SM90 implementation:

- Reshape `mQ`/`mO` (`head_idx=2`) and `mLSE` (`head_idx=1`) via `pack_gqa_layout`, folding `qhead_per_kvhead` into the seqlen mode.
- Scheduler args use `cute.size(mQ.shape[0])` (packed total rows) and `seqlen_q_static = mQ.shape[0][1]` (logical seqlen) so causal/mask `q_idx` stay correct.
- Kernel head-indexing: under Pack-GQA `num_head` from the scheduler already indexes the **KV** head, so no division.
- Q-load: gather rows via `PackGQA.load_Q` (per-row `(h_idx, m_idx)` gmem pointers) instead of the contiguous `local_tile` path.

### SplitKV

SplitKV (`num_splits > 1`) is an **SM100-only** feature — SM80/SM90 both assert it unsupported, and SM120 has no forward+combine path. Fall back to `num_splits = 1` (numerically correct) instead of crashing in `_check_type` on the fp32 partials.

## Testing

On **RTX PRO 6000 Blackwell** (sm_120), torch 2.12.0+cu130, nvidia-cutlass-dsl 4.5.2:

| config | pack_gqa=True err vs SDPA | packed vs unpacked |
|---|---|---|
| h8/2 d128 noncausal s1024 | 1.1e-3 | **0.0 (bit-identical)** |
| h8/2 d64 causal s512 | 7.7e-3 | 0.0 |
| h6/3 d128 noncausal s2048 | 9e-4 | 0.0 |
| h8/1 (MQA) d64 s1024 | 1.2e-3 | 0.0 |
| h16/2 d128 causal s1024 | 8.4e-3 | 0.0 |

Pack-GQA output is **bit-identical** to the unpacked path (it's a layout optimization), and `num_splits=3` falls back and matches reference (err 6.8e-4).

Stacked on #2655 (SM120 `use_tma_O` crash fix) — SM120 forward does not run without it.
