### PR TITLE
Parallelize splitkv alignment templated kernels, remove flag

### DIFF
--- a/csrc/flash_attn/src/flash_fwd_launch_template.h
+++ b/csrc/flash_attn/src/flash_fwd_launch_template.h
@@ -160,25 +160,34 @@ void run_flash_splitkv_fwd(Flash_fwd_params &params, cudaStream_t stream) {
     }
 }
 
+// The num_splits==1 blocksize-aligned splitkv template. If a user specifies
+// num_splits=1, we assume they want bitwise identical numerics across the split
+// KV and standard kernels so we align kBlockN to match.
+// We technically can combine this into one dispatch under run_flash_splitkv_fwd
+// but that pathologically slowed down build time by doubling the number of kernels
+// in a single file, which made build go from minutes to hours. Thus, it is pulled
+// into its own function so it can be explicitly instantiated in a separate file
+// (flash_fwd_split_align_*.cu) and compiled in parallel instead of serializing in
+// one ptxas invocation.
+template<typename T, int Headdim, bool Is_causal>
+void run_mha_fwd_splitkv_align(Flash_fwd_params &params, cudaStream_t stream) {
+    constexpr static int kBlockM = 64;
+    constexpr static int kBlockN_standard = Headdim <= 64 ? 128 : 64;
+    run_flash_splitkv_fwd<Flash_fwd_kernel_traits<Headdim, kBlockM, kBlockN_standard, 4, false, false, T>, Is_causal>(params, stream);
+}
+
 template<typename T, int Headdim, bool Is_causal>
 void run_mha_fwd_splitkv_dispatch(Flash_fwd_params &params, cudaStream_t stream) {
     constexpr static int kBlockM = 64;
     // TD [2023-08-28]: nvcc segfaults for headdim 96 with block size 64 x 256,
     // and for headdim 192 with block size 64 x 128.
     constexpr static int kBlockN = Headdim <= 64 ? 256 : (Headdim <= 128 ? 128 : 64);
-#ifndef FLASHATTENTION_DISABLE_SPLIT_ALIGNMENT
-    // If a user specifies num_splits=1, we assume they want bitwise identical
-    // numerics across the split KV and standard kernels so we align kBLockN to
-    // match.
-    // This compiles a second splitkv kernel tree (a different kBlockN), which
-    // could push build time to hours+. Define FLASHATTENTION_DISABLE_SPLIT_ALIGNMENT
-    // to skip.
     if (params.num_splits == 1) {
-        constexpr static int kBlockN_standard = Headdim <= 64 ? 128 : 64;
-        run_flash_splitkv_fwd<Flash_fwd_kernel_traits<Headdim, kBlockM, kBlockN_standard, 4, false, false, T>, Is_causal>(params, stream);
+        // Defined in flash_fwd_split_align_*.cu; declared extern in the main
+        // flash_fwd_split_*.cu so this call does not re-instantiate the tree here.
+        run_mha_fwd_splitkv_align<T, Headdim, Is_causal>(params, stream);
         return;
     }
-#endif
     run_flash_splitkv_fwd<Flash_fwd_kernel_traits<Headdim, kBlockM, kBlockN, 4, false, false, T>, Is_causal>(params, stream);
 }
 

