### PR TITLE
[ROCm] Expose AITER_USE_SYSTEM_TRITON to preserve system Triton for flash-attn builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,14 @@ cd flash-attention
 FLASH_ATTENTION_TRITON_AMD_ENABLE="TRUE" pip install --no-build-isolation .
 ```
 
+If your ROCm PyTorch environment already provides a compatible Triton package
+(for example, a container image with a PyTorch-pinned ROCm Triton wheel), set
+`FLASH_ATTENTION_USE_SYSTEM_TRITON="TRUE"` to keep that Triton package instead
+of installing another one:
+```sh
+FLASH_ATTENTION_TRITON_AMD_ENABLE="TRUE" FLASH_ATTENTION_USE_SYSTEM_TRITON="TRUE" pip install --no-build-isolation .
+```
+
 To use a specific aiter commit (e.g., for testing or development):
 ```sh
 cd flash-attention

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,9 @@ FORCE_CXX11_ABI = os.getenv("FLASH_ATTENTION_FORCE_CXX11_ABI", "FALSE") == "TRUE
 ROCM_BACKEND: Optional[Literal["triton", "ck"]] = None
 if IS_ROCM:
     ROCM_BACKEND = "triton" if os.getenv("FLASH_ATTENTION_TRITON_AMD_ENABLE", "FALSE") == "TRUE" else "ck"
+USE_SYSTEM_TRITON = (
+    ROCM_BACKEND == "triton" and os.getenv("FLASH_ATTENTION_USE_SYSTEM_TRITON", "FALSE") == "TRUE"
+)
 NVCC_THREADS = os.getenv("NVCC_THREADS") or "4"
 
 @functools.lru_cache(maxsize=None)
@@ -227,9 +230,14 @@ if IS_ROCM:
             assert os.path.isdir("third_party/aiter"), (
                 "third_party/aiter is missing, please use source distribution or git clone"
             )
+        env = os.environ.copy()
+        if USE_SYSTEM_TRITON:
+            env["AITER_USE_SYSTEM_TRITON"] = "1"
+
         subprocess.run(
             [sys.executable, "-m", "pip", "install", "--no-build-isolation", "third_party/aiter"],
             check=True,
+            env=env,
         )
     elif ROCM_BACKEND == "ck":
         if os.path.isdir(".git"):
@@ -676,10 +684,11 @@ class NinjaBuildExtension(BuildExtension):
 # Build install_requires based on platform
 if ROCM_BACKEND == "triton":
     # Note: torch is excluded because pip resolves it to CUDA PyTorch from PyPI, overwriting any pre-installed ROCm PyTorch. Users must have torch installed.
-    install_requires = [
-        "einops",
-        "triton>=3.6.0" if sys.platform != "win32" else "triton-windows>=3.6.0",
-    ]
+    install_requires = ["einops"]
+    if not USE_SYSTEM_TRITON:
+        install_requires.append(
+            "triton>=3.6.0" if sys.platform != "win32" else "triton-windows>=3.6.0"
+        )
 else:
     install_requires = [
         "torch",

--- a/tests/test_setup_system_triton.py
+++ b/tests/test_setup_system_triton.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+
+def test_rocm_triton_backend_can_keep_system_triton():
+    setup_py = Path(__file__).resolve().parents[1] / "setup.py"
+    source = setup_py.read_text()
+
+    assert "FLASH_ATTENTION_USE_SYSTEM_TRITON" in source
+    assert "USE_SYSTEM_TRITON_REQUESTED" not in source
+    assert (
+        'USE_SYSTEM_TRITON = (\n'
+        '    ROCM_BACKEND == "triton" and os.getenv("FLASH_ATTENTION_USE_SYSTEM_TRITON", "FALSE") == "TRUE"\n'
+        ')'
+    ) in source
+    assert 'env["AITER_USE_SYSTEM_TRITON"] = "1"' in source
+    assert "if not USE_SYSTEM_TRITON:" in source
+    assert '"triton>=3.6.0" if sys.platform != "win32" else "triton-windows>=3.6.0"' in source


### PR DESCRIPTION
Allow ROCm Triton backend builds to opt into the Triton already pinned by the surrounding PyTorch environment and propagate that choice to bundled AITER so it does not replace Triton during setup by exposing the `AITER_USE_SYSTEM_TRITON` environment variable with `FLASH_ATTENTION_USE_SYSTEM_TRITON`. Gate the env var so it only applies when ROCM_BACKEND is triton.