### PR TITLE
[NVIDIA][CuTe,Fwd/Bwd,sm120] Attention dropout (#2436), forward + backward

### DIFF
--- a/flash_attn/cute/flash_bwd.py
+++ b/flash_attn/cute/flash_bwd.py
@@ -11,11 +11,12 @@ import cuda.bindings.driver as cuda
 import cutlass
 import cutlass.cute as cute
 from cutlass.cute.nvgpu import cpasync, warp
-from cutlass import Int32
+from cutlass import Int32, Int64
 import cutlass.utils as utils_basic
 
 from quack import layout_utils
 from flash_attn.cute import ampere_helpers as sm80_utils
+from flash_attn.cute import philox
 from flash_attn.cute.cute_dsl_utils import assume_tensor_aligned
 from flash_attn.cute import utils
 from flash_attn.cute.mask import AttentionMask
@@ -50,6 +51,7 @@ class FlashAttentionBackwardSm80:
         V_in_regs: bool = False,
         score_mod: cutlass.Constexpr | None = None,
         score_mod_bwd: cutlass.Constexpr | None = None,
+        dropout_p: float = 0.0,
     ):
         """Initializes the configuration for a flash attention v2 kernel.
 
@@ -97,6 +99,7 @@ class FlashAttentionBackwardSm80:
         self.share_QV_smem = V_in_regs
         self.score_mod = score_mod
         self.score_mod_bwd = score_mod_bwd
+        self.dropout_p = dropout_p
 
     @staticmethod
     def can_implement(
@@ -391,6 +394,8 @@ class FlashAttentionBackwardSm80:
         mdV_semaphore: Optional[cute.Tensor] = None,
         aux_data: AuxData = AuxData(),
         blocksparse_tensors: Optional[BlockSparseTensors] = None,
+        dropout_seed: Optional[Int64] = None,
+        dropout_offset: Optional[Int64] = None,
         # Always keep stream as the last parameter (EnvStream: obtained implicitly via TVM FFI).
         stream: cuda.CUstream = None,
     ):
@@ -482,6 +487,8 @@ class FlashAttentionBackwardSm80:
             tile_sched_params,
             TileScheduler,
             aux_data,
+            dropout_seed,
+            dropout_offset,
         ).launch(
             grid=grid_dim,
             block=[self.num_threads, 1, 1],
@@ -527,9 +534,15 @@ class FlashAttentionBackwardSm80:
         tile_sched_params: ParamsBase,
         TileScheduler: cutlass.Constexpr[Callable],
         aux_data: AuxData = AuxData(),
+        dropout_seed: Optional[Int64] = None,
+        dropout_offset: Optional[Int64] = None,
     ):
         # Thread index, block index
         tidx, _, _ = cute.arch.thread_idx()
+
+        # Stash dropout RNG state for compute_one_m_block (runtime SSA values).
+        self._dropout_seed = dropout_seed
+        self._dropout_offset = dropout_offset
 
         tile_scheduler = TileScheduler.create(tile_sched_params)
         work_tile = tile_scheduler.initial_work_tile_info()
@@ -837,6 +850,10 @@ class FlashAttentionBackwardSm80:
                 batch_idx=batch_idx, head_idx=head_idx,
                 mask_seqlen=True, mask_causal=self.is_causal
             )
+            dropout_fn = partial(
+                self.apply_dropout, n_block=n_block, batch_idx=batch_idx,
+                head_idx=head_idx, seqlen_info=seqlen, thr_mma_SdP=thr_mma_sdp,
+            )
             smem_pipe_read_q = cutlass.Int32(0)
             smem_pipe_read_do = cutlass.Int32(0)
             smem_pipe_write_q = cutlass.Int32(self.num_stages_Q - 1)
@@ -845,6 +862,7 @@ class FlashAttentionBackwardSm80:
                 compute_one_m_block(
                     m_tile, smem_pipe_read_q, smem_pipe_read_do, smem_pipe_write_q, smem_pipe_write_do,
                     mask_fn=mask_fn,
+                    dropout_fn=dropout_fn,
                 )
                 smem_pipe_read_q = self.advance_pipeline(smem_pipe_read_q, self.num_stages_Q)
                 smem_pipe_read_do = self.advance_pipeline(smem_pipe_read_do, self.num_stages_dO)
@@ -884,6 +902,7 @@ class FlashAttentionBackwardSm80:
         softmax_scale_log2: cutlass.Float32,
         aux_data: AuxData = AuxData(),
         mask_fn: Optional[Callable] = None,
+        dropout_fn: Optional[Callable] = None,
     ):
         def load_Q_next():
             m_block_next = m_block + (self.num_stages_Q - 1 if cutlass.const_expr(self.num_stages_Q > 1) else 1)
@@ -941,6 +960,12 @@ class FlashAttentionBackwardSm80:
         assert cute.size(acc_S_mn, mode=[0]) == cute.size(tLSErLSE)
         for r in cutlass.range(cute.size(acc_S_mn, mode=[0]), unroll_full=True):
             acc_S_mn[r, None].store(cute.math.exp2(acc_S_mn[r, None].load() * softmax_scale_log2 - tLSErLSE[r], fastmath=True))
+        # Dropout: regenerate the IDENTICAL keep-mask used in the forward pass and
+        # apply it to the recomputed P (zero dropped positions, scale kept by 1/(1-p)).
+        # Zeroing P here automatically zeroes the dV and dS contributions of dropped
+        # entries, matching the forward where those entries did not contribute to O.
+        if cutlass.const_expr(self.dropout_p > 0.0):
+            dropout_fn(acc_S, m_block=m_block)
         # if cute.arch.thread_idx()[0] == 0 and cute.arch.block_idx()[0] == bidx: cute.print_tensor(acc_S_mn)
 
         # MMA dP
@@ -1054,6 +1079,41 @@ class FlashAttentionBackwardSm80:
         if cutlass.const_expr(self.num_stages_Q == 1):
             cute.arch.barrier()
             dQ_mma(load_Q_next)
+
+    @cute.jit
+    def apply_dropout(
+        self,
+        acc_S: cute.Tensor,
+        thr_mma_SdP: cute.ThrMma,
+        batch_idx,
+        head_idx,
+        m_block,
+        n_block,
+        seqlen_info: SeqlenInfoQK,
+    ):
+        """Regenerate the forward dropout keep-mask on the recomputed P and apply it.
+
+        Must produce the IDENTICAL mask as the forward pass: keyed by global
+        (batch, head, q_idx, kv_idx). The bwd S tile is (n, m) transposed when
+        SdP_swapAB, so the identity tensor coords are swapped accordingly and we
+        pass q_idx/kv_idx in the correct order to the shared applicator.
+        """
+        acc_shape = (self.m_block_size, self.n_block_size)
+        cS = cute.make_identity_tensor(acc_shape if not self.SdP_swapAB else acc_shape[::-1])
+        offset = (m_block * self.m_block_size, n_block * self.n_block_size)
+        cS = cute.domain_offset(offset if not self.SdP_swapAB else offset[::-1], cS)
+        tScS = thr_mma_SdP.partition_C(cS)
+        p_keep = cutlass.Float32(1.0 - self.dropout_p)
+        scale = cutlass.Float32(1.0 / (1.0 - self.dropout_p))
+        philox.apply_dropout(
+            acc_S, tScS,
+            self._dropout_seed, self._dropout_offset,
+            p_keep, scale,
+            batch_idx, head_idx,
+            num_heads=1,
+            seqlen_k=seqlen_info.seqlen_k,
+            transpose_indices=self.SdP_swapAB,
+        )
 
     @cute.jit
     def epilogue(

--- a/flash_attn/cute/flash_bwd.py
+++ b/flash_attn/cute/flash_bwd.py
@@ -436,7 +436,16 @@ class FlashAttentionBackwardSm80:
         tile_sched_params = TileScheduler.to_underlying_arguments(tile_sched_args)
         grid_dim = TileScheduler.get_grid_shape(tile_sched_params)
 
-        softmax_scale_log2, softmax_scale = utils.compute_softmax_scale_log2(softmax_scale, self.score_mod)
+        # NB: keep softmax_scale as a real Float32 (do NOT null it via
+        # compute_softmax_scale_log2): the backward uses softmax_scale to rescale dK
+        # (acc_dK *= softmax_scale when qhead_per_kvhead == 1), and the kernel arg is
+        # typed Float32, so a None would crash at launch. Fold log2(e) separately.
+        LOG2_E = math.log2(math.e)
+        if cutlass.const_expr(self.score_mod is None):
+            softmax_scale_log2 = softmax_scale * LOG2_E
+        else:
+            # score_mod is applied to S * softmax_scale, then use the change-of-base only.
+            softmax_scale_log2 = LOG2_E
         self.kernel(
             mQ,
             mK,

--- a/flash_attn/cute/flash_bwd.py
+++ b/flash_attn/cute/flash_bwd.py
@@ -436,7 +436,17 @@ class FlashAttentionBackwardSm80:
         tile_sched_params = TileScheduler.to_underlying_arguments(tile_sched_args)
         grid_dim = TileScheduler.get_grid_shape(tile_sched_params)
 
-        softmax_scale_log2, softmax_scale = utils.compute_softmax_scale_log2(softmax_scale, self.score_mod)
+        # NB: keep softmax_scale as a real Float32 (do NOT null it via
+        # compute_softmax_scale_log2): the backward uses softmax_scale to rescale dK
+        # (acc_dK *= softmax_scale when qhead_per_kvhead == 1), and the kernel arg is
+        # typed Float32, so a None would crash at launch. Fold log2(e) separately,
+        # matching the SM100 backward.
+        LOG2_E = math.log2(math.e)
+        if cutlass.const_expr(self.score_mod is None):
+            softmax_scale_log2 = softmax_scale * LOG2_E
+        else:
+            # score_mod is applied to S * softmax_scale, then use the change-of-base only.
+            softmax_scale_log2 = LOG2_E
         self.kernel(
             mQ,
             mK,

--- a/flash_attn/cute/flash_fwd.py
+++ b/flash_attn/cute/flash_fwd.py
@@ -14,7 +14,7 @@ import cuda.bindings.driver as cuda
 
 import cutlass
 import cutlass.cute as cute
-from cutlass import Float32, Int32, const_expr
+from cutlass import Float32, Int32, Int64, const_expr
 from cutlass.cute.nvgpu import cpasync, warp
 import cutlass.utils as utils_basic
 from cutlass.base_dsl.arch import Arch
@@ -30,7 +30,8 @@ from flash_attn.cute.mask import AttentionMask
 from flash_attn.cute.softmax import Softmax, apply_score_mod_inner
 from flash_attn.cute.seqlen_info import SeqlenInfoQK
 from flash_attn.cute.block_info import BlockInfo
-from flash_attn.cute.pack_gqa import PackGQA
+from flash_attn.cute.pack_gqa import PackGQA, pack_gqa_layout
+from flash_attn.cute import philox
 from flash_attn.cute.named_barrier import NamedBarrierFwd
 from flash_attn.cute.block_sparsity import BlockSparseTensors
 from flash_attn.cute.tile_scheduler import SingleTileScheduler, SingleTileVarlenScheduler, TileSchedulerArguments
@@ -57,6 +58,7 @@ class FlashAttentionForwardBase:
         mask_mod: Optional[cutlass.Constexpr] = None,
         has_aux_tensors: bool = False,
         q_subtile_factor: int = 1,
+        dropout_p: float = 0.0,
     ):
         """Initializes the configuration for a flash attention kernel.
 
