### PR TITLE
ci: install cutlass-dsl/quack at runtime to decouple from the baked image

### DIFF
--- a/tools/ci/run_fa4_ci.py
+++ b/tools/ci/run_fa4_ci.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import re
 import shlex
 import subprocess
 from dataclasses import dataclass
@@ -57,6 +58,31 @@ def read_free_gpu_indices(min_free_memory_mb: int) -> list[str]:
     return parse_free_gpu_indices(result.stdout, min_free_memory_mb)
 
 
+# ── Runtime DSL pin (decouples cutlass-dsl from the baked image) ─────────────────
+
+def read_dep_spec(pyproject_path: Path, name: str) -> str:
+    """Read a dependency's version specifier (e.g. '==4.6.0.dev0', '>=0.5.0') from pyproject.
+
+    Regex (not tomllib) on purpose: this runs on the HOST python (3.10 on the self-hosted runner),
+    which may not have a TOML parser or `packaging`. Any `[extras]` between the name and the
+    specifier are ignored — the caller re-adds the extra it needs.
+    """
+    text = pyproject_path.read_text()
+    m = re.search(rf"{re.escape(name)}(?:\[[^\]]*\])?\s*([=<>!~][^\"'\],]*)", text)
+    if not m:
+        raise SystemExit(f"Could not find a version specifier for `{name}` in {pyproject_path}")
+    return m.group(1).strip()
+
+
+def read_cuda_major() -> int:
+    """Driver's max CUDA major from nvidia-smi header (picks the cutlass-dsl libs variant)."""
+    out = subprocess.run(["nvidia-smi"], check=True, capture_output=True, text=True).stdout
+    m = re.search(r"CUDA Version:\s*(\d+)\.", out)
+    if not m:
+        raise SystemExit("Could not parse 'CUDA Version: X.Y' from nvidia-smi output")
+    return int(m.group(1))
+
+
 # ── Step plan ─────────────────────────────────────────────────────────────────
 
 def build_step_plan(
@@ -102,25 +128,63 @@ def build_step_plan(
 
 # ── Step runner ───────────────────────────────────────────────────────────────
 
-def run_step(step: Step, repo_root: Path, base_env: dict[str, str], sif: str, work_dir: str) -> None:
-    print(f"=== {step.name} ===")
+def prepare_overlay(
+    repo_root: Path,
+    base_env: dict[str, str],
+    sif: str,
+    work_dir: str,
+    overlay: str,
+    cutlass_spec: str,
+    quack_spec: str,
+    dsl_variant: str,
+) -> None:
+    """Provision the disk-backed overlay once: install the DSL stack + FA4, then floor-check.
 
-    # Install FA4 from the current repo inside this exec invocation.
-    # --no-deps keeps the SIF's baked torch/cudnn; deps are expected to already satisfy the
-    # pyproject floors via the image (rebuilt with tools/ci/docker/build.sh). We do NOT upgrade
-    # deps here: the --writable-tmpfs overlay is RAM-backed and too small to hold a cutlass-dsl
-    # reinstall (it ENOSPCs and can corrupt the baked torch). Instead assert_dsl_floor.py below
-    # fails loudly if the image is stale, pointing at a rebake.
-    # Must be done per-step because --writable-tmpfs creates a fresh overlay each time.
-    install_cmd = f"uv pip install --system --break-system-packages --no-deps -q -e {shlex.quote(str(repo_root / 'flash_attn/cute'))}"
+    This is what decouples the fast-moving DSL stack from the baked image — CI installs the versions
+    declared in flash_attn/cute/pyproject.toml at runtime, so a floor bump no longer needs an image
+    rebake. nvidia-cutlass-dsl and quack-kernels are COUPLED (quack annotates cutlass internals like
+    cute.core.ThrMma at import), so they must be installed together at compatible versions; uv's
+    joint resolve picks the quack that matches the pinned cutlass (exactly what the image build does).
 
-    # Guard against a SIF baked with deps below the pyproject floor (the silent --no-deps gap that
-    # otherwise surfaces as a cryptic DSLRuntimeError on the SM100 path). Cheap: reads versions, no install.
+    Why this shape:
+    - The baked cutlass-dsl ships a `.pth` that adds a vendored `nvidia_cutlass_dsl/python_packages`
+      tree to sys.path. A plain `uv pip install` over it leaves stale files/.pyc in that tree and
+      silently mixes versions (symptoms: cute.core missing `ThrMma`, an old libs `fmax` signature).
+      So we delete the baked cutlass + quack trees outright, then install into a clean slate.
+    - The install goes into the image's real site-packages (not a PYTHONPATH shim, which would leave
+      the baked copy co-resident on the `nvidia.*` namespace and re-introduce the mix).
+    - That needs a writable, roomy layer: a DISK-backed --overlay (created in main()), not the
+      RAM-backed --writable-tmpfs, which is too small and ENOSPCs on a DSL reinstall.
+    - --prerelease=allow: the cutlass pin is often a dev build (e.g. 4.6.0.dev0) with transitive
+      pre-releases that uv otherwise refuses.
+    """
+    print(f"=== Provision overlay: cutlass-dsl[{dsl_variant}]{cutlass_spec} + quack-kernels{quack_spec} + FA4 ===")
+    site_packages = "SP=$(python3 -c 'import sysconfig; print(sysconfig.get_paths()[\"purelib\"])')"
+    nuke_baked_dsl = (
+        'rm -rf "$SP"/nvidia_cutlass_dsl* "$SP"/nvidia/cutlass_dsl* '
+        '"$SP"/quack "$SP"/quack_kernels* 2>/dev/null || true'
+    )
+    uv_cache_export = f"export UV_CACHE_DIR={shlex.quote(os.path.join(work_dir, 'uv_cache'))}"
+    dsl_install_cmd = (
+        f"uv pip install --system --break-system-packages --prerelease=allow -q "
+        f"'nvidia-cutlass-dsl[{dsl_variant}]{cutlass_spec}' 'quack-kernels{quack_spec}'"
+    )
+    # Install FA4 from the current repo. --no-deps keeps the SIF's baked torch/cudnn (and the
+    # runtime DSL stack installed above).
+    fa4_install_cmd = f"uv pip install --system --break-system-packages --no-deps -q -e {shlex.quote(str(repo_root / 'flash_attn/cute'))}"
+    # Sanity-check the importable deps satisfy the pyproject floors (verifies the runtime install
+    # took effect; for any image-backed dep it still catches a stale SIF below the floor).
     floor_check_cmd = (
         f"python3 {shlex.quote(str(repo_root / 'tools/ci/assert_dsl_floor.py'))} "
         f"{shlex.quote(str(repo_root / 'flash_attn/cute/pyproject.toml'))}"
     )
+    parts = [uv_cache_export, site_packages, nuke_baked_dsl, dsl_install_cmd, fa4_install_cmd, floor_check_cmd]
+    cmd = ["apptainer", "exec", "--nv", "--overlay", overlay, "--bind", work_dir, sif, "bash", "-c", " && ".join(parts)]
+    subprocess.run(cmd, check=True, cwd=repo_root, env=base_env)
 
+
+def run_step(step: Step, repo_root: Path, base_env: dict[str, str], sif: str, work_dir: str, overlay: str) -> None:
+    print(f"=== {step.name} ===")
     # Convert relative test/benchmark paths to absolute so we can run from /tmp.
     # Running from /tmp ensures Python does not insert repo_root into sys.path[0]
     # (which would cause flash_attn/__init__.py to trigger FA2 imports unavailable in the SIF).
@@ -130,11 +194,9 @@ def run_step(step: Step, repo_root: Path, base_env: dict[str, str], sif: str, wo
     ]
     env_exports = " && ".join(f"export {k}={shlex.quote(v)}" for k, v in step.extra_env.items())
     inner_cmd = shlex.join(command)
-    shell_parts = [install_cmd, floor_check_cmd]
-    if env_exports:
-        shell_parts.append(env_exports)
+    shell_parts = [env_exports] if env_exports else []
     shell_parts.append(f"cd /tmp && {inner_cmd}")
-    cmd = ["apptainer", "exec", "--nv", "--writable-tmpfs", "--bind", work_dir, sif, "bash", "-c", " && ".join(shell_parts)]
+    cmd = ["apptainer", "exec", "--nv", "--overlay", overlay, "--bind", work_dir, sif, "bash", "-c", " && ".join(shell_parts)]
     subprocess.run(cmd, check=True, cwd=repo_root, env=base_env)
 
 
@@ -171,16 +233,39 @@ def main() -> None:
     base_env = {**os.environ, "FLASH_ATTENTION_CUTE_DSL_CACHE_ENABLED": "1"}
     work_dir = os.environ.get("CI_WORK_DIR", f"/scratch/user/{os.environ.get('USER', 'user')}")
 
-    for step in build_step_plan(
-        test_target=args.test_target,
-        test_filter=args.test_filter,
-        compile_workers=args.compile_workers,
-        run_workers=args.run_workers,
-        test_visible_devices=test_visible_devices,
-        benchmark_visible_devices=benchmark_visible_devices,
-        skip_benchmark=args.skip_benchmark,
-    ):
-        run_step(step, repo_root=repo_root, base_env=base_env, sif=args.sif, work_dir=work_dir)
+    # Runtime DSL versions, read straight from pyproject (single source of truth) and installed into
+    # a fresh disk-backed overlay that replaces the SIF's baked versions. Recreate the overlay each
+    # run so a changed pin can't inherit a stale install from a previous job.
+    pyproject = repo_root / "flash_attn/cute/pyproject.toml"
+    cutlass_spec = read_dep_spec(pyproject, "nvidia-cutlass-dsl")
+    quack_spec = read_dep_spec(pyproject, "quack-kernels")
+    dsl_variant = "cu13" if read_cuda_major() >= 13 else "cu12"
+    overlay = os.path.join(work_dir, "fa4_ci_overlay.img")
+    os.makedirs(work_dir, exist_ok=True)
+    if os.path.exists(overlay):
+        os.remove(overlay)
+    subprocess.run(["apptainer", "overlay", "create", "--size", "4096", overlay], check=True)
+    print(f"Runtime DSL: cutlass-dsl[{dsl_variant}]{cutlass_spec} + quack-kernels{quack_spec} (into {overlay})")
+
+    try:
+        prepare_overlay(
+            repo_root=repo_root, base_env=base_env, sif=args.sif, work_dir=work_dir,
+            overlay=overlay, cutlass_spec=cutlass_spec, quack_spec=quack_spec, dsl_variant=dsl_variant,
+        )
+        for step in build_step_plan(
+            test_target=args.test_target,
+            test_filter=args.test_filter,
+            compile_workers=args.compile_workers,
+            run_workers=args.run_workers,
+            test_visible_devices=test_visible_devices,
+            benchmark_visible_devices=benchmark_visible_devices,
+            skip_benchmark=args.skip_benchmark,
+        ):
+            run_step(step, repo_root=repo_root, base_env=base_env, sif=args.sif, work_dir=work_dir, overlay=overlay)
+    finally:
+        # The overlay can hold gigabytes; don't leave it behind on the runner between jobs.
+        if os.path.exists(overlay):
+            os.remove(overlay)
 
     print("=== All tests passed ===")
 


### PR DESCRIPTION
## Problem

The DSL stack (`nvidia-cutlass-dsl`, `quack-kernels`) is the *only* thing that forces a CI image rebake. Every floor bump in `flash_attn/cute/pyproject.toml` leaves the baked SIF below floor, so `assert_dsl_floor.py` reds CI on every push until someone manually rebakes the image and repoints the digest in `ci.yml`. We've now done this twice (cutlass-dsl 4.5.2 → 4.6.0.dev0). The image's torch/cudnn/CUDA base, by contrast, rarely changes.

## What this does

`tools/ci/run_fa4_ci.py` now installs the `cutlass-dsl` + `quack-kernels` versions **read straight from `pyproject.toml`** (single source of truth) at run time, replacing whatever the SIF baked. A DSL floor bump then needs **no rebake** — CI tracks `pyproject` directly. The image becomes just a stable torch/CUDA base.

Mechanically, the driver now:

1. Creates a disk-backed `apptainer overlay` (recreated each run, removed in `finally`).
2. In a one-time `prepare_overlay` step: removes the baked cutlass/quack trees, installs the pinned cutlass-dsl + quack-kernels into the real site-packages, installs FA4 editable (`--no-deps`, keeping baked torch), and runs the floor check.
3. Runs the test/benchmark steps lean over the same overlay.

## Why these specific choices (each is load-bearing — learned the hard way)

- **cutlass-dsl and quack-kernels must be installed together.** They are coupled: `quack` annotates cutlass internals (e.g. `cute.core.ThrMma`) at import, so quack 0.5.0 explodes on cutlass 4.6.0.dev0. uv's joint resolve picks the quack that matches the pinned cutlass (quack 0.5.3) — exactly what the image build does.
- **The baked cutlass trees are deleted before installing.** cutlass-dsl ships a `.pth` that adds a vendored `nvidia_cutlass_dsl/python_packages` tree to `sys.path`. A plain `uv pip install` over it leaves stale files/`.pyc` that silently mix versions (symptoms: `cute.core` missing `ThrMma`, an old libs `fmax()` signature). Nuking first guarantees one consistent install.
- **Install goes into the real site-packages, not a `PYTHONPATH`/`--target` shim.** A shim leaves the baked copy co-resident on the `nvidia.*` namespace (PEP 420 merges them), re-introducing the mix.
- **A disk-backed `--overlay`, not `--writable-tmpfs`.** The RAM-backed tmpfs is too small and ENOSPCs on a DSL reinstall.
- **Versions are parsed from `pyproject` by regex** (the self-hosted runner's host Python may lack a TOML parser); the libs variant (`cu13`/`cu12`) is chosen from the driver CUDA version.

## Verification (B200)

Ran the patched driver against an image baking the **old** stack (cutlass 4.5.2 / quack 0.5.0):

```
Runtime DSL: cutlass-dsl[cu13]==4.6.0.dev0 + quack-kernels>=0.5.0
DSL floor check OK: nvidia-cutlass-dsl=4.6.0.dev0, quack-kernels=0.5.3   ← upgraded at runtime
Pass 1 (compile): 4 passed in 272.72s
Pass 2 (GPU run): 4 passed in 56.72s
Benchmark (fwd+bwd) ran
=== All tests passed ===   (exit 0)
```

i.e. CI goes green against a stale image with **no rebake**.

## Notes

- This is independent of the image-rebake fix (cutlass-dsl 4.6.0.dev0 floor) — that should still land to get CI green immediately; this change stops the rebake treadmill going forward.
- After this, the image only needs rebaking for torch / cudnn / CUDA-base changes.
- `assert_dsl_floor.py` is unchanged and still runs — it now validates the runtime install took effect (and still catches any genuinely image-backed dep below floor).