### PR TITLE
ci: rebake cu130 image for cutlass-dsl 4.6.0.dev0 floor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,4 +45,4 @@ jobs:
         with:
           test-filter: ${{ env.FA4_TEST_FILTER }}
           fa4_image_cu129: "togethercomputer/training-performance:flash-attn-cu12.9-26.03.25@sha256:304a5c3d2b3a75b151cd2a964cd26d444e0d8b5686d63943df13378c9705f943"
-          fa4_image_cu130: "togethercomputer/training-performance:flash-attn-cu13.0-26.06.10@sha256:f1efd03b9d78cf65d9f8df107d2f6f6d0a464cb8b773fd9364765f22f4772006"
+          fa4_image_cu130: "togethercomputer/training-performance:flash-attn-cu13.0-26.06.27@sha256:2c31843c7137cbe909611eb70a9b6940581a2e3018d2c8b629f84dfd04b9bfd7"

--- a/tools/ci/docker/Dockerfile
+++ b/tools/ci/docker/Dockerfile
@@ -25,6 +25,9 @@ RUN uv pip install --system --break-system-packages --no-cache --pre \
 # The package itself (version 0.0.0 via setuptools-scm fallback) is overwritten at
 # step time by the editable install from the mounted repo.
 COPY flash_attn/cute/ /tmp/fa4/
-RUN uv pip install --system --break-system-packages --no-cache "/tmp/fa4[cu13,dev]"
+# --prerelease=allow: the cutlass-dsl floor is pinned to a dev build (e.g. 4.6.0.dev0), whose
+# cu13 extra pulls transitive pre-release deps (nvidia-cutlass-dsl-libs-base==4.6.0.dev0 …).
+# uv honors the explicit top-level pre-release pin but refuses transitive pre-releases without this.
+RUN uv pip install --system --break-system-packages --no-cache --prerelease=allow "/tmp/fa4[cu13,dev]"
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
PR #2648 bumped the `flash_attn/cute/pyproject.toml` floor to `nvidia-cutlass-dsl==4.6.0.dev0`, but the CI image (`26.06.10`) still ships **4.5.2**. `assert_dsl_floor.py` correctly fails every push to `main` with:

```
nvidia-cutlass-dsl: installed 4.5.2 does not satisfy floor ==4.6.0.dev0
```

so FA4 CI has been red on every push since #2648 landed (confirmed on runs for #2648, #2679, #2680 — all the same root cause, dying ~10s in before any kernel compiles). This rebakes the image to the new floor.

## Changes
- **`tools/ci/docker/Dockerfile`**: add `--prerelease=allow` to the FA4 install. The dev-build floor pulls transitive pre-releases (`nvidia-cutlass-dsl-libs-base==4.6.0.dev0`, `nvidia-cutlass-dsl-libs-cu13`, ...) that `uv` refuses without it — the previous stable `4.5.2` floor did not need this.
- **`.github/workflows/ci.yml`**: bump `fa4_image_cu130` to the rebaked `26.06.27` image.

## Rebaked image
`togethercomputer/training-performance:flash-attn-cu13.0-26.06.27@sha256:2c31843c7137cbe909611eb70a9b6940581a2e3018d2c8b629f84dfd04b9bfd7`
(cutlass-dsl `4.6.0.dev0`, quack-kernels `0.5.3`, torch `2.12.1`)

## Verification (B200)
End-to-end `run_fa4_ci.py` on the rebaked SIF:
- `DSL floor check OK: nvidia-cutlass-dsl=4.6.0.dev0, quack-kernels=0.5.3`
- Pass 1 (compile): 4 passed in 127.90s
- Pass 2 (GPU run): 4 passed in 56.40s
- fwd+bwd benchmark ran; `=== All tests passed ===` (exit 0)

Note: this repo's CI only triggers on push to `main`/`ci-fix` (no `pull_request`), so this PR shows no CI checks — the green signal only appears once it lands on `main`.