@@ -99,6 +101,7 @@ class FlashAttentionForwardBase:
         self.Q_in_regs = Q_in_regs
         self.score_mod = score_mod
         self.mask_mod = mask_mod
+        self.dropout_p = dropout_p
         self.qk_acc_dtype = Float32
         self.score_vec_size: cutlass.Constexpr = getattr(
             score_mod, "__vec_size__", 1 if cutlass.const_expr(has_aux_tensors) else 2
@@ -638,6 +641,8 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
         learnable_sink: Optional[cute.Tensor] = None,
         blocksparse_tensors: Optional[BlockSparseTensors] = None,
         aux_data: AuxData = AuxData(),
+        dropout_seed: Optional[Int64] = None,
+        dropout_offset: Optional[Int64] = None,
         # Always keep stream as the last parameter (EnvStream: obtained implicitly via TVM FFI).
         stream: cuda.CUstream = None,
     ):
@@ -739,6 +744,8 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
             TileScheduler,
             aux_data,
             fastdiv_mods,
+            dropout_seed,
+            dropout_offset,
         ).launch(
             grid=grid_dim,
             block=[self.num_threads, 1, 1],
@@ -778,9 +785,15 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
         TileScheduler: cutlass.Constexpr[Callable],
         aux_data: AuxData = AuxData(),
         fastdiv_mods=None,
+        dropout_seed: Optional[Int64] = None,
+        dropout_offset: Optional[Int64] = None,
     ):
         # Thread index, block index
         tidx, _, _ = cute.arch.thread_idx()