--- a/csrc/flash_attn/src/flash_fwd_split_align_hdim128_bf16_causal_sm80.cu
+++ b/csrc/flash_attn/src/flash_fwd_split_align_hdim128_bf16_causal_sm80.cu
@@ -1,0 +1,11 @@
+// Copyright (c) 2024, Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template void run_mha_fwd_splitkv_align<cutlass::bfloat16_t, 128, true>(Flash_fwd_params &params, cudaStream_t stream);
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/flash_attn/src/flash_fwd_split_align_hdim128_bf16_sm80.cu
+++ b/csrc/flash_attn/src/flash_fwd_split_align_hdim128_bf16_sm80.cu
@@ -1,0 +1,11 @@
+// Copyright (c) 2024, Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template void run_mha_fwd_splitkv_align<cutlass::bfloat16_t, 128, false>(Flash_fwd_params &params, cudaStream_t stream);
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/flash_attn/src/flash_fwd_split_align_hdim128_fp16_causal_sm80.cu
+++ b/csrc/flash_attn/src/flash_fwd_split_align_hdim128_fp16_causal_sm80.cu
@@ -1,0 +1,11 @@
+// Copyright (c) 2024, Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template void run_mha_fwd_splitkv_align<cutlass::half_t, 128, true>(Flash_fwd_params &params, cudaStream_t stream);
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/flash_attn/src/flash_fwd_split_align_hdim128_fp16_sm80.cu
+++ b/csrc/flash_attn/src/flash_fwd_split_align_hdim128_fp16_sm80.cu
@@ -1,0 +1,11 @@
+// Copyright (c) 2024, Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template void run_mha_fwd_splitkv_align<cutlass::half_t, 128, false>(Flash_fwd_params &params, cudaStream_t stream);
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/flash_attn/src/flash_fwd_split_align_hdim192_bf16_causal_sm80.cu
+++ b/csrc/flash_attn/src/flash_fwd_split_align_hdim192_bf16_causal_sm80.cu
@@ -1,0 +1,11 @@
+// Copyright (c) 2024, Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template void run_mha_fwd_splitkv_align<cutlass::bfloat16_t, 192, true>(Flash_fwd_params &params, cudaStream_t stream);
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/flash_attn/src/flash_fwd_split_align_hdim192_bf16_sm80.cu
+++ b/csrc/flash_attn/src/flash_fwd_split_align_hdim192_bf16_sm80.cu
@@ -1,0 +1,11 @@
+// Copyright (c) 2024, Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template void run_mha_fwd_splitkv_align<cutlass::bfloat16_t, 192, false>(Flash_fwd_params &params, cudaStream_t stream);
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/flash_attn/src/flash_fwd_split_align_hdim192_fp16_causal_sm80.cu
+++ b/csrc/flash_attn/src/flash_fwd_split_align_hdim192_fp16_causal_sm80.cu
@@ -1,0 +1,11 @@
+// Copyright (c) 2024, Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template void run_mha_fwd_splitkv_align<cutlass::half_t, 192, true>(Flash_fwd_params &params, cudaStream_t stream);
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/flash_attn/src/flash_fwd_split_align_hdim192_fp16_sm80.cu
+++ b/csrc/flash_attn/src/flash_fwd_split_align_hdim192_fp16_sm80.cu
@@ -1,0 +1,11 @@
+// Copyright (c) 2024, Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template void run_mha_fwd_splitkv_align<cutlass::half_t, 192, false>(Flash_fwd_params &params, cudaStream_t stream);
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/flash_attn/src/flash_fwd_split_align_hdim256_bf16_causal_sm80.cu
+++ b/csrc/flash_attn/src/flash_fwd_split_align_hdim256_bf16_causal_sm80.cu
@@ -1,0 +1,11 @@
+// Copyright (c) 2024, Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template void run_mha_fwd_splitkv_align<cutlass::bfloat16_t, 256, true>(Flash_fwd_params &params, cudaStream_t stream);
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/flash_attn/src/flash_fwd_split_align_hdim256_bf16_sm80.cu
+++ b/csrc/flash_attn/src/flash_fwd_split_align_hdim256_bf16_sm80.cu
@@ -1,0 +1,11 @@
+// Copyright (c) 2024, Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template void run_mha_fwd_splitkv_align<cutlass::bfloat16_t, 256, false>(Flash_fwd_params &params, cudaStream_t stream);
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/flash_attn/src/flash_fwd_split_align_hdim256_fp16_causal_sm80.cu
+++ b/csrc/flash_attn/src/flash_fwd_split_align_hdim256_fp16_causal_sm80.cu
@@ -1,0 +1,11 @@
+// Copyright (c) 2024, Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template void run_mha_fwd_splitkv_align<cutlass::half_t, 256, true>(Flash_fwd_params &params, cudaStream_t stream);
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/flash_attn/src/flash_fwd_split_align_hdim256_fp16_sm80.cu
+++ b/csrc/flash_attn/src/flash_fwd_split_align_hdim256_fp16_sm80.cu
@@ -1,0 +1,11 @@
+// Copyright (c) 2024, Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template void run_mha_fwd_splitkv_align<cutlass::half_t, 256, false>(Flash_fwd_params &params, cudaStream_t stream);
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/flash_attn/src/flash_fwd_split_align_hdim32_bf16_causal_sm80.cu
+++ b/csrc/flash_attn/src/flash_fwd_split_align_hdim32_bf16_causal_sm80.cu
@@ -1,0 +1,11 @@
+// Copyright (c) 2024, Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template void run_mha_fwd_splitkv_align<cutlass::bfloat16_t, 32, true>(Flash_fwd_params &params, cudaStream_t stream);
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/flash_attn/src/flash_fwd_split_align_hdim32_bf16_sm80.cu
+++ b/csrc/flash_attn/src/flash_fwd_split_align_hdim32_bf16_sm80.cu
@@ -1,0 +1,11 @@
+// Copyright (c) 2024, Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template void run_mha_fwd_splitkv_align<cutlass::bfloat16_t, 32, false>(Flash_fwd_params &params, cudaStream_t stream);
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/flash_attn/src/flash_fwd_split_align_hdim32_fp16_causal_sm80.cu
+++ b/csrc/flash_attn/src/flash_fwd_split_align_hdim32_fp16_causal_sm80.cu
@@ -1,0 +1,11 @@
+// Copyright (c) 2024, Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template void run_mha_fwd_splitkv_align<cutlass::half_t, 32, true>(Flash_fwd_params &params, cudaStream_t stream);
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/flash_attn/src/flash_fwd_split_align_hdim32_fp16_sm80.cu
+++ b/csrc/flash_attn/src/flash_fwd_split_align_hdim32_fp16_sm80.cu
@@ -1,0 +1,11 @@
+// Copyright (c) 2024, Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template void run_mha_fwd_splitkv_align<cutlass::half_t, 32, false>(Flash_fwd_params &params, cudaStream_t stream);
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/flash_attn/src/flash_fwd_split_align_hdim64_bf16_causal_sm80.cu
+++ b/csrc/flash_attn/src/flash_fwd_split_align_hdim64_bf16_causal_sm80.cu
@@ -1,0 +1,11 @@
+// Copyright (c) 2024, Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template void run_mha_fwd_splitkv_align<cutlass::bfloat16_t, 64, true>(Flash_fwd_params &params, cudaStream_t stream);
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/flash_attn/src/flash_fwd_split_align_hdim64_bf16_sm80.cu
+++ b/csrc/flash_attn/src/flash_fwd_split_align_hdim64_bf16_sm80.cu
@@ -1,0 +1,11 @@
+// Copyright (c) 2024, Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template void run_mha_fwd_splitkv_align<cutlass::bfloat16_t, 64, false>(Flash_fwd_params &params, cudaStream_t stream);
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/flash_attn/src/flash_fwd_split_align_hdim64_fp16_causal_sm80.cu
+++ b/csrc/flash_attn/src/flash_fwd_split_align_hdim64_fp16_causal_sm80.cu
@@ -1,0 +1,11 @@
+// Copyright (c) 2024, Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template void run_mha_fwd_splitkv_align<cutlass::half_t, 64, true>(Flash_fwd_params &params, cudaStream_t stream);
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/flash_attn/src/flash_fwd_split_align_hdim64_fp16_sm80.cu
+++ b/csrc/flash_attn/src/flash_fwd_split_align_hdim64_fp16_sm80.cu
@@ -1,0 +1,11 @@
+// Copyright (c) 2024, Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template void run_mha_fwd_splitkv_align<cutlass::half_t, 64, false>(Flash_fwd_params &params, cudaStream_t stream);
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/flash_attn/src/flash_fwd_split_align_hdim96_bf16_causal_sm80.cu
+++ b/csrc/flash_attn/src/flash_fwd_split_align_hdim96_bf16_causal_sm80.cu
@@ -1,0 +1,11 @@
+// Copyright (c) 2024, Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template void run_mha_fwd_splitkv_align<cutlass::bfloat16_t, 96, true>(Flash_fwd_params &params, cudaStream_t stream);
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/flash_attn/src/flash_fwd_split_align_hdim96_bf16_sm80.cu
+++ b/csrc/flash_attn/src/flash_fwd_split_align_hdim96_bf16_sm80.cu
@@ -1,0 +1,11 @@
+// Copyright (c) 2024, Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template void run_mha_fwd_splitkv_align<cutlass::bfloat16_t, 96, false>(Flash_fwd_params &params, cudaStream_t stream);
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/flash_attn/src/flash_fwd_split_align_hdim96_fp16_causal_sm80.cu
+++ b/csrc/flash_attn/src/flash_fwd_split_align_hdim96_fp16_causal_sm80.cu
@@ -1,0 +1,11 @@
+// Copyright (c) 2024, Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template void run_mha_fwd_splitkv_align<cutlass::half_t, 96, true>(Flash_fwd_params &params, cudaStream_t stream);
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/flash_attn/src/flash_fwd_split_align_hdim96_fp16_sm80.cu
+++ b/csrc/flash_attn/src/flash_fwd_split_align_hdim96_fp16_sm80.cu
@@ -1,0 +1,11 @@
+// Copyright (c) 2024, Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template void run_mha_fwd_splitkv_align<cutlass::half_t, 96, false>(Flash_fwd_params &params, cudaStream_t stream);
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/flash_attn/src/flash_fwd_split_hdim128_bf16_causal_sm80.cu
+++ b/csrc/flash_attn/src/flash_fwd_split_hdim128_bf16_causal_sm80.cu
@@ -6,6 +6,11 @@
 
 namespace FLASH_NAMESPACE {
 
+// The num_splits==1 blocksize-aligned tree is instantiated in its own translation unit
+// (flash_fwd_split_align_*.cu) so it compiles in parallel; declare it extern so
+// the dispatch below references it instead of re-instantiating.
+extern template void run_mha_fwd_splitkv_align<cutlass::bfloat16_t, 128, true>(Flash_fwd_params &params, cudaStream_t stream);
+
 template void run_mha_fwd_splitkv_dispatch<cutlass::bfloat16_t, 128, true>(Flash_fwd_params &params, cudaStream_t stream);
 
 } // namespace FLASH_NAMESPACE

