### PR TITLE
fix(hd256/sm100): make q/k/v contiguous before dedicated hd256 kernel

### DIFF
--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -910,6 +910,14 @@ def _flash_attn_fwd(
                         )
                     # pack_gqa is an auto-selected optimization; disable it for hd256 kernel
                     pack_gqa = False
+                    # The hd256 dedicated kernel builds tensor layouts with hardcoded
+                    # contiguous strides computed from shape dimensions, so non-contiguous
+                    # inputs (e.g. from .transpose()) produce wrong memory accesses.
+                    # maybe_contiguous() above only guarantees stride(-1)==1; make fully
+                    # contiguous here before the compile key is derived from shapes.
+                    q = q.contiguous() if not q.is_contiguous() else q
+                    k = k.contiguous() if not k.is_contiguous() else k
+                    v = v.contiguous() if not v.is_contiguous() else v
 
                 flash_fwd_obj_cls = (
                     BlackwellFusedMultiHeadAttentionForward
@@ -1804,6 +1812,12 @@ def _flash_attn_bwd(
                     "SM100 backward with head_dim=256 does not support dlse"
                 assert seqused_q is None and seqused_k is None, \
                     "SM100 backward with head_dim=256 does not support seqused_q/seqused_k"
+                # Same as forward: hd256 kernel uses hardcoded contiguous strides.
+                q = q.contiguous() if not q.is_contiguous() else q
+                k = k.contiguous() if not k.is_contiguous() else k
+                v = v.contiguous() if not v.is_contiguous() else v
+                out = out.contiguous() if not out.is_contiguous() else out
+                dout = dout.contiguous() if not dout.is_contiguous() else dout
 
                 dq_tile_mn = (128, 128)
                 dkdv_tile_mn = (128, 64)


### PR DESCRIPTION

Fixes #2665

## Problem

On B200 (SM100/SM110) with `head_dim=256`, passing non-contiguous tensors
(e.g. from `.transpose()`) to `flash_attn_func` produces silently wrong
outputs — max absolute error ~0.15 vs ~0.0005 on H100.

The root cause is in `BlackwellFusedMultiHeadAttentionForward`
(`sm100_hd256_2cta_fmha_forward.py`). Unlike the regular SM100 kernel, which
reads actual tensor strides via `cute.select(mQ.layout, ...)`, the hd256
dedicated kernel builds its CuTe tensor layouts using **hardcoded strides
computed from shape dimensions**:

```python
# stride for seqlen dim is assumed to be d * h_r * h_k
q_layout = cute.make_layout(
    (s_q_total, d, ((h_r, h_k), b)),
    stride=(d64 * h_r64 * h_k64, 1, ((d64, d64 * h_r64), stride_b_qo)),
)
```

The shared `maybe_contiguous()` helper only ensures `stride(-1) == 1` (last
dimension is contiguous), so a tensor like `q.transpose(1, 2)` — which has
the correct shape but non-standard strides in other dimensions — passes
through unchecked and causes the kernel to read from the wrong memory
locations.

## Fix

In `interface.py`, after the existing hd256 assertion block in both the
forward and backward paths, explicitly make `q`, `k`, `v` (and `out`,
`dout` in backward) fully contiguous before the dedicated kernel is
compiled and called:

```python
# Forward path
q = q.contiguous() if not q.is_contiguous() else q
k = k.contiguous() if not k.is_contiguous() else k
v = v.contiguous() if not v.is_contiguous() else v
```

This is a no-op for already-contiguous inputs (the common path), and
avoids a silent correctness bug for non-contiguous inputs.

## Reproduction (from issue #2665)

```python
import torch
from flash_attn import flash_attn_func

# Non-contiguous via transpose — fails on B200 with hdim=256 before this fix
batch, seqlen, nheads, hdim = 2, 1024, 16, 256
q = torch.randn(batch, nheads, seqlen, hdim, device="cuda", dtype=torch.float16)
k = torch.randn(batch, nheads, seqlen, hdim, device="cuda", dtype=torch.float16)
v = torch.randn(batch, nheads, seqlen, hdim, device="cuda", dtype=torch.float16)

out = flash_attn_func(q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2))[0]
ref = torch.nn.functional.scaled_dot_product_attention(q, k, v).transpose(1, 2)
print(f"max abs error: {(out - ref).abs().max():.6f}")
# Before fix: ~0.1555 on B200
# After fix:  ~0.0005 on B200 (matches H100)
```

## Testing

<img width="1554" height="705" alt="image" src="https://github.com/user-attachments/assets/d84ec889-8f3b-4e24-9eef-174f5e36d7ed" />

Design Notes: 
Key design decisions:
- Groups A (tests 1 & 2) are the only ones that assert a large error - they exist specifically to prove the bug is real, not just that the fix is present.
- Groups B, E use bit-exact (torch.equal) where both sides go through the same kernel path after the fix materialises the tensor and any layout bug produces a measurable bit difference.
- Group C uses SDPA as ground truth to bound absolute numerical error across all shapes.
- All 21 tests are skipped automatically on non-SM100 hardware via the module-level pytestmark.

## Notes

- Only affects SM100/SM110 (B200/B100) with `head_dim=256`.
- All other head dimensions use the regular `FlashAttentionForwardSm100`
  kernel, which correctly handles non-contiguous inputs via `cute.select`.
- No change to kernel code; fix is purely at the Python dispatch layer.
