### PR TITLE
Make dropout-disabled FA2 libtorch ABI stable

### DIFF
--- a/csrc/flash_attn/flash_api.cpp
+++ b/csrc/flash_attn/flash_api.cpp
@@ -2,8 +2,7 @@
  * Copyright (c) 2024, Tri Dao.
  ******************************************************************************/
 
-// Include these 2 headers instead of torch/extension.h since we don't need all of the torch headers.
-#include <torch/python.h>
+#include <torch/library.h>
 #include <torch/nn/functional.h>
 #include <c10/cuda/CUDAGuard.h>
 #include <c10/cuda/CUDAStream.h>
@@ -366,17 +365,17 @@ void set_params_alibi(Flash_fwd_params &params, std::optional<at::Tensor> &alibi
 }
 
 std::vector<at::Tensor>
-mha_fwd(at::Tensor &q,         // batch_size x seqlen_q x num_heads x round_multiple(head_size, 8)
+mha_fwd(at::Tensor q,         // batch_size x seqlen_q x num_heads x round_multiple(head_size, 8)
         const at::Tensor &k,         // batch_size x seqlen_k x num_heads_k x round_multiple(head_size, 8)
         const at::Tensor &v,         // batch_size x seqlen_k x num_heads_k x round_multiple(head_size, 8)
-        std::optional<at::Tensor> &out_,             // batch_size x seqlen_q x num_heads x round_multiple(head_size, 8)
-        std::optional<at::Tensor> &alibi_slopes_, // num_heads or batch_size x num_heads
-        const float p_dropout,
-        const float softmax_scale,
+        std::optional<at::Tensor> out_,             // batch_size x seqlen_q x num_heads x round_multiple(head_size, 8)
+        std::optional<at::Tensor> alibi_slopes_, // num_heads or batch_size x num_heads
+        const double p_dropout,
+        const double softmax_scale,
         bool is_causal,
-        int window_size_left,
-        int window_size_right,
-        const float softcap,
+        int64_t window_size_left,
+        int64_t window_size_right,
+        const double softcap,
         const bool return_softmax,
         // Retained only for backwards-compat arg positioning; must be None.
         std::optional<at::Tensor> unused_generator_compat) {
@@ -536,29 +535,29 @@ mha_fwd(at::Tensor &q,         // batch_size x seqlen_q x num_heads x round_mult
 }
 
 std::vector<at::Tensor>
-mha_varlen_fwd(at::Tensor &q,  // total_q x num_heads x head_size, total_q := \sum_{i=0}^{b} s_i
+mha_varlen_fwd(at::Tensor q,  // total_q x num_heads x head_size, total_q := \sum_{i=0}^{b} s_i
                const at::Tensor &k,  // total_k x num_heads_k x head_size, total_k := \sum_{i=0}^{b} s_i or num_blocks x page_block_size x num_heads_k x head_size if there's a block_table.
                const at::Tensor &v,  // total_k x num_heads_k x head_size, total_k := \sum_{i=0}^{b} s_i or num_blocks x page_block_size x num_heads_k x head_size if there's a block_table.
-               std::optional<at::Tensor> &out_, // total_q x num_heads x head_size, total_q := \sum_{i=0}^{b} s_i
+               std::optional<at::Tensor> out_, // total_q x num_heads x head_size, total_q := \sum_{i=0}^{b} s_i
                const at::Tensor &cu_seqlens_q,  // b+1
                const at::Tensor &cu_seqlens_k,  // b+1
-               std::optional<at::Tensor> &seqused_k, // b. If given, only this many elements of each batch element's keys are used.
-               std::optional<const at::Tensor> &leftpad_k_, // batch_size
-               std::optional<at::Tensor> &block_table_, // batch_size x max_num_blocks_per_seq
-               std::optional<at::Tensor> &alibi_slopes_, // num_heads or b x num_heads
-               int max_seqlen_q,
-               const int max_seqlen_k,
-               const float p_dropout,
-               const float softmax_scale,
+               std::optional<at::Tensor> seqused_k, // b. If given, only this many elements of each batch element's keys are used.
+               const std::optional<at::Tensor> &leftpad_k_, // batch_size
+               std::optional<at::Tensor> block_table_, // batch_size x max_num_blocks_per_seq
+               std::optional<at::Tensor> alibi_slopes_, // num_heads or b x num_heads
+               int64_t max_seqlen_q,
+               const int64_t max_seqlen_k,
+               const double p_dropout,
+               const double softmax_scale,
                const bool zero_tensors,
                bool is_causal,
-               int window_size_left,
-               int window_size_right,
-               const float softcap,
+               int64_t window_size_left,
+               int64_t window_size_right,
+               const double softcap,
                const bool return_softmax,
                // Retained only for backwards-compat arg positioning; must be None.
                std::optional<at::Tensor> unused_generator_compat,
-               int num_splits = 0) {
+               int64_t num_splits = 0) {
 
     TORCH_CHECK(!unused_generator_compat.has_value(),
                 "flash-attn: the RNG `generator` argument is no longer supported and must be None; "
@@ -804,20 +803,20 @@ mha_bwd(const at::Tensor &dout,  // batch_size x seqlen_q x num_heads, x multipl
         const at::Tensor &v,   // batch_size x seqlen_k x num_heads_k x head_size
         const at::Tensor &out,   // batch_size x seqlen_q x num_heads x head_size
         const at::Tensor &softmax_lse,     // b x h x seqlen_q
-        std::optional<at::Tensor> &dq_,   // batch_size x seqlen_q x num_heads x head_size
-        std::optional<at::Tensor> &dk_,   // batch_size x seqlen_k x num_heads_k x head_size
-        std::optional<at::Tensor> &dv_,   // batch_size x seqlen_k x num_heads_k x head_size
-        std::optional<at::Tensor> &alibi_slopes_, // num_heads or batch_size x num_heads
-        const float p_dropout,         // probability to drop
-        const float softmax_scale,
+        std::optional<at::Tensor> dq_,   // batch_size x seqlen_q x num_heads x head_size
+        std::optional<at::Tensor> dk_,   // batch_size x seqlen_k x num_heads_k x head_size
+        std::optional<at::Tensor> dv_,   // batch_size x seqlen_k x num_heads_k x head_size
+        std::optional<at::Tensor> alibi_slopes_, // num_heads or batch_size x num_heads
+        const double p_dropout,         // probability to drop
+        const double softmax_scale,
         const bool is_causal,
-        int window_size_left,
-        int window_size_right,
-        const float softcap,
+        int64_t window_size_left,
+        int64_t window_size_right,
+        const double softcap,
         const bool deterministic,
         // Retained only for backwards-compat arg positioning; must be None.
         std::optional<at::Tensor> unused_generator_compat,
-        std::optional<at::Tensor> &rng_state) {
+        std::optional<at::Tensor> rng_state) {
 
     TORCH_CHECK(!unused_generator_compat.has_value(),
                 "flash-attn: the RNG `generator` argument is no longer supported and must be None; "
@@ -1014,25 +1013,25 @@ mha_varlen_bwd(const at::Tensor &dout,  // total_q x num_heads, x head_size
                const at::Tensor &v,   // total_k x num_heads_k x head_size, total_k := \sum_{i=0}^{b} s_i
                const at::Tensor &out,   // total_q x num_heads x head_size
                const at::Tensor &softmax_lse,    // h x total_q, softmax logsumexp
-               std::optional<at::Tensor> &dq_,   // total_q x num_heads x head_size, total_q := \sum_{i=0}^{b} s_i
-               std::optional<at::Tensor> &dk_,   // total_k x num_heads_k x head_size, total_k := \sum_{i=0}^{b} s_i
-               std::optional<at::Tensor> &dv_,   // total_k x num_heads_k x head_size, total_k := \sum_{i=0}^{b} s_i
+               std::optional<at::Tensor> dq_,   // total_q x num_heads x head_size, total_q := \sum_{i=0}^{b} s_i
+               std::optional<at::Tensor> dk_,   // total_k x num_heads_k x head_size, total_k := \sum_{i=0}^{b} s_i
+               std::optional<at::Tensor> dv_,   // total_k x num_heads_k x head_size, total_k := \sum_{i=0}^{b} s_i
                const at::Tensor &cu_seqlens_q,  // b+1
                const at::Tensor &cu_seqlens_k,  // b+1
-               std::optional<at::Tensor> &alibi_slopes_, // num_heads or b x num_heads
-               const int max_seqlen_q,
-               const int max_seqlen_k,          // max sequence length to choose the kernel
-               const float p_dropout,         // probability to drop
-               const float softmax_scale,
+               std::optional<at::Tensor> alibi_slopes_, // num_heads or b x num_heads
+               const int64_t max_seqlen_q,
+               const int64_t max_seqlen_k,          // max sequence length to choose the kernel
+               const double p_dropout,         // probability to drop
+               const double softmax_scale,
                const bool zero_tensors,
                const bool is_causal,
-               int window_size_left,
-               int window_size_right,
-               const float softcap,
+               int64_t window_size_left,
+               int64_t window_size_right,
+               const double softcap,
                const bool deterministic,
                // Retained only for backwards-compat arg positioning; must be None.
                std::optional<at::Tensor> unused_generator_compat,
-               std::optional<at::Tensor> &rng_state) {
+               std::optional<at::Tensor> rng_state) {
 
     TORCH_CHECK(!unused_generator_compat.has_value(),
                 "flash-attn: the RNG `generator` argument is no longer supported and must be None; "
@@ -1241,26 +1240,26 @@ mha_varlen_bwd(const at::Tensor &dout,  // total_q x num_heads, x head_size
 }
 
 std::vector<at::Tensor>
-mha_fwd_kvcache(at::Tensor &q,                 // batch_size x seqlen_q x num_heads x head_size
-                const at::Tensor &kcache,            // batch_size_c x seqlen_k x num_heads_k x head_size or num_blocks x page_block_size x num_heads_k x head_size if there's a block_table.
-                const at::Tensor &vcache,            // batch_size_c x seqlen_k x num_heads_k x head_size or num_blocks x page_block_size x num_heads_k x head_size if there's a block_table.
-                std::optional<const at::Tensor> &k_, // batch_size x seqlen_knew x num_heads_k x head_size
-                std::optional<const at::Tensor> &v_, // batch_size x seqlen_knew x num_heads_k x head_size
-                std::optional<const at::Tensor> &seqlens_k_, // batch_size
-                std::optional<const at::Tensor> &rotary_cos_, // seqlen_ro x (rotary_dim / 2)
-                std::optional<const at::Tensor> &rotary_sin_, // seqlen_ro x (rotary_dim / 2)
-                std::optional<const at::Tensor> &cache_batch_idx_, // indices to index into the KV cache
-                std::optional<const at::Tensor> &leftpad_k_, // batch_size
-                std::optional<at::Tensor> &block_table_, // batch_size x max_num_blocks_per_seq
-                std::optional<at::Tensor> &alibi_slopes_, // num_heads or batch_size x num_heads
-                std::optional<at::Tensor> &out_,             // batch_size x seqlen_q x num_heads x head_size
-                const float softmax_scale,
+mha_fwd_kvcache(at::Tensor q,                 // batch_size x seqlen_q x num_heads x head_size
+                at::Tensor &kcache,            // batch_size_c x seqlen_k x num_heads_k x head_size or num_blocks x page_block_size x num_heads_k x head_size if there's a block_table.
+                at::Tensor &vcache,            // batch_size_c x seqlen_k x num_heads_k x head_size or num_blocks x page_block_size x num_heads_k x head_size if there's a block_table.
+                const std::optional<at::Tensor> &k_, // batch_size x seqlen_knew x num_heads_k x head_size
+                const std::optional<at::Tensor> &v_, // batch_size x seqlen_knew x num_heads_k x head_size
+                const std::optional<at::Tensor> &seqlens_k_, // batch_size
+                const std::optional<at::Tensor> &rotary_cos_, // seqlen_ro x (rotary_dim / 2)
+                const std::optional<at::Tensor> &rotary_sin_, // seqlen_ro x (rotary_dim / 2)
+                const std::optional<at::Tensor> &cache_batch_idx_, // indices to index into the KV cache
+                const std::optional<at::Tensor> &leftpad_k_, // batch_size
+                std::optional<at::Tensor> block_table_, // batch_size x max_num_blocks_per_seq
+                std::optional<at::Tensor> alibi_slopes_, // num_heads or batch_size x num_heads
+                std::optional<at::Tensor> out_,             // batch_size x seqlen_q x num_heads x head_size
+                const double softmax_scale,
                 bool is_causal,
-                int window_size_left,
-                int window_size_right,
-                const float softcap,
+                int64_t window_size_left,
+                int64_t window_size_right,
+                const double softcap,
                 bool is_rotary_interleaved,   // if true, rotary combines indices 0 & 1, else indices 0 & rotary_dim / 2
-                int num_splits
+                int64_t num_splits
                 ) {
 
     // Otherwise the kernel will be launched from cuda:0 device
@@ -1532,11 +1531,116 @@ mha_fwd_kvcache(at::Tensor &q,                 // batch_size x seqlen_q x num_he
 }
 } // namespace FLASH_NAMESPACE
 
-PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
-    m.doc() = "FlashAttention";
-    m.def("fwd", &FLASH_NAMESPACE::mha_fwd, "Forward pass");
-    m.def("varlen_fwd", &FLASH_NAMESPACE::mha_varlen_fwd, "Forward pass (variable length)");
-    m.def("bwd", &FLASH_NAMESPACE::mha_bwd, "Backward pass");
-    m.def("varlen_bwd", &FLASH_NAMESPACE::mha_varlen_bwd, "Backward pass (variable length)");
-    m.def("fwd_kvcache", &FLASH_NAMESPACE::mha_fwd_kvcache, "Forward pass, with KV-cache");
+TORCH_LIBRARY(flash_attn_2, m) {
+    m.def("fwd("
+        "Tensor q,"
+        "Tensor k,"
+        "Tensor v,"
+        "Tensor!? out,"
+        "Tensor? alibi_slopes,"
+        "float p_dropout,"
+        "float softmax_scale,"
+        "bool is_causal,"
+        "int window_size_left,"
+        "int window_size_right,"
+        "float softcap,"
+        "bool return_softmax,"
+        "Tensor? unused_generator_compat) -> Tensor[]");
+    m.def("varlen_fwd("
+        "Tensor q,"
+        "Tensor k,"
+        "Tensor v,"
+        "Tensor!? out,"
+        "Tensor cu_seqlens_q,"
+        "Tensor cu_seqlens_k,"
+        "Tensor? seqused_k,"
+        "Tensor? leftpad_k,"
+        "Tensor? block_table,"
+        "Tensor? alibi_slopes,"
+        "int max_seqlen_q,"
+        "int max_seqlen_k,"
+        "float p_dropout,"
+        "float softmax_scale,"
+        "bool zero_tensors,"
+        "bool is_causal,"
+        "int window_size_left,"
+        "int window_size_right,"
+        "float softcap,"
+        "bool return_softmax,"
+        "Tensor? unused_generator_compat,"
+        "int num_splits=0) -> Tensor[]");
+    m.def("bwd("
+        "Tensor dout,"
+        "Tensor q,"
+        "Tensor k,"
+        "Tensor v,"
+        "Tensor out,"
+        "Tensor softmax_lse,"
+        "Tensor!? dq,"
+        "Tensor!? dk,"
+        "Tensor!? dv,"
+        "Tensor? alibi_slopes,"
+        "float p_dropout,"
+        "float softmax_scale,"
+        "bool is_causal,"
+        "int window_size_left,"
+        "int window_size_right,"
+        "float softcap,"
+        "bool deterministic,"
+        "Tensor? unused_generator_compat,"
+        "Tensor? rng_state) -> Tensor[]");
+    m.def("varlen_bwd("
+        "Tensor dout,"
+        "Tensor q,"
+        "Tensor k,"
+        "Tensor v,"
+        "Tensor out,"
+        "Tensor softmax_lse,"
+        "Tensor!? dq,"
+        "Tensor!? dk,"
+        "Tensor!? dv,"
+        "Tensor cu_seqlens_q,"
+        "Tensor cu_seqlens_k,"
+        "Tensor? alibi_slopes,"
+        "int max_seqlen_q,"
+        "int max_seqlen_k,"
+        "float p_dropout,"
+        "float softmax_scale,"
+        "bool zero_tensors,"
+        "bool is_causal,"
+        "int window_size_left,"
+        "int window_size_right,"
+        "float softcap,"
+        "bool deterministic,"
+        "Tensor? unused_generator_compat,"
+        "Tensor? rng_state) -> Tensor[]");
+    m.def("fwd_kvcache("
+        "Tensor q,"
+        "Tensor! kcache,"
+        "Tensor! vcache,"
+        "Tensor? k,"
+        "Tensor? v,"
+        "Tensor? seqlens_k,"
+        "Tensor? rotary_cos,"
+        "Tensor? rotary_sin,"
+        "Tensor? cache_batch_idx,"
+        "Tensor? leftpad_k,"
+        "Tensor? block_table,"
+        "Tensor? alibi_slopes,"
+        "Tensor!? out,"
+        "float softmax_scale,"
+        "bool is_causal,"
+        "int window_size_left,"
+        "int window_size_right,"
+        "float softcap,"
+        "bool is_rotary_interleaved,"
+        "int num_splits) -> Tensor[]");
+}
+
+TORCH_LIBRARY_IMPL(flash_attn_2, CUDA, m) {
+    m.impl("fwd", &FLASH_NAMESPACE::mha_fwd);
+    m.impl("varlen_fwd", &FLASH_NAMESPACE::mha_varlen_fwd);
+    m.impl("bwd", &FLASH_NAMESPACE::mha_bwd);
+    m.impl("varlen_bwd", &FLASH_NAMESPACE::mha_varlen_bwd);
+    m.impl("fwd_kvcache", &FLASH_NAMESPACE::mha_fwd_kvcache);
 }

--- a/csrc/flash_attn/flash_api_unstable.cpp
+++ b/csrc/flash_attn/flash_api_unstable.cpp
@@ -2,31 +2,14 @@
  * Copyright (c) 2024, Tri Dao.
  ******************************************************************************/
 
-#include <torch/csrc/stable/library.h>
-#include <torch/csrc/stable/tensor.h>
-#include <torch/csrc/stable/ops.h>
-#include <torch/csrc/stable/accelerator.h>
-
-#include <torch/headeronly/core/ScalarType.h>
-#include <torch/headeronly/util/Exception.h>   // STD_TORCH_CHECK
-#include <torch/headeronly/util/shim_utils.h>  // TORCH_ERROR_CODE_CHECK
-
-#include <torch/csrc/inductor/aoti_torch/c/shim.h>  // aoti_torch_get_current_cuda_stream
-#include <cuda_runtime.h>
-
-#include <cstdint>
-#include <cmath>
-#include <limits>
-#include <optional>
-#include <tuple>
-#include <vector>
-
-
+#include <torch/library.h>
+#include <torch/nn/functional.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAStream.h>
 #ifndef FLASHATTENTION_DISABLE_DROPOUT
 #include <ATen/cuda/CUDAGeneratorImpl.h>  // For at::PhiloxCudaState / at::CUDAGeneratorImpl (default-generator dropout path)
 #include "philox_unpack.cuh"  // For at::cuda::philox::unpack
 #include <type_traits>  // For std::is_trivially_copyable (philox_args buffer assert below)
-#include <mutex>        // For std::lock_guard guarding the default generator
 #endif
 
 #include <cutlass/numeric_types.h>
@@ -36,21 +19,11 @@
 #include "flash.h"
 #include "static_switch.h"
 
-#define CHECK_DEVICE(x) STD_TORCH_CHECK(x.is_cuda(), #x " must be on CUDA")
-#define CHECK_SHAPE(x, ...) STD_TORCH_CHECK(x.sizes().equals({__VA_ARGS__}), #x " must have shape (" #__VA_ARGS__ ")")
-#define CHECK_CONTIGUOUS(x) STD_TORCH_CHECK(x.is_contiguous(), #x " must be contiguous")
+#define CHECK_DEVICE(x) TORCH_CHECK(x.is_cuda(), #x " must be on CUDA")
+#define CHECK_SHAPE(x, ...) TORCH_CHECK(x.sizes() == torch::IntArrayRef({__VA_ARGS__}), #x " must have shape (" #__VA_ARGS__ ")")
+#define CHECK_CONTIGUOUS(x) TORCH_CHECK(x.is_contiguous(), #x " must be contiguous")
 
 namespace FLASH_NAMESPACE {
-
-using torch::stable::Tensor;
-using torch::headeronly::ScalarType;
-
-// Stable-ABI replacement for at::cuda::getCurrentCUDAStream().stream().
-static inline cudaStream_t get_current_cuda_stream(const Tensor &t) {
-    void *stream_ptr = nullptr;
-    TORCH_ERROR_CODE_CHECK(aoti_torch_get_current_cuda_stream(t.get_device_index(), &stream_ptr));
-    return static_cast<cudaStream_t>(stream_ptr);
-}
 
 #ifndef FLASHATTENTION_DISABLE_DROPOUT
 // Flash_fwd_params keeps philox state as an opaque uint64_t buffer (see flash.h) so the
@@ -79,10 +52,10 @@ void set_params_fprop(Flash_fwd_params &params,
                       const size_t d,
                       const size_t d_rounded,
                       // device pointers
-                      const Tensor q,
-                      const Tensor k,
-                      const Tensor v,
-                      Tensor out,
+                      const at::Tensor q,
+                      const at::Tensor k,
+                      const at::Tensor v,
+                      at::Tensor out,
                       void *cu_seqlens_q_d,
                       void *cu_seqlens_k_d,
                       void *seqused_k,
@@ -99,7 +72,7 @@ void set_params_fprop(Flash_fwd_params &params,
     // Reset the parameters
     params = {};
 
-    params.is_bf16 = q.scalar_type() == ScalarType::BFloat16;
+    params.is_bf16 = q.dtype() == torch::kBFloat16;
 
     // Set the pointers and strides.
     params.q_ptr = q.data_ptr();
@@ -151,7 +124,7 @@ void set_params_fprop(Flash_fwd_params &params,
 
     // Set the different scale values.
     #ifdef FLASHATTENTION_DISABLE_SOFTCAP
-        STD_TORCH_CHECK(softcap <= 0.0, "This flash attention build does not support softcap.");
+        TORCH_CHECK(softcap <= 0.0, "This flash attention build does not support softcap.");
     #endif
     if (softcap > 0.0) {
         params.softcap = softmax_scale / softcap;
@@ -173,9 +146,9 @@ void set_params_fprop(Flash_fwd_params &params,
     params.p_dropout_in_uint8_t = uint8_t(std::floor(params.p_dropout * 255.0));
     params.rp_dropout = 1.f / params.p_dropout;
     params.scale_softmax_rp_dropout = params.rp_dropout * params.scale_softmax;
-    STD_TORCH_CHECK(p_dropout < 1.f);
+    TORCH_CHECK(p_dropout < 1.f);
     #ifdef FLASHATTENTION_DISABLE_DROPOUT
-        STD_TORCH_CHECK(p_dropout == 0.0f, "This flash attention build does not support dropout.");
+        TORCH_CHECK(p_dropout == 0.0f, "This flash attention build does not support dropout.");
     #endif
 
     // Causal is the special case where window_size_right == 0 and window_size_left < 0.
@@ -188,14 +161,14 @@ void set_params_fprop(Flash_fwd_params &params,
     params.window_size_right = window_size_right;
 
     #ifdef FLASHATTENTION_DISABLE_LOCAL
-        STD_TORCH_CHECK(params.is_causal || (window_size_left < 0 && window_size_right < 0),
+        TORCH_CHECK(params.is_causal || (window_size_left < 0 && window_size_right < 0),
             "This flash attention build does not support local attention.");
     #endif
 
     params.is_seqlens_k_cumulative = true;
 
     #ifdef FLASHATTENTION_DISABLE_UNEVEN_K
-        STD_TORCH_CHECK(d == d_rounded, "This flash attention build does not support headdim not being a multiple of 32.");
+        TORCH_CHECK(d == d_rounded, "This flash attention build does not support headdim not being a multiple of 32.");
     #endif
 
     params.unpadded_lse = unpadded_lse;
@@ -214,14 +187,14 @@ void set_params_dgrad(Flash_bwd_params &params,
                       const size_t d,
                       const size_t d_rounded,
                       // device pointers
-                      const Tensor q,
-                      const Tensor k,
-                      const Tensor v,
-                      const Tensor out,
-                      const Tensor dout,
-                      Tensor dq,
-                      Tensor dk,
-                      Tensor dv,
+                      const at::Tensor q,
+                      const at::Tensor k,
+                      const at::Tensor v,
+                      const at::Tensor out,
+                      const at::Tensor dout,
+                      at::Tensor dq,
+                      at::Tensor dk,
+                      at::Tensor dv,
                       void *cu_seqlens_q_d,
                       void *cu_seqlens_k_d,
                       void *dq_accum_d,
@@ -340,10 +313,10 @@ inline int num_splits_heuristic(int batch_nheads_mblocks, int num_SMs, int num_n
     return 1;
 }
 
-std::tuple<Tensor, Tensor> set_params_splitkv(Flash_fwd_params &params, const int batch_size,
+std::tuple<at::Tensor, at::Tensor> set_params_splitkv(Flash_fwd_params &params, const int batch_size,
     const int num_heads, const int head_size, const int max_seqlen_k, const int max_seqlen_q,
     const int head_size_rounded, const float p_dropout,
-    const int num_splits, const int num_sm, const Tensor &ref) {
+    const int num_splits, const int num_sm, struct c10::TensorOptions opts) {
 
     // This needs to match with run_mha_fwd_splitkv_dispatch
     const int block_n = head_size <= 64 ? 256 : (head_size <= 128 ? 128 : 64);
@@ -352,8 +325,8 @@ std::tuple<Tensor, Tensor> set_params_splitkv(Flash_fwd_params &params, const in
     // In any case we don't expect seqlen_q to be larger than 64 for inference.
     const int num_m_blocks = (max_seqlen_q + 64 - 1) / 64;
     params.num_splits = num_splits;
-    Tensor softmax_lse_accum;
-    Tensor out_accum;
+    at::Tensor softmax_lse_accum;
+    at::Tensor out_accum;
 
     if (p_dropout == 0.0f) {  // SplitKV is not implemented for dropout
         if (num_splits < 1) {
@@ -361,28 +334,28 @@ std::tuple<Tensor, Tensor> set_params_splitkv(Flash_fwd_params &params, const in
             params.num_splits = num_splits_heuristic(batch_size * num_heads * num_m_blocks, num_sm * 2, num_n_blocks, 128);
         }
         if (params.num_splits > 1) {
-            softmax_lse_accum = torch::stable::new_empty(ref, {params.num_splits, batch_size, num_heads, max_seqlen_q}, ScalarType::Float);
-            out_accum = torch::stable::new_empty(ref, {params.num_splits, batch_size, num_heads, max_seqlen_q, head_size_rounded}, ScalarType::Float);
+            softmax_lse_accum = torch::empty({params.num_splits, batch_size, num_heads, max_seqlen_q}, opts.dtype(at::kFloat));
+            out_accum = torch::empty({params.num_splits, batch_size, num_heads, max_seqlen_q, head_size_rounded}, opts.dtype(at::kFloat));
             params.softmax_lseaccum_ptr = softmax_lse_accum.data_ptr();
             params.oaccum_ptr = out_accum.data_ptr();
         }
-        STD_TORCH_CHECK(params.num_splits <= 128, "num_splits > 128 not supported");
+        TORCH_CHECK(params.num_splits <= 128, "num_splits > 128 not supported");
     }
 
     return std::make_tuple(softmax_lse_accum, out_accum);
 }
 
-void set_params_alibi(Flash_fwd_params &params, std::optional<Tensor> &alibi_slopes_, int batch_size, int num_heads){
+void set_params_alibi(Flash_fwd_params &params, std::optional<at::Tensor> &alibi_slopes_, int batch_size, int num_heads){
 #ifdef FLASHATTENTION_DISABLE_ALIBI
-    STD_TORCH_CHECK(!alibi_slopes_.has_value(), "This flash attention build does not support alibi.");
+    TORCH_CHECK(!alibi_slopes_.has_value(), "This flash attention build does not support alibi.");
     params.alibi_slopes_ptr = nullptr;
 #else
     if (alibi_slopes_.has_value()) {
         auto alibi_slopes = alibi_slopes_.value();
-        STD_TORCH_CHECK(alibi_slopes.scalar_type() == ScalarType::Float, "ALiBi slopes must have dtype fp32");
+        TORCH_CHECK(alibi_slopes.dtype() == torch::kFloat32, "ALiBi slopes must have dtype fp32");
         CHECK_DEVICE(alibi_slopes);
-        STD_TORCH_CHECK(alibi_slopes.stride(-1) == 1, "ALiBi slopes tensor must have contiguous last dimension");
-        STD_TORCH_CHECK(alibi_slopes.sizes().equals({num_heads}) || alibi_slopes.sizes().equals({batch_size, num_heads}));
+        TORCH_CHECK(alibi_slopes.stride(-1) == 1, "ALiBi slopes tensor must have contiguous last dimension");
+        TORCH_CHECK(alibi_slopes.sizes() == torch::IntArrayRef({num_heads}) || alibi_slopes.sizes() == torch::IntArrayRef({batch_size, num_heads}));
         params.alibi_slopes_ptr = alibi_slopes.data_ptr();
         params.alibi_slopes_batch_stride = alibi_slopes.dim() == 2 ? alibi_slopes.stride(0) : 0;
     } else {
@@ -391,12 +364,12 @@ void set_params_alibi(Flash_fwd_params &params, std::optional<Tensor> &alibi_slo
 #endif
 }
 
-std::vector<Tensor>
-mha_fwd(Tensor q,         // batch_size x seqlen_q x num_heads x round_multiple(head_size, 8)
-        const Tensor &k,         // batch_size x seqlen_k x num_heads_k x round_multiple(head_size, 8)
-        const Tensor &v,         // batch_size x seqlen_k x num_heads_k x round_multiple(head_size, 8)
-        std::optional<Tensor> out_,             // batch_size x seqlen_q x num_heads x round_multiple(head_size, 8)
-        std::optional<Tensor> alibi_slopes_, // num_heads or batch_size x num_heads
+std::vector<at::Tensor>
+mha_fwd(at::Tensor q,         // batch_size x seqlen_q x num_heads x round_multiple(head_size, 8)
+        const at::Tensor &k,         // batch_size x seqlen_k x num_heads_k x round_multiple(head_size, 8)
+        const at::Tensor &v,         // batch_size x seqlen_k x num_heads_k x round_multiple(head_size, 8)
+        std::optional<at::Tensor> out_,             // batch_size x seqlen_q x num_heads x round_multiple(head_size, 8)
+        std::optional<at::Tensor> alibi_slopes_, // num_heads or batch_size x num_heads
         const double p_dropout,
         const double softmax_scale,
         bool is_causal,
@@ -405,30 +378,30 @@ mha_fwd(Tensor q,         // batch_size x seqlen_q x num_heads x round_multiple(
         const double softcap,
         const bool return_softmax,
         // Retained only for backwards-compat arg positioning; must be None.
-        std::optional<Tensor> unused_generator_compat) {
+        std::optional<at::Tensor> unused_generator_compat) {
 
-    STD_TORCH_CHECK(!unused_generator_compat.has_value(),
-        "flash-attn: the RNG `generator` argument is no longer supported and must be None; "
-        "dropout (when enabled) uses the default CUDA generator.");
+    TORCH_CHECK(!unused_generator_compat.has_value(),
+                "flash-attn: the RNG `generator` argument is no longer supported and must be None; "
+                "dropout (when enabled) uses the default CUDA generator.");
 
     // Otherwise the kernel will be launched from cuda:0 device
-    torch::stable::accelerator::DeviceGuard device_guard(q.get_device_index());
+    at::cuda::CUDAGuard device_guard{q.device()};
 
     auto [cc_major, cc_minor] = get_compute_capability(get_current_device());
     bool is_sm8x_min = cc_major >= 8;
-    STD_TORCH_CHECK(is_sm8x_min, "FlashAttention only supports Ampere GPUs or newer.");
+    TORCH_CHECK(is_sm8x_min, "FlashAttention only supports Ampere GPUs or newer.");
 
-    auto q_dtype = q.scalar_type();
-    STD_TORCH_CHECK(q_dtype == ScalarType::Half || q_dtype == ScalarType::BFloat16,
+    auto q_dtype = q.dtype();
+    TORCH_CHECK(q_dtype == torch::kFloat16 || q_dtype == torch::kBFloat16,
                 "FlashAttention only support fp16 and bf16 data type");
-    STD_TORCH_CHECK(k.scalar_type() == q_dtype, "query and key must have the same dtype");
-    STD_TORCH_CHECK(v.scalar_type() == q_dtype, "query and value must have the same dtype");
+    TORCH_CHECK(k.dtype() == q_dtype, "query and key must have the same dtype");
+    TORCH_CHECK(v.dtype() == q_dtype, "query and value must have the same dtype");
 
     CHECK_DEVICE(q); CHECK_DEVICE(k); CHECK_DEVICE(v);
 
-    STD_TORCH_CHECK(q.stride(-1) == 1, "Input tensor must have contiguous last dimension");
-    STD_TORCH_CHECK(k.stride(-1) == 1, "Input tensor must have contiguous last dimension");
-    STD_TORCH_CHECK(v.stride(-1) == 1, "Input tensor must have contiguous last dimension");
+    TORCH_CHECK(q.stride(-1) == 1, "Input tensor must have contiguous last dimension");
+    TORCH_CHECK(k.stride(-1) == 1, "Input tensor must have contiguous last dimension");
+    TORCH_CHECK(v.stride(-1) == 1, "Input tensor must have contiguous last dimension");
 
     const auto sizes = q.sizes();
 
@@ -438,12 +411,12 @@ mha_fwd(Tensor q,         // batch_size x seqlen_q x num_heads x round_multiple(
     const int head_size = sizes[3];
     const int seqlen_k = k.size(1);
     const int num_heads_k = k.size(2);
-    STD_TORCH_CHECK(batch_size > 0, "batch size must be positive");
-    STD_TORCH_CHECK(head_size <= 256, "FlashAttention forward only supports head dimension at most 256");
-    STD_TORCH_CHECK(head_size % 8 == 0, "query, key, value, and out_ must have a head_size that is a multiple of 8");
-    STD_TORCH_CHECK(num_heads % num_heads_k == 0, "Number of heads in key/value must divide number of heads in query");
+    TORCH_CHECK(batch_size > 0, "batch size must be positive");
+    TORCH_CHECK(head_size <= 256, "FlashAttention forward only supports head dimension at most 256");
+    TORCH_CHECK(head_size % 8 == 0, "query, key, value, and out_ must have a head_size that is a multiple of 8");
+    TORCH_CHECK(num_heads % num_heads_k == 0, "Number of heads in key/value must divide number of heads in query");
 
-    if (softcap > 0.f) { STD_TORCH_CHECK(p_dropout == 0.f, "Softcapping does not support dropout for now"); }
+    if (softcap > 0.f) { TORCH_CHECK(p_dropout == 0.f, "Softcapping does not support dropout for now"); }
 
     if (window_size_left >= seqlen_k) { window_size_left = -1; }
     if (window_size_right >= seqlen_k) { window_size_right = -1; }
@@ -457,7 +430,7 @@ mha_fwd(Tensor q,         // batch_size x seqlen_q x num_heads x round_multiple(
     const int seqlenq_ngroups_swapped = seqlen_q == 1 && num_heads > num_heads_k && window_size_left < 0 && window_size_right < 0 && p_dropout == 0.f && head_size % 8 == 0 && !alibi_slopes_.has_value();
     const int ngroups = num_heads / num_heads_k;
     if (seqlenq_ngroups_swapped) {
-        q = torch::stable::transpose(torch::stable::reshape(q, {batch_size, num_heads_k, ngroups, head_size}), 1, 2);
+        q = q.reshape({batch_size, num_heads_k, ngroups, head_size}).transpose(1, 2);
         seqlen_q = ngroups;
         num_heads = num_heads_k;
     }
@@ -466,18 +439,18 @@ mha_fwd(Tensor q,         // batch_size x seqlen_q x num_heads x round_multiple(
     CHECK_SHAPE(k, batch_size, seqlen_k, num_heads_k, head_size);
     CHECK_SHAPE(v, batch_size, seqlen_k, num_heads_k, head_size);
 
-    Tensor out;
+    at::Tensor out;
     if (out_.has_value()) {
         out = out_.value();
-        STD_TORCH_CHECK(out.scalar_type() == q_dtype, "Output must have the same dtype as inputs");
+        TORCH_CHECK(out.dtype() == q_dtype, "Output must have the same dtype as inputs");
         CHECK_DEVICE(out);
-        STD_TORCH_CHECK(out.stride(-1) == 1, "Output tensor must have contiguous last dimension");
+        TORCH_CHECK(out.stride(-1) == 1, "Output tensor must have contiguous last dimension");
         CHECK_SHAPE(out, batch_size, sizes[1], sizes[2], head_size);
         if (seqlenq_ngroups_swapped) {
-            out = torch::stable::transpose(torch::stable::reshape(out, {batch_size, num_heads_k, ngroups, head_size}), 1, 2);
+            out = out.reshape({batch_size, num_heads_k, ngroups, head_size}).transpose(1, 2);
         }
     } else {
-        out = torch::stable::empty_like(q);
+        out = torch::empty_like(q);
     }
 
     auto round_multiple = [](int x, int m) { return (x + m - 1) / m * m; };
@@ -485,15 +458,17 @@ mha_fwd(Tensor q,         // batch_size x seqlen_q x num_heads x round_multiple(
     const int seqlen_q_rounded = round_multiple(seqlen_q, 128);
     const int seqlen_k_rounded = round_multiple(seqlen_k, 128);
 
-    auto softmax_lse = torch::stable::new_empty(q, {batch_size, num_heads, seqlen_q}, ScalarType::Float);
-    Tensor p;
+    auto opts = q.options();
+
+    auto softmax_lse = torch::empty({batch_size, num_heads, seqlen_q}, opts.dtype(at::kFloat));
+    at::Tensor p;
     // Only return softmax if there's dropout to reduce compilation time
     if (return_softmax) {
-        STD_TORCH_CHECK(p_dropout > 0.0f, "return_softmax is only supported when p_dropout > 0.0");
-        p = torch::stable::new_empty(q, {batch_size, num_heads, seqlen_q_rounded, seqlen_k_rounded});
+        TORCH_CHECK(p_dropout > 0.0f, "return_softmax is only supported when p_dropout > 0.0");
+        p = torch::empty({ batch_size, num_heads, seqlen_q_rounded, seqlen_k_rounded }, opts);
     }
     else {
-        p = torch::stable::new_empty(q, {0});
+        p = torch::empty({ 0 }, opts);
     }
 
     Flash_fwd_params params;
@@ -517,12 +492,13 @@ mha_fwd(Tensor q,         // batch_size x seqlen_q x num_heads x round_multiple(
                      );
 
     // Keep references to these tensors to extend their lifetime
-    Tensor softmax_lse_accum, out_accum;
+    at::Tensor softmax_lse_accum, out_accum;
     std::tie(softmax_lse_accum, out_accum) = set_params_splitkv(
         params, batch_size, num_heads, head_size, seqlen_k, seqlen_q,
-        head_size_rounded, p_dropout, /*num_splits*/ 0, get_num_sm(get_current_device()), q);
+        head_size_rounded, p_dropout, /*num_splits*/ 0, get_num_sm(get_current_device()), opts);
 
-    auto rng_state = torch::stable::new_empty(q, {2}, ScalarType::Long);
+    auto options = torch::TensorOptions().dtype(torch::kFloat32).device(torch::kCUDA);
+    auto rng_state = torch::empty({2}, options.dtype(torch::kInt64));
     // Forward kernel will populate memory with the seed and offset.
     params.rng_state = reinterpret_cast<uint64_t*>(rng_state.data_ptr());
 
@@ -542,33 +518,33 @@ mha_fwd(Tensor q,         // batch_size x seqlen_q x num_heads x round_multiple(
     set_params_alibi(params, alibi_slopes_, batch_size, num_heads);
 
     if (seqlen_k > 0) {
-        auto stream = get_current_cuda_stream(q);
+        auto stream = at::cuda::getCurrentCUDAStream().stream();
         run_mha_fwd(params, stream);
     } else {
         // If seqlen_k == 0, then we have an empty tensor. We need to set the output to 0.
-        torch::stable::zero_(out);
-        torch::stable::fill_(softmax_lse, std::numeric_limits<float>::infinity());
+        out.zero_();
+        softmax_lse.fill_(std::numeric_limits<float>::infinity());
     }
 
     if (seqlenq_ngroups_swapped) {
-        out = torch::stable::reshape(torch::stable::transpose(out, 1, 2), {batch_size, 1, num_heads_k * seqlen_q, head_size});
-        q = torch::stable::reshape(torch::stable::transpose(q, 1, 2), {batch_size, 1, num_heads_k * seqlen_q, head_size});
-        softmax_lse = torch::stable::reshape(softmax_lse, {batch_size, num_heads_k * seqlen_q, 1});
+        out = out.transpose(1, 2).reshape({batch_size, 1, num_heads_k * seqlen_q, head_size});
+        q = q.transpose(1, 2).reshape({batch_size, 1, num_heads_k * seqlen_q, head_size});
+        softmax_lse = softmax_lse.reshape({batch_size, num_heads_k * seqlen_q, 1});
     }
     return {out, softmax_lse, p, rng_state};
 }
 
-std::vector<Tensor>
-mha_varlen_fwd(Tensor q,  // total_q x num_heads x head_size, total_q := \sum_{i=0}^{b} s_i
-               const Tensor &k,  // total_k x num_heads_k x head_size, total_k := \sum_{i=0}^{b} s_i or num_blocks x page_block_size x num_heads_k x head_size if there's a block_table.
-               const Tensor &v,  // total_k x num_heads_k x head_size, total_k := \sum_{i=0}^{b} s_i or num_blocks x page_block_size x num_heads_k x head_size if there's a block_table.
-               std::optional<Tensor> out_, // total_q x num_heads x head_size, total_q := \sum_{i=0}^{b} s_i
-               const Tensor &cu_seqlens_q,  // b+1
-               const Tensor &cu_seqlens_k,  // b+1
-               std::optional<Tensor> seqused_k, // b. If given, only this many elements of each batch element's keys are used.
-               const std::optional<Tensor> &leftpad_k_, // batch_size
-               std::optional<Tensor> block_table_, // batch_size x max_num_blocks_per_seq
-               std::optional<Tensor> alibi_slopes_, // num_heads or b x num_heads
+std::vector<at::Tensor>
+mha_varlen_fwd(at::Tensor q,  // total_q x num_heads x head_size, total_q := \sum_{i=0}^{b} s_i
+               const at::Tensor &k,  // total_k x num_heads_k x head_size, total_k := \sum_{i=0}^{b} s_i or num_blocks x page_block_size x num_heads_k x head_size if there's a block_table.
+               const at::Tensor &v,  // total_k x num_heads_k x head_size, total_k := \sum_{i=0}^{b} s_i or num_blocks x page_block_size x num_heads_k x head_size if there's a block_table.
+               std::optional<at::Tensor> out_, // total_q x num_heads x head_size, total_q := \sum_{i=0}^{b} s_i
+               const at::Tensor &cu_seqlens_q,  // b+1
+               const at::Tensor &cu_seqlens_k,  // b+1
+               std::optional<at::Tensor> seqused_k, // b. If given, only this many elements of each batch element's keys are used.
+               const std::optional<at::Tensor> &leftpad_k_, // batch_size
+               std::optional<at::Tensor> block_table_, // batch_size x max_num_blocks_per_seq
+               std::optional<at::Tensor> alibi_slopes_, // num_heads or b x num_heads
                int64_t max_seqlen_q,
                const int64_t max_seqlen_k,
                const double p_dropout,
@@ -580,44 +556,44 @@ mha_varlen_fwd(Tensor q,  // total_q x num_heads x head_size, total_q := \sum_{i
                const double softcap,
                const bool return_softmax,
                // Retained only for backwards-compat arg positioning; must be None.
-               std::optional<Tensor> unused_generator_compat,
+               std::optional<at::Tensor> unused_generator_compat,
                int64_t num_splits = 0) {
 
-    STD_TORCH_CHECK(!unused_generator_compat.has_value(),
-        "flash-attn: the RNG `generator` argument is no longer supported and must be None; "
-        "dropout (when enabled) uses the default CUDA generator.");
+    TORCH_CHECK(!unused_generator_compat.has_value(),
+                "flash-attn: the RNG `generator` argument is no longer supported and must be None; "
+                "dropout (when enabled) uses the default CUDA generator.");
 
     // Otherwise the kernel will be launched from cuda:0 device
-    torch::stable::accelerator::DeviceGuard device_guard(q.get_device_index());
+    at::cuda::CUDAGuard device_guard{q.device()};
 
     auto [cc_major, cc_minor] = get_compute_capability(get_current_device());
     bool is_sm8x_min = cc_major >= 8;
-    STD_TORCH_CHECK(is_sm8x_min, "FlashAttention only supports Ampere GPUs or newer.");
+    TORCH_CHECK(is_sm8x_min, "FlashAttention only supports Ampere GPUs or newer.");
 
-    auto q_dtype = q.scalar_type();
-    STD_TORCH_CHECK(q_dtype == ScalarType::Half || q_dtype == ScalarType::BFloat16,
+    auto q_dtype = q.dtype();
+    TORCH_CHECK(q_dtype == torch::kFloat16 || q_dtype == torch::kBFloat16,
                 "FlashAttention only support fp16 and bf16 data type");
-    STD_TORCH_CHECK(k.scalar_type() == q_dtype, "query and key must have the same dtype");
-    STD_TORCH_CHECK(v.scalar_type() == q_dtype, "query and value must have the same dtype");
-    STD_TORCH_CHECK(cu_seqlens_q.scalar_type() == ScalarType::Int, "cu_seqlens_q must have dtype int32");
-    STD_TORCH_CHECK(cu_seqlens_k.scalar_type() == ScalarType::Int, "cu_seqlens_k must have dtype int32");
+    TORCH_CHECK(k.dtype() == q_dtype, "query and key must have the same dtype");
+    TORCH_CHECK(v.dtype() == q_dtype, "query and value must have the same dtype");
+    TORCH_CHECK(cu_seqlens_q.dtype() == torch::kInt32, "cu_seqlens_q must have dtype int32");
+    TORCH_CHECK(cu_seqlens_k.dtype() == torch::kInt32, "cu_seqlens_k must have dtype int32");
 
     CHECK_DEVICE(q); CHECK_DEVICE(k); CHECK_DEVICE(v);
     CHECK_DEVICE(cu_seqlens_q);
     CHECK_DEVICE(cu_seqlens_k);
 
-    Tensor block_table;
+    at::Tensor block_table;
     const bool paged_KV = block_table_.has_value();
     if (paged_KV) {
         block_table = block_table_.value();
         CHECK_DEVICE(block_table);
-        STD_TORCH_CHECK(block_table.scalar_type() == ScalarType::Int, "block_table must have dtype torch.int32");
-        STD_TORCH_CHECK(block_table.stride(-1) == 1, "block_table must have contiguous last dimension");
+        TORCH_CHECK(block_table.dtype() == torch::kInt32, "block_table must have dtype torch.int32");
+        TORCH_CHECK(block_table.stride(-1) == 1, "block_table must have contiguous last dimension");
     }
 
-    STD_TORCH_CHECK(q.stride(-1) == 1, "Input tensor must have contiguous last dimension");
-    STD_TORCH_CHECK(k.stride(-1) == 1, "Input tensor must have contiguous last dimension");
-    STD_TORCH_CHECK(v.stride(-1) == 1, "Input tensor must have contiguous last dimension");
+    TORCH_CHECK(q.stride(-1) == 1, "Input tensor must have contiguous last dimension");
+    TORCH_CHECK(k.stride(-1) == 1, "Input tensor must have contiguous last dimension");
+    TORCH_CHECK(v.stride(-1) == 1, "Input tensor must have contiguous last dimension");
     CHECK_CONTIGUOUS(cu_seqlens_q);
     CHECK_CONTIGUOUS(cu_seqlens_k);
 
@@ -628,12 +604,12 @@ mha_varlen_fwd(Tensor q,  // total_q x num_heads x head_size, total_q := \sum_{i
     const int head_size = sizes[2];
     const int num_heads_k = paged_KV ? k.size(2) : k.size(1);
 
-    if (softcap > 0.f) { STD_TORCH_CHECK(p_dropout == 0.f, "Softcapping does not support dropout for now"); }
+    if (softcap > 0.f) { TORCH_CHECK(p_dropout == 0.f, "Softcapping does not support dropout for now"); }
 
     const int max_num_blocks_per_seq = !paged_KV ? 0 : block_table.size(1);
     const int num_blocks = !paged_KV ? 0 : k.size(0);
     const int page_block_size = !paged_KV ? 1 : k.size(1);
-    STD_TORCH_CHECK(!paged_KV || page_block_size % 256 == 0, "Paged KV cache block size must be divisible by 256");
+    TORCH_CHECK(!paged_KV || page_block_size % 256 == 0, "Paged KV cache block size must be divisible by 256");
 
     if (max_seqlen_q == 1 && !alibi_slopes_.has_value()) { is_causal = false; }  // causal=true is the same as causal=false in this case
     if (is_causal) { window_size_right = 0; }
@@ -645,18 +621,18 @@ mha_varlen_fwd(Tensor q,  // total_q x num_heads x head_size, total_q := \sum_{i
     const int seqlenq_ngroups_swapped = max_seqlen_q == 1 && num_heads > num_heads_k && window_size_left < 0 && window_size_right < 0 && p_dropout == 0.f && head_size % 8 == 0 && !alibi_slopes_.has_value();
     const int ngroups = num_heads / num_heads_k;
     if (seqlenq_ngroups_swapped) {
-        q = torch::stable::reshape(torch::stable::transpose(torch::stable::reshape(q, {batch_size, num_heads_k, ngroups, head_size}), 1, 2), {batch_size * ngroups, num_heads_k, head_size});
+        q = q.reshape({batch_size, num_heads_k, ngroups, head_size}).transpose(1, 2).reshape({batch_size * ngroups, num_heads_k, head_size});
         max_seqlen_q = ngroups;
         num_heads = num_heads_k;
         cu_seqlens_q_d = nullptr;
     }
 
-    const int total_q = q.size(0);
+    const int total_q = q.sizes()[0];
 
-    STD_TORCH_CHECK(batch_size > 0, "batch size must be positive");
-    STD_TORCH_CHECK(head_size <= 256, "FlashAttention forward only supports head dimension at most 256");
-    STD_TORCH_CHECK(head_size % 8 == 0, "query, key, value, and out_ must have a head_size that is a multiple of 8");
-    STD_TORCH_CHECK(num_heads % num_heads_k == 0, "Number of heads in key/value must divide number of heads in query");
+    TORCH_CHECK(batch_size > 0, "batch size must be positive");
+    TORCH_CHECK(head_size <= 256, "FlashAttention forward only supports head dimension at most 256");
+    TORCH_CHECK(head_size % 8 == 0, "query, key, value, and out_ must have a head_size that is a multiple of 8");
+    TORCH_CHECK(num_heads % num_heads_k == 0, "Number of heads in key/value must divide number of heads in query");
 
     if (window_size_left >= max_seqlen_k) { window_size_left = -1; }
     if (window_size_right >= max_seqlen_k) { window_size_right = -1; }
@@ -676,24 +652,24 @@ mha_varlen_fwd(Tensor q,  // total_q x num_heads x head_size, total_q := \sum_{i
     CHECK_SHAPE(cu_seqlens_k, batch_size + 1);
     if (seqused_k.has_value()){
         auto seqused_k_ = seqused_k.value();
-        STD_TORCH_CHECK(seqused_k_.scalar_type() == ScalarType::Int, "seqused_k must have dtype int32");
-        STD_TORCH_CHECK(seqused_k_.is_cuda(), "seqused_k must be on CUDA device");
-        STD_TORCH_CHECK(seqused_k_.is_contiguous(), "seqused_k must be contiguous");
+        TORCH_CHECK(seqused_k_.dtype() == torch::kInt32, "seqused_k must have dtype int32");
+        TORCH_CHECK(seqused_k_.is_cuda(), "seqused_k must be on CUDA device");
+        TORCH_CHECK(seqused_k_.is_contiguous(), "seqused_k must be contiguous");
         CHECK_SHAPE(seqused_k_, batch_size);
     }
 
-    Tensor out;
+    at::Tensor out;
     if (out_.has_value()) {
         out = out_.value();
-        STD_TORCH_CHECK(out.scalar_type() == q_dtype, "Output must have the same dtype as inputs");
+        TORCH_CHECK(out.dtype() == q_dtype, "Output must have the same dtype as inputs");
         CHECK_DEVICE(out);
-        STD_TORCH_CHECK(out.stride(-1) == 1, "Output tensor must have contiguous last dimension");
+        TORCH_CHECK(out.stride(-1) == 1, "Output tensor must have contiguous last dimension");
         CHECK_SHAPE(out, sizes[0], sizes[1], head_size);
         if (seqlenq_ngroups_swapped) {
-            out = torch::stable::reshape(torch::stable::transpose(torch::stable::reshape(out, {batch_size, num_heads_k, ngroups, head_size}), 1, 2), {batch_size * ngroups, num_heads_k, head_size});
+            out = out.reshape({batch_size, num_heads_k, ngroups, head_size}).transpose(1, 2).reshape({batch_size * ngroups, num_heads_k, head_size});
         }
     } else {
-        out = torch::stable::empty_like(q);
+        out = torch::empty_like(q);
     }
 
     auto round_multiple = [](int x, int m) { return (x + m - 1) / m * m; };
@@ -701,21 +677,22 @@ mha_varlen_fwd(Tensor q,  // total_q x num_heads x head_size, total_q := \sum_{i
     const int seqlen_q_rounded = round_multiple(max_seqlen_q, 128);
     const int seqlen_k_rounded = round_multiple(max_seqlen_k, 128);
 
-    auto softmax_lse = torch::stable::new_empty(q, {num_heads, total_q}, ScalarType::Float);
-    Tensor p;
+    auto opts = q.options();
+    auto softmax_lse = torch::empty({num_heads, total_q}, opts.dtype(at::kFloat));
+    at::Tensor p;
     // Only return softmax if there's dropout to reduce compilation time
     if (return_softmax) {
-        STD_TORCH_CHECK(p_dropout > 0.0f, "return_softmax is only supported when p_dropout > 0.0");
-        p = torch::stable::new_empty(q, {batch_size, num_heads, seqlen_q_rounded, seqlen_k_rounded});
+        TORCH_CHECK(p_dropout > 0.0f, "return_softmax is only supported when p_dropout > 0.0");
+        p = torch::empty({ batch_size, num_heads, seqlen_q_rounded, seqlen_k_rounded }, opts);
     }
     else {
-        p = torch::stable::new_empty(q, {0});
+        p = torch::empty({ 0 }, opts);
     }
 
     if (zero_tensors) {
-        torch::stable::zero_(out);
-        torch::stable::fill_(softmax_lse, -std::numeric_limits<float>::infinity());
-        if (return_softmax) { torch::stable::zero_(p); }
+        out.zero_();
+        softmax_lse.fill_(-std::numeric_limits<float>::infinity());
+        if (return_softmax) {p.zero_();}
     }
 
     Flash_fwd_params params;
@@ -741,35 +718,36 @@ mha_varlen_fwd(Tensor q,  // total_q x num_heads x head_size, total_q := \sum_{i
     params.total_q = total_q;
 
     if (paged_KV) {
-        params.block_table = block_table.mutable_data_ptr<int>();
+        params.block_table = block_table.data_ptr<int>();
         params.block_table_batch_stride = block_table.stride(0);
         params.k_batch_stride = k.stride(0);
         params.v_batch_stride = v.stride(0);
     }
     params.page_block_size = page_block_size;
     // Keep references to these tensors to extend their lifetime
-    Tensor softmax_lse_accum, out_accum;
+    at::Tensor softmax_lse_accum, out_accum;
     if (seqlenq_ngroups_swapped) {
         std::tie(softmax_lse_accum, out_accum) =
             set_params_splitkv(params, batch_size, num_heads, head_size,
                                max_seqlen_k, max_seqlen_q, head_size_rounded,
-                               p_dropout, num_splits, get_num_sm(get_current_device()), q);
+                               p_dropout, num_splits, get_num_sm(get_current_device()), opts);
     } else if (paged_KV) {
-        STD_TORCH_CHECK(num_splits <= 1, "num_splits > 1 is not supported for varlen paged KV");
+        TORCH_CHECK(num_splits <= 1, "num_splits > 1 is not supported for varlen paged KV");
         params.num_splits = num_splits;
     }
 
     if (leftpad_k_.has_value()) {
         auto leftpad_k = leftpad_k_.value();
-        STD_TORCH_CHECK(!paged_KV, "We don't support Paged KV and leftpad_k running at the same time yet");
-        STD_TORCH_CHECK(leftpad_k.scalar_type() == ScalarType::Int, "leftpad_k must have dtype int32");
+        TORCH_CHECK(!paged_KV, "We don't support Paged KV and leftpad_k running at the same time yet");
+        TORCH_CHECK(leftpad_k.dtype() == torch::kInt32, "leftpad_k must have dtype int32");
         CHECK_DEVICE(leftpad_k);
         CHECK_CONTIGUOUS(leftpad_k);
         CHECK_SHAPE(leftpad_k, batch_size);
         params.leftpad_k = static_cast<int *>(leftpad_k.data_ptr());
     }
 
-    auto rng_state = torch::stable::new_empty(q, {2}, ScalarType::Long);
+    auto options = torch::TensorOptions().dtype(torch::kFloat32).device(torch::kCUDA);
+    auto rng_state = torch::empty({2}, options.dtype(torch::kInt64));
     // Forward kernel will populate memory with the seed and offset.
     params.rng_state = reinterpret_cast<uint64_t*>(rng_state.data_ptr());
 
@@ -789,18 +767,20 @@ mha_varlen_fwd(Tensor q,  // total_q x num_heads x head_size, total_q := \sum_{i
     set_params_alibi(params, alibi_slopes_, batch_size, num_heads);
 
     if (max_seqlen_k > 0) {
-        auto stream = get_current_cuda_stream(q);
+        auto stream = at::cuda::getCurrentCUDAStream().stream();
         run_mha_fwd(params, stream, paged_KV);
     } else {
         // If seqlen_k == 0, then we have an empty tensor. We need to set the output to 0.
-        torch::stable::zero_(out);
-        torch::stable::fill_(softmax_lse, std::numeric_limits<float>::infinity());
+        out.zero_();
+        softmax_lse.fill_(std::numeric_limits<float>::infinity());
     }
 
     if (seqlenq_ngroups_swapped) {
-        out = torch::stable::reshape(torch::stable::transpose(torch::stable::reshape(out, {batch_size, max_seqlen_q, num_heads_k, head_size}), 1, 2), {batch_size, num_heads_k * max_seqlen_q, head_size});
-        q = torch::stable::reshape(torch::stable::transpose(torch::stable::reshape(q, {batch_size, max_seqlen_q, num_heads_k, head_size}), 1, 2), {batch_size, num_heads_k * max_seqlen_q, head_size});
-        softmax_lse = torch::stable::reshape(softmax_lse, {num_heads * max_seqlen_q, batch_size});
+        int64_t size_before[] = {batch_size, max_seqlen_q, num_heads_k, head_size};
+        int64_t size_after[] = {batch_size, num_heads_k * max_seqlen_q, head_size};
+        out = out.reshape(size_before).transpose(1, 2).reshape(size_after);
+        q = q.reshape(size_before).transpose(1, 2).reshape(size_after);
+        softmax_lse = softmax_lse.reshape({num_heads * max_seqlen_q, batch_size});
     }
 
     return {out, softmax_lse, p, rng_state};
@@ -816,17 +796,17 @@ void run_mha_bwd(Flash_bwd_params &params, cudaStream_t stream) {
     });
 }
 
-std::vector<Tensor>
-mha_bwd(const Tensor &dout,  // batch_size x seqlen_q x num_heads, x multiple_of(head_size_og, 8)
-        const Tensor &q,   // batch_size x seqlen_q x num_heads x head_size
-        const Tensor &k,   // batch_size x seqlen_k x num_heads_k x head_size
-        const Tensor &v,   // batch_size x seqlen_k x num_heads_k x head_size
-        const Tensor &out,   // batch_size x seqlen_q x num_heads x head_size
-        const Tensor &softmax_lse,     // b x h x seqlen_q
-        std::optional<Tensor> dq_,   // batch_size x seqlen_q x num_heads x head_size
-        std::optional<Tensor> dk_,   // batch_size x seqlen_k x num_heads_k x head_size
-        std::optional<Tensor> dv_,   // batch_size x seqlen_k x num_heads_k x head_size
-        std::optional<Tensor> alibi_slopes_, // num_heads or batch_size x num_heads
+std::vector<at::Tensor>
+mha_bwd(const at::Tensor &dout,  // batch_size x seqlen_q x num_heads, x multiple_of(head_size_og, 8)
+        const at::Tensor &q,   // batch_size x seqlen_q x num_heads x head_size
+        const at::Tensor &k,   // batch_size x seqlen_k x num_heads_k x head_size
+        const at::Tensor &v,   // batch_size x seqlen_k x num_heads_k x head_size
+        const at::Tensor &out,   // batch_size x seqlen_q x num_heads x head_size
+        const at::Tensor &softmax_lse,     // b x h x seqlen_q
+        std::optional<at::Tensor> dq_,   // batch_size x seqlen_q x num_heads x head_size
+        std::optional<at::Tensor> dk_,   // batch_size x seqlen_k x num_heads_k x head_size
+        std::optional<at::Tensor> dv_,   // batch_size x seqlen_k x num_heads_k x head_size
+        std::optional<at::Tensor> alibi_slopes_, // num_heads or batch_size x num_heads
         const double p_dropout,         // probability to drop
         const double softmax_scale,
         const bool is_causal,
@@ -835,44 +815,44 @@ mha_bwd(const Tensor &dout,  // batch_size x seqlen_q x num_heads, x multiple_of
         const double softcap,
         const bool deterministic,
         // Retained only for backwards-compat arg positioning; must be None.
-        std::optional<Tensor> unused_generator_compat,
-        std::optional<Tensor> rng_state) {
+        std::optional<at::Tensor> unused_generator_compat,
+        std::optional<at::Tensor> rng_state) {
 
-    STD_TORCH_CHECK(!unused_generator_compat.has_value(),
-        "flash-attn: the RNG `generator` argument is no longer supported and must be None; "
-        "dropout (when enabled) uses the default CUDA generator.");
+    TORCH_CHECK(!unused_generator_compat.has_value(),
+                "flash-attn: the RNG `generator` argument is no longer supported and must be None; "
+                "dropout (when enabled) uses the default CUDA generator.");
 
     #ifdef FLASHATTENTION_DISABLE_BACKWARD
-        STD_TORCH_CHECK(false, "This flash attention build does not support backward.");
+        TORCH_CHECK(false, "This flash attention build does not support backward.");
     #endif
     if (is_causal) { window_size_right = 0; }
 
     // Otherwise the kernel will be launched from cuda:0 device
-    torch::stable::accelerator::DeviceGuard device_guard(q.get_device_index());
+    at::cuda::CUDAGuard device_guard{q.device()};
 
     auto [cc_major, cc_minor] = get_compute_capability(get_current_device());
     bool is_sm8x_min = cc_major >= 8;
-    STD_TORCH_CHECK(is_sm8x_min, "FlashAttention only supports Ampere GPUs or newer.");
+    TORCH_CHECK(is_sm8x_min, "FlashAttention only supports Ampere GPUs or newer.");
 
     [[maybe_unused]] bool is_dropout = p_dropout > 0.0;
-    auto stream = get_current_cuda_stream(q);
+    auto stream = at::cuda::getCurrentCUDAStream().stream();
 
-    auto q_dtype = q.scalar_type();
-    STD_TORCH_CHECK(q_dtype == ScalarType::Half || q_dtype == ScalarType::BFloat16,
+    auto q_dtype = q.dtype();
+    TORCH_CHECK(q_dtype == torch::kFloat16 || q_dtype == torch::kBFloat16,
                 "FlashAttention only support fp16 and bf16 data type");
-    STD_TORCH_CHECK(k.scalar_type() == q_dtype, "query and key must have the same dtype");
-    STD_TORCH_CHECK(v.scalar_type() == q_dtype, "query and value must have the same dtype");
-    STD_TORCH_CHECK(out.scalar_type() == q_dtype, "query and out must have the same dtype");
-    STD_TORCH_CHECK(dout.scalar_type() == q_dtype, "query and dout must have the same dtype");
+    TORCH_CHECK(k.dtype() == q_dtype, "query and key must have the same dtype");
+    TORCH_CHECK(v.dtype() == q_dtype, "query and value must have the same dtype");
+    TORCH_CHECK(out.dtype() == q_dtype, "query and out must have the same dtype");
+    TORCH_CHECK(dout.dtype() == q_dtype, "query and dout must have the same dtype");
 
     CHECK_DEVICE(q); CHECK_DEVICE(k); CHECK_DEVICE(v);
     CHECK_DEVICE(out); CHECK_DEVICE(dout); CHECK_DEVICE(softmax_lse);
 
-    STD_TORCH_CHECK(q.stride(-1) == 1, "Input tensor must have contiguous last dimension");
-    STD_TORCH_CHECK(k.stride(-1) == 1, "Input tensor must have contiguous last dimension");
-    STD_TORCH_CHECK(v.stride(-1) == 1, "Input tensor must have contiguous last dimension");
-    STD_TORCH_CHECK(out.stride(-1) == 1, "out tensor must have contiguous last dimension");
-    STD_TORCH_CHECK(dout.stride(-1) == 1, "dout tensor must have contiguous last dimension");
+    TORCH_CHECK(q.stride(-1) == 1, "Input tensor must have contiguous last dimension");
+    TORCH_CHECK(k.stride(-1) == 1, "Input tensor must have contiguous last dimension");
+    TORCH_CHECK(v.stride(-1) == 1, "Input tensor must have contiguous last dimension");
+    TORCH_CHECK(out.stride(-1) == 1, "out tensor must have contiguous last dimension");
+    TORCH_CHECK(dout.stride(-1) == 1, "dout tensor must have contiguous last dimension");
 
     const auto sizes = q.sizes();
 
@@ -882,17 +862,17 @@ mha_bwd(const Tensor &dout,  // batch_size x seqlen_q x num_heads, x multiple_of
     const int head_size = sizes[3];
     const int seqlen_k = k.size(1);
     const int num_heads_k = k.size(2);
-    STD_TORCH_CHECK(batch_size > 0, "batch size must be positive");
-    STD_TORCH_CHECK(head_size % 8 == 0, "head_size should be a multiple of 8");
-    STD_TORCH_CHECK(head_size <= 256, "FlashAttention backward only supports head dimension at most 256");
-    STD_TORCH_CHECK(num_heads % num_heads_k == 0, "Number of heads in key/value must divide number of heads in query");
+    TORCH_CHECK(batch_size > 0, "batch size must be positive");
+    TORCH_CHECK(head_size % 8 == 0, "head_size should be a multiple of 8");
+    TORCH_CHECK(head_size <= 256, "FlashAttention backward only supports head dimension at most 256");
+    TORCH_CHECK(num_heads % num_heads_k == 0, "Number of heads in key/value must divide number of heads in query");
 
     auto round_multiple = [](int x, int m) { return (x + m - 1) / m * m; };
     const int head_size_rounded = round_multiple(head_size, head_size <= 128 ? 32 : 64);
     const int seqlen_q_rounded = round_multiple(seqlen_q, 128);
     const int seqlen_k_rounded = round_multiple(seqlen_k, 128);
 
-    if (softcap > 0.f) { STD_TORCH_CHECK(p_dropout == 0.f, "Softcapping does not support dropout for now"); }
+    if (softcap > 0.f) { TORCH_CHECK(p_dropout == 0.f, "Softcapping does not support dropout for now"); }
 
     if (window_size_left >= seqlen_k) { window_size_left = -1; }
     if (window_size_right >= seqlen_k) { window_size_right = -1; }
@@ -903,57 +883,58 @@ mha_bwd(const Tensor &dout,  // batch_size x seqlen_q x num_heads, x multiple_of
     CHECK_SHAPE(out, batch_size, seqlen_q, num_heads, head_size);
     CHECK_SHAPE(dout, batch_size, seqlen_q, num_heads, head_size);
 
-    Tensor dq, dk, dv;
+    at::Tensor dq, dk, dv;
     if (dq_.has_value()) {
         dq = dq_.value();
-        STD_TORCH_CHECK(dq.scalar_type() == q_dtype, "dq must have the same dtype as q");
+        TORCH_CHECK(dq.dtype() == q_dtype, "dq must have the same dtype as q");
         CHECK_DEVICE(dq);
-        STD_TORCH_CHECK(dq.stride(-1) == 1, "dq must have contiguous last dimension");
+        TORCH_CHECK(dq.stride(-1) == 1, "dq must have contiguous last dimension");
         CHECK_SHAPE(dq, batch_size, seqlen_q, num_heads, head_size);
     } else {
-        dq = torch::stable::empty_like(q);
+        dq = torch::empty_like(q);
     }
     if (dk_.has_value()) {
         dk = dk_.value();
-        STD_TORCH_CHECK(dk.scalar_type() == q_dtype, "dk must have the same dtype as q");
+        TORCH_CHECK(dk.dtype() == q_dtype, "dk must have the same dtype as q");
         CHECK_DEVICE(dk);
-        STD_TORCH_CHECK(dk.stride(-1) == 1, "dk must have contiguous last dimension");
+        TORCH_CHECK(dk.stride(-1) == 1, "dk must have contiguous last dimension");
         CHECK_SHAPE(dk, batch_size, seqlen_k, num_heads_k, head_size);
     } else {
-        dk = torch::stable::empty_like(k);
+        dk = torch::empty_like(k);
     }
     if (dv_.has_value()) {
         dv = dv_.value();
-        STD_TORCH_CHECK(dv.scalar_type() == q_dtype, "dv must have the same dtype as q");
+        TORCH_CHECK(dv.dtype() == q_dtype, "dv must have the same dtype as q");
         CHECK_DEVICE(dv);
-        STD_TORCH_CHECK(dv.stride(-1) == 1, "dv must have contiguous last dimension");
+        TORCH_CHECK(dv.stride(-1) == 1, "dv must have contiguous last dimension");
         CHECK_SHAPE(dv, batch_size, seqlen_k, num_heads_k, head_size);
     } else {
-        dv = torch::stable::empty_like(v);
+        dv = torch::empty_like(v);
     }
 
     // bool loop = seqlen_k > blocksize_c;
     // TODO: change later, for now set to true for simplicity
     bool loop = true;
 
-    auto softmax_d = torch::stable::new_empty(q, {batch_size, num_heads, seqlen_q_rounded}, ScalarType::Float);
-    Tensor dq_accum;
-    Tensor dk_accum, dv_accum;
+    auto opts = q.options();
+    auto softmax_d = torch::empty({batch_size, num_heads, seqlen_q_rounded}, opts.dtype(at::kFloat));
+    at::Tensor dq_accum;
+    at::Tensor dk_accum, dv_accum;
     if (loop) {
         if (!deterministic) {
-            dq_accum = torch::stable::new_empty(q, {batch_size, seqlen_q_rounded, num_heads, head_size_rounded}, ScalarType::Float);
+            dq_accum = torch::empty({batch_size, seqlen_q_rounded, num_heads, head_size_rounded}, opts.dtype(at::kFloat));
         } else {
             const int nsplits = (get_num_sm(get_current_device()) + batch_size * num_heads - 1) / (batch_size * num_heads);
-            dq_accum = torch::stable::new_zeros(q, {nsplits, batch_size, seqlen_q_rounded, num_heads, head_size_rounded}, ScalarType::Float);
+            dq_accum = torch::zeros({nsplits, batch_size, seqlen_q_rounded, num_heads, head_size_rounded}, opts.dtype(at::kFloat));
         }
-        // dk_accum = torch::stable::new_empty(q, {batch_size, num_heads_k, seqlen_k_rounded, head_size_rounded}, ScalarType::Float);
-        // dv_accum = torch::stable::new_empty(q, {batch_size, num_heads_k, seqlen_k_rounded, head_size_rounded}, ScalarType::Float);
+        // dk_accum = torch::empty({batch_size, num_heads_k, seqlen_k_rounded, head_size_rounded}, opts.dtype(at::kFloat));
+        // dv_accum = torch::empty({batch_size, num_heads_k, seqlen_k_rounded, head_size_rounded}, opts.dtype(at::kFloat));
     }
 
-    Tensor dk_expanded, dv_expanded;
+    at::Tensor dk_expanded, dv_expanded;
     if (num_heads_k != num_heads) {  // MQA / GQA
-        dk_expanded = torch::stable::new_empty(q, {batch_size, seqlen_k, num_heads, head_size});
-        dv_expanded = torch::stable::new_empty(q, {batch_size, seqlen_k, num_heads, head_size});
+        dk_expanded = torch::empty({batch_size, seqlen_k, num_heads, head_size}, opts);
+        dv_expanded = torch::empty({batch_size, seqlen_k, num_heads, head_size}, opts);
     } else {
         dk_expanded = dk;
         dv_expanded = dv;
@@ -1011,40 +992,33 @@ mha_bwd(const Tensor &dout,  // batch_size x seqlen_q x num_heads, x multiple_of
         launch(params, stream);
     } else {
         // If seqlen_q == 0, then we have an empty tensor. We need to set the output to 0.
-        torch::stable::zero_(dk_expanded);
-        torch::stable::zero_(dv_expanded);
-        torch::stable::zero_(softmax_d);
+        dk_expanded.zero_();
+        dv_expanded.zero_();
+        softmax_d.zero_();
     }
 
     // For MQA/GQA we need to sum dK and dV across the groups
     if (num_heads_k != num_heads) {
-        // Reduce over the group dim (3). A braced {3} binds ambiguously to the
-        // std::optional<IntHeaderOnlyArrayRef> dim parameter and silently reduces the
-        // wrong axis, so build a named IntHeaderOnlyArrayRef via the C-array ctor instead.
-        const int64_t reduce_dim[] = {3};
-        const torch::headeronly::IntHeaderOnlyArrayRef dim_ref(reduce_dim);
-        Tensor dk_grouped = torch::stable::reshape(dk_expanded, {batch_size, seqlen_k, num_heads_k, num_heads / num_heads_k, head_size});
-        Tensor dv_grouped = torch::stable::reshape(dv_expanded, {batch_size, seqlen_k, num_heads_k, num_heads / num_heads_k, head_size});
-        torch::stable::sum_out(dk, dk_grouped, dim_ref);
-        torch::stable::sum_out(dv, dv_grouped, dim_ref);
+        at::sum_out(dk, at::reshape(dk_expanded, {batch_size, seqlen_k, num_heads_k, num_heads / num_heads_k, head_size}), {3});
+        at::sum_out(dv, at::reshape(dv_expanded, {batch_size, seqlen_k, num_heads_k, num_heads / num_heads_k, head_size}), {3});
     }
 
     return { dq, dk, dv, softmax_d };
 }
 
-std::vector<Tensor>
-mha_varlen_bwd(const Tensor &dout,  // total_q x num_heads, x head_size
-               const Tensor &q,   // total_q x num_heads x head_size, total_q := \sum_{i=0}^{b} s_i
-               const Tensor &k,   // total_k x num_heads_k x head_size, total_k := \sum_{i=0}^{b} s_i
-               const Tensor &v,   // total_k x num_heads_k x head_size, total_k := \sum_{i=0}^{b} s_i
-               const Tensor &out,   // total_q x num_heads x head_size
-               const Tensor &softmax_lse,    // h x total_q, softmax logsumexp
-               std::optional<Tensor> dq_,   // total_q x num_heads x head_size, total_q := \sum_{i=0}^{b} s_i
-               std::optional<Tensor> dk_,   // total_k x num_heads_k x head_size, total_k := \sum_{i=0}^{b} s_i
-               std::optional<Tensor> dv_,   // total_k x num_heads_k x head_size, total_k := \sum_{i=0}^{b} s_i
-               const Tensor &cu_seqlens_q,  // b+1
-               const Tensor &cu_seqlens_k,  // b+1
-               std::optional<Tensor> alibi_slopes_, // num_heads or b x num_heads
+std::vector<at::Tensor>
+mha_varlen_bwd(const at::Tensor &dout,  // total_q x num_heads, x head_size
+               const at::Tensor &q,   // total_q x num_heads x head_size, total_q := \sum_{i=0}^{b} s_i
+               const at::Tensor &k,   // total_k x num_heads_k x head_size, total_k := \sum_{i=0}^{b} s_i
+               const at::Tensor &v,   // total_k x num_heads_k x head_size, total_k := \sum_{i=0}^{b} s_i
+               const at::Tensor &out,   // total_q x num_heads x head_size
+               const at::Tensor &softmax_lse,    // h x total_q, softmax logsumexp
+               std::optional<at::Tensor> dq_,   // total_q x num_heads x head_size, total_q := \sum_{i=0}^{b} s_i
+               std::optional<at::Tensor> dk_,   // total_k x num_heads_k x head_size, total_k := \sum_{i=0}^{b} s_i
+               std::optional<at::Tensor> dv_,   // total_k x num_heads_k x head_size, total_k := \sum_{i=0}^{b} s_i
+               const at::Tensor &cu_seqlens_q,  // b+1
+               const at::Tensor &cu_seqlens_k,  // b+1
+               std::optional<at::Tensor> alibi_slopes_, // num_heads or b x num_heads
                const int64_t max_seqlen_q,
                const int64_t max_seqlen_k,          // max sequence length to choose the kernel
                const double p_dropout,         // probability to drop
@@ -1056,47 +1030,47 @@ mha_varlen_bwd(const Tensor &dout,  // total_q x num_heads, x head_size
                const double softcap,
                const bool deterministic,
                // Retained only for backwards-compat arg positioning; must be None.
-               std::optional<Tensor> unused_generator_compat,
-               std::optional<Tensor> rng_state) {
+               std::optional<at::Tensor> unused_generator_compat,
+               std::optional<at::Tensor> rng_state) {
 
-    STD_TORCH_CHECK(!unused_generator_compat.has_value(),
-        "flash-attn: the RNG `generator` argument is no longer supported and must be None; "
-        "dropout (when enabled) uses the default CUDA generator.");
+    TORCH_CHECK(!unused_generator_compat.has_value(),
+                "flash-attn: the RNG `generator` argument is no longer supported and must be None; "
+                "dropout (when enabled) uses the default CUDA generator.");
 
     #ifdef FLASHATTENTION_DISABLE_BACKWARD
-        STD_TORCH_CHECK(false, "This flash attention build does not support backward.");
+        TORCH_CHECK(false, "This flash attention build does not support backward.");
     #endif
     if (is_causal) { window_size_right = 0; }
 
     // Otherwise the kernel will be launched from cuda:0 device
-    torch::stable::accelerator::DeviceGuard device_guard(q.get_device_index());
+    at::cuda::CUDAGuard device_guard{q.device()};
 
     auto [cc_major, cc_minor] = get_compute_capability(get_current_device());
     bool is_sm8x_min = cc_major >= 8;
-    STD_TORCH_CHECK(is_sm8x_min, "FlashAttention only supports Ampere GPUs or newer.");
+    TORCH_CHECK(is_sm8x_min, "FlashAttention only supports Ampere GPUs or newer.");
 
     [[maybe_unused]] bool is_dropout = p_dropout > 0.0;
-    auto stream = get_current_cuda_stream(q);
+    auto stream = at::cuda::getCurrentCUDAStream().stream();
 
-    auto q_dtype = q.scalar_type();
-    STD_TORCH_CHECK(q_dtype == ScalarType::Half || q_dtype == ScalarType::BFloat16,
+    auto q_dtype = q.dtype();
+    TORCH_CHECK(q_dtype == torch::kFloat16 || q_dtype == torch::kBFloat16,
                 "FlashAttention only support fp16 and bf16 data type");
-    STD_TORCH_CHECK(k.scalar_type() == q_dtype, "query and key must have the same dtype");
-    STD_TORCH_CHECK(v.scalar_type() == q_dtype, "query and value must have the same dtype");
-    STD_TORCH_CHECK(out.scalar_type() == q_dtype, "query and out must have the same dtype");
-    STD_TORCH_CHECK(dout.scalar_type() == q_dtype, "query and dout must have the same dtype");
-    STD_TORCH_CHECK(cu_seqlens_q.scalar_type() == ScalarType::Int, "cu_seqlens_q must have dtype int32");
-    STD_TORCH_CHECK(cu_seqlens_k.scalar_type() == ScalarType::Int, "cu_seqlens_k must have dtype int32");
+    TORCH_CHECK(k.dtype() == q_dtype, "query and key must have the same dtype");
+    TORCH_CHECK(v.dtype() == q_dtype, "query and value must have the same dtype");
+    TORCH_CHECK(out.dtype() == q_dtype, "query and out must have the same dtype");
+    TORCH_CHECK(dout.dtype() == q_dtype, "query and dout must have the same dtype");
+    TORCH_CHECK(cu_seqlens_q.dtype() == torch::kInt32, "cu_seqlens_q must have dtype int32");
+    TORCH_CHECK(cu_seqlens_k.dtype() == torch::kInt32, "cu_seqlens_k must have dtype int32");
 
     CHECK_DEVICE(q); CHECK_DEVICE(k); CHECK_DEVICE(v);
     CHECK_DEVICE(out); CHECK_DEVICE(dout); CHECK_DEVICE(softmax_lse);
     CHECK_DEVICE(cu_seqlens_q); CHECK_DEVICE(cu_seqlens_k);
 
-    STD_TORCH_CHECK(q.stride(-1) == 1, "Input tensor must have contiguous last dimension");
-    STD_TORCH_CHECK(k.stride(-1) == 1, "Input tensor must have contiguous last dimension");
-    STD_TORCH_CHECK(v.stride(-1) == 1, "Input tensor must have contiguous last dimension");
-    STD_TORCH_CHECK(out.stride(-1) == 1, "out tensor must have contiguous last dimension");
-    STD_TORCH_CHECK(dout.stride(-1) == 1, "dout tensor must have contiguous last dimension");
+    TORCH_CHECK(q.stride(-1) == 1, "Input tensor must have contiguous last dimension");
+    TORCH_CHECK(k.stride(-1) == 1, "Input tensor must have contiguous last dimension");
+    TORCH_CHECK(v.stride(-1) == 1, "Input tensor must have contiguous last dimension");
+    TORCH_CHECK(out.stride(-1) == 1, "out tensor must have contiguous last dimension");
+    TORCH_CHECK(dout.stride(-1) == 1, "dout tensor must have contiguous last dimension");
     CHECK_CONTIGUOUS(cu_seqlens_q);
     CHECK_CONTIGUOUS(cu_seqlens_k);
 
@@ -1108,11 +1082,11 @@ mha_varlen_bwd(const Tensor &dout,  // total_q x num_heads, x head_size
     const int head_size = sizes[2];
     const int total_k = k.size(0);
     const int num_heads_k = k.size(1);
-    STD_TORCH_CHECK(batch_size > 0, "batch size must be positive");
-    STD_TORCH_CHECK(head_size % 8 == 0, "head_size should be a multiple of 8");
-    STD_TORCH_CHECK(head_size <= 256, "FlashAttention backward only supports head dimension at most 256");
-    STD_TORCH_CHECK(num_heads % num_heads_k == 0, "Number of heads in key/value must divide number of heads in query");
-    if (softcap > 0.f) { STD_TORCH_CHECK(p_dropout == 0.f, "Softcapping does not support dropout for now"); }
+    TORCH_CHECK(batch_size > 0, "batch size must be positive");
+    TORCH_CHECK(head_size % 8 == 0, "head_size should be a multiple of 8");
+    TORCH_CHECK(head_size <= 256, "FlashAttention backward only supports head dimension at most 256");
+    TORCH_CHECK(num_heads % num_heads_k == 0, "Number of heads in key/value must divide number of heads in query");
+    if (softcap > 0.f) { TORCH_CHECK(p_dropout == 0.f, "Softcapping does not support dropout for now"); }
 
     auto round_multiple = [](int x, int m) { return (x + m - 1) / m * m; };
     const int head_size_rounded = round_multiple(head_size, head_size <= 128 ? 32 : 64);
@@ -1130,41 +1104,42 @@ mha_varlen_bwd(const Tensor &dout,  // total_q x num_heads, x head_size
     CHECK_SHAPE(cu_seqlens_q, batch_size + 1);
     CHECK_SHAPE(cu_seqlens_k, batch_size + 1);
 
-    Tensor dq, dk, dv;
+    at::Tensor dq, dk, dv;
     if (dq_.has_value()) {
         dq = dq_.value();
-        STD_TORCH_CHECK(dq.scalar_type() == q_dtype, "dq must have the same dtype as q");
+        TORCH_CHECK(dq.dtype() == q_dtype, "dq must have the same dtype as q");
         CHECK_DEVICE(dq);
-        STD_TORCH_CHECK(dq.stride(-1) == 1, "dq must have contiguous last dimension");
+        TORCH_CHECK(dq.stride(-1) == 1, "dq must have contiguous last dimension");
         CHECK_SHAPE(dq, total_q, num_heads, head_size);
     } else {
-        dq = torch::stable::empty_like(q);
+        dq = torch::empty_like(q);
     }
     if (dk_.has_value()) {
         dk = dk_.value();
-        STD_TORCH_CHECK(dk.scalar_type() == q_dtype, "dk must have the same dtype as q");
+        TORCH_CHECK(dk.dtype() == q_dtype, "dk must have the same dtype as q");
         CHECK_DEVICE(dk);
-        STD_TORCH_CHECK(dk.stride(-1) == 1, "dk must have contiguous last dimension");
+        TORCH_CHECK(dk.stride(-1) == 1, "dk must have contiguous last dimension");
         CHECK_SHAPE(dk, total_k, num_heads_k, head_size);
     } else {
-        dk = torch::stable::empty_like(k);
+        dk = torch::empty_like(k);
     }
     if (dv_.has_value()) {
         dv = dv_.value();
-        STD_TORCH_CHECK(dv.scalar_type() == q_dtype, "dv must have the same dtype as q");
+        TORCH_CHECK(dv.dtype() == q_dtype, "dv must have the same dtype as q");
         CHECK_DEVICE(dv);
-        STD_TORCH_CHECK(dv.stride(-1) == 1, "dv must have contiguous last dimension");
+        TORCH_CHECK(dv.stride(-1) == 1, "dv must have contiguous last dimension");
         CHECK_SHAPE(dv, total_k, num_heads_k, head_size);
     } else {
-        dv = torch::stable::empty_like(v);
+        dv = torch::empty_like(v);
     }
 
     // bool loop = max_seqlen_k > blocksize_c;
     // TODO: change later, for now set to true for simplicity
     bool loop = true;
 
-    auto softmax_d = torch::stable::new_empty(q, {num_heads, total_q + 128 * batch_size}, ScalarType::Float);
-    Tensor dq_accum;
+    auto opts = q.options();
+    auto softmax_d = torch::empty({num_heads, total_q + 128 * batch_size}, opts.dtype(at::kFloat));
+    at::Tensor dq_accum;
     if (loop) {
         // We don't want to allocate dq_accum of size (batch, seqlen_q_rounded, num_heads, head_size_rounded)
         // because that would be too large if there is a very long sequence and the rest of the sequences are short.
@@ -1176,27 +1151,27 @@ mha_varlen_bwd(const Tensor &dout,  // total_q x num_heads, x head_size
         // allowed to do. So we won't have to do any bound checking, and performance should stay the same.
         // Same holds for softmax_d, since LSE is stored in unpadded format.
         if (!deterministic) {
-            dq_accum = torch::stable::new_empty(q, {total_q + 128 * batch_size, num_heads, head_size_rounded}, ScalarType::Float);
+            dq_accum = torch::empty({total_q + 128 * batch_size, num_heads, head_size_rounded}, opts.dtype(at::kFloat));
         } else {
             const int nsplits = (get_num_sm(get_current_device()) + batch_size * num_heads - 1) / (batch_size * num_heads);
-            dq_accum = torch::stable::new_zeros(q, {nsplits, total_q + 128 * batch_size, num_heads, head_size_rounded}, ScalarType::Float);
+            dq_accum = torch::zeros({nsplits, total_q + 128 * batch_size, num_heads, head_size_rounded}, opts.dtype(at::kFloat));
         }
     }
 
-    Tensor dk_expanded, dv_expanded;
+    at::Tensor dk_expanded, dv_expanded;
     if (num_heads_k != num_heads) {  // MQA / GQA
-        dk_expanded = torch::stable::new_empty(q, {total_k, num_heads, head_size});
-        dv_expanded = torch::stable::new_empty(q, {total_k, num_heads, head_size});
+        dk_expanded = torch::empty({total_k, num_heads, head_size}, opts);
+        dv_expanded = torch::empty({total_k, num_heads, head_size}, opts);
     } else {
         dk_expanded = dk;
         dv_expanded = dv;
     }
 
     if( zero_tensors ) {
-        torch::stable::zero_(dq);
-        torch::stable::zero_(dk_expanded);
-        torch::stable::zero_(dv_expanded);
-        torch::stable::zero_(softmax_d);
+        dq.zero_();
+        dk_expanded.zero_();
+        dv_expanded.zero_();
+        softmax_d.zero_();
     }
 
     Flash_bwd_params params;
@@ -1250,40 +1225,34 @@ mha_varlen_bwd(const Tensor &dout,  // total_q x num_heads, x head_size
         launch(params, stream);
     } else {
         // If seqlen_q == 0, then we have an empty tensor. We need to set the output to 0.
-        torch::stable::zero_(dk_expanded);
-        torch::stable::zero_(dv_expanded);
-        torch::stable::zero_(softmax_d);
+        dk_expanded.zero_();
+        dv_expanded.zero_();
+        softmax_d.zero_();
     }
 
     // For MQA/GQA we need to sum dK and dV across the groups
     if (num_heads_k != num_heads) {
-        // Reduce over the group dim (2). See the mha_bwd note: a braced {2} binds
-        // ambiguously to std::optional<IntHeaderOnlyArrayRef>; build it explicitly.
-        const int64_t reduce_dim[] = {2};
-        const torch::headeronly::IntHeaderOnlyArrayRef dim_ref(reduce_dim);
-        Tensor dk_grouped = torch::stable::reshape(dk_expanded, {total_k, num_heads_k, num_heads / num_heads_k, head_size});
-        Tensor dv_grouped = torch::stable::reshape(dv_expanded, {total_k, num_heads_k, num_heads / num_heads_k, head_size});
-        torch::stable::sum_out(dk, dk_grouped, dim_ref);
-        torch::stable::sum_out(dv, dv_grouped, dim_ref);
+        at::sum_out(dk, at::reshape(dk_expanded, {total_k, num_heads_k, num_heads / num_heads_k, head_size}), {2});
+        at::sum_out(dv, at::reshape(dv_expanded, {total_k, num_heads_k, num_heads / num_heads_k, head_size}), {2});
     }
 
     return { dq, dk, dv, softmax_d };
 }
 
-std::vector<Tensor>
-mha_fwd_kvcache(Tensor q,                 // batch_size x seqlen_q x num_heads x head_size
-                Tensor &kcache,            // batch_size_c x seqlen_k x num_heads_k x head_size or num_blocks x page_block_size x num_heads_k x head_size if there's a block_table.
-                Tensor &vcache,            // batch_size_c x seqlen_k x num_heads_k x head_size or num_blocks x page_block_size x num_heads_k x head_size if there's a block_table.
-                const std::optional<Tensor> &k_, // batch_size x seqlen_knew x num_heads_k x head_size
-                const std::optional<Tensor> &v_, // batch_size x seqlen_knew x num_heads_k x head_size
-                const std::optional<Tensor> &seqlens_k_, // batch_size
-                const std::optional<Tensor> &rotary_cos_, // seqlen_ro x (rotary_dim / 2)
-                const std::optional<Tensor> &rotary_sin_, // seqlen_ro x (rotary_dim / 2)
-                const std::optional<Tensor> &cache_batch_idx_, // indices to index into the KV cache
-                const std::optional<Tensor> &leftpad_k_, // batch_size
-                std::optional<Tensor> block_table_, // batch_size x max_num_blocks_per_seq
-                std::optional<Tensor> alibi_slopes_, // num_heads or batch_size x num_heads
-                std::optional<Tensor> out_,             // batch_size x seqlen_q x num_heads x head_size
+std::vector<at::Tensor>
+mha_fwd_kvcache(at::Tensor q,                 // batch_size x seqlen_q x num_heads x head_size
+                at::Tensor &kcache,            // batch_size_c x seqlen_k x num_heads_k x head_size or num_blocks x page_block_size x num_heads_k x head_size if there's a block_table.
+                at::Tensor &vcache,            // batch_size_c x seqlen_k x num_heads_k x head_size or num_blocks x page_block_size x num_heads_k x head_size if there's a block_table.
+                const std::optional<at::Tensor> &k_, // batch_size x seqlen_knew x num_heads_k x head_size
+                const std::optional<at::Tensor> &v_, // batch_size x seqlen_knew x num_heads_k x head_size
+                const std::optional<at::Tensor> &seqlens_k_, // batch_size
+                const std::optional<at::Tensor> &rotary_cos_, // seqlen_ro x (rotary_dim / 2)
+                const std::optional<at::Tensor> &rotary_sin_, // seqlen_ro x (rotary_dim / 2)
+                const std::optional<at::Tensor> &cache_batch_idx_, // indices to index into the KV cache
+                const std::optional<at::Tensor> &leftpad_k_, // batch_size
+                std::optional<at::Tensor> block_table_, // batch_size x max_num_blocks_per_seq
+                std::optional<at::Tensor> alibi_slopes_, // num_heads or batch_size x num_heads
+                std::optional<at::Tensor> out_,             // batch_size x seqlen_q x num_heads x head_size
                 const double softmax_scale,
                 bool is_causal,
                 int64_t window_size_left,
@@ -1294,32 +1263,32 @@ mha_fwd_kvcache(Tensor q,                 // batch_size x seqlen_q x num_heads x
                 ) {
 
     // Otherwise the kernel will be launched from cuda:0 device
-    torch::stable::accelerator::DeviceGuard device_guard(q.get_device_index());
+    at::cuda::CUDAGuard device_guard{q.device()};
 
     auto [cc_major, cc_minor] = get_compute_capability(get_current_device());
     bool is_sm8x_min = cc_major >= 8;
-    STD_TORCH_CHECK(is_sm8x_min, "FlashAttention only supports Ampere GPUs or newer.");
+    TORCH_CHECK(is_sm8x_min, "FlashAttention only supports Ampere GPUs or newer.");
 
-    auto q_dtype = q.scalar_type();
-    STD_TORCH_CHECK(q_dtype == ScalarType::Half || q_dtype == ScalarType::BFloat16,
+    auto q_dtype = q.dtype();
+    TORCH_CHECK(q_dtype == torch::kFloat16 || q_dtype == torch::kBFloat16,
                 "FlashAttention only support fp16 and bf16 data type");
-    STD_TORCH_CHECK(kcache.scalar_type() == q_dtype, "query and key must have the same dtype");
-    STD_TORCH_CHECK(vcache.scalar_type() == q_dtype, "query and value must have the same dtype");
+    TORCH_CHECK(kcache.dtype() == q_dtype, "query and key must have the same dtype");
+    TORCH_CHECK(vcache.dtype() == q_dtype, "query and value must have the same dtype");
 
     CHECK_DEVICE(q); CHECK_DEVICE(kcache); CHECK_DEVICE(vcache);
 
-    STD_TORCH_CHECK(q.stride(-1) == 1, "Input tensor must have contiguous last dimension");
-    STD_TORCH_CHECK(kcache.stride(-1) == 1, "Input tensor must have contiguous last dimension");
-    STD_TORCH_CHECK(vcache.stride(-1) == 1, "Input tensor must have contiguous last dimension");
+    TORCH_CHECK(q.stride(-1) == 1, "Input tensor must have contiguous last dimension");
+    TORCH_CHECK(kcache.stride(-1) == 1, "Input tensor must have contiguous last dimension");
+    TORCH_CHECK(vcache.stride(-1) == 1, "Input tensor must have contiguous last dimension");
 
-    Tensor block_table;
+    at::Tensor block_table;
     const bool paged_KV = block_table_.has_value();
     if (paged_KV) {
-        STD_TORCH_CHECK(!cache_batch_idx_.has_value(), "Paged KVcache does not support cache_batch_idx");
+        TORCH_CHECK(!cache_batch_idx_.has_value(), "Paged KVcache does not support cache_batch_idx");
         block_table = block_table_.value();
         CHECK_DEVICE(block_table);
-        STD_TORCH_CHECK(block_table.scalar_type() == ScalarType::Int, "block_table must have dtype torch.int32");
-        STD_TORCH_CHECK(block_table.stride(-1) == 1, "block_table must have contiguous last dimension");
+        TORCH_CHECK(block_table.dtype() == torch::kInt32, "block_table must have dtype torch.int32");
+        TORCH_CHECK(block_table.stride(-1) == 1, "block_table must have contiguous last dimension");
     }
 
     const auto sizes = q.sizes();
@@ -1332,13 +1301,13 @@ mha_fwd_kvcache(Tensor q,                 // batch_size x seqlen_q x num_heads x
     const int max_num_blocks_per_seq = !paged_KV ? 0 : block_table.size(1);
     const int num_blocks = !paged_KV ? 0 : kcache.size(0);
     const int page_block_size = !paged_KV ? 1 : kcache.size(1);
-    STD_TORCH_CHECK(!paged_KV || page_block_size % 256 == 0, "Paged KV cache block size must be divisible by 256");
+    TORCH_CHECK(!paged_KV || page_block_size % 256 == 0, "Paged KV cache block size must be divisible by 256");
     const int seqlen_k = !paged_KV ? kcache.size(1) : max_num_blocks_per_seq * page_block_size;
     const int num_heads_k = kcache.size(2);
     const int batch_size_c = !paged_KV ? kcache.size(0) : batch_size;
-    STD_TORCH_CHECK(batch_size > 0, "batch size must be positive");
-    STD_TORCH_CHECK(head_size_og <= 256, "FlashAttention forward only supports head dimension at most 256");
-    STD_TORCH_CHECK(num_heads % num_heads_k == 0, "Number of heads in key/value must divide number of heads in query");
+    TORCH_CHECK(batch_size > 0, "batch size must be positive");
+    TORCH_CHECK(head_size_og <= 256, "FlashAttention forward only supports head dimension at most 256");
+    TORCH_CHECK(num_heads % num_heads_k == 0, "Number of heads in key/value must divide number of heads in query");
 
     // causal=true is the same as causal=false in this case
     if (seqlen_q == 1 && !alibi_slopes_.has_value()) { is_causal = false; }
@@ -1349,7 +1318,7 @@ mha_fwd_kvcache(Tensor q,                 // batch_size x seqlen_q x num_heads x
     const int seqlenq_ngroups_swapped = seqlen_q == 1 && num_heads > num_heads_k && window_size_left < 0 && window_size_right < 0 && head_size_og % 8 == 0 && !alibi_slopes_.has_value();
     if (seqlenq_ngroups_swapped) {
         const int ngroups = num_heads / num_heads_k;
-        q = torch::stable::transpose(torch::stable::reshape(q, {batch_size, num_heads_k, ngroups, head_size_og}), 1, 2);
+        q = q.reshape({batch_size, num_heads_k, ngroups, head_size_og}).transpose(1, 2);
         seqlen_q = ngroups;
         num_heads = num_heads_k;
     }
@@ -1367,27 +1336,27 @@ mha_fwd_kvcache(Tensor q,                 // batch_size x seqlen_q x num_heads x
         CHECK_SHAPE(block_table, batch_size, max_num_blocks_per_seq);
     }
 
-    Tensor q_padded, kcache_padded, vcache_padded;
+    at::Tensor q_padded, kcache_padded, vcache_padded;
     if (head_size_og % 8 != 0) {
-        q_padded = torch::stable::pad(q, {0, 8 - head_size_og % 8});
-        kcache_padded = torch::stable::pad(kcache, {0, 8 - head_size_og % 8});
-        vcache_padded = torch::stable::pad(vcache, {0, 8 - head_size_og % 8});
+        q_padded = torch::nn::functional::pad(q, torch::nn::functional::PadFuncOptions({0, 8 - head_size_og % 8}));
+        kcache_padded = torch::nn::functional::pad(kcache, torch::nn::functional::PadFuncOptions({0, 8 - head_size_og % 8}));
+        vcache_padded = torch::nn::functional::pad(vcache, torch::nn::functional::PadFuncOptions({0, 8 - head_size_og % 8}));
     } else {
         q_padded = q;
         kcache_padded = kcache;
         vcache_padded = vcache;
     }
 
-    Tensor out;
+    at::Tensor out;
     if (out_.has_value()) {
         out = out_.value();
-        STD_TORCH_CHECK(out.scalar_type() == q_dtype, "Output must have the same dtype as inputs");
+        TORCH_CHECK(out.dtype() == q_dtype, "Output must have the same dtype as inputs");
         CHECK_DEVICE(out);
-        STD_TORCH_CHECK(out.stride(-1) == 1, "Output tensor must have contiguous last dimension");
+        TORCH_CHECK(out.stride(-1) == 1, "Output tensor must have contiguous last dimension");
         CHECK_SHAPE(out, batch_size, seqlen_q, num_heads, head_size_og);
-        if (head_size_og % 8 != 0) { out = torch::stable::empty_like(q_padded); }
+        if (head_size_og % 8 != 0) { out = torch::empty_like(q_padded); }
     } else {
-        out = torch::stable::empty_like(q_padded);
+        out = torch::empty_like(q_padded);
     }
 
     auto round_multiple = [](int x, int m) { return (x + m - 1) / m * m; };
@@ -1396,7 +1365,9 @@ mha_fwd_kvcache(Tensor q,                 // batch_size x seqlen_q x num_heads x
     const int seqlen_q_rounded = round_multiple(seqlen_q, 128);
     const int seqlen_k_rounded = round_multiple(seqlen_k, 128);
 
-    auto softmax_lse = torch::stable::new_empty(q, {batch_size, num_heads, seqlen_q}, ScalarType::Float);
+    auto opts = q.options();
+
+    auto softmax_lse = torch::empty({batch_size, num_heads, seqlen_q}, opts.dtype(at::kFloat));
 
     Flash_fwd_params params;
     set_params_fprop(params,
@@ -1418,24 +1389,24 @@ mha_fwd_kvcache(Tensor q,                 // batch_size x seqlen_q x num_heads x
                      softcap
                      );
 
-    Tensor k, v, k_padded, v_padded;
+    at::Tensor k, v, k_padded, v_padded;
     if (k_.has_value()) {
-        STD_TORCH_CHECK(v_.has_value(), "If key is supplied, value must also be passed in");
-        STD_TORCH_CHECK(seqlens_k_.has_value(), "If key is supplied, seqlens_k must also be passed in");
-        STD_TORCH_CHECK(seqlen_q <= seqlen_k, "If key is supplied, it must have seqlen <= the seqlen of the KV cache");
+        TORCH_CHECK(v_.has_value(), "If key is supplied, value must also be passed in");
+        TORCH_CHECK(seqlens_k_.has_value(), "If key is supplied, seqlens_k must also be passed in");
+        TORCH_CHECK(seqlen_q <= seqlen_k, "If key is supplied, it must have seqlen <= the seqlen of the KV cache");
         k = k_.value();
         v = v_.value();
-        STD_TORCH_CHECK(k.scalar_type() == q_dtype, "Key must have the same dtype as query");
-        STD_TORCH_CHECK(v.scalar_type() == q_dtype, "Value must have the same dtype as query");
+        TORCH_CHECK(k.dtype() == q_dtype, "Key must have the same dtype as query");
+        TORCH_CHECK(v.dtype() == q_dtype, "Value must have the same dtype as query");
         CHECK_DEVICE(k); CHECK_DEVICE(v);
-        STD_TORCH_CHECK(k.stride(-1) == 1, "Key tensor must have contiguous last dimension");
-        STD_TORCH_CHECK(v.stride(-1) == 1, "Value tensor must have contiguous last dimension");
+        TORCH_CHECK(k.stride(-1) == 1, "Key tensor must have contiguous last dimension");
+        TORCH_CHECK(v.stride(-1) == 1, "Value tensor must have contiguous last dimension");
         int seqlen_knew = k.size(1);
         CHECK_SHAPE(k, batch_size, seqlen_knew, num_heads_k, head_size_og);
         CHECK_SHAPE(v, batch_size, seqlen_knew, num_heads_k, head_size_og);
         if (head_size_og % 8 != 0) {
-            k_padded = torch::stable::pad(k, {0, 8 - head_size_og % 8});
-            v_padded = torch::stable::pad(v, {0, 8 - head_size_og % 8});
+            k_padded = torch::nn::functional::pad(k, torch::nn::functional::PadFuncOptions({0, 8 - head_size_og % 8}));
+            v_padded = torch::nn::functional::pad(v, torch::nn::functional::PadFuncOptions({0, 8 - head_size_og % 8}));
         } else {
             k_padded = k;
             v_padded = v;
@@ -1454,7 +1425,7 @@ mha_fwd_kvcache(Tensor q,                 // batch_size x seqlen_q x num_heads x
 
     if (seqlens_k_.has_value()) {
         auto seqlens_k = seqlens_k_.value();
-        STD_TORCH_CHECK(seqlens_k.scalar_type() == ScalarType::Int, "seqlens_k must have dtype int32");
+        TORCH_CHECK(seqlens_k.dtype() == torch::kInt32, "seqlens_k must have dtype int32");
         CHECK_DEVICE(seqlens_k);
         CHECK_CONTIGUOUS(seqlens_k);
         CHECK_SHAPE(seqlens_k, batch_size);
@@ -1467,10 +1438,8 @@ mha_fwd_kvcache(Tensor q,                 // batch_size x seqlen_q x num_heads x
         // Note: .max().item() forces a device->host sync, so we only pay it for the paged KV case.
         if (paged_KV) {
             const int seqlen_knew = k_.has_value() ? k.size(1) : 0;
-            int32_t seqlens_k_max = 0;  // stable-ABI seqlens_k.max().item<int>()
-            TORCH_ERROR_CODE_CHECK(aoti_torch_item_int32(torch::stable::amax(seqlens_k, 0).get(), &seqlens_k_max));
-            const int max_seqlen_k = seqlens_k_max + seqlen_knew;
-            STD_TORCH_CHECK(max_seqlen_k <= max_num_blocks_per_seq * page_block_size,
+            const int max_seqlen_k = seqlens_k.max().item<int>() + seqlen_knew;
+            TORCH_CHECK(max_seqlen_k <= max_num_blocks_per_seq * page_block_size,
                         "Paged KV cache: max(seqlens_k)", seqlen_knew > 0 ? " + seqlen_knew" : "", " (= ", max_seqlen_k,
                         ") exceeds the capacity addressable by block_table (max_num_blocks_per_seq * page_block_size = ",
                         max_num_blocks_per_seq * page_block_size, "). Allocate more columns in block_table, otherwise the "
@@ -1480,9 +1449,9 @@ mha_fwd_kvcache(Tensor q,                 // batch_size x seqlen_q x num_heads x
     }
     params.is_seqlens_k_cumulative = !(seqlens_k_.has_value());
     if (leftpad_k_.has_value()) {
-        STD_TORCH_CHECK(!paged_KV, "We don't support Paged KV and leftpad_k running at the same time yet");
+        TORCH_CHECK(!paged_KV, "We don't support Paged KV and leftpad_k running at the same time yet");
         auto leftpad_k = leftpad_k_.value();
-        STD_TORCH_CHECK(leftpad_k.scalar_type() == ScalarType::Int, "leftpad_k must have dtype int32");
+        TORCH_CHECK(leftpad_k.dtype() == torch::kInt32, "leftpad_k must have dtype int32");
         CHECK_DEVICE(leftpad_k);
         CHECK_CONTIGUOUS(leftpad_k);
         CHECK_SHAPE(leftpad_k, batch_size);
@@ -1490,24 +1459,24 @@ mha_fwd_kvcache(Tensor q,                 // batch_size x seqlen_q x num_heads x
     }
 
     if (rotary_cos_.has_value()) {
-        STD_TORCH_CHECK(k_.has_value(), "If rotary cos/sin are provided, new key / value to be appended to KV cache must also be provided");
+        TORCH_CHECK(k_.has_value(), "If rotary cos/sin are provided, new key / value to be appended to KV cache must also be provided");
         auto rotary_cos = rotary_cos_.value();
         CHECK_DEVICE(rotary_cos);
         params.rotary_dim = rotary_cos.size(1) * 2;
-        STD_TORCH_CHECK(params.rotary_dim <= head_size, "rotary_dim must be <= headdim");
-        STD_TORCH_CHECK(params.rotary_dim % 16 == 0, "Only rotary dimensions divisible by 16 are currently supported");
+        TORCH_CHECK(params.rotary_dim <= head_size, "rotary_dim must be <= headdim");
+        TORCH_CHECK(params.rotary_dim % 16 == 0, "Only rotary dimensions divisible by 16 are currently supported");
         const int seqlen_ro = rotary_cos.size(0);
-        STD_TORCH_CHECK(seqlen_ro >= seqlen_k, "cos/sin seqlen must be at least the seqlen of KV cache");
+        TORCH_CHECK(seqlen_ro >= seqlen_k, "cos/sin seqlen must be at least the seqlen of KV cache");
         CHECK_SHAPE(rotary_cos, seqlen_ro, params.rotary_dim / 2);
         CHECK_CONTIGUOUS(rotary_cos);
-        STD_TORCH_CHECK(rotary_cos.scalar_type() == q_dtype, "rotary_cos must have the same dtype as query");
+        TORCH_CHECK(rotary_cos.scalar_type() == q_dtype, "rotary_cos must have the same dtype as query");
 
-        STD_TORCH_CHECK(rotary_sin_.has_value(), "If rotary cos is provided, rotary sin must also be provided");
+        TORCH_CHECK(rotary_sin_.has_value(), "If rotary cos is provided, rotary sin must also be provided");
         auto rotary_sin = rotary_sin_.value();
         CHECK_DEVICE(rotary_sin);
         CHECK_SHAPE(rotary_sin, seqlen_ro, params.rotary_dim / 2);
         CHECK_CONTIGUOUS(rotary_sin);
-        STD_TORCH_CHECK(rotary_sin.scalar_type() == q_dtype, "rotary_cos must have the same dtype as query");
+        TORCH_CHECK(rotary_sin.scalar_type() == q_dtype, "rotary_cos must have the same dtype as query");
         params.rotary_cos_ptr = rotary_cos.data_ptr();
         params.rotary_sin_ptr = rotary_sin.data_ptr();
         params.is_rotary_interleaved = is_rotary_interleaved;
@@ -1519,18 +1488,18 @@ mha_fwd_kvcache(Tensor q,                 // batch_size x seqlen_q x num_heads x
         auto cache_batch_idx = cache_batch_idx_.value();
         CHECK_DEVICE(cache_batch_idx);
         CHECK_CONTIGUOUS(cache_batch_idx);
-        STD_TORCH_CHECK(cache_batch_idx.scalar_type() == ScalarType::Int, "cache_batch_idx must have dtype int32");
+        TORCH_CHECK(cache_batch_idx.scalar_type() == torch::kInt32, "cache_batch_idx must have dtype int32");
         params.cache_batch_idx = reinterpret_cast<int *>(cache_batch_idx.data_ptr());
     }
 
     // Keep references to these tensors to extend their lifetime
-    Tensor softmax_lse_accum, out_accum;
+    at::Tensor softmax_lse_accum, out_accum;
     std::tie(softmax_lse_accum, out_accum) = set_params_splitkv(
         params, batch_size, num_heads, head_size, seqlen_k, seqlen_q,
-        head_size_rounded, /*dropout*/ 0.f, num_splits, get_num_sm(get_current_device()), q);
+        head_size_rounded, /*dropout*/ 0.f, num_splits, get_num_sm(get_current_device()), opts);
 
     if (paged_KV) {
-        params.block_table = block_table.mutable_data_ptr<int>();
+        params.block_table = block_table.data_ptr<int>();
         params.block_table_batch_stride = block_table.stride(0);
     }
     params.page_block_size = page_block_size;
@@ -1538,33 +1507,31 @@ mha_fwd_kvcache(Tensor q,                 // batch_size x seqlen_q x num_heads x
 
     set_params_alibi(params, alibi_slopes_, batch_size, num_heads);
 
-    auto stream = get_current_cuda_stream(q);
+    auto stream = at::cuda::getCurrentCUDAStream().stream();
     // Only split kernel supports appending to KV cache, or indexing to the cache with cache_batch_idx,
     // or paged KV cache
     run_mha_fwd(params, stream, /*force_split_kernel=*/k_.has_value() || cache_batch_idx_.has_value() || paged_KV);
 
     if (head_size_og % 8 != 0) {
-        out = torch::stable::narrow(out, out.dim() - 1, 0, head_size_og);
-        if (out_.has_value()) { Tensor out_val = out_.value(); torch::stable::copy_(out_val, out); }
+        out = out.index({"...", torch::indexing::Slice(torch::indexing::None, head_size_og)});
+        if (out_.has_value()) { out_.value().copy_(out); }
         if (k_.has_value()) {
             // It's expensive to copy the KV cache here for the case where head size not divisible by 8,
             // but we don't expect to get this case in practice. This is just so that the code works for that case.
-            Tensor kcache_src = torch::stable::narrow(kcache_padded, kcache_padded.dim() - 1, 0, head_size_og);
-            Tensor vcache_src = torch::stable::narrow(vcache_padded, vcache_padded.dim() - 1, 0, head_size_og);
-            torch::stable::copy_(kcache, kcache_src);
-            torch::stable::copy_(vcache, vcache_src);
+            kcache.copy_(kcache_padded.index({"...", torch::indexing::Slice(torch::indexing::None, head_size_og)}));
+            vcache.copy_(vcache_padded.index({"...", torch::indexing::Slice(torch::indexing::None, head_size_og)}));
         }
     }
 
     if (seqlenq_ngroups_swapped) {
-        out = torch::stable::reshape(torch::stable::transpose(out, 1, 2), {batch_size, 1, num_heads_k * seqlen_q, head_size_og});
-        softmax_lse = torch::stable::reshape(softmax_lse, {batch_size, num_heads_k * seqlen_q, 1});
+        out = out.transpose(1, 2).reshape({batch_size, 1, num_heads_k * seqlen_q, head_size_og});
+        softmax_lse = softmax_lse.reshape({batch_size, num_heads_k * seqlen_q, 1});
     }
     return {out, softmax_lse};
 }
 } // namespace FLASH_NAMESPACE
 
-STABLE_TORCH_LIBRARY(flash_attn_2, m) {
+TORCH_LIBRARY(flash_attn_2, m) {
     m.def("fwd("
         "Tensor q,"
         "Tensor k,"
@@ -1670,10 +1637,10 @@ STABLE_TORCH_LIBRARY(flash_attn_2, m) {
         "int num_splits) -> Tensor[]");
 }
 
-STABLE_TORCH_LIBRARY_IMPL(flash_attn_2, CUDA, m) {
-    m.impl("fwd", TORCH_BOX(&FLASH_NAMESPACE::mha_fwd));
-    m.impl("varlen_fwd", TORCH_BOX(&FLASH_NAMESPACE::mha_varlen_fwd));
-    m.impl("bwd", TORCH_BOX(&FLASH_NAMESPACE::mha_bwd));
-    m.impl("varlen_bwd", TORCH_BOX(&FLASH_NAMESPACE::mha_varlen_bwd));
-    m.impl("fwd_kvcache", TORCH_BOX(&FLASH_NAMESPACE::mha_fwd_kvcache));
+TORCH_LIBRARY_IMPL(flash_attn_2, CUDA, m) {
+    m.impl("fwd", &FLASH_NAMESPACE::mha_fwd);
+    m.impl("varlen_fwd", &FLASH_NAMESPACE::mha_varlen_fwd);
+    m.impl("bwd", &FLASH_NAMESPACE::mha_bwd);
+    m.impl("varlen_bwd", &FLASH_NAMESPACE::mha_varlen_bwd);
+    m.impl("fwd_kvcache", &FLASH_NAMESPACE::mha_fwd_kvcache);
 }

--- a/csrc/flash_attn/src/cuda_check.h
+++ b/csrc/flash_attn/src/cuda_check.h
@@ -1,0 +1,17 @@
+/******************************************************************************
+ * Copyright (c) 2026, Tri Dao.
+ ******************************************************************************/
+
+#pragma once
+
+#include <cuda_runtime.h>
+
+#ifdef TORCH_TARGET_VERSION
+#include <torch/csrc/stable/macros.h>
+#define FLASHATTENTION_CUDA_CHECK(EXPR) STD_CUDA_CHECK(EXPR)
+#define FLASHATTENTION_CUDA_KERNEL_LAUNCH_CHECK() STD_CUDA_KERNEL_LAUNCH_CHECK()
+#else
+#include <c10/cuda/CUDAException.h>
+#define FLASHATTENTION_CUDA_CHECK(EXPR) C10_CUDA_CHECK(EXPR)
+#define FLASHATTENTION_CUDA_KERNEL_LAUNCH_CHECK() C10_CUDA_KERNEL_LAUNCH_CHECK()
+#endif

--- a/csrc/flash_attn/src/flash_bwd_launch_template.h
+++ b/csrc/flash_attn/src/flash_bwd_launch_template.h
@@ -5,7 +5,7 @@
 #pragma once
 
 #include "namespace_config.h"
-#include <c10/cuda/CUDAException.h>  // For C10_CUDA_CHECK and C10_CUDA_KERNEL_LAUNCH_CHECK
+#include "cuda_check.h"
 
 #include "static_switch.h"
 #include "hardware_info.h"
@@ -86,7 +86,7 @@ void run_flash_bwd_seqk_parallel(Flash_bwd_params &params, cudaStream_t stream) 
     } else {
         flash_bwd_dot_do_o_kernel<false, Kernel_traits><<<grid_m, Kernel_traits::kNThreads, 0, stream>>>(params);
     }
-    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    FLASHATTENTION_CUDA_KERNEL_LAUNCH_CHECK();
 
     // We want to specialize to is_even_MN and not just is_even_M, since in the case where N is not
     // a multiple of kBlockN, we'll need to apply mask in the loop.
@@ -105,11 +105,11 @@ void run_flash_bwd_seqk_parallel(Flash_bwd_params &params, cudaStream_t stream) 
                         auto kernel = &flash_bwd_dq_dk_dv_loop_seqk_parallel_kernel<Kernel_traits, Is_dropout && !Is_softcap, Is_causal, Is_local && !Is_causal, Has_alibi, IsEvenMNConst && IsEvenKConst && !Is_local && !Has_alibi && Kernel_traits::kHeadDim <= 128, IsEvenKConst && !Has_alibi, Is_softcap>;
                         // auto kernel = &flash_bwd_dq_dk_dv_loop_seqk_parallel_kernel<Kernel_traits, false, Is_causal, false, false, true, true>;
                         if (smem_size_dq_dk_dv >= 48 * 1024)  {
-                            C10_CUDA_CHECK(cudaFuncSetAttribute(
+                            FLASHATTENTION_CUDA_CHECK(cudaFuncSetAttribute(
                                 kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size_dq_dk_dv));
                         }
                         kernel<<<grid_n, Kernel_traits::kNThreads, smem_size_dq_dk_dv, stream>>>(params);
-                        C10_CUDA_KERNEL_LAUNCH_CHECK();
+                        FLASHATTENTION_CUDA_KERNEL_LAUNCH_CHECK();
                     });
                 });
             });
@@ -118,11 +118,11 @@ void run_flash_bwd_seqk_parallel(Flash_bwd_params &params, cudaStream_t stream) 
 
     auto kernel_dq = &flash_bwd_convert_dq_kernel<Kernel_traits>;
     if (Kernel_traits::kSmemdQSize >= 48 * 1024)  {
-        C10_CUDA_CHECK(cudaFuncSetAttribute(
+        FLASHATTENTION_CUDA_CHECK(cudaFuncSetAttribute(
             kernel_dq, cudaFuncAttributeMaxDynamicSharedMemorySize, Kernel_traits::kSmemdQSize));
     }
     kernel_dq<<<grid_m, Kernel_traits::kNThreads, Kernel_traits::kSmemdQSize, stream>>>(params, !params.deterministic ? 1 : gridDimx);
-    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    FLASHATTENTION_CUDA_KERNEL_LAUNCH_CHECK();
 }
 
 template<typename Kernel_traits, bool Is_dropout, bool Is_causal>
@@ -141,7 +141,7 @@ void run_mha_bwd_hdim32(Flash_bwd_params &params, cudaStream_t stream) {
     cudaError status_ = cudaDeviceGetAttribute(
         &max_smem_per_block, cudaDevAttrMaxSharedMemoryPerBlockOptin, device);
     if (status_ != cudaSuccess) {
-      C10_CUDA_CHECK(status_);
+      FLASHATTENTION_CUDA_CHECK(status_);
     }
     DROPOUT_SWITCH(params.p_dropout < 1.f, Is_dropout, [&] {
         if (max_smem_per_block >= 2 * ((3 * 128 + 2 * 128) * Headdim + 2 * 128 * 128)) { // 104 KB
@@ -165,7 +165,7 @@ void run_mha_bwd_hdim64(Flash_bwd_params &params, cudaStream_t stream) {
     cudaError status_ = cudaDeviceGetAttribute(
         &max_smem_per_block, cudaDevAttrMaxSharedMemoryPerBlockOptin, device);
     if (status_ != cudaSuccess) {
-      C10_CUDA_CHECK(status_);
+      FLASHATTENTION_CUDA_CHECK(status_);
     }
     // printf("max_smem_per_block = %d\n", max_smem_per_block);
     DROPOUT_SWITCH(params.p_dropout < 1.f, Is_dropout, [&] {
@@ -210,7 +210,7 @@ void run_mha_bwd_hdim96(Flash_bwd_params &params, cudaStream_t stream) {
     cudaError status_ = cudaDeviceGetAttribute(
         &max_smem_per_block, cudaDevAttrMaxSharedMemoryPerBlockOptin, device);
     if (status_ != cudaSuccess) {
-      C10_CUDA_CHECK(status_);
+      FLASHATTENTION_CUDA_CHECK(status_);
     }
     // printf("max_smem_per_block = %d\n", max_smem_per_block);
     DROPOUT_SWITCH(params.p_dropout < 1.f, Is_dropout, [&] {
@@ -236,7 +236,7 @@ void run_mha_bwd_hdim128(Flash_bwd_params &params, cudaStream_t stream) {
     cudaError status_ = cudaDeviceGetAttribute(
         &max_smem_per_block, cudaDevAttrMaxSharedMemoryPerBlockOptin, device);
     if (status_ != cudaSuccess) {
-      C10_CUDA_CHECK(status_);
+      FLASHATTENTION_CUDA_CHECK(status_);
     }
     // printf("max_smem_per_block = %d\n", max_smem_per_block);
     DROPOUT_SWITCH(params.p_dropout < 1.f, Is_dropout, [&] {
@@ -270,7 +270,7 @@ void run_mha_bwd_hdim192(Flash_bwd_params &params, cudaStream_t stream) {
     cudaError status_ = cudaDeviceGetAttribute(
         &max_smem_per_block, cudaDevAttrMaxSharedMemoryPerBlockOptin, device);
     if (status_ != cudaSuccess) {
-      C10_CUDA_CHECK(status_);
+      FLASHATTENTION_CUDA_CHECK(status_);
     }
     DROPOUT_SWITCH(params.p_dropout < 1.f, Is_dropout, [&] {
         if (max_smem_per_block >= 136 * 1024) {
@@ -290,7 +290,7 @@ void run_mha_bwd_hdim256(Flash_bwd_params &params, cudaStream_t stream) {
     cudaError status_ = cudaDeviceGetAttribute(
         &max_smem_per_block, cudaDevAttrMaxSharedMemoryPerBlockOptin, device);
     if (status_ != cudaSuccess) {
-      C10_CUDA_CHECK(status_);
+      FLASHATTENTION_CUDA_CHECK(status_);
     }
     DROPOUT_SWITCH(params.p_dropout < 1.f, Is_dropout, [&] {
         if (max_smem_per_block >= 176 * 1024) {  // H100

--- a/csrc/flash_attn/src/flash_fwd_launch_template.h
+++ b/csrc/flash_attn/src/flash_fwd_launch_template.h
@@ -4,7 +4,7 @@
 
 #pragma once
 #include "namespace_config.h"
-#include <c10/cuda/CUDAException.h>  // For C10_CUDA_CHECK and C10_CUDA_KERNEL_LAUNCH_CHECK
+#include "cuda_check.h"
 
 #include "static_switch.h"
 #include "hardware_info.h"
@@ -81,7 +81,7 @@ void run_flash_fwd(Flash_fwd_params &params, cudaStream_t stream) {
                             // printf("IsEvenMNConst = %d, IsEvenKConst = %d, Is_local = %d, Is_causal = %d, ReturnSoftmaxConst = %d, Is_dropout = %d\n", int(IsEvenMNConst), int(IsEvenKConst), int(Is_local), int(Is_causal), int(ReturnSoftmaxConst), int(Is_dropout));
                             // auto kernel = &flash_fwd_kernel<Kernel_traits, false, Is_causal, false, true, true, false>;
                             if (smem_size >= 48 * 1024) {
-                                C10_CUDA_CHECK(cudaFuncSetAttribute(
+                                FLASHATTENTION_CUDA_CHECK(cudaFuncSetAttribute(
                                     kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
                             }
                             // int ctas_per_sm;
@@ -89,7 +89,7 @@ void run_flash_fwd(Flash_fwd_params &params, cudaStream_t stream) {
                             //     &ctas_per_sm, kernel, Kernel_traits::kNThreads, smem_size);
                             // printf("smem_size = %d, CTAs per SM = %d\n", int(smem_size), ctas_per_sm);
                             kernel<<<grid, Kernel_traits::kNThreads, smem_size, stream>>>(params);
-                            C10_CUDA_KERNEL_LAUNCH_CHECK();
+                            FLASHATTENTION_CUDA_KERNEL_LAUNCH_CHECK();
                         });
                     });
                 });
@@ -121,11 +121,11 @@ void run_flash_splitkv_fwd(Flash_fwd_params &params, cudaStream_t stream) {
                                 // auto kernel = &flash_fwd_splitkv_kernel<Kernel_traits, Is_causal, false, true, Split, Append_KV>;
                                 // auto kernel = &flash_fwd_splitkv_kernel<Kernel_traits, Is_causal, false, IsEvenKConst>;
                                 if (smem_size >= 48 * 1024) {
-                                    C10_CUDA_CHECK(cudaFuncSetAttribute(
+                                    FLASHATTENTION_CUDA_CHECK(cudaFuncSetAttribute(
                                         kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
                                 }
                                 kernel<<<grid, Kernel_traits::kNThreads, smem_size, stream>>>(params);
-                                C10_CUDA_KERNEL_LAUNCH_CHECK();
+                                FLASHATTENTION_CUDA_KERNEL_LAUNCH_CHECK();
                             });
                         });
                     });
@@ -155,7 +155,7 @@ void run_flash_splitkv_fwd(Flash_fwd_params &params, cudaStream_t stream) {
             } else if (params.num_splits <= 128) {
                 flash_fwd_splitkv_combine_kernel<Kernel_traits, kBlockM, 7, IsEvenKConst><<<grid_combine, Kernel_traits::kNThreads, 0, stream>>>(params);
             }
-            C10_CUDA_KERNEL_LAUNCH_CHECK();
+            FLASHATTENTION_CUDA_KERNEL_LAUNCH_CHECK();
         });
     }
 }
@@ -306,7 +306,7 @@ void run_mha_fwd_hdim256(Flash_fwd_params &params, cudaStream_t stream) {
     status_ = cudaDeviceGetAttribute(
         &max_smem_per_block, cudaDevAttrMaxSharedMemoryPerBlockOptin, device);
     if (status_ != cudaSuccess) {
-      C10_CUDA_CHECK(status_);
+      FLASHATTENTION_CUDA_CHECK(status_);
     }
     // printf("max_smem_per_sm = %d, max_smem_per_block = %d\n", max_smem_per_sm, max_smem_per_block);
     DROPOUT_SWITCH(params.p_dropout < 1.f, Is_dropout, [&] {

--- a/flash_attn/flash_attn_interface.py
+++ b/flash_attn/flash_attn_interface.py
@@ -20,7 +20,17 @@ if not USE_TRITON_ROCM and getattr(torch.version, 'hip', None) is not None:
 if USE_TRITON_ROCM:
     from aiter.ops.triton._triton_kernels.flash_attn_triton_amd import flash_attn_2 as flash_attn_gpu
 else:
-    import flash_attn_2_cuda as flash_attn_gpu
+    # `flash_attn_2_cuda` is now a CPython agnostic shared library that registers its ops into
+    # torch.ops.flash_attn_2 (via TORCH_LIBRARY). It's no longer an importable pybind module.
+    # Load the shared library so its static registration runs, then alias the op namespace so
+    # existing `flash_attn_gpu.<op>(...)` calls work.
+    import importlib.util as _importlib_util
+
+    _flash_attn_2_spec = _importlib_util.find_spec("flash_attn_2_cuda")
+    if _flash_attn_2_spec is None or _flash_attn_2_spec.origin is None:
+        raise ImportError("Could not locate the flash_attn_2_cuda shared library")
+    torch.ops.load_library(_flash_attn_2_spec.origin)
+    flash_attn_gpu = torch.ops.flash_attn_2
 
 # isort: on
 

--- a/setup.py
+++ b/setup.py
@@ -449,6 +449,7 @@ if not SKIP_CUDA_BUILD and not IS_ROCM:
                 "cxx": compiler_c17_flag + feature_flags,
                 "nvcc": append_nvcc_threads(nvcc_flags + cc_flag + feature_flags),
             },
+            py_limited_api=True,
             include_dirs=[
                 Path(this_dir) / "csrc" / "flash_attn",
                 Path(this_dir) / "csrc" / "flash_attn" / "src",
@@ -795,6 +796,8 @@ setup(
     else {
         "bdist_wheel": CachedWheelsCommand,
     },
+    # Tag with py_limited_api only for the CUDA build which is CPython agnostic by avoiding pybind.
+    options={"bdist_wheel": {"py_limited_api": "cp39"}} if ext_modules and not IS_ROCM else {},
     python_requires=">=3.9",
     install_requires=install_requires,
     setup_requires=[

--- a/setup.py
+++ b/setup.py
@@ -336,18 +336,30 @@ if not SKIP_CUDA_BUILD and not IS_ROCM:
         nvcc_flags.extend(["-Xcompiler", "/Zc:__cplusplus"])
         compiler_c17_flag=["-O2", "/std:c++17", "/Zc:__cplusplus"]
 
+    # The stable Tensor APIs used by flash_api.cpp require torch 2.10.
+    use_stable_torch_api = (TORCH_MAJOR, TORCH_MINOR) >= (2, 10)
+    flash_api_source = (
+        "csrc/flash_attn/flash_api.cpp"
+        if use_stable_torch_api
+        else "csrc/flash_attn/flash_api_unstable.cpp"
+    )
+
+    # USE_CUDA exposes the CUDA shims flash_api.cpp uses across cxx + nvcc
+    feature_flags = ["-DUSE_CUDA"] if use_stable_torch_api else []
+
     # Opt-in: disable building dropout and its dependent headers (ATen philox/RNG
-    # headers) from the FA2 build. This flag must be shared across both cxx and nvcc
-    # compilers, as FA2 is defined in both flash_api.cpp (cxx) and CUDA kernels.
-    feature_flags = []
+    # headers) in FA2. This flag must be shared across both cxx and nvcc.
     if os.getenv("FLASH_ATTENTION_DISABLE_DROPOUT", "FALSE") == "TRUE":
         feature_flags.append("-DFLASHATTENTION_DISABLE_DROPOUT")
+        if use_stable_torch_api:
+            # Only the dropout-disabled build can be fully ABI stable with torch.
+            feature_flags.append("-DTORCH_TARGET_VERSION=0x020a000000000000")
 
     ext_modules.append(
         CUDAExtension(
             name="flash_attn_2_cuda",
             sources=[
-                "csrc/flash_attn/flash_api.cpp",
+                flash_api_source,
                 "csrc/flash_attn/src/flash_fwd_hdim32_fp16_sm80.cu",
                 "csrc/flash_attn/src/flash_fwd_hdim32_bf16_sm80.cu",
                 "csrc/flash_attn/src/flash_fwd_hdim64_fp16_sm80.cu",
@@ -797,8 +809,8 @@ setup(
         "bdist_wheel": CachedWheelsCommand,
     },
     # Tag with py_limited_api only for the CUDA build which is CPython agnostic by avoiding pybind.
-    options={"bdist_wheel": {"py_limited_api": "cp39"}} if ext_modules and not IS_ROCM else {},
-    python_requires=">=3.9",
+    options={"bdist_wheel": {"py_limited_api": "cp310"}} if ext_modules and not IS_ROCM else {},
+    python_requires=">=3.10",
     install_requires=install_requires,
     setup_requires=[
         "packaging",


### PR DESCRIPTION
TL;DR: FA2 with dropout disabled is now ABI stable with torch 2.10+ and CPython 3.10+.

Here's how to think about each commit:
* [`9272e29` (this PR)](https://github.com/Dao-AILab/flash-attention/pull/2688/changes/9272e298414c164ef0517671a1c018e1418ec4f1): Use TORCH_LIBRARY instead of pybind to enable building 1 wheel across multiple Python versions, thus enabling building FA2 in a CPython agnostic manner.
* [`d5f02eb` (this PR)](https://github.com/Dao-AILab/flash-attention/pull/2688/changes/d5f02eb0d77c97b66a3815f938ddc184f63b5002) Migrate to libtorch stable ABI. Since the APIs are only available 2.10+, I introduce branching based on build time torch version so that `flash_api.cpp` will be built if 2.10+, otherwise `flash_api_unstable.cpp` will be built. `flash_api_unstable.cpp` is identical to `flash_api.cpp` from the previous commit.

### Test Plan:

#### Correctness
 **For the new stable dropout disabled build**, I ran all tests that did not specify dropout of 0.17: `FA2_TEST_NUM_GPUS=8 pytest tests/test_flash_attn.py -k "not 0.17" -q -p no:cacheprovider -n 8 --dist=load --tb=short -rfE`
which yielded:
```
===================================== short test summary info =====================================
FAILED tests/test_flash_attn.py::test_flash_attn_splitkv[1-339-True-160-False-False-True-False-dtype0] - AssertionError: assert 0.00390625 <= ((8 * 0.0) + 0.0002)
FAILED tests/test_flash_attn.py::test_flash_attn_splitkv[1-339-True-160-False-False-True-True-dtype0] - AssertionError: assert 0.00390625 <= ((8 * 0.0) + 0.0002)
FAILED tests/test_flash_attn.py::test_flash_attn_splitkv[16-100000-False-96-True-False-True-False-dtype0] - AssertionError: assert 0.0020751953125 <= ((2 * 0.0009765625) + 1e-05)
FAILED tests/test_flash_attn.py::test_flash_attn_splitkv[16-100000-False-96-True-False-True-True-dtype0] - AssertionError: assert 0.0020751953125 <= ((2 * 0.0009765625) + 1e-05)
4 failed, 261717 passed, 152064 skipped in 353.06s (0:05:53)
```

Everything passed except these 4, which are pre-existing for me on main.

To parallelize across my GPUs, I used the following tests/conftest.py generated by Claude:

<details>

```
import os

# Pin each pytest-xdist worker to a distinct GPU (round-robin) before any CUDA
# initialization, so `-n <num_gpus>` spreads the suite across all GPUs.
_worker = os.environ.get("PYTEST_XDIST_WORKER", "")
if _worker.startswith("gw"):
    _num_gpus = int(os.environ.get("FA2_TEST_NUM_GPUS", "8"))
    os.environ["CUDA_VISIBLE_DEVICES"] = str(int(_worker[2:]) % _num_gpus)
```

</details>

For the dropout enabled build of flash_api.cpp:, more tests, same results:
`FA2_TEST_NUM_GPUS=8 python -m pytest tests/test_flash_attn.py -q -p no:cacheprovider -n 8 --dist=load --tb=short -rfE`
```
============================================== short test summary info ==============================================
FAILED tests/test_flash_attn.py::test_flash_attn_splitkv[1-339-True-160-False-False-True-False-dtype0] - AssertionError: assert 0.00390625 <= ((8 * 0.0) + 0.0002)
FAILED tests/test_flash_attn.py::test_flash_attn_splitkv[1-339-True-160-False-False-True-True-dtype0] - AssertionError: assert 0.00390625 <= ((8 * 0.0) + 0.0002)
FAILED tests/test_flash_attn.py::test_flash_attn_splitkv[16-100000-False-96-True-False-True-False-dtype0] - AssertionError: assert 0.0020751953125 <= ((2 * 0.0009765625) + 1e-05)
FAILED tests/test_flash_attn.py::test_flash_attn_splitkv[16-100000-False-96-True-False-True-True-dtype0] - AssertionError: assert 0.0020751953125 <= ((2 * 0.0009765625) + 1e-05)
4 failed, 312357 passed, 196416 skipped in 705.62s (0:11:45)
```

And lastly, for a torch 2.9 build of flash_api_unstable.cpp, same pass:
`FA2_TEST_NUM_GPUS=8 python -m pytest tests/test_flash_attn.py -q -p no:cacheprovider -n 8 --dist=load --tb=short -rfE`
```
============================================== short test summary info ==============================================
FAILED tests/test_flash_attn.py::test_flash_attn_splitkv[1-339-True-160-False-False-True-False-dtype0] - AssertionError: assert 0.00390625 <= ((8 * 0.0) + 0.0002)
FAILED tests/test_flash_attn.py::test_flash_attn_splitkv[1-339-True-160-False-False-True-True-dtype0] - AssertionError: assert 0.00390625 <= ((8 * 0.0) + 0.0002)
FAILED tests/test_flash_attn.py::test_flash_attn_splitkv[16-100000-False-96-True-False-True-False-dtype0] - AssertionError: assert 0.0020751953125 <= ((2 * 0.0009765625) + 1e-05)
FAILED tests/test_flash_attn.py::test_flash_attn_splitkv[16-100000-False-96-True-False-True-True-dtype0] - AssertionError: assert 0.0020751953125 <= ((2 * 0.0009765625) + 1e-05)
4 failed, 312357 passed, 196416 skipped in 477.24s (0:07:57)
```

#### Perf

I ran the benchmark script for both before this commit (unstable .so) and after (stable .so) to verify that the difference is insignificant:

<img width="706" height="451" alt="image" src="https://github.com/user-attachments/assets/e9da74b0-94c7-4aad-ac32-6868f91ad1e1" />


Stats and script are hidden below:

<details>

On this branch (stable):
```
(fa2-pt210) ➜  flash-attention git:(fa2-abi-stable) ✗ CUDA_VISIBLE_DEVICES=1 taskset -c 0-32 python benchmarks/benchmark_flash_attention.py
CUDA_VISIBLE_DEVICES=1 taskset -c 0-32 python benchmarks/benchmark_flash_attention.py
### causal=False, headdim=64, batch_size=32, seqlen=512 ###
Flash2 fwd: 252.49 TFLOPs/s, bwd: 189.86 TFLOPs/s, fwd + bwd: 204.34 TFLOPs/s
Pytorch fwd: 43.18 TFLOPs/s, bwd: 51.42 TFLOPs/s, fwd + bwd: 48.76 TFLOPs/s
### causal=False, headdim=64, batch_size=16, seqlen=1024 ###
Flash2 fwd: 294.78 TFLOPs/s, bwd: 238.75 TFLOPs/s, fwd + bwd: 252.46 TFLOPs/s
Pytorch fwd: 50.61 TFLOPs/s, bwd: 57.11 TFLOPs/s, fwd + bwd: 55.09 TFLOPs/s
### causal=False, headdim=64, batch_size=8, seqlen=2048 ###
Flash2 fwd: 308.09 TFLOPs/s, bwd: 263.71 TFLOPs/s, fwd + bwd: 275.03 TFLOPs/s
Pytorch fwd: 50.10 TFLOPs/s, bwd: 65.18 TFLOPs/s, fwd + bwd: 60.02 TFLOPs/s
### causal=False, headdim=64, batch_size=4, seqlen=4096 ###
Flash2 fwd: 311.97 TFLOPs/s, bwd: 279.80 TFLOPs/s, fwd + bwd: 288.30 TFLOPs/s
Pytorch fwd: 49.06 TFLOPs/s, bwd: 68.12 TFLOPs/s, fwd + bwd: 61.32 TFLOPs/s
### causal=False, headdim=64, batch_size=2, seqlen=8192 ###
Flash2 fwd: 310.20 TFLOPs/s, bwd: 299.23 TFLOPs/s, fwd + bwd: 302.28 TFLOPs/s
Pytorch fwd: 44.90 TFLOPs/s, bwd: 69.67 TFLOPs/s, fwd + bwd: 60.19 TFLOPs/s
### causal=False, headdim=64, batch_size=1, seqlen=16384 ###
Flash2 fwd: 298.48 TFLOPs/s, bwd: 299.11 TFLOPs/s, fwd + bwd: 298.93 TFLOPs/s
Pytorch fwd: 64.72 TFLOPs/s, bwd: 69.52 TFLOPs/s, fwd + bwd: 68.08 TFLOPs/s
### causal=False, headdim=128, batch_size=32, seqlen=512 ###
Flash2 fwd: 299.40 TFLOPs/s, bwd: 190.57 TFLOPs/s, fwd + bwd: 212.65 TFLOPs/s
Pytorch fwd: 66.23 TFLOPs/s, bwd: 82.88 TFLOPs/s, fwd + bwd: 77.32 TFLOPs/s
### causal=False, headdim=128, batch_size=16, seqlen=1024 ###
Flash2 fwd: 340.76 TFLOPs/s, bwd: 238.05 TFLOPs/s, fwd + bwd: 260.48 TFLOPs/s
Pytorch fwd: 84.78 TFLOPs/s, bwd: 99.85 TFLOPs/s, fwd + bwd: 95.02 TFLOPs/s
### causal=False, headdim=128, batch_size=8, seqlen=2048 ###
Flash2 fwd: 370.21 TFLOPs/s, bwd: 273.29 TFLOPs/s, fwd + bwd: 295.38 TFLOPs/s
Pytorch fwd: 90.36 TFLOPs/s, bwd: 119.49 TFLOPs/s, fwd + bwd: 109.42 TFLOPs/s
### causal=False, headdim=128, batch_size=4, seqlen=4096 ###
Flash2 fwd: 377.48 TFLOPs/s, bwd: 289.66 TFLOPs/s, fwd + bwd: 310.29 TFLOPs/s
Pytorch fwd: 91.99 TFLOPs/s, bwd: 129.72 TFLOPs/s, fwd + bwd: 116.11 TFLOPs/s
### causal=False, headdim=128, batch_size=2, seqlen=8192 ###
Flash2 fwd: 357.99 TFLOPs/s, bwd: 308.66 TFLOPs/s, fwd + bwd: 321.31 TFLOPs/s
Pytorch fwd: 86.36 TFLOPs/s, bwd: 135.64 TFLOPs/s, fwd + bwd: 116.63 TFLOPs/s
### causal=False, headdim=128, batch_size=1, seqlen=16384 ###
Flash2 fwd: 366.66 TFLOPs/s, bwd: 305.34 TFLOPs/s, fwd + bwd: 320.66 TFLOPs/s
Pytorch fwd: 126.11 TFLOPs/s, bwd: 138.11 TFLOPs/s, fwd + bwd: 134.45 TFLOPs/s
### causal=True, headdim=64, batch_size=32, seqlen=512 ###
Flash2 fwd: 174.68 TFLOPs/s, bwd: 118.25 TFLOPs/s, fwd + bwd: 130.27 TFLOPs/s
Pytorch fwd: 14.71 TFLOPs/s, bwd: 25.80 TFLOPs/s, fwd + bwd: 21.23 TFLOPs/s
### causal=True, headdim=64, batch_size=16, seqlen=1024 ###
Flash2 fwd: 238.87 TFLOPs/s, bwd: 173.90 TFLOPs/s, fwd + bwd: 188.56 TFLOPs/s
Pytorch fwd: 16.40 TFLOPs/s, bwd: 28.56 TFLOPs/s, fwd + bwd: 23.57 TFLOPs/s
### causal=True, headdim=64, batch_size=8, seqlen=2048 ###
Flash2 fwd: 275.14 TFLOPs/s, bwd: 220.12 TFLOPs/s, fwd + bwd: 233.46 TFLOPs/s
Pytorch fwd: 15.94 TFLOPs/s, bwd: 32.57 TFLOPs/s, fwd + bwd: 25.09 TFLOPs/s
### causal=True, headdim=64, batch_size=4, seqlen=4096 ###
Flash2 fwd: 299.20 TFLOPs/s, bwd: 249.19 TFLOPs/s, fwd + bwd: 261.69 TFLOPs/s
Pytorch fwd: 13.98 TFLOPs/s, bwd: 34.04 TFLOPs/s, fwd + bwd: 24.14 TFLOPs/s
### causal=True, headdim=64, batch_size=2, seqlen=8192 ###
Flash2 fwd: 307.31 TFLOPs/s, bwd: 267.18 TFLOPs/s, fwd + bwd: 277.54 TFLOPs/s
Pytorch fwd: 13.05 TFLOPs/s, bwd: 34.84 TFLOPs/s, fwd + bwd: 23.59 TFLOPs/s
### causal=True, headdim=64, batch_size=1, seqlen=16384 ###
Flash2 fwd: 310.93 TFLOPs/s, bwd: 294.93 TFLOPs/s, fwd + bwd: 299.33 TFLOPs/s
Pytorch fwd: 16.53 TFLOPs/s, bwd: 34.75 TFLOPs/s, fwd + bwd: 26.43 TFLOPs/s
### causal=True, headdim=128, batch_size=32, seqlen=512 ###
Flash2 fwd: 191.00 TFLOPs/s, bwd: 129.37 TFLOPs/s, fwd + bwd: 142.51 TFLOPs/s
Pytorch fwd: 24.07 TFLOPs/s, bwd: 41.41 TFLOPs/s, fwd + bwd: 34.34 TFLOPs/s
### causal=True, headdim=128, batch_size=16, seqlen=1024 ###
Flash2 fwd: 262.47 TFLOPs/s, bwd: 190.22 TFLOPs/s, fwd + bwd: 206.46 TFLOPs/s
Pytorch fwd: 28.94 TFLOPs/s, bwd: 50.00 TFLOPs/s, fwd + bwd: 41.39 TFLOPs/s
### causal=True, headdim=128, batch_size=8, seqlen=2048 ###
Flash2 fwd: 303.89 TFLOPs/s, bwd: 236.78 TFLOPs/s, fwd + bwd: 252.73 TFLOPs/s
Pytorch fwd: 29.78 TFLOPs/s, bwd: 59.72 TFLOPs/s, fwd + bwd: 46.40 TFLOPs/s
### causal=True, headdim=128, batch_size=4, seqlen=4096 ###
Flash2 fwd: 325.09 TFLOPs/s, bwd: 265.49 TFLOPs/s, fwd + bwd: 280.17 TFLOPs/s
Pytorch fwd: 26.54 TFLOPs/s, bwd: 64.85 TFLOPs/s, fwd + bwd: 45.91 TFLOPs/s
### causal=True, headdim=128, batch_size=2, seqlen=8192 ###
Flash2 fwd: 341.13 TFLOPs/s, bwd: 289.05 TFLOPs/s, fwd + bwd: 302.24 TFLOPs/s
Pytorch fwd: 25.29 TFLOPs/s, bwd: 67.78 TFLOPs/s, fwd + bwd: 45.79 TFLOPs/s
### causal=True, headdim=128, batch_size=1, seqlen=16384 ###
Flash2 fwd: 335.62 TFLOPs/s, bwd: 319.17 TFLOPs/s, fwd + bwd: 323.71 TFLOPs/s
Pytorch fwd: 31.82 TFLOPs/s, bwd: 69.02 TFLOPs/s, fwd + bwd: 51.74 TFLOPs/s
```

On fully-yank-dropout (now main) (unstable, but with the same functionality):
```
(fa2-pt210) ➜  flash-attention git:(fully-yank-dropout) ✗ CUDA_VISIBLE_DEVICES=1 taskset -c 0-32 python benchmarks/benchmark_flash_attention.py
### causal=False, headdim=64, batch_size=32, seqlen=512 ###
Flash2 fwd: 252.53 TFLOPs/s, bwd: 189.25 TFLOPs/s, fwd + bwd: 203.84 TFLOPs/s
Pytorch fwd: 43.26 TFLOPs/s, bwd: 51.47 TFLOPs/s, fwd + bwd: 48.82 TFLOPs/s
### causal=False, headdim=64, batch_size=16, seqlen=1024 ###
Flash2 fwd: 295.27 TFLOPs/s, bwd: 239.06 TFLOPs/s, fwd + bwd: 252.81 TFLOPs/s
Pytorch fwd: 50.63 TFLOPs/s, bwd: 57.20 TFLOPs/s, fwd + bwd: 55.16 TFLOPs/s
### causal=False, headdim=64, batch_size=8, seqlen=2048 ###
Flash2 fwd: 310.09 TFLOPs/s, bwd: 257.43 TFLOPs/s, fwd + bwd: 270.56 TFLOPs/s
Pytorch fwd: 50.22 TFLOPs/s, bwd: 65.18 TFLOPs/s, fwd + bwd: 60.07 TFLOPs/s
### causal=False, headdim=64, batch_size=4, seqlen=4096 ###
Flash2 fwd: 310.32 TFLOPs/s, bwd: 279.80 TFLOPs/s, fwd + bwd: 287.89 TFLOPs/s
Pytorch fwd: 48.96 TFLOPs/s, bwd: 68.14 TFLOPs/s, fwd + bwd: 61.28 TFLOPs/s
### causal=False, headdim=64, batch_size=2, seqlen=8192 ###
Flash2 fwd: 306.62 TFLOPs/s, bwd: 299.81 TFLOPs/s, fwd + bwd: 301.72 TFLOPs/s
Pytorch fwd: 44.60 TFLOPs/s, bwd: 69.66 TFLOPs/s, fwd + bwd: 60.02 TFLOPs/s
### causal=False, headdim=64, batch_size=1, seqlen=16384 ###
Flash2 fwd: 302.94 TFLOPs/s, bwd: 297.38 TFLOPs/s, fwd + bwd: 298.95 TFLOPs/s
Pytorch fwd: 64.70 TFLOPs/s, bwd: 69.52 TFLOPs/s, fwd + bwd: 68.07 TFLOPs/s
### causal=False, headdim=128, batch_size=32, seqlen=512 ###
Flash2 fwd: 299.58 TFLOPs/s, bwd: 190.48 TFLOPs/s, fwd + bwd: 212.60 TFLOPs/s
Pytorch fwd: 65.88 TFLOPs/s, bwd: 82.19 TFLOPs/s, fwd + bwd: 76.76 TFLOPs/s
### causal=False, headdim=128, batch_size=16, seqlen=1024 ###
Flash2 fwd: 341.31 TFLOPs/s, bwd: 238.52 TFLOPs/s, fwd + bwd: 260.98 TFLOPs/s
Pytorch fwd: 84.93 TFLOPs/s, bwd: 100.11 TFLOPs/s, fwd + bwd: 95.24 TFLOPs/s
### causal=False, headdim=128, batch_size=8, seqlen=2048 ###
Flash2 fwd: 365.52 TFLOPs/s, bwd: 271.10 TFLOPs/s, fwd + bwd: 292.70 TFLOPs/s
Pytorch fwd: 90.25 TFLOPs/s, bwd: 119.37 TFLOPs/s, fwd + bwd: 109.29 TFLOPs/s
### causal=False, headdim=128, batch_size=4, seqlen=4096 ###
Flash2 fwd: 374.05 TFLOPs/s, bwd: 292.16 TFLOPs/s, fwd + bwd: 311.65 TFLOPs/s
Pytorch fwd: 92.42 TFLOPs/s, bwd: 129.73 TFLOPs/s, fwd + bwd: 116.31 TFLOPs/s
### causal=False, headdim=128, batch_size=2, seqlen=8192 ###
Flash2 fwd: 352.59 TFLOPs/s, bwd: 307.71 TFLOPs/s, fwd + bwd: 319.33 TFLOPs/s
Pytorch fwd: 86.35 TFLOPs/s, bwd: 135.67 TFLOPs/s, fwd + bwd: 116.64 TFLOPs/s
### causal=False, headdim=128, batch_size=1, seqlen=16384 ###
Flash2 fwd: 367.87 TFLOPs/s, bwd: 303.27 TFLOPs/s, fwd + bwd: 319.29 TFLOPs/s
Pytorch fwd: 126.01 TFLOPs/s, bwd: 138.15 TFLOPs/s, fwd + bwd: 134.45 TFLOPs/s
### causal=True, headdim=64, batch_size=32, seqlen=512 ###
Flash2 fwd: 175.15 TFLOPs/s, bwd: 118.33 TFLOPs/s, fwd + bwd: 130.42 TFLOPs/s
Pytorch fwd: 14.71 TFLOPs/s, bwd: 25.81 TFLOPs/s, fwd + bwd: 21.23 TFLOPs/s
### causal=True, headdim=64, batch_size=16, seqlen=1024 ###
Flash2 fwd: 238.76 TFLOPs/s, bwd: 173.09 TFLOPs/s, fwd + bwd: 187.85 TFLOPs/s
Pytorch fwd: 16.36 TFLOPs/s, bwd: 28.60 TFLOPs/s, fwd + bwd: 23.57 TFLOPs/s
### causal=True, headdim=64, batch_size=8, seqlen=2048 ###
Flash2 fwd: 275.99 TFLOPs/s, bwd: 218.35 TFLOPs/s, fwd + bwd: 232.21 TFLOPs/s
Pytorch fwd: 15.88 TFLOPs/s, bwd: 32.57 TFLOPs/s, fwd + bwd: 25.05 TFLOPs/s
### causal=True, headdim=64, batch_size=4, seqlen=4096 ###
Flash2 fwd: 299.40 TFLOPs/s, bwd: 243.87 TFLOPs/s, fwd + bwd: 257.52 TFLOPs/s
Pytorch fwd: 13.98 TFLOPs/s, bwd: 34.05 TFLOPs/s, fwd + bwd: 24.14 TFLOPs/s
### causal=True, headdim=64, batch_size=2, seqlen=8192 ###
Flash2 fwd: 300.37 TFLOPs/s, bwd: 273.32 TFLOPs/s, fwd + bwd: 280.54 TFLOPs/s
Pytorch fwd: 13.06 TFLOPs/s, bwd: 34.83 TFLOPs/s, fwd + bwd: 23.59 TFLOPs/s
### causal=True, headdim=64, batch_size=1, seqlen=16384 ###
Flash2 fwd: 301.54 TFLOPs/s, bwd: 294.52 TFLOPs/s, fwd + bwd: 296.49 TFLOPs/s
Pytorch fwd: 16.54 TFLOPs/s, bwd: 34.74 TFLOPs/s, fwd + bwd: 26.43 TFLOPs/s
### causal=True, headdim=128, batch_size=32, seqlen=512 ###
Flash2 fwd: 192.48 TFLOPs/s, bwd: 129.69 TFLOPs/s, fwd + bwd: 143.02 TFLOPs/s
Pytorch fwd: 24.16 TFLOPs/s, bwd: 41.51 TFLOPs/s, fwd + bwd: 34.44 TFLOPs/s
### causal=True, headdim=128, batch_size=16, seqlen=1024 ###
Flash2 fwd: 264.67 TFLOPs/s, bwd: 190.91 TFLOPs/s, fwd + bwd: 207.43 TFLOPs/s
Pytorch fwd: 28.96 TFLOPs/s, bwd: 49.92 TFLOPs/s, fwd + bwd: 41.37 TFLOPs/s
### causal=True, headdim=128, batch_size=8, seqlen=2048 ###
Flash2 fwd: 302.26 TFLOPs/s, bwd: 235.89 TFLOPs/s, fwd + bwd: 251.68 TFLOPs/s
Pytorch fwd: 29.76 TFLOPs/s, bwd: 59.73 TFLOPs/s, fwd + bwd: 46.38 TFLOPs/s
### causal=True, headdim=128, batch_size=4, seqlen=4096 ###
Flash2 fwd: 330.48 TFLOPs/s, bwd: 260.23 TFLOPs/s, fwd + bwd: 277.05 TFLOPs/s
Pytorch fwd: 26.77 TFLOPs/s, bwd: 64.89 TFLOPs/s, fwd + bwd: 46.13 TFLOPs/s
### causal=True, headdim=128, batch_size=2, seqlen=8192 ###
Flash2 fwd: 345.91 TFLOPs/s, bwd: 287.04 TFLOPs/s, fwd + bwd: 301.71 TFLOPs/s
Pytorch fwd: 25.33 TFLOPs/s, bwd: 67.78 TFLOPs/s, fwd + bwd: 45.83 TFLOPs/s
### causal=True, headdim=128, batch_size=1, seqlen=16384 ###
Flash2 fwd: 331.04 TFLOPs/s, bwd: 317.95 TFLOPs/s, fwd + bwd: 321.59 TFLOPs/s
Pytorch fwd: 31.79 TFLOPs/s, bwd: 69.02 TFLOPs/s, fwd + bwd: 51.72 TFLOPs/s
```

Script to compare them:
```
#!/usr/bin/env python3
"""Compare TFLOP/s between two benchmark_flash_attention.py runs.

Parses the stdout of two runs (e.g. before/after a change) and prints a
per-config fwd / bwd / fwd+bwd delta table for one method (default Flash2).

Usage:
    # baseline build
    CUDA_VISIBLE_DEVICES=1 python benchmarks/benchmark_flash_attention.py | tee before.txt
    # ... rebuild / switch branch ...
    CUDA_VISIBLE_DEVICES=1 python benchmarks/benchmark_flash_attention.py | tee after.txt
    python agent_space/compare_bench.py before.txt after.txt
    python agent_space/compare_bench.py before.txt after.txt --method Pytorch
"""
import argparse
import math
import re
import sys

GREEN, RED, RESET = "\033[32m", "\033[31m", "\033[0m"

CONFIG_RE = re.compile(r"^###\s*(.+?)\s*###\s*$")
ROW_RE = re.compile(
    r"^(\S+)\s+fwd:\s*([^\s,]+)\s*TFLOPs/s,\s*"
    r"bwd:\s*([^\s,]+)\s*TFLOPs/s,\s*"
    r"fwd \+ bwd:\s*([^\s,]+)\s*TFLOPs/s"
)


def parse(path):
    """path -> {config_str: {method: (fwd, bwd, fwd_bwd)}}, preserving order."""
    out = {}
    cfg = None
    with open(path) as f:
        for line in f:
            m = CONFIG_RE.match(line)
            if m:
                cfg = m.group(1)
                out.setdefault(cfg, {})
                continue
            m = ROW_RE.match(line)
            if m and cfg is not None:
                method = m.group(1)
                fwd, bwd, fb = (float(x) for x in m.groups()[1:])
                out[cfg][method] = (fwd, bwd, fb)
    return out


def short_cfg(s):
    """'causal=False, headdim=64, batch_size=32, seqlen=512' -> compact label."""
    d = dict(kv.split("=") for kv in s.replace(", ", ",").split(",") if "=" in kv)
    return (f"c={d.get('causal','?'):<5} hd={d.get('headdim','?'):<3} "
            f"bs={d.get('batch_size','?'):<3} sl={d.get('seqlen','?'):<5}")


def pct(before, after):
    if before == 0 or math.isnan(before) or math.isnan(after):
        return float("nan")
    return (after / before - 1.0) * 100.0


def fmt_pct(p):
    s = "n/a" if math.isnan(p) else f"{p:+.1f}%"
    return f"{s:>8}"


def colorize(s, p, enable):
    """Wrap a (pre-padded) string green if p>=0, red if p<0; pass-through if disabled."""
    if not enable or math.isnan(p):
        return s
    return f"{GREEN if p >= 0 else RED}{s}{RESET}"


def main():
    ap = argparse.ArgumentParser(description=__doc__,
                                 formatter_class=argparse.RawDescriptionHelpFormatter)
    ap.add_argument("before")
    ap.add_argument("after")
    ap.add_argument("--method", default="Flash2", help="method to compare (default: Flash2)")
    ap.add_argument("--threshold", type=float, default=2.0,
                    help="flag regressions worse than this %% (default: 2.0)")
    ap.add_argument("--color", choices=["auto", "always", "never"], default="auto",
                    help="colorize deltas (default: auto = only on a TTY)")
    args = ap.parse_args()

    use_color = args.color == "always" or (args.color == "auto" and sys.stdout.isatty())
    before, after = parse(args.before), parse(args.after)
    method = args.method

    # Keep the order of the baseline file, then append any after-only configs.
    configs = list(before) + [c for c in after if c not in before]

    g = "fwd TF/s".center(24) + "  " + "bwd TF/s".center(24) + "  " + "fwd+bwd TF/s".center(24)
    print(f"\nmethod = {method}   ({args.before}  ->  {args.after})\n")
    print(f"{'':<28}{g}")
    sub = f"{'before':>7}{'after':>8}{'Δ':>8} "
    print(f"{'config':<28}{sub} {sub} {sub}")
    print("-" * (28 + 3 * 24 + 4))

    # ratio products for geomean per metric; worst regression tracker
    log_sum = [0.0, 0.0, 0.0]
    log_n = [0, 0, 0]
    worst = (float("inf"), None, None)  # (delta%, config, metric)

    for cfg in configs:
        b = before.get(cfg, {}).get(method)
        a = after.get(cfg, {}).get(method)
        if b is None or a is None:
            miss = args.before if b is None else args.after
            print(f"{short_cfg(cfg):<28}  (missing in {miss})")
            continue
        cells = ""
        for i, name in enumerate(("fwd", "bwd", "fwd+bwd")):
            p = pct(b[i], a[i])
            cells += f"{b[i]:>7.1f}{a[i]:>8.1f}{colorize(fmt_pct(p), p, use_color)} "
            if not math.isnan(p):
                log_sum[i] += math.log(a[i] / b[i])
                log_n[i] += 1
                if p < worst[0]:
                    worst = (p, cfg, name)
        print(f"{short_cfg(cfg):<28}{cells}")

    print("-" * (28 + 3 * 24 + 4))
    geo = ""
    for i in range(3):
        gp = (math.exp(log_sum[i] / log_n[i]) - 1) * 100 if log_n[i] else float("nan")
        geo += f"{'':>15}{colorize(fmt_pct(gp), gp, use_color)} "
    print(f"{'geomean Δ':<28}{geo}")

    if worst[1] is not None and worst[0] < -args.threshold:
        msg = (f"⚠  worst regression: {worst[0]:+.1f}% on {worst[2]} "
               f"@ {short_cfg(worst[1]).strip()}")
        print("\n" + (f"{RED}{msg}{RESET}" if use_color else msg))
    elif worst[1] is not None:
        msg = (f"✓  no regression worse than {args.threshold:.1f}% "
               f"(worst: {worst[0]:+.1f}% on {worst[2]} @ {short_cfg(worst[1]).strip()})")
        print("\n" + (f"{GREEN}{msg}{RESET}" if use_color else msg))


if __name__ == "__main__":
    main()
```

</details>

#### No unstable APIs
68 stable! no unstable in the dropout disabled .so.

```
(fa2-pt210) ➜  flash-attention git:(fa2-abi-stable) ✗ torch-abi-audit ./flash_attn_2_cuda.abi3.so
Package: flash_attn_2_cuda.abi3.so
  Root: /home/janeyx/repos/flash-attention
  Torch ABI:   STABLE
  CPython ABI: n/a
  Extensions:  0
  Bundled libs: 1
  -- bundled libs --
    [STABLE  ] [abi3-tagged-no-capi   ] flash_attn_2_cuda.abi3.so  (stable_shim=68, unstable=0)
```