+
+        # Stash dropout RNG state for compute_one_n_block (runtime SSA values).
+        self._dropout_seed = dropout_seed
+        self._dropout_offset = dropout_offset
 
         tile_scheduler = TileScheduler.create(tile_sched_params)
         work_tile = tile_scheduler.initial_work_tile_info()
@@ -1177,6 +1190,16 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
             mask_fn(acc_S, n_block=n_block)
         row_scale = softmax.online_softmax(acc_S, is_first=is_first_n_block, check_inf=check_inf)
         softmax.rescale_O(mma_params.acc_O, row_scale)
+        if const_expr(self.dropout_p > 0.0):
+            self.apply_dropout(
+                mma_params.thr_mma_qk,
+                batch_idx,
+                head_idx,
+                m_block,
+                acc_S,
+                n_block,
+                seqlen=seqlen,
+            )
         rP = cute.make_fragment_like(acc_S, self.dtype)
         rP.store(acc_S.load().to(self.dtype))
         tOrP = layout_utils.reshape_acc_to_frgA(rP)
@@ -1229,6 +1252,38 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
             seqlen_info=seqlen,
             constant_q_idx=None,
             qhead_per_kvhead=self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
+        )
+
+    @cute.jit
+    def apply_dropout(
+        self,
+        thr_mma_qk,
+        batch_idx,
+        head_idx,
+        m_block,
+        acc_S,
+        n_block,
+        seqlen,
+    ):
+        # Build the same global (q_idx, kv_idx) identity coords used by mask/score_mod,
+        # so the forward and the backward recompute draw the IDENTICAL keep-mask.
+        cS = cute.make_identity_tensor((self.tile_m, self.tile_n))
+        cS = cute.domain_offset((m_block * self.tile_m, n_block * self.tile_n), cS)
+        tScS = thr_mma_qk.partition_C(cS)
+        p_keep = Float32(1.0 - self.dropout_p)
+        scale = Float32(1.0 / (1.0 - self.dropout_p))
+        philox.apply_dropout(
+            acc_S,
+            tScS,
+            self._dropout_seed,
+            self._dropout_offset,
+            p_keep,
+            scale,
+            batch_idx,
+            head_idx,
+            num_heads=1,
+            seqlen_k=seqlen.seqlen_k,
+            transpose_indices=False,
         )
 
 