--- a/csrc/flash_attn/src/flash_fwd_split_hdim128_bf16_sm80.cu
+++ b/csrc/flash_attn/src/flash_fwd_split_hdim128_bf16_sm80.cu
@@ -6,6 +6,11 @@
 
 namespace FLASH_NAMESPACE {
 
+// The num_splits==1 blocksize-aligned tree is instantiated in its own translation unit
+// (flash_fwd_split_align_*.cu) so it compiles in parallel; declare it extern so
+// the dispatch below references it instead of re-instantiating.
+extern template void run_mha_fwd_splitkv_align<cutlass::bfloat16_t, 128, false>(Flash_fwd_params &params, cudaStream_t stream);
+
 template void run_mha_fwd_splitkv_dispatch<cutlass::bfloat16_t, 128, false>(Flash_fwd_params &params, cudaStream_t stream);
 
 } // namespace FLASH_NAMESPACE

--- a/csrc/flash_attn/src/flash_fwd_split_hdim128_fp16_causal_sm80.cu
+++ b/csrc/flash_attn/src/flash_fwd_split_hdim128_fp16_causal_sm80.cu
@@ -6,6 +6,11 @@
 
 namespace FLASH_NAMESPACE {
 
+// The num_splits==1 blocksize-aligned tree is instantiated in its own translation unit
+// (flash_fwd_split_align_*.cu) so it compiles in parallel; declare it extern so
+// the dispatch below references it instead of re-instantiating.
+extern template void run_mha_fwd_splitkv_align<cutlass::half_t, 128, true>(Flash_fwd_params &params, cudaStream_t stream);
+
 template void run_mha_fwd_splitkv_dispatch<cutlass::half_t, 128, true>(Flash_fwd_params &params, cudaStream_t stream);
 
 } // namespace FLASH_NAMESPACE

