### PR TITLE
[cute] Fix int32 overflow in SM100 LPT tile scheduler for long context

### DIFF
--- a/flash_attn/cute/tile_scheduler.py
+++ b/flash_attn/cute/tile_scheduler.py
@@ -423,7 +423,9 @@ class SingleTileLPTScheduler:
             assert scheduling_mode in (SchedulingMode.STATIC, SchedulingMode.CLC), (
                 f"Only STATIC and CLC are supported, got {scheduling_mode!r}"
             )
-            size_one_kv_head = args.seqlen_k * (args.headdim + args.headdim_v) * args.element_size
+            # int64: this product overflows int32 once seqlen_k * (headdim +
+            # headdim_v) * element_size > 2**31 (seqlen_k > ~4M for hdim-128 bf16).
+            size_one_kv_head = cutlass.Int64(args.seqlen_k) * (args.headdim + args.headdim_v) * args.element_size
             size_one_head = size_one_kv_head
             size_l2 = 50 * 1024 * 1024  # 40 MB for K & V
             # Swizzle is the size of each "section". Round swizzle to a power of 2
@@ -431,7 +433,7 @@ class SingleTileLPTScheduler:
             # swizzle is how many heads can fit in L2
             # Seems faster if swizzle is a power of 2
             log2_floor = lambda n: 31 - clz(n)
-            swizzle = 1 if size_l2 < size_one_head else (1 << log2_floor(size_l2 // size_one_head))
+            swizzle = 1 if size_l2 < size_one_head else (1 << log2_floor(Int32(size_l2 // size_one_head)))
             # If we're in the last section (called residual), we don't want to divide by
             # swizzle. Instead we want to divide by the remainder.
             num_hb_quotient = (args.num_head * args.num_batch) // swizzle
@@ -654,12 +656,14 @@ class SingleTileLPTBwdScheduler:
             args: TileSchedulerArguments, *, loc=None, ip=None
         ) -> "SingleTileLPTBwdScheduler.Params":
             size_l2 = 50 * 1024 * 1024
-            size_one_qdo_head = args.seqlen_k * (args.headdim + args.headdim_v) * args.element_size
-            size_one_dqaccum_head = args.seqlen_k * (args.headdim) * 4
+            # int64: these products overflow int32 at large seqlen_k (> ~4M for
+            # hdim-128 bf16; the dqaccum *4 term wraps even sooner).
+            size_one_qdo_head = cutlass.Int64(args.seqlen_k) * (args.headdim + args.headdim_v) * args.element_size
+            size_one_dqaccum_head = cutlass.Int64(args.seqlen_k) * (args.headdim) * 4
             # size_one_dqaccum_head = 0
             size_one_head = size_one_qdo_head + size_one_dqaccum_head
             log2_floor = lambda n: 31 - clz(n)
-            swizzle = 1 if size_l2 < size_one_head else (1 << log2_floor(size_l2 // size_one_head))
+            swizzle = 1 if size_l2 < size_one_head else (1 << log2_floor(Int32(size_l2 // size_one_head)))
             # swizzle = 8
             # If we're in the last section (called residual), we don't want to divide by
             # swizzle. Instead we want to divide by the remainder.


### PR DESCRIPTION
The LPT tile scheduler sizes its L2 swizzle from

`seqlen_k * (headdim + headdim_v) * element_size`

in int32. For long context this overflows once it exceeds 2**31 (seqlen_k > ~4M for hdim-128 bf16), making size_one_head negative. That corrupts the swizzle and the L2 divmods, so get_current_work decodes an out-of-bounds batch_idx and the kernel performs an illegal memory access (cudaErrorIllegalAddress) on SM100.

Compute the byte size in int64. swizzle stays small and is cast back to int32 for the device-side divmods, so there is no behavior or perf change for non-overflowing shapes.

Fixes both SingleTileLPTScheduler (forward; selected for causal/local) and SingleTileLPTBwdScheduler (backward; its extra seqlen_k * headdim * 4 term overflows even sooner).

Repro on SM100 (e.g. GB200), causal forward at seqlen_k = 2**22:

```
    import torch
    from flash_attn.cute.interface import flash_attn_func

    sq, sk = 2048, 4_194_304  # seqlen_k = 2**22 -> int32 overflow
    q = torch.randn(1, sq, 8, 128, dtype=torch.bfloat16, device="cuda")
    k = torch.randn(1, sk, 1, 128, dtype=torch.bfloat16, device="cuda")
    v = torch.randn(1, sk, 1, 128, dtype=torch.bfloat16, device="cuda")
    out = flash_attn_func(q, k, v, causal=True)
    torch.cuda.synchronize()  # cudaErrorIllegalAddress here before the fix
```

Crashes before this change, runs clean after; seqlen_k = 2**22 - 128 is clean both ways (the int32 boundary). Verified clean under compute-sanitizer memcheck.