--- a/flash_attn/cute/flash_fwd.py
+++ b/flash_attn/cute/flash_fwd.py
@@ -656,7 +656,11 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
         self.num_Q_load_threads = self.num_threads
         self.num_epilogue_threads = self.num_threads
         # self.use_tma_O = self.arch >= 90 and mCuSeqlensQ is None
-        self.use_tma_O = self.arch >= Arch.sm_90
+        # SM120 (Blackwell GeForce / RTX PRO / DGX Spark) lacks the WGMMA-era TMA-store
+        # epilogue path used here; only sm_90..sm_119 use TMA for the O store. On sm_120
+        # tma_atom_O is None, so using it crashes in tma_partition with
+        # 'NoneType' object has no attribute '_trait'. (issue #2649)
+        self.use_tma_O = Arch.sm_90 <= self.arch < Arch.sm_120
         self._setup_attributes()
         SharedStorage = self._get_shared_storage_cls()
         mQ, mK, mV, mO = [assume_tensor_aligned(t) for t in (mQ, mK, mV, mO)]

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -332,6 +332,9 @@ def _flash_attn_fwd(
     k_descale: Optional[torch.Tensor] = None,
     v_descale: Optional[torch.Tensor] = None,
     gather_kv_indices: Optional[torch.Tensor] = None,
+    dropout_p: float = 0.0,
+    dropout_seed: Optional[int] = None,
+    dropout_offset: int = 0,
 ) -> Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor]]:
     """Forward pass for FlashAttention.
 
@@ -761,6 +764,7 @@ def _flash_attn_fwd(
         gather_kv_length,
         sparse_kv,
         disable_sparse_kv_bitmask,
+        dropout_p > 0.0,
         fa_logging.get_fa_log_level(),
     )
 
@@ -971,6 +975,7 @@ def _flash_attn_fwd(
                 score_mod=score_mod,
                 mask_mod=mask_mod,
                 has_aux_tensors=aux_tensors is not None,
+                dropout_p=dropout_p,
             )
         else:
             raise ValueError(
@@ -1024,6 +1029,17 @@ def _flash_attn_fwd(
                 sparse_tensors,
                 AuxData(cute_aux_tensors, aux_scalars),
             ])
+            # SM120 forward __call__ takes (dropout_seed, dropout_offset) before stream.
+            if arch // 10 == 12:
+                if dropout_p > 0.0:
+                    _seed = dropout_seed if dropout_seed is not None else int(
+                        torch.randint(0, 2**62, (1,), dtype=torch.int64).item()
+                    )
+                    compile_args.append(cutlass.Int64(_seed))
+                    compile_args.append(cutlass.Int64(dropout_offset))
+                else:
+                    compile_args.append(cutlass.Int64(0))
+                    compile_args.append(cutlass.Int64(0))
             compile_args.append(current_stream)
             _flash_attn_fwd.compile_cache[compile_key] = cute.compile(
                 *compile_args, options="--enable-tvm-ffi"
@@ -1099,6 +1115,16 @@ def _flash_attn_fwd(
                 else None,
                 AuxData(aux_tensors, aux_scalars),
             ])
+            if arch // 10 == 12:
+                if dropout_p > 0.0:
+                    _seed_rt = dropout_seed if dropout_seed is not None else int(
+                        torch.randint(0, 2**62, (1,), dtype=torch.int64).item()
+                    )
+                    call_args.append(cutlass.Int64(_seed_rt))
+                    call_args.append(cutlass.Int64(dropout_offset))
+                else:
+                    call_args.append(cutlass.Int64(0))
+                    call_args.append(cutlass.Int64(0))
             _flash_attn_fwd.compile_cache[compile_key](*call_args)
     if is_split_kv:
         _flash_attn_fwd_combine(
@@ -1344,6 +1370,9 @@ def _flash_attn_bwd(
     aux_scalars: Optional[tuple] = None,
     block_sparse_tensors: Optional[BlockSparseTensorsTorch] = None,
     dlse: Optional[torch.Tensor] = None,
+    dropout_p: float = 0.0,
+    dropout_seed: Optional[int] = None,
+    dropout_offset: int = 0,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     aux_scalars = tuple(aux_scalars) if aux_scalars else None
     arch = _get_device_arch()
@@ -1739,6 +1768,7 @@ def _flash_attn_bwd(
             # Prevent TVM stride poisoning when only one block is present.
             (seqlen_q_rounded // m_block_size == 1),
             (seqlen_k_rounded // n_block_size == 1),
+            dropout_p > 0.0,
         )
     else:
         compile_key = (
@@ -1820,6 +1850,7 @@ def _flash_attn_bwd(
                 V_in_regs=V_in_regs,
                 score_mod=score_mod,
                 score_mod_bwd=score_mod_bwd,
+                dropout_p=dropout_p,
             )
         elif arch // 10 == 9:
             fa_bwd_obj = FlashAttentionBackwardSm90(
@@ -1915,7 +1946,7 @@ def _flash_attn_bwd(
         dq_accum_tensor = dq_tensor if use_dedicated_hd256_kernel else dq_accum_tensor
 
         # TODO: check @can_implement
-        _flash_attn_bwd.compile_cache[compile_key] = cute.compile(
+        _bwd_compile_args = [
             fa_bwd_obj,
             q_tensor,
             k_tensor,
@@ -1938,12 +1969,24 @@ def _flash_attn_bwd(
             dV_semaphore_tensor,
             AuxData(cute_aux_tensors, aux_scalars),
             sparse_tensors_compile,
-            current_stream,
+        ]
+        # SM120 backward __call__ takes (dropout_seed, dropout_offset) before stream.
+        if arch // 10 == 12:
+            if dropout_p > 0.0:
+                _bseed = dropout_seed if dropout_seed is not None else 0
+                _bwd_compile_args.append(cutlass.Int64(_bseed))
+                _bwd_compile_args.append(cutlass.Int64(dropout_offset))
+            else:
+                _bwd_compile_args.append(cutlass.Int64(0))
+                _bwd_compile_args.append(cutlass.Int64(0))
+        _bwd_compile_args.append(current_stream)
+        _flash_attn_bwd.compile_cache[compile_key] = cute.compile(
+            *_bwd_compile_args,
             options="--enable-tvm-ffi",
         )
     if not is_fake_mode():
         dq_accum = dq if use_dedicated_hd256_kernel else dq_accum
-        _flash_attn_bwd.compile_cache[compile_key](
+        _bwd_call_args = [
             q.detach(),
             k.detach(),
             v.detach(),
@@ -1976,7 +2019,16 @@ def _flash_attn_bwd(
             )
             if normalized_block_sparse_tensors is not None
             else None,
-        )
+        ]
+        if arch // 10 == 12:
+            if dropout_p > 0.0:
+                _bseed_rt = dropout_seed if dropout_seed is not None else 0
+                _bwd_call_args.append(cutlass.Int64(_bseed_rt))
+                _bwd_call_args.append(cutlass.Int64(dropout_offset))
+            else:
+                _bwd_call_args.append(cutlass.Int64(0))
+                _bwd_call_args.append(cutlass.Int64(0))
+        _flash_attn_bwd.compile_cache[compile_key](*_bwd_call_args)
     # Postprocess: convert dq_accum from float32 to dq in bf16/fp16
     # hd=256 2CTA backward has its own internal postprocess, skip here.
     if not use_dedicated_hd256_kernel:
@@ -2461,6 +2513,7 @@ class FlashAttnFunc(torch.autograd.Function):
         block_sparse_tensors: Optional[BlockSparseTensorsTorch] = None,
         block_sparse_tensors_bwd: Optional[BlockSparseTensorsTorch] = None,
         return_lse: bool = False,
+        dropout_p: float = 0.0,
     ):
         aux_scalars = tuple(aux_scalars) if aux_scalars else None
         shared_kv = k is v
@@ -2470,6 +2523,11 @@ class FlashAttnFunc(torch.autograd.Function):
             # by setting q, k to None
             qv = q if qv is None else qv
             q = k = None
+        # One RNG seed generated in the forward and reused in the backward so both
+        # regenerate the IDENTICAL dropout keep-mask.
+        dropout_seed = None
+        if dropout_p > 0.0:
+            dropout_seed = int(torch.randint(0, 2**62, (1,), dtype=torch.int64).item())
         out, lse, p, row_max = _flash_attn_fwd(
             q,
             k,
@@ -2490,6 +2548,9 @@ class FlashAttnFunc(torch.autograd.Function):
             block_sparse_tensors=block_sparse_tensors,
             return_lse=return_lse,
             gather_kv_indices=gather_kv_indices,
+            dropout_p=dropout_p,
+            dropout_seed=dropout_seed,
+            dropout_offset=0,
         )
         ctx.save_for_backward(q, k, v, qv, out, lse, p, row_max, gather_kv_indices, *(aux_tensors or ()))
         ctx.shared_kv = shared_kv
@@ -2504,6 +2565,8 @@ class FlashAttnFunc(torch.autograd.Function):
         ctx.mask_mod = mask_mod
         ctx.aux_scalars = aux_scalars
         ctx.block_sparse_tensors_bwd = block_sparse_tensors_bwd
+        ctx.dropout_p = dropout_p
+        ctx.dropout_seed = dropout_seed
         ctx.set_materialize_grads(False)
         return out, lse
 
@@ -2555,6 +2618,9 @@ class FlashAttnFunc(torch.autograd.Function):
                 aux_scalars=ctx.aux_scalars,
                 block_sparse_tensors=ctx.block_sparse_tensors_bwd,
                 dlse=dlse,
+                dropout_p=ctx.dropout_p,
+                dropout_seed=ctx.dropout_seed,
+                dropout_offset=0,
             )
             return dq, dk, dv, *((None,) * 30)  # Extra Nones is fine
 
@@ -2748,6 +2814,7 @@ def flash_attn_func(
     block_sparse_tensors: Optional[BlockSparseTensorsTorch] = None,
     block_sparse_tensors_bwd: Optional[BlockSparseTensorsTorch] = None,
     return_lse: bool = False,
+    dropout_p: float = 0.0,
 ):
     return FlashAttnFunc.apply(
         q,
@@ -2771,6 +2838,7 @@ def flash_attn_func(
         block_sparse_tensors,
         block_sparse_tensors_bwd,
         return_lse,
+        dropout_p,
     )
 
 

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -1380,6 +1380,7 @@ def _flash_attn_bwd(
         cluster_size = 1
         use_2cta_instrs = False
         num_threads = 128
+        dQ_single_wg = False  # SM120 single-warpgroup dQ; was undefined in the compile key.
         assert not (block_sparse_tensors is not None), "Block sparsity backward not supported on SM 12.0"
         assert score_mod is None and score_mod_bwd is None, "score_mod backward not supported on SM 12.0"
         assert mask_mod is None, "mask_mod backward not supported on SM 12.0"

--- a/flash_attn/cute/philox.py
+++ b/flash_attn/cute/philox.py
@@ -1,0 +1,114 @@
+# Copyright (c) 2025, Tri Dao.
+# Philox4x32 counter-based RNG + dropout helpers for FA4 CuTe-DSL kernels.
+#
+# Bit-exact with csrc/flash_attn/src/philox.cuh (6 loop rounds + 1 final round)
+# and csrc/flash_attn/src/dropout.h indexing. Used to apply dropout to the
+# attention probabilities P after softmax (forward) and to regenerate the
+# identical keep-mask during the backward pass.
+
+import cutlass
+import cutlass.cute as cute
+from cutlass import Int32, Int64, Float32, const_expr
+
+PHILOX_A = 0xD2511F53
+PHILOX_B = 0xCD9E8D57
+PHILOX_W0 = 0x9E3779B9
+PHILOX_W1 = 0xBB67AE85
+
+
+@cute.jit
+def _mulhi_u32(a: Int32, b: Int32) -> Int32:
+    """High 32 bits of the UNSIGNED 32x32 product (int32 is signed in the DSL)."""
+    a64 = a.to(Int64) & Int64(0xFFFFFFFF)
+    b64 = b.to(Int64) & Int64(0xFFFFFFFF)
+    return ((a64 * b64) >> 32).to(Int32)
+
+
+@cute.jit
+def philox_4x32(seed: Int64, subsequence: Int64, offset: Int64):
+    """Return a 4-tuple of uint32 (as Int32) random words: philox(seed, subsequence, offset).
+
+    Matches the 7-round (6 loop + 1 final) Philox in philox.cuh exactly.
+    """
+    k0 = (seed & Int64(0xFFFFFFFF)).to(Int32)
+    k1 = ((seed >> 32) & Int64(0xFFFFFFFF)).to(Int32)
+    c0 = (offset & Int64(0xFFFFFFFF)).to(Int32)
+    c1 = ((offset >> 32) & Int64(0xFFFFFFFF)).to(Int32)
+    c2 = (subsequence & Int64(0xFFFFFFFF)).to(Int32)
+    c3 = ((subsequence >> 32) & Int64(0xFFFFFFFF)).to(Int32)
+    for _ in cutlass.range_constexpr(6):
+        hi0 = _mulhi_u32(Int32(PHILOX_A), c0)
+        lo0 = Int32(PHILOX_A) * c0
+        hi1 = _mulhi_u32(Int32(PHILOX_B), c2)
+        lo1 = Int32(PHILOX_B) * c2
+        c0, c1, c2, c3 = hi1 ^ c1 ^ k0, lo1, hi0 ^ c3 ^ k1, lo0
+        k0 = k0 + Int32(PHILOX_W0)
+        k1 = k1 + Int32(PHILOX_W1)
+    hi0 = _mulhi_u32(Int32(PHILOX_A), c0)
+    lo0 = Int32(PHILOX_A) * c0
+    hi1 = _mulhi_u32(Int32(PHILOX_B), c2)
+    lo1 = Int32(PHILOX_B) * c2
+    return hi1 ^ c1 ^ k0, lo1, hi0 ^ c3 ^ k1, lo0
+
+
+@cute.jit
+def uniform_from_uint32(x: Int32) -> Float32:
+    """Map a uint32 to a Float32 in [0, 1) (24-bit mantissa, like curand_uniform)."""
+    # take top 24 bits -> [0, 2^24) -> scale by 2^-24
+    u = (x.to(Int64) & Int64(0xFFFFFFFF))
+    top = (u >> 8).to(Int32)  # 24 bits
+    return top.to(Float32) * Float32(1.0 / 16777216.0)
+
+
+@cute.jit
+def keep_threshold_u32(p_keep: Float32) -> Int32:
+    """uint32 threshold: keep a draw if (uint32 >> 8) < round(p_keep * 2^24).
+
+    Using the same 24-bit space as uniform_from_uint32 so the test is
+    `uniform < p_keep`.
+    """
+    thr = cute.math.floor(p_keep * Float32(16777216.0))
+    return thr.to(Int32)
+
+
+@cute.jit
+def apply_dropout(
+    acc_S: cute.Tensor,        # post-softmax probabilities P (will be modified in-place)
+    tScS: cute.Tensor,         # identity tensor: tScS[i] = (q_idx, kv_idx) global coords
+    seed: Int64,
+    offset: Int64,
+    p_keep: Float32,           # 1 - dropout_p
+    scale: Float32,            # 1 / (1 - dropout_p)
+    batch_idx: Int32,
+    head_idx: Int32,
+    num_heads: cutlass.Constexpr[int],
+    seqlen_k: Int32,
+    transpose_indices: cutlass.Constexpr[bool] = False,
+):
+    """Apply inverted dropout to P in-place, keyed by global (batch, head, q_idx, kv_idx).
+
+    Layout-agnostic: each element's RNG draw is determined solely by its global
+    coordinates, so the forward pass and the backward recompute generate the
+    IDENTICAL keep-mask regardless of fragment layout. When ``transpose_indices``
+    is set (backward SdP_swapAB), tScS[i] holds (kv_idx, q_idx) instead of
+    (q_idx, kv_idx), so we swap accordingly.
+    """
+    n_vals = cutlass.const_expr(cute.size(acc_S.shape))
+    bh = batch_idx * Int32(num_heads) + head_idx
+    if cutlass.const_expr(transpose_indices):
+        q_pos = cutlass.const_expr(1)
+        kv_pos = cutlass.const_expr(0)
+    else:
+        q_pos = cutlass.const_expr(0)
+        kv_pos = cutlass.const_expr(1)
+    for i in cutlass.range(n_vals, unroll_full=True):
+        q_idx = tScS[i][q_pos]
+        kv_idx = tScS[i][kv_pos]
+        # Global linear element id within this (batch, head) plane.
+        lin = q_idx.to(Int64) * seqlen_k.to(Int64) + kv_idx.to(Int64)
+        subseq = bh.to(Int64)
+        r0, r1, r2, r3 = philox_4x32(seed, subseq, offset + lin)
+        u = uniform_from_uint32(r0)  # [0, 1)
+        keep = u < p_keep
+        acc_S[i] = acc_S[i] * scale if keep else Float32(0.0)
+

--- a/flash_attn/cute/utils.py
+++ b/flash_attn/cute/utils.py
@@ -472,9 +472,16 @@ def atomic_add_fp32(a: float | Float32, gmem_ptr: cute.Pointer, *, loc=None, ip=
     #     is_align_stack=False,
     #     asm_dialect=llvm.AsmDialect.AD_ATT,
     # )
-    nvvm.atomicrmw(
-        res=T.f32(), op=nvvm.AtomicOpKind.FADD, ptr=gmem_ptr.llvm_ptr, a=Float32(a).ir_value()
-    )
+    # The nvvm.atomicrmw binding signature differs across CUTLASS-DSL CUDA toolkit
+    # builds: cu12.x takes (res=, op=, ptr=, a=) while cu13 takes positional
+    # (op, ptr, a) with the result type inferred (no res= kwarg). Support both.
+    _a = Float32(a).ir_value()
+    try:
+        nvvm.atomicrmw(nvvm.AtomicOpKind.FADD, gmem_ptr.llvm_ptr, _a)
+    except TypeError:
+        nvvm.atomicrmw(
+            res=T.f32(), op=nvvm.AtomicOpKind.FADD, ptr=gmem_ptr.llvm_ptr, a=_a
+        )
 
 
 @dsl_user_op


### PR DESCRIPTION
## Summary

Implements **attention dropout (#2436) for the CuTe-DSL forward AND backward** on SM120 (Blackwell GeForce / RTX PRO 6000 / DGX Spark), self-contained on upstream `main`.

This PR is **complete and standalone**: it also carries the two SM120 prerequisites the dropout backward needs to run at all (so it works on a clean `main` checkout without depending on any other open PR). The `use_tma_O` fix is also submitted separately as #2655; reviewers can take it from either place.

## Commits

1. **SM120 `use_tma_O` crash fix (#2649)** — SM120 forward crashed in `tma_partition` (TMA O-store atom is null on SM120). Restrict TMA O-store to sm_90..sm_119.
2. **SM120 backward enablement** — two bugs prevented the SM120 backward from running:
   - `dQ_single_wg` was referenced in the bwd compile key but never defined in the SM120 branch (`UnboundLocalError`).
   - `__call__` used `compute_softmax_scale_log2()`, which returns `softmax_scale=None` when `score_mod is None`; but the kernel arg is typed `Float32` and the backward rescales `dK` by `softmax_scale`, so launch crashed (`None to Float`). Compute `softmax_scale_log2` inline (fold `LOG2_E`) and keep `softmax_scale` a real `Float32`, matching the SM100 backward.
   - Also make `utils.atomic_add_fp32` robust to the `nvvm.atomicrmw` binding signature across nvidia-cutlass-dsl CUDA-toolkit builds (cu12.x `res=/op=/ptr=/a=` vs cu13 positional).
3. **Dropout (#2436), forward + backward**:
   - `philox.py`: Philox4x32 counter-based RNG + `apply_dropout()`, keyed by **global** `(batch, head, q_idx, kv_idx)` so forward and the backward recompute draw the **identical** keep-mask regardless of fragment layout (backward `S` is transposed under `SdP_swapAB`; handled).
   - Forward: inverted dropout (zero dropped, scale kept by `1/(1-p)`) on `P` after `online_softmax`. One RNG seed per call, reused in backward via `ctx`.
   - Backward: regenerate the same mask on recomputed `P`; zeroing dropped `P` zeroes the `dV`/`dS` contributions, matching the forward.

## Testing (RTX PRO 6000 Blackwell, sm_120, torch 2.12.0+cu130, cutlass-dsl 4.5.2)

- `dropout_p=0` matches PyTorch SDPA (max err <= 9e-3 bf16) with finite grads — no-op default, no regression.
- Backward now runs and matches a PyTorch fp32 reference: `|dq/dk/dv - ref| <= 1.3e-2` (hdim 64/96/128, causal & non-causal).
- Dropout changes the output and keeps grads finite; forward+backward are **deterministic for a fixed seed**.
- Forward keep-fraction **0.702** vs 0.70 target, with exact inverted scaling `1/S/(1-p)` (measured 0.02234 vs 0.02232) — statistically correct, unbiased.

## API

`flash_attn_func(..., dropout_p=0.0)`. Seed is managed internally (drawn in forward, reused in backward).