--- a/csrc/flash_attn/src/flash_fwd_split_hdim128_fp16_sm80.cu
+++ b/csrc/flash_attn/src/flash_fwd_split_hdim128_fp16_sm80.cu
@@ -6,6 +6,11 @@
 
 namespace FLASH_NAMESPACE {
 
+// The num_splits==1 blocksize-aligned tree is instantiated in its own translation unit
+// (flash_fwd_split_align_*.cu) so it compiles in parallel; declare it extern so
+// the dispatch below references it instead of re-instantiating.
+extern template void run_mha_fwd_splitkv_align<cutlass::half_t, 128, false>(Flash_fwd_params &params, cudaStream_t stream);
+
 template void run_mha_fwd_splitkv_dispatch<cutlass::half_t, 128, false>(Flash_fwd_params &params, cudaStream_t stream);
 
 } // namespace FLASH_NAMESPACE

--- a/csrc/flash_attn/src/flash_fwd_split_hdim192_bf16_causal_sm80.cu
+++ b/csrc/flash_attn/src/flash_fwd_split_hdim192_bf16_causal_sm80.cu
@@ -6,6 +6,11 @@
 
 namespace FLASH_NAMESPACE {
 
+// The num_splits==1 blocksize-aligned tree is instantiated in its own translation unit
+// (flash_fwd_split_align_*.cu) so it compiles in parallel; declare it extern so
+// the dispatch below references it instead of re-instantiating.
+extern template void run_mha_fwd_splitkv_align<cutlass::bfloat16_t, 192, true>(Flash_fwd_params &params, cudaStream_t stream);
+
 template void run_mha_fwd_splitkv_dispatch<cutlass::bfloat16_t, 192, true>(Flash_fwd_params &params, cudaStream_t stream);
 
 } // namespace FLASH_NAMESPACE

--- a/csrc/flash_attn/src/flash_fwd_split_hdim192_bf16_sm80.cu
+++ b/csrc/flash_attn/src/flash_fwd_split_hdim192_bf16_sm80.cu
@@ -6,6 +6,11 @@
 
 namespace FLASH_NAMESPACE {
 
+// The num_splits==1 blocksize-aligned tree is instantiated in its own translation unit
+// (flash_fwd_split_align_*.cu) so it compiles in parallel; declare it extern so
+// the dispatch below references it instead of re-instantiating.
+extern template void run_mha_fwd_splitkv_align<cutlass::bfloat16_t, 192, false>(Flash_fwd_params &params, cudaStream_t stream);
+
 template void run_mha_fwd_splitkv_dispatch<cutlass::bfloat16_t, 192, false>(Flash_fwd_params &params, cudaStream_t stream);
 
 } // namespace FLASH_NAMESPACE

--- a/csrc/flash_attn/src/flash_fwd_split_hdim192_fp16_causal_sm80.cu
+++ b/csrc/flash_attn/src/flash_fwd_split_hdim192_fp16_causal_sm80.cu
@@ -6,6 +6,11 @@
 
 namespace FLASH_NAMESPACE {
 
+// The num_splits==1 blocksize-aligned tree is instantiated in its own translation unit
+// (flash_fwd_split_align_*.cu) so it compiles in parallel; declare it extern so
+// the dispatch below references it instead of re-instantiating.
+extern template void run_mha_fwd_splitkv_align<cutlass::half_t, 192, true>(Flash_fwd_params &params, cudaStream_t stream);
+
 template void run_mha_fwd_splitkv_dispatch<cutlass::half_t, 192, true>(Flash_fwd_params &params, cudaStream_t stream);
 
 } // namespace FLASH_NAMESPACE

--- a/csrc/flash_attn/src/flash_fwd_split_hdim192_fp16_sm80.cu
+++ b/csrc/flash_attn/src/flash_fwd_split_hdim192_fp16_sm80.cu
@@ -6,6 +6,11 @@
 
 namespace FLASH_NAMESPACE {
 
+// The num_splits==1 blocksize-aligned tree is instantiated in its own translation unit
+// (flash_fwd_split_align_*.cu) so it compiles in parallel; declare it extern so
+// the dispatch below references it instead of re-instantiating.
+extern template void run_mha_fwd_splitkv_align<cutlass::half_t, 192, false>(Flash_fwd_params &params, cudaStream_t stream);
+
 template void run_mha_fwd_splitkv_dispatch<cutlass::half_t, 192, false>(Flash_fwd_params &params, cudaStream_t stream);
 
 } // namespace FLASH_NAMESPACE

--- a/csrc/flash_attn/src/flash_fwd_split_hdim256_bf16_causal_sm80.cu
+++ b/csrc/flash_attn/src/flash_fwd_split_hdim256_bf16_causal_sm80.cu
@@ -6,6 +6,11 @@
 
 namespace FLASH_NAMESPACE {
 
+// The num_splits==1 blocksize-aligned tree is instantiated in its own translation unit
+// (flash_fwd_split_align_*.cu) so it compiles in parallel; declare it extern so
+// the dispatch below references it instead of re-instantiating.
+extern template void run_mha_fwd_splitkv_align<cutlass::bfloat16_t, 256, true>(Flash_fwd_params &params, cudaStream_t stream);
+
 template void run_mha_fwd_splitkv_dispatch<cutlass::bfloat16_t, 256, true>(Flash_fwd_params &params, cudaStream_t stream);
 
 } // namespace FLASH_NAMESPACE

