### PR TITLE
[Cute] Assume 16B stride divisibility for SM100 backward LSE/dPsum bulk-copy inputs

### DIFF
--- a/flash_attn/cute/flash_bwd_mla_sm100.py
+++ b/flash_attn/cute/flash_bwd_mla_sm100.py
@@ -371,11 +371,11 @@ class FlashAttentionSparseMLABackwardSm100:
             *(cute.assume(s, divby=128 // mX.element_type.width) for s in mX.stride[:-1]),
             mX.stride[-1],
         )
-        mQv, mV, mdV, mdO, mP, mdS, mScaleP = [
+        mQv, mV, mdV, mdO, mP, mdS, mScaleP, mdPsum = [
             cute.make_tensor(mX.iterator, cute.make_layout(mX.shape, stride=new_stride(mX)))
             if mX is not None
             else None
-            for mX in (mQv, mV, mdV, mdO, mP, mdS, mScaleP)
+            for mX in (mQv, mV, mdV, mdO, mP, mdS, mScaleP, mdPsum)
         ]
         # (b, s, h, d)  -> (s, d, h, b)  or
         # (total, h, d) -> (total, d, h)

--- a/flash_attn/cute/flash_bwd_sm100.py
+++ b/flash_attn/cute/flash_bwd_sm100.py
@@ -485,7 +485,9 @@ class FlashAttentionBackwardSm100:
             assert self.dk_dtype.width == 32, "Must accumulate dK in float precision for GQA"
             assert self.dv_dtype.width == 32, "Must accumulate dV in float precision for GQA"
 
-        mdQaccum, mdK, mdV = [assume_tensor_aligned(t) for t in (mdQaccum, mdK, mdV)]
+        mdQaccum, mdK, mdV, mLSE, mdPsum = [
+            assume_tensor_aligned(t) for t in (mdQaccum, mdK, mdV, mLSE, mdPsum)
+        ]
 
         # (b, s, n, h) --> (s, h, n, b) or (t, n, h) -> (t, h, n)
         QO_layout_transpose = [1, 3, 2, 0] if const_expr(mCuSeqlensQ is None) else [0, 2, 1]


### PR DESCRIPTION
Resolves **Finding 1** of #2677. 

## What & why
SM100 backward stats (LSE, dPsum) are loaded via `cp.async.bulk` (`CopyBulkG2SOp`), which needs the source pointer's 16B alignment provable at compile time. Newer cute-dsl can't deduce that for sliced inputs unless their strides carry the divisibility assumption, so the bulk copy fails to compile on real tensors (the FakeTensor path hides it).

- `flash_bwd_mla_sm100.py`: add `mdPsum` to the `new_stride` list (only omission; `ScaleP` etc. were already covered).
- `flash_bwd_sm100.py`: add the assumption for `mLSE` and `mdPsum` (it had none).

These are the only two FA4 kernels using `CopyBulkG2SOp` (forward and SM90/SM80/SM120 backward use other copy paths), so this covers every affected site.

## Notes
- Finding 2 of #2677 (the redundant `elect_one`) is **not** touched — `CopyBulkG2SOp` currently needs the manual elect, so removing it hangs; deferred to a future cute-dsl release.
- Correctness-neutral (only asserts alignment that already holds). B200 + cutlass-dsl 4.6.0.dev0: `test_flash_attn_mla_absorbed` (sparse backward) passes with and without the change. The reported compile failure only appears on a newer nightly, so the failing "before" isn't reproducible here.

Co-authored with @dongxiao92, who reported it and suggested the `mdPsum` fix.
