### PR TITLE
Expand FLASHATTENTION_DISABLE_DROPOUT to not bring in unneeded headers

### DIFF
--- a/csrc/flash_attn/flash_api.cpp
+++ b/csrc/flash_attn/flash_api.cpp
@@ -7,8 +7,11 @@
 #include <torch/nn/functional.h>
 #include <c10/cuda/CUDAGuard.h>
 #include <c10/cuda/CUDAStream.h>
-#include <ATen/cuda/CUDAGeneratorImpl.h>  // For at::Generator and at::PhiloxCudaState
+#ifndef FLASHATTENTION_DISABLE_DROPOUT
+#include <ATen/cuda/CUDAGeneratorImpl.h>  // For at::PhiloxCudaState / at::CUDAGeneratorImpl (default-generator dropout path)
 #include "philox_unpack.cuh"  // For at::cuda::philox::unpack
+#include <type_traits>  // For std::is_trivially_copyable (philox_args buffer assert below)
+#endif
 
 #include <cutlass/numeric_types.h>
 
@@ -22,6 +25,21 @@
 #define CHECK_CONTIGUOUS(x) TORCH_CHECK(x.is_contiguous(), #x " must be contiguous")
 
 namespace FLASH_NAMESPACE {
+
+#ifndef FLASHATTENTION_DISABLE_DROPOUT
+// Flash_fwd_params keeps philox state as an opaque uint64_t buffer (see flash.h) so the
+// shared header avoids ATen Generator types. Validate the buffer against the real
+// at::PhiloxCudaState layout here, where the type is actually visible.
+static_assert(sizeof(at::PhiloxCudaState) <= sizeof(Flash_fwd_params::philox_args),
+              "Flash_fwd_params::philox_args buffer is too small for at::PhiloxCudaState");
+static_assert(alignof(at::PhiloxCudaState) <= alignof(decltype(Flash_fwd_params::philox_args)),
+              "Flash_fwd_params::philox_args buffer is under-aligned for at::PhiloxCudaState");
+static_assert(std::is_trivially_copyable<at::PhiloxCudaState>::value,
+              "at::PhiloxCudaState must be trivially copyable: it is placement-new'd into "
+              "philox_args and the whole Flash_fwd_params is copied by value to the device kernel "
+              "(so the bytes must be memcpy-safe); this also guarantees a trivial destructor, so "
+              "the placement-new needs no matching delete");
+#endif
 
 void set_params_fprop(Flash_fwd_params &params,
                       // sizes
@@ -360,7 +378,12 @@ mha_fwd(at::Tensor &q,         // batch_size x seqlen_q x num_heads x round_mult
         int window_size_right,
         const float softcap,
         const bool return_softmax,
-        std::optional<at::Generator> gen_) {
+        // Retained only for backwards-compat arg positioning; must be None.
+        std::optional<at::Tensor> unused_generator_compat) {
+
+    TORCH_CHECK(!unused_generator_compat.has_value(),
+                "flash-attn: the RNG `generator` argument is no longer supported and must be None; "
+                "dropout (when enabled) uses the default CUDA generator.");
 
     // Otherwise the kernel will be launched from cuda:0 device
     at::cuda::CUDAGuard device_guard{q.device()};
@@ -475,22 +498,23 @@ mha_fwd(at::Tensor &q,         // batch_size x seqlen_q x num_heads x round_mult
         params, batch_size, num_heads, head_size, seqlen_k, seqlen_q,
         head_size_rounded, p_dropout, /*num_splits*/ 0, get_num_sm(get_current_device()), opts);
 
-    // number of times random will be generated per thread, to offset philox counter in thc random
-    // state
-    // We use a custom RNG that increases the offset by batch_size * nheads * 32.
-    int64_t counter_offset = params.b * params.h * 32;
     auto options = torch::TensorOptions().dtype(torch::kFloat32).device(torch::kCUDA);
     auto rng_state = torch::empty({2}, options.dtype(torch::kInt64));
     // Forward kernel will populate memory with the seed and offset.
     params.rng_state = reinterpret_cast<uint64_t*>(rng_state.data_ptr());
 
+#ifndef FLASHATTENTION_DISABLE_DROPOUT
     if (p_dropout > 0.0)  {
-        auto gen = at::get_generator_or_default<at::CUDAGeneratorImpl>(
-            gen_, at::cuda::detail::getDefaultCUDAGenerator());
+        // number of times random will be generated per thread, to offset philox counter in thc random
+        // state
+        // We use a custom RNG that increases the offset by batch_size * nheads * 32.
+        int64_t counter_offset = params.b * params.h * 32;
+        auto gen = at::cuda::detail::getDefaultCUDAGenerator();
         // See Note [Acquire lock when using random generators]
-        std::lock_guard<std::mutex> lock(gen->mutex_);
-        params.philox_args = gen->philox_cuda_state(counter_offset);
+        std::lock_guard<std::mutex> lock(gen.mutex());
+        new (params.philox_args) at::PhiloxCudaState(gen.get<at::CUDAGeneratorImpl>()->philox_cuda_state(counter_offset));
     }
+#endif
 
     set_params_alibi(params, alibi_slopes_, batch_size, num_heads);
 
@@ -532,8 +556,13 @@ mha_varlen_fwd(at::Tensor &q,  // total_q x num_heads x head_size, total_q := \s
                int window_size_right,
                const float softcap,
                const bool return_softmax,
-               std::optional<at::Generator> gen_,
+               // Retained only for backwards-compat arg positioning; must be None.
+               std::optional<at::Tensor> unused_generator_compat,
                int num_splits = 0) {
+
+    TORCH_CHECK(!unused_generator_compat.has_value(),
+                "flash-attn: the RNG `generator` argument is no longer supported and must be None; "
+                "dropout (when enabled) uses the default CUDA generator.");
 
     // Otherwise the kernel will be launched from cuda:0 device
     at::cuda::CUDAGuard device_guard{q.device()};
@@ -718,22 +747,23 @@ mha_varlen_fwd(at::Tensor &q,  // total_q x num_heads x head_size, total_q := \s
         params.leftpad_k = static_cast<int *>(leftpad_k.data_ptr());
     }
 
-    // number of times random will be generated per thread, to offset philox counter in thc random
-    // state
-    // We use a custom RNG that increases the offset by batch_size * nheads * 32.
-    int64_t counter_offset = params.b * params.h * 32;
     auto options = torch::TensorOptions().dtype(torch::kFloat32).device(torch::kCUDA);
     auto rng_state = torch::empty({2}, options.dtype(torch::kInt64));
     // Forward kernel will populate memory with the seed and offset.
     params.rng_state = reinterpret_cast<uint64_t*>(rng_state.data_ptr());
 
+#ifndef FLASHATTENTION_DISABLE_DROPOUT
     if (p_dropout > 0.0)  {
-        auto gen = at::get_generator_or_default<at::CUDAGeneratorImpl>(
-            gen_, at::cuda::detail::getDefaultCUDAGenerator());
+        // number of times random will be generated per thread, to offset philox counter in thc random
+        // state
+        // We use a custom RNG that increases the offset by batch_size * nheads * 32.
+        int64_t counter_offset = params.b * params.h * 32;
+        auto gen = at::cuda::detail::getDefaultCUDAGenerator();
         // See Note [Acquire lock when using random generators]
-        std::lock_guard<std::mutex> lock(gen->mutex_);
-        params.philox_args = gen->philox_cuda_state(counter_offset);
+        std::lock_guard<std::mutex> lock(gen.mutex());
+        new (params.philox_args) at::PhiloxCudaState(gen.get<at::CUDAGeneratorImpl>()->philox_cuda_state(counter_offset));
     }
+#endif
 
     set_params_alibi(params, alibi_slopes_, batch_size, num_heads);
 
@@ -785,8 +815,13 @@ mha_bwd(const at::Tensor &dout,  // batch_size x seqlen_q x num_heads, x multipl
         int window_size_right,
         const float softcap,
         const bool deterministic,
-        std::optional<at::Generator> gen_,
+        // Retained only for backwards-compat arg positioning; must be None.
+        std::optional<at::Tensor> unused_generator_compat,
         std::optional<at::Tensor> &rng_state) {
+
+    TORCH_CHECK(!unused_generator_compat.has_value(),
+                "flash-attn: the RNG `generator` argument is no longer supported and must be None; "
+                "dropout (when enabled) uses the default CUDA generator.");
 
     #ifdef FLASHATTENTION_DISABLE_BACKWARD
         TORCH_CHECK(false, "This flash attention build does not support backward.");
@@ -800,7 +835,7 @@ mha_bwd(const at::Tensor &dout,  // batch_size x seqlen_q x num_heads, x multipl
     bool is_sm8x_min = cc_major >= 8;
     TORCH_CHECK(is_sm8x_min, "FlashAttention only supports Ampere GPUs or newer.");
 
-    bool is_dropout = p_dropout > 0.0;
+    [[maybe_unused]] bool is_dropout = p_dropout > 0.0;
     auto stream = at::cuda::getCurrentCUDAStream().stream();
 
     auto q_dtype = q.dtype();
@@ -936,21 +971,20 @@ mha_bwd(const at::Tensor &dout,  // batch_size x seqlen_q x num_heads, x multipl
 
     auto launch = &run_mha_bwd;
 
-    auto gen = at::get_generator_or_default<at::CUDAGeneratorImpl>(
-        gen_, at::cuda::detail::getDefaultCUDAGenerator());
-
-    // We use a custom RNG that increases the offset by batch_size * nheads * 32.
-    int64_t counter_offset = params.b * params.h * 32;
-
     if ( rng_state.has_value() ) {
         params.rng_state = reinterpret_cast<uint64_t*>(rng_state.value().data_ptr());
+#ifndef FLASHATTENTION_DISABLE_DROPOUT
     } else if( is_dropout ) {
+        // We use a custom RNG that increases the offset by batch_size * nheads * 32.
+        int64_t counter_offset = params.b * params.h * 32;
+        auto gen = at::cuda::detail::getDefaultCUDAGenerator();
         // See Note [Acquire lock when using random generators]
-        std::lock_guard<std::mutex> lock(gen->mutex_);
-        params.philox_args = gen->philox_cuda_state(counter_offset);
-        auto seeds = at::cuda::philox::unpack(params.philox_args);
+        std::lock_guard<std::mutex> lock(gen.mutex());
+        new (params.philox_args) at::PhiloxCudaState(gen.get<at::CUDAGeneratorImpl>()->philox_cuda_state(counter_offset));
+        auto seeds = at::cuda::philox::unpack(*reinterpret_cast<at::PhiloxCudaState const*>(params.philox_args));
         params.rng_state[0] = std::get<0>(seeds);
         params.rng_state[1] = std::get<1>(seeds);
+#endif
     }
 
     set_params_alibi(params, alibi_slopes_, batch_size, num_heads);
@@ -996,8 +1030,13 @@ mha_varlen_bwd(const at::Tensor &dout,  // total_q x num_heads, x head_size
                int window_size_right,
                const float softcap,
                const bool deterministic,
-               std::optional<at::Generator> gen_,
+               // Retained only for backwards-compat arg positioning; must be None.
+               std::optional<at::Tensor> unused_generator_compat,
                std::optional<at::Tensor> &rng_state) {
+
+    TORCH_CHECK(!unused_generator_compat.has_value(),
+                "flash-attn: the RNG `generator` argument is no longer supported and must be None; "
+                "dropout (when enabled) uses the default CUDA generator.");
 
     #ifdef FLASHATTENTION_DISABLE_BACKWARD
         TORCH_CHECK(false, "This flash attention build does not support backward.");
@@ -1011,7 +1050,7 @@ mha_varlen_bwd(const at::Tensor &dout,  // total_q x num_heads, x head_size
     bool is_sm8x_min = cc_major >= 8;
     TORCH_CHECK(is_sm8x_min, "FlashAttention only supports Ampere GPUs or newer.");
 
-    bool is_dropout = p_dropout > 0.0;
+    [[maybe_unused]] bool is_dropout = p_dropout > 0.0;
     auto stream = at::cuda::getCurrentCUDAStream().stream();
 
     auto q_dtype = q.dtype();
@@ -1165,21 +1204,20 @@ mha_varlen_bwd(const at::Tensor &dout,  // total_q x num_heads, x head_size
 
     auto launch = &run_mha_bwd;
 
-    auto gen = at::get_generator_or_default<at::CUDAGeneratorImpl>(
-        gen_, at::cuda::detail::getDefaultCUDAGenerator());
-
-    // We use a custom RNG that increases the offset by batch_size * nheads * 32.
-    int64_t counter_offset = params.b * params.h * 32;
-
     if ( rng_state.has_value() ) {
         params.rng_state = reinterpret_cast<uint64_t*>(rng_state.value().data_ptr());
+#ifndef FLASHATTENTION_DISABLE_DROPOUT
     } else if( is_dropout ) {
+        // We use a custom RNG that increases the offset by batch_size * nheads * 32.
+        int64_t counter_offset = params.b * params.h * 32;
+        auto gen = at::cuda::detail::getDefaultCUDAGenerator();
         // See Note [Acquire lock when using random generators]
-        std::lock_guard<std::mutex> lock(gen->mutex_);
-        params.philox_args = gen->philox_cuda_state(counter_offset);
-        auto seeds = at::cuda::philox::unpack(params.philox_args);
+        std::lock_guard<std::mutex> lock(gen.mutex());
+        new (params.philox_args) at::PhiloxCudaState(gen.get<at::CUDAGeneratorImpl>()->philox_cuda_state(counter_offset));
+        auto seeds = at::cuda::philox::unpack(*reinterpret_cast<at::PhiloxCudaState const*>(params.philox_args));
         params.rng_state[0] = std::get<0>(seeds);
         params.rng_state[1] = std::get<1>(seeds);
+#endif
     }
 
     set_params_alibi(params, alibi_slopes_, batch_size, num_heads);

--- a/csrc/flash_attn/src/flash.h
+++ b/csrc/flash_attn/src/flash.h
@@ -7,9 +7,8 @@
 #include "namespace_config.h"
 
 #include <cuda.h>
+#include <cstdint>
 #include <vector>
-
-#include <ATen/cuda/CUDAGeneratorImpl.h> // For at::Generator and at::PhiloxCudaState
 
 namespace FLASH_NAMESPACE {
 constexpr int TOTAL_DIM = 0;
@@ -118,8 +117,13 @@ struct Flash_fwd_params : public Qkv_params {
     int window_size_left, window_size_right;
     float softcap;
 
-    // Random state.
-    at::PhiloxCudaState philox_args;
+    // Random state, stored as an opaque buffer that will potentially hold at::PhiloxCudaState.
+    // We intentionally use an opaque buffer to allow the disabled dropout binary to stay
+    // free of unnecessary headers like <ATen/cuda/CUDAGeneratorImpl.h>.
+    // flash_api.cpp will write into this buffer via placement-new of an at::PhiloxCudaState
+    // (guarded by FLASHATTENTION_DISABLE_DROPOUT) and the forward kernel (in flash_fwd_kernel.h)
+    // will read it back via reinterpret_cast. Size validated by static_assert in flash_api.cpp.
+    uint64_t philox_args[4];
 
     // Pointer to the RNG seed (idx 0) and offset (idx 1).
     uint64_t * rng_state;

--- a/csrc/flash_attn/src/flash_fwd_kernel.h
+++ b/csrc/flash_attn/src/flash_fwd_kernel.h
@@ -5,8 +5,11 @@
 #pragma once
 
 #include "namespace_config.h"
+#ifndef FLASHATTENTION_DISABLE_DROPOUT
 #include "philox_unpack.cuh" // For at::cuda::philox::unpack
+#endif
 
+#include <tuple>
 #include <cute/tensor.hpp>
 
 #include <cutlass/cutlass.h>
@@ -66,7 +69,11 @@ inline __device__ void compute_attn_1rowblock(const Params &params, const int bi
     constexpr int kHeadDim = Kernel_traits::kHeadDim;
     constexpr int kNWarps = Kernel_traits::kNWarps;
 
-    auto seed_offset = at::cuda::philox::unpack(params.philox_args);
+#ifndef FLASHATTENTION_DISABLE_DROPOUT
+    auto seed_offset = at::cuda::philox::unpack(*reinterpret_cast<at::PhiloxCudaState const*>(params.philox_args));
+#else
+    auto seed_offset = std::make_tuple(uint64_t(0), uint64_t(0));
+#endif
     FLASH_NAMESPACE::Dropout dropout(std::get<0>(seed_offset), std::get<1>(seed_offset), params.p_dropout_in_uint8_t,
                            bidb, bidh, tidx, params.h);
 

--- a/csrc/flash_attn/src/philox_unpack.cuh
+++ b/csrc/flash_attn/src/philox_unpack.cuh
@@ -1,4 +1,5 @@
 // This is purely so that it works with torch 2.1. For torch 2.2+ we can include ATen/cuda/PhiloxUtils.cuh
 
 #pragma once
-#include <ATen/cuda/detail/UnpackRaw.cuh>
+#include <ATen/cuda/PhiloxCudaState.h>     // For at::PhiloxCudaState
+#include <ATen/cuda/detail/UnpackRaw.cuh>  // For at::cuda::philox::unpack

--- a/flash_attn/flash_attn_interface.py
+++ b/flash_attn/flash_attn_interface.py
@@ -109,7 +109,7 @@ def _flash_attn_forward(
         window_size_right,
         softcap,
         return_softmax,
-        None,
+        None,  # unused generator slot, kept for backwards-compat arg positioning
     )
     return out, softmax_lse, S_dmask, rng_state
 
@@ -195,7 +195,7 @@ def _flash_attn_varlen_forward(
         window_size_right,
         softcap,
         return_softmax,
-        None,
+        None,  # unused generator slot, kept for backwards-compat arg positioning
         num_splits,
     )
     # if out.isnan().any() or softmax_lse.isnan().any():
@@ -295,7 +295,7 @@ def _flash_attn_backward(
         window_size_right,
         softcap,
         deterministic,
-        None,
+        None,  # unused generator slot, kept for backwards-compat arg positioning
         rng_state,
     )
     return softmax_d
@@ -400,7 +400,7 @@ def _flash_attn_varlen_backward(
         window_size_right,
         softcap,
         deterministic,
-        None,
+        None,  # unused generator slot, kept for backwards-compat arg positioning
         rng_state,
     )
     # if dk.isnan().any() or dk.isnan().any() or dv.isnan().any() or softmax_d.isnan().any():

--- a/setup.py
+++ b/setup.py
@@ -336,6 +336,13 @@ if not SKIP_CUDA_BUILD and not IS_ROCM:
         nvcc_flags.extend(["-Xcompiler", "/Zc:__cplusplus"])
         compiler_c17_flag=["-O2", "/std:c++17", "/Zc:__cplusplus"]
 
+    # Opt-in: disable building dropout and its dependent headers (ATen philox/RNG
+    # headers) from the FA2 build. This flag must be shared across both cxx and nvcc
+    # compilers, as FA2 is defined in both flash_api.cpp (cxx) and CUDA kernels.
+    feature_flags = []
+    if os.getenv("FLASH_ATTENTION_DISABLE_DROPOUT", "FALSE") == "TRUE":
+        feature_flags.append("-DFLASHATTENTION_DISABLE_DROPOUT")
+
     ext_modules.append(
         CUDAExtension(
             name="flash_attn_2_cuda",
@@ -439,8 +446,8 @@ if not SKIP_CUDA_BUILD and not IS_ROCM:
                 "csrc/flash_attn/src/flash_fwd_split_align_hdim256_bf16_causal_sm80.cu",
             ],
             extra_compile_args={
-                "cxx": compiler_c17_flag,
-                "nvcc": append_nvcc_threads(nvcc_flags + cc_flag),
+                "cxx": compiler_c17_flag + feature_flags,
+                "nvcc": append_nvcc_threads(nvcc_flags + cc_flag + feature_flags),
             },
             include_dirs=[
                 Path(this_dir) / "csrc" / "flash_attn",

--- a/tests/test_flash_attn.py
+++ b/tests/test_flash_attn.py
@@ -2644,3 +2644,47 @@ def test_flash_attn_kvcache_paged_block_table_bounds(append_knew, paged_kv_block
     )
     assert out.shape == (batch_size, 1, nheads, d)
     assert not out.isnan().any()
+
+
+def test_flash_attn_generator_arg_must_be_none():
+    """The optional RNG `generator` slot is retained only for backwards-compat arg
+    positioning on all four raw C++ entry points (fwd/varlen_fwd/bwd/varlen_bwd):
+    the arg is still accepted but must be None; a non-None value trips a targeted
+    TORCH_CHECK."""
+    from flash_attn.flash_attn_interface import USE_TRITON_ROCM, flash_attn_gpu
+
+    if USE_TRITON_ROCM:
+        pytest.skip("compat-slot assert is only in the CUDA extension")
+
+    device = "cuda"
+    dtype = torch.bfloat16
+    match = r"generator` argument is no longer supported"
+
+    # Dims are irrelevant: the TORCH_CHECK fires first
+    batch, seqlen, nheads, nheads_k, head_dim = 1, 1, 2, 1, 8
+    q = torch.randn(batch, seqlen, nheads, head_dim, device=device, dtype=dtype)
+    k = torch.randn(batch, seqlen, nheads_k, head_dim, device=device, dtype=dtype)
+    v = torch.randn(batch, seqlen, nheads_k, head_dim, device=device, dtype=dtype)
+    scale = head_dim ** -0.5
+    lse = torch.randn(batch, nheads, seqlen, device=device, dtype=torch.float32)
+    bad = torch.empty(1, device=device)  # any non-None value for the generator slot
+
+    with pytest.raises(RuntimeError, match=match):
+        flash_attn_gpu.fwd(q, k, v, None, None, 0.0, scale, True, -1, -1, 0.0, False, bad)
+    with pytest.raises(RuntimeError, match=match):
+        flash_attn_gpu.bwd(q, q, k, v, q, lse, None, None, None, None,
+                           0.0, scale, True, -1, -1, 0.0, False, bad, None)
+
+    # For varlen
+    total_q = batch * seqlen
+    qf = q.view(total_q, nheads, head_dim)  # contiguous -> free reshape
+    kf = k.view(total_q, nheads_k, head_dim)
+    vf = v.view(total_q, nheads_k, head_dim)
+    cu = torch.arange(0, total_q + 1, seqlen, dtype=torch.int32, device=device)
+
+    with pytest.raises(RuntimeError, match=match):
+        flash_attn_gpu.varlen_fwd(qf, kf, vf, None, cu, cu, None, None, None, None,
+                                  seqlen, seqlen, 0.0, scale, False, True, -1, -1, 0.0, False, bad, 0)
+    with pytest.raises(RuntimeError, match=match):
+        flash_attn_gpu.varlen_bwd(qf, qf, kf, vf, qf, lse, None, None, None, cu, cu, None,
+                                  seqlen, seqlen, 0.0, scale, False, True, -1, -1, 0.0, False, bad, None)

--- a/tests/test_flash_attn.py
+++ b/tests/test_flash_attn.py
@@ -14,7 +14,7 @@ from flash_attn import (
     flash_attn_with_kvcache,
 )
 from flash_attn.bert_padding import pad_input, unpad_input
-from flash_attn.flash_attn_interface import _get_block_size_n
+from flash_attn.flash_attn_interface import _get_block_size_n, USE_TRITON_ROCM
 from flash_attn.layers.rotary import apply_rotary_emb
 
 MAX_HEADDIM_SM8x = 192
@@ -2646,15 +2646,13 @@ def test_flash_attn_kvcache_paged_block_table_bounds(append_knew, paged_kv_block
     assert not out.isnan().any()
 
 
+@pytest.mark.skipif(USE_TRITON_ROCM, reason="compat-slot assert is only in the CUDA extension")
 def test_flash_attn_generator_arg_must_be_none():
     """The optional RNG `generator` slot is retained only for backwards-compat arg
     positioning on all four raw C++ entry points (fwd/varlen_fwd/bwd/varlen_bwd):
     the arg is still accepted but must be None; a non-None value trips a targeted
     TORCH_CHECK."""
-    from flash_attn.flash_attn_interface import USE_TRITON_ROCM, flash_attn_gpu
-
-    if USE_TRITON_ROCM:
-        pytest.skip("compat-slot assert is only in the CUDA extension")
+    from flash_attn.flash_attn_interface import flash_attn_gpu
 
     device = "cuda"
     dtype = torch.bfloat16


### PR DESCRIPTION
TL;DR: If we expand the disable dropout macro and drop generator support we can enable stable ABI builds for flash, vLLM, and sglang (and other downstream libs). I did quite a bit of recursive GitHub searching which leads me to believe that majority of C++ users are just passing in an null opt for the gen arg anyway. cc @tridao 

So we do the two things:
1. expand disable dropout macro to not pull in at::Generator and Philox related headers, which prevent eventual ABI stable support. This does affect the dropout enabled case because we change from using PhiloxState directly to an opaque buffer, but there's no change in functionality.
3. drop custom generator support in C++ (it already wasn't there in python) -- FA2 will now only ever use the default generator. We DO keep around empty argument slots to minimize the churn of this BC break.

##  Breaking: Custom RNG generator support removed from the C++ APIs

The raw FA2 forward and backward entry points no longer accept a custom `torch.Generator`; the argument must be `None`.

Passing a `torch.Generator` object into the raw extension entry points (`fwd` / `varlen_fwd` / `bwd` / `varlen_bwd`) now raises a pybind `TypeError: ... incompatible function arguments` as the argument slot is now `Tensor?` and only accepts `None`.

Passing a `Tensor`  will hit: `RuntimeError: flash-attn: the RNG `generator` argument is no longer supported and must be None; dropout (when enabled) uses the default CUDA generator.`

**Workaround**: If your use case was to be able to get deterministic behavior, use `torch.manual_seed` to control the default generator in Python instead:
```
import torch
torch.manual_seed(1234)              # seeds the default CPU + all CUDA generators
out = flash_attn_func(q, k, v, dropout_p=0.1, causal=True)
```

## Test Plan
Everything is run on GPU: H100 (sm_90) with torch `2.10.0+cu129`. I ended up building with 12.8 cuz 12.9 causes nans.

I added a new test case to enforce the BC break (note below).

### Part 1 — confirming nothing regressed with default dropout enabled build

**build command:** `CUDA_HOME=/usr/local/cuda-12.8 FLASH_ATTN_CUDA_ARCHS=90 pip install -e . --no-build-isolation -v`

There are dropout kernels in the binary:
```
(fa2-pt210) ➜  flash-attention git:(fully-yank-dropout) cuobjdump --dump-elf-symbols flash_attn_2_cuda*.so | c++filt | grep 'flash_fwd_kernel<' | grep -cE '>, true,'
grep: warning: GREP_COLOR='1;32' is deprecated; use GREP_COLORS='mt=1;32'
238
```

Dense forward+backward across head dims 64 & 128, both dtypes, dropout {0.0, 0.17}, all masking modes (causal/local/alibi/deterministic) — confirms the new opaque-philox plumbing didn't break the default path

```
$ python -m pytest tests/test_flash_attn.py::test_flash_attn_output -k '(113-203-64 or 113-203-128) and mha and not 50.0'
........................................................................ [ 28%]
........................................................................ [ 56%]
........................................................................ [ 84%]
........................................                                 [100%]
256 passed, 84224 deselected in 21.52s
```

Variable-length forward+backward, same configs

```
$ python -m pytest tests/test_flash_attn.py::test_flash_attn_varlen_output -k '(113-203-64 or 113-203-128) and mha and not 50.0'
........................................................................ [ 28%]
........................................................................ [ 56%]
........................................................................ [ 84%]
........................................                                 [100%]
256 passed, 92672 deselected in 22.70s
```

GQA head-grouping path with `dropout_p=0.17` at d=128.

```
$ python -m pytest tests/test_flash_attn.py::test_flash_attn_output -k '113-203-128 and gqa and 0.17 and not 50.0'
................................................................         [100%]
64 passed, 84416 deselected in 20.65s
```

KV-cache + splitkv entry point (`num_splits` 1 & 0), no dropout — confirm that the schema change is okay

```
$ python -m pytest tests/test_flash_attn.py::test_flash_attn_kvcache -k '(64-256-64 or 1-128-64) and gqa and 0.0 and None and not True'
....                                                                     [100%]
4 passed, 304124 deselected in 26.54s
```

### Part 2 — dropout=0 tests pass dropout disabled build 

**build command:** `CUDA_HOME=/usr/local/cuda-12.8 FLASH_ATTN_CUDA_ARCHS=90 FLASH_ATTENTION_DISABLE_DROPOUT=TRUE pip install -e . --no-build-isolation -v`

The disabled build should drop the dropout (`Is_dropout=true`) kernels entirely — confirm none remain in the binary (`.so` is also 271 MB vs 341 MB for the enabled build).
```
(fa2-pt210) ➜  flash-attention git:(fully-yank-dropout) cuobjdump --dump-elf-symbols flash_attn_2_cuda*.so | c++filt | grep 'flash_fwd_kernel<' | grep -cE '>, true,'
grep: warning: GREP_COLOR='1;32' is deprecated; use GREP_COLORS='mt=1;32'
0
```

There are no references to Philox and Generator in the binary:
```
nm -C flash_attn_2_cuda.cpython-312-x86_64-linux-gnu.so | grep -iE "philox|generator"
grep: warning: GREP_COLOR='1;32' is deprecated; use GREP_COLORS='mt=1;32'
(fa2-pt210) ➜  flash-attention git:(fully-yank-dropout) 
```

Dense forward+backward at dropout=0 (head dims 64 & 128, both dtypes, all masking modes) — confirms attention is still correct after stripping the ATen RNG headers.

```
$ python -m pytest tests/test_flash_attn.py::test_flash_attn_output -k '(113-203-64 or 113-203-128) and mha and not 50.0 and not 0.17'
........................................................................ [ 56%]
........................................................                 [100%]
128 passed, 84352 deselected in 21.14s
```

Variable-length forward+backward at dropout=0, same configs.

```
$ python -m pytest tests/test_flash_attn.py::test_flash_attn_varlen_output -k '(113-203-64 or 113-203-128) and mha and not 50.0 and not 0.17'
........................................................................ [ 56%]
........................................................                 [100%]
128 passed, 92800 deselected in 21.60s
```

`dropout_p > 0` must still be rejected (not silently ignored) in the disabled build.

```
(fa2-pt210) ➜  flash-attention git:(fully-yank-dropout) python -c "import torch, flash_attn; q=k=v=torch.randn(2,128,4,64,device='cuda',dtype=torch.float16); flash_attn.flash_attn_func(q,k,v,dropout_p=0.17)"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/janeyx/repos/flash-attention/flash_attn/flash_attn_interface.py", line 1213, in flash_attn_func
    return FlashAttnFunc.apply(
           ^^^^^^^^^^^^^^^^^^^^
  File "/home/janeyx/.conda/envs/fa2-pt210/lib/python3.12/site-packages/torch/autograd/function.py", line 583, in apply
    return super().apply(*args, **kwargs)  # type: ignore[misc]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/janeyx/repos/flash-attention/flash_attn/flash_attn_interface.py", line 851, in forward
    out_padded, softmax_lse, S_dmask, rng_state = _wrapped_flash_attn_forward(
                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/janeyx/.conda/envs/fa2-pt210/lib/python3.12/site-packages/torch/_ops.py", line 1209, in __call__
    return self._op(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/janeyx/.conda/envs/fa2-pt210/lib/python3.12/site-packages/torch/_library/autograd.py", line 112, in autograd_impl
    result = forward_no_grad(*args, Metadata(keyset, keyword_only_args))
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/janeyx/.conda/envs/fa2-pt210/lib/python3.12/site-packages/torch/_library/autograd.py", line 41, in forward_no_grad
    result = op.redispatch(keyset & _C._after_autograd_keyset, *args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/janeyx/.conda/envs/fa2-pt210/lib/python3.12/site-packages/torch/_ops.py", line 826, in redispatch
    return self._handle.redispatch_boxed(keyset, *args, **kwargs)  # type: ignore[return-value]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/janeyx/.conda/envs/fa2-pt210/lib/python3.12/site-packages/torch/_library/custom_ops.py", line 347, in backend_impl
    result = self._backend_fns[device_type](*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/janeyx/.conda/envs/fa2-pt210/lib/python3.12/site-packages/torch/_compile.py", line 54, in inner
    return disable_fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/janeyx/.conda/envs/fa2-pt210/lib/python3.12/site-packages/torch/_dynamo/eval_frame.py", line 1181, in _fn
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/home/janeyx/.conda/envs/fa2-pt210/lib/python3.12/site-packages/torch/_library/custom_ops.py", line 382, in wrapped_fn
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/home/janeyx/repos/flash-attention/flash_attn/flash_attn_interface.py", line 99, in _flash_attn_forward
    out, softmax_lse, S_dmask, rng_state = flash_attn_gpu.fwd(
                                           ^^^^^^^^^^^^^^^^^^^
RuntimeError: This flash attention build does not support dropout.
```