--- a/csrc/flash_attn/src/flash_fwd_split_hdim256_bf16_sm80.cu
+++ b/csrc/flash_attn/src/flash_fwd_split_hdim256_bf16_sm80.cu
@@ -6,6 +6,11 @@
 
 namespace FLASH_NAMESPACE {
 
+// The num_splits==1 blocksize-aligned tree is instantiated in its own translation unit
+// (flash_fwd_split_align_*.cu) so it compiles in parallel; declare it extern so
+// the dispatch below references it instead of re-instantiating.
+extern template void run_mha_fwd_splitkv_align<cutlass::bfloat16_t, 256, false>(Flash_fwd_params &params, cudaStream_t stream);
+
 template void run_mha_fwd_splitkv_dispatch<cutlass::bfloat16_t, 256, false>(Flash_fwd_params &params, cudaStream_t stream);
 
 } // namespace FLASH_NAMESPACE

--- a/csrc/flash_attn/src/flash_fwd_split_hdim256_fp16_causal_sm80.cu
+++ b/csrc/flash_attn/src/flash_fwd_split_hdim256_fp16_causal_sm80.cu
@@ -6,6 +6,11 @@
 
 namespace FLASH_NAMESPACE {
 
+// The num_splits==1 blocksize-aligned tree is instantiated in its own translation unit
+// (flash_fwd_split_align_*.cu) so it compiles in parallel; declare it extern so
+// the dispatch below references it instead of re-instantiating.
+extern template void run_mha_fwd_splitkv_align<cutlass::half_t, 256, true>(Flash_fwd_params &params, cudaStream_t stream);
+
 template void run_mha_fwd_splitkv_dispatch<cutlass::half_t, 256, true>(Flash_fwd_params &params, cudaStream_t stream);
 
 } // namespace FLASH_NAMESPACE

--- a/csrc/flash_attn/src/flash_fwd_split_hdim256_fp16_sm80.cu
+++ b/csrc/flash_attn/src/flash_fwd_split_hdim256_fp16_sm80.cu
@@ -6,6 +6,11 @@
 
 namespace FLASH_NAMESPACE {
 
+// The num_splits==1 blocksize-aligned tree is instantiated in its own translation unit
+// (flash_fwd_split_align_*.cu) so it compiles in parallel; declare it extern so
+// the dispatch below references it instead of re-instantiating.
+extern template void run_mha_fwd_splitkv_align<cutlass::half_t, 256, false>(Flash_fwd_params &params, cudaStream_t stream);
+
 template void run_mha_fwd_splitkv_dispatch<cutlass::half_t, 256, false>(Flash_fwd_params &params, cudaStream_t stream);
 
 } // namespace FLASH_NAMESPACE

--- a/csrc/flash_attn/src/flash_fwd_split_hdim32_bf16_causal_sm80.cu
+++ b/csrc/flash_attn/src/flash_fwd_split_hdim32_bf16_causal_sm80.cu
@@ -6,6 +6,11 @@
 
 namespace FLASH_NAMESPACE {
 
+// The num_splits==1 blocksize-aligned tree is instantiated in its own translation unit
+// (flash_fwd_split_align_*.cu) so it compiles in parallel; declare it extern so
+// the dispatch below references it instead of re-instantiating.
+extern template void run_mha_fwd_splitkv_align<cutlass::bfloat16_t, 32, true>(Flash_fwd_params &params, cudaStream_t stream);
+
 template void run_mha_fwd_splitkv_dispatch<cutlass::bfloat16_t, 32, true>(Flash_fwd_params &params, cudaStream_t stream);
 
 } // namespace FLASH_NAMESPACE

--- a/csrc/flash_attn/src/flash_fwd_split_hdim32_bf16_sm80.cu
+++ b/csrc/flash_attn/src/flash_fwd_split_hdim32_bf16_sm80.cu
@@ -6,6 +6,11 @@
 
 namespace FLASH_NAMESPACE {
 
+// The num_splits==1 blocksize-aligned tree is instantiated in its own translation unit
+// (flash_fwd_split_align_*.cu) so it compiles in parallel; declare it extern so
+// the dispatch below references it instead of re-instantiating.
+extern template void run_mha_fwd_splitkv_align<cutlass::bfloat16_t, 32, false>(Flash_fwd_params &params, cudaStream_t stream);
+
 template void run_mha_fwd_splitkv_dispatch<cutlass::bfloat16_t, 32, false>(Flash_fwd_params &params, cudaStream_t stream);
 
 } // namespace FLASH_NAMESPACE

--- a/csrc/flash_attn/src/flash_fwd_split_hdim32_fp16_causal_sm80.cu
+++ b/csrc/flash_attn/src/flash_fwd_split_hdim32_fp16_causal_sm80.cu
@@ -6,6 +6,11 @@
 
 namespace FLASH_NAMESPACE {
 
+// The num_splits==1 blocksize-aligned tree is instantiated in its own translation unit
+// (flash_fwd_split_align_*.cu) so it compiles in parallel; declare it extern so
+// the dispatch below references it instead of re-instantiating.
+extern template void run_mha_fwd_splitkv_align<cutlass::half_t, 32, true>(Flash_fwd_params &params, cudaStream_t stream);
+
 template void run_mha_fwd_splitkv_dispatch<cutlass::half_t, 32, true>(Flash_fwd_params &params, cudaStream_t stream);
 
 } // namespace FLASH_NAMESPACE

