### PR TITLE
[CuTe] Make is_fake_mode() torch.compile-safe (skip active_fake_mode under Dynamo)

### DIFF
--- a/flash_attn/cute/testing.py
+++ b/flash_attn/cute/testing.py
@@ -484,4 +484,16 @@ def maybe_fake_tensor_mode(fake: bool = True):
 
 
 def is_fake_mode() -> bool:
+    # During torch.compile / Dynamo tracing there are no real tensors to
+    # validate, and `active_fake_mode()` lives in Dynamo's MOD_SKIPLIST so
+    # calling it inside a traced region raises Unsupported ("Attempted to call
+    # function marked as skipped"). Treat compile-time tracing the same as fake
+    # mode so guards that gate real-tensor assertions (e.g. `.is_cuda` checks)
+    # are skipped cleanly under compilation. `torch.compiler.is_compiling()` is
+    # safe to trace.
+    try:
+        if torch.compiler.is_compiling():
+            return True
+    except Exception:
+        pass
     return active_fake_mode() is not None


### PR DESCRIPTION
## What

`flash_attn_func` (CuTeDSL / FA4) is currently uncompilable under `torch.compile`. `_flash_attn_fwd` gates its real-tensor `.is_cuda` assertions behind `is_fake_mode()`, which calls `torch._guards.active_fake_mode()`. That symbol is in Dynamo's `MOD_SKIPLIST`, so tracing into it raises:

```
torch._dynamo.exc.Unsupported: Attempted to call function marked as skipped
  Explanation: ... the function `active_fake_mode` in file `torch/_guards.py` should not be traced.
```

## Fix

Under compilation there are no real tensors to validate, so compile-time tracing and fake mode should be treated identically. `is_fake_mode()` now checks `torch.compiler.is_compiling()` first (which is safe to trace) and short-circuits to `True` before touching `active_fake_mode()`.

```python
def is_fake_mode() -> bool:
    try:
        if torch.compiler.is_compiling():
            return True
    except Exception:
        pass
    return active_fake_mode() is not None
```

## Repro

```python
import torch
from flash_attn.cute import flash_attn_func

q = torch.randn(1, 4096, 16, 128, device="cuda", dtype=torch.bfloat16)
k = torch.randn(1, 4096, 16, 128, device="cuda", dtype=torch.bfloat16)
v = torch.randn(1, 4096, 16, 128, device="cuda", dtype=torch.bfloat16)

def f(q, k, v):
    return flash_attn_func(q, k, v, causal=False)

f(q, k, v)                                   # eager: OK
torch.compile(f, fullgraph=True)(q, k, v)    # before: Unsupported; after: OK
```

## Verification

On sm120 (RTX PRO 6000 Blackwell, torch 2.12, CUDA 13.2):

- `torch.compile(flash_attn_func, fullgraph=True)` now traces successfully.
- Compiled output is **bitwise-identical to eager** (`max_diff == 0.0`).
- Both match `F.scaled_dot_product_attention` at the bf16 noise floor (`4.9e-4`).

The change only affects the tracing-time guard path; eager numerics are untouched.