--- a/csrc/flash_attn/src/flash_fwd_split_hdim32_fp16_sm80.cu
+++ b/csrc/flash_attn/src/flash_fwd_split_hdim32_fp16_sm80.cu
@@ -6,6 +6,11 @@
 
 namespace FLASH_NAMESPACE {
 
+// The num_splits==1 blocksize-aligned tree is instantiated in its own translation unit
+// (flash_fwd_split_align_*.cu) so it compiles in parallel; declare it extern so
+// the dispatch below references it instead of re-instantiating.
+extern template void run_mha_fwd_splitkv_align<cutlass::half_t, 32, false>(Flash_fwd_params &params, cudaStream_t stream);
+
 template void run_mha_fwd_splitkv_dispatch<cutlass::half_t, 32, false>(Flash_fwd_params &params, cudaStream_t stream);
 
 } // namespace FLASH_NAMESPACE

--- a/csrc/flash_attn/src/flash_fwd_split_hdim64_bf16_causal_sm80.cu
+++ b/csrc/flash_attn/src/flash_fwd_split_hdim64_bf16_causal_sm80.cu
@@ -6,6 +6,11 @@
 
 namespace FLASH_NAMESPACE {
 
+// The num_splits==1 blocksize-aligned tree is instantiated in its own translation unit
+// (flash_fwd_split_align_*.cu) so it compiles in parallel; declare it extern so
+// the dispatch below references it instead of re-instantiating.
+extern template void run_mha_fwd_splitkv_align<cutlass::bfloat16_t, 64, true>(Flash_fwd_params &params, cudaStream_t stream);
+
 template void run_mha_fwd_splitkv_dispatch<cutlass::bfloat16_t, 64, true>(Flash_fwd_params &params, cudaStream_t stream);
 
 } // namespace FLASH_NAMESPACE

--- a/csrc/flash_attn/src/flash_fwd_split_hdim64_bf16_sm80.cu
+++ b/csrc/flash_attn/src/flash_fwd_split_hdim64_bf16_sm80.cu
@@ -6,6 +6,11 @@
 
 namespace FLASH_NAMESPACE {
 
+// The num_splits==1 blocksize-aligned tree is instantiated in its own translation unit
+// (flash_fwd_split_align_*.cu) so it compiles in parallel; declare it extern so
+// the dispatch below references it instead of re-instantiating.
+extern template void run_mha_fwd_splitkv_align<cutlass::bfloat16_t, 64, false>(Flash_fwd_params &params, cudaStream_t stream);
+
 template void run_mha_fwd_splitkv_dispatch<cutlass::bfloat16_t, 64, false>(Flash_fwd_params &params, cudaStream_t stream);
 
 } // namespace FLASH_NAMESPACE

--- a/csrc/flash_attn/src/flash_fwd_split_hdim64_fp16_causal_sm80.cu
+++ b/csrc/flash_attn/src/flash_fwd_split_hdim64_fp16_causal_sm80.cu
@@ -6,6 +6,11 @@
 
 namespace FLASH_NAMESPACE {
 
+// The num_splits==1 blocksize-aligned tree is instantiated in its own translation unit
+// (flash_fwd_split_align_*.cu) so it compiles in parallel; declare it extern so
+// the dispatch below references it instead of re-instantiating.
+extern template void run_mha_fwd_splitkv_align<cutlass::half_t, 64, true>(Flash_fwd_params &params, cudaStream_t stream);
+
 template void run_mha_fwd_splitkv_dispatch<cutlass::half_t, 64, true>(Flash_fwd_params &params, cudaStream_t stream);
 
 } // namespace FLASH_NAMESPACE

--- a/csrc/flash_attn/src/flash_fwd_split_hdim64_fp16_sm80.cu
+++ b/csrc/flash_attn/src/flash_fwd_split_hdim64_fp16_sm80.cu
@@ -6,6 +6,11 @@
 
 namespace FLASH_NAMESPACE {
 
+// The num_splits==1 blocksize-aligned tree is instantiated in its own translation unit
+// (flash_fwd_split_align_*.cu) so it compiles in parallel; declare it extern so
+// the dispatch below references it instead of re-instantiating.
+extern template void run_mha_fwd_splitkv_align<cutlass::half_t, 64, false>(Flash_fwd_params &params, cudaStream_t stream);
+
 template void run_mha_fwd_splitkv_dispatch<cutlass::half_t, 64, false>(Flash_fwd_params &params, cudaStream_t stream);
 
 } // namespace FLASH_NAMESPACE

--- a/csrc/flash_attn/src/flash_fwd_split_hdim96_bf16_causal_sm80.cu
+++ b/csrc/flash_attn/src/flash_fwd_split_hdim96_bf16_causal_sm80.cu
@@ -6,6 +6,11 @@
 
 namespace FLASH_NAMESPACE {
 
+// The num_splits==1 blocksize-aligned tree is instantiated in its own translation unit
+// (flash_fwd_split_align_*.cu) so it compiles in parallel; declare it extern so
+// the dispatch below references it instead of re-instantiating.
+extern template void run_mha_fwd_splitkv_align<cutlass::bfloat16_t, 96, true>(Flash_fwd_params &params, cudaStream_t stream);
+
 template void run_mha_fwd_splitkv_dispatch<cutlass::bfloat16_t, 96, true>(Flash_fwd_params &params, cudaStream_t stream);
 
 } // namespace FLASH_NAMESPACE

--- a/csrc/flash_attn/src/flash_fwd_split_hdim96_bf16_sm80.cu
+++ b/csrc/flash_attn/src/flash_fwd_split_hdim96_bf16_sm80.cu
@@ -6,6 +6,11 @@
 
 namespace FLASH_NAMESPACE {
 
+// The num_splits==1 blocksize-aligned tree is instantiated in its own translation unit
+// (flash_fwd_split_align_*.cu) so it compiles in parallel; declare it extern so
+// the dispatch below references it instead of re-instantiating.
+extern template void run_mha_fwd_splitkv_align<cutlass::bfloat16_t, 96, false>(Flash_fwd_params &params, cudaStream_t stream);
+
 template void run_mha_fwd_splitkv_dispatch<cutlass::bfloat16_t, 96, false>(Flash_fwd_params &params, cudaStream_t stream);
 
 } // namespace FLASH_NAMESPACE

--- a/csrc/flash_attn/src/flash_fwd_split_hdim96_fp16_causal_sm80.cu
+++ b/csrc/flash_attn/src/flash_fwd_split_hdim96_fp16_causal_sm80.cu
@@ -6,6 +6,11 @@
 
 namespace FLASH_NAMESPACE {
 
+// The num_splits==1 blocksize-aligned tree is instantiated in its own translation unit
+// (flash_fwd_split_align_*.cu) so it compiles in parallel; declare it extern so
+// the dispatch below references it instead of re-instantiating.
+extern template void run_mha_fwd_splitkv_align<cutlass::half_t, 96, true>(Flash_fwd_params &params, cudaStream_t stream);
+
 template void run_mha_fwd_splitkv_dispatch<cutlass::half_t, 96, true>(Flash_fwd_params &params, cudaStream_t stream);
 
 } // namespace FLASH_NAMESPACE

--- a/csrc/flash_attn/src/flash_fwd_split_hdim96_fp16_sm80.cu
+++ b/csrc/flash_attn/src/flash_fwd_split_hdim96_fp16_sm80.cu
@@ -6,6 +6,11 @@
 
 namespace FLASH_NAMESPACE {
 
+// The num_splits==1 blocksize-aligned tree is instantiated in its own translation unit
+// (flash_fwd_split_align_*.cu) so it compiles in parallel; declare it extern so
+// the dispatch below references it instead of re-instantiating.
+extern template void run_mha_fwd_splitkv_align<cutlass::half_t, 96, false>(Flash_fwd_params &params, cudaStream_t stream);
+
 template void run_mha_fwd_splitkv_dispatch<cutlass::half_t, 96, false>(Flash_fwd_params &params, cudaStream_t stream);
 
 } // namespace FLASH_NAMESPACE

--- a/csrc/flash_attn/src/generate_kernels.py
+++ b/csrc/flash_attn/src/generate_kernels.py
@@ -31,7 +31,21 @@ def get_fwd_split_template() -> str:
 
 namespace FLASH_NAMESPACE {{
 
+// The num_splits==1 blocksize-aligned tree is instantiated in its own translation unit
+// (flash_fwd_split_align_*.cu) so it compiles in parallel; declare it extern so
+// the dispatch below references it instead of re-instantiating.
+extern template void run_mha_fwd_splitkv_align<{DTYPE}, {HEAD_DIM}, {IS_CAUSAL}>(Flash_fwd_params &params, cudaStream_t stream);
+
 template void run_mha_fwd_splitkv_dispatch<{DTYPE}, {HEAD_DIM}, {IS_CAUSAL}>(Flash_fwd_params &params, cudaStream_t stream);
+
+}} // namespace FLASH_NAMESPACE"""
+
+def get_fwd_split_align_template() -> str:
+    return NAMESPACE_INCLUDE + """#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {{
+
+template void run_mha_fwd_splitkv_align<{DTYPE}, {HEAD_DIM}, {IS_CAUSAL}>(Flash_fwd_params &params, cudaStream_t stream);
 
 }} // namespace FLASH_NAMESPACE"""
 
@@ -60,7 +74,8 @@ class Kernel:
         template_funcs = {
             "fwd": get_fwd_template,
             "bwd": get_bwd_template,
-            "fwd_split": get_fwd_split_template
+            "fwd_split": get_fwd_split_template,
+            "fwd_split_align": get_fwd_split_align_template,
         }
         template_func = template_funcs[self.direction]
         return template_func().format(
@@ -74,7 +89,7 @@ class Kernel:
         return f"flash_{self.direction}_hdim{self.head_dim}_{self.dtype}_{'causal_' if self.is_causal == 'true' else ''}sm{self.sm}.cu"
 
 def get_all_kernels() -> List[Kernel]:
-    for direction in ["fwd", "fwd_split", "bwd"]:
+    for direction in ["fwd", "fwd_split", "fwd_split_align", "bwd"]:
         for dtype, head_dim, is_causal, sm in itertools.product(DTYPE_MAP.keys(), HEAD_DIMENSIONS, IS_CAUSAL, SM):
             yield Kernel(sm=sm, dtype=dtype, head_dim=head_dim, is_causal=is_causal, direction=direction)
 

--- a/setup.py
+++ b/setup.py
@@ -301,14 +301,6 @@ if not SKIP_CUDA_BUILD and not IS_ROCM:
         nvcc_flags.extend(["-Xcompiler", "/Zc:__cplusplus"])
         compiler_c17_flag=["-O2", "/std:c++17", "/Zc:__cplusplus"]
 
-    # Opt-in: skip the num_splits==1 blocksize-alignment instantiation in the
-    # splitkv dispatch. That alignment (PR #2448) compiles a second splitkv kernel
-    # tree per head dim, roughly doubling ptxas time for hd32/64/96/128 (hd64 can
-    # stall ptxas for hours). Disabling it keeps num_splits==1 correct but no
-    # longer bitwise-identical to the standard kernel. nvcc-only (header in .cu).
-    if os.getenv("FLASH_ATTENTION_DISABLE_SPLIT_ALIGNMENT", "FALSE") == "TRUE":
-        nvcc_flags.append("-DFLASHATTENTION_DISABLE_SPLIT_ALIGNMENT")
-
     ext_modules.append(
         CUDAExtension(
             name="flash_attn_2_cuda",
@@ -386,6 +378,30 @@ if not SKIP_CUDA_BUILD and not IS_ROCM:
                 "csrc/flash_attn/src/flash_fwd_split_hdim192_bf16_causal_sm80.cu",
                 "csrc/flash_attn/src/flash_fwd_split_hdim256_fp16_causal_sm80.cu",
                 "csrc/flash_attn/src/flash_fwd_split_hdim256_bf16_causal_sm80.cu",
+                "csrc/flash_attn/src/flash_fwd_split_align_hdim32_fp16_sm80.cu",
+                "csrc/flash_attn/src/flash_fwd_split_align_hdim32_bf16_sm80.cu",
+                "csrc/flash_attn/src/flash_fwd_split_align_hdim64_fp16_sm80.cu",
+                "csrc/flash_attn/src/flash_fwd_split_align_hdim64_bf16_sm80.cu",
+                "csrc/flash_attn/src/flash_fwd_split_align_hdim96_fp16_sm80.cu",
+                "csrc/flash_attn/src/flash_fwd_split_align_hdim96_bf16_sm80.cu",
+                "csrc/flash_attn/src/flash_fwd_split_align_hdim128_fp16_sm80.cu",
+                "csrc/flash_attn/src/flash_fwd_split_align_hdim128_bf16_sm80.cu",
+                "csrc/flash_attn/src/flash_fwd_split_align_hdim192_fp16_sm80.cu",
+                "csrc/flash_attn/src/flash_fwd_split_align_hdim192_bf16_sm80.cu",
+                "csrc/flash_attn/src/flash_fwd_split_align_hdim256_fp16_sm80.cu",
+                "csrc/flash_attn/src/flash_fwd_split_align_hdim256_bf16_sm80.cu",
+                "csrc/flash_attn/src/flash_fwd_split_align_hdim32_fp16_causal_sm80.cu",
+                "csrc/flash_attn/src/flash_fwd_split_align_hdim32_bf16_causal_sm80.cu",
+                "csrc/flash_attn/src/flash_fwd_split_align_hdim64_fp16_causal_sm80.cu",
+                "csrc/flash_attn/src/flash_fwd_split_align_hdim64_bf16_causal_sm80.cu",
+                "csrc/flash_attn/src/flash_fwd_split_align_hdim96_fp16_causal_sm80.cu",
+                "csrc/flash_attn/src/flash_fwd_split_align_hdim96_bf16_causal_sm80.cu",
+                "csrc/flash_attn/src/flash_fwd_split_align_hdim128_fp16_causal_sm80.cu",
+                "csrc/flash_attn/src/flash_fwd_split_align_hdim128_bf16_causal_sm80.cu",
+                "csrc/flash_attn/src/flash_fwd_split_align_hdim192_fp16_causal_sm80.cu",
+                "csrc/flash_attn/src/flash_fwd_split_align_hdim192_bf16_causal_sm80.cu",
+                "csrc/flash_attn/src/flash_fwd_split_align_hdim256_fp16_causal_sm80.cu",
+                "csrc/flash_attn/src/flash_fwd_split_align_hdim256_bf16_causal_sm80.cu",
             ],
             extra_compile_args={
                 "cxx": compiler_c17_flag,


### PR DESCRIPTION
This PR fixes the build slowdown due to the num_splits=1 templating that was doubling the kernels (from 160 to 320) in one translation unit. This PR fixes it by forcing the num_splits templates to live in their own files so that the compiler could work in parallel. This drives build down from 4h+ to 5 minutes when one wants to build with num_split=1 bitwise alignment.

The one cost is that this drives FA2 from 73 translation units to 97, which is just a consequence of having 24 more files.

With that the FLASHATTENTION_DISABLE_SPLIT_ALIGNMENT is no longer useful so we might as well remove it esp because I just introduced it in #2680

Test Plan:
```
(fa2-pt210) ➜  flash-attention git:(parallelize-split-alignment) pytest tests/test_flash_attn.py -k "kvcache or paged_kv_num_splits" -n 4
...
======================================== 152066 passed, 152064 skipped in 840.39s (0:14:00) ========================================
```

cc @liangel-02 @drisspg 