### PR TITLE
[CuTe, SM100] Remove redundant bulk-copy elect_one and align DSL 4.6.1 dependencies

### DIFF
--- a/flash_attn/cute/block_sparse_utils.py
+++ b/flash_attn/cute/block_sparse_utils.py
@@ -1090,12 +1090,11 @@ def produce_block_sparse_q_loads_bwd_sm100(
                 load_Q(m_block_safe, producer_state=producer_state_Q_LSE)
                 pipeline_Q.producer_commit(producer_state_Q_LSE)
                 pipeline_LSE.producer_acquire(producer_state_Q_LSE)
-                with cute.arch.elect_one():
-                    copy_stats(
-                        gLSE[None, m_block_safe],
-                        sLSE[None, producer_state_Q_LSE.index],
-                        mbar_ptr=pipeline_LSE.producer_get_barrier(producer_state_Q_LSE),
-                    )
+                copy_stats(
+                    gLSE[None, m_block_safe],
+                    sLSE[None, producer_state_Q_LSE.index],
+                    mbar_ptr=pipeline_LSE.producer_get_barrier(producer_state_Q_LSE),
+                )
                 producer_state_Q_LSE.advance()
             if const_expr(should_load_dO):
                 pipeline_dO.producer_acquire(
@@ -1105,12 +1104,11 @@ def produce_block_sparse_q_loads_bwd_sm100(
                 load_dO(m_block_safe, producer_state=producer_state_dO_dPsum)
                 pipeline_dO.producer_commit(producer_state_dO_dPsum)
                 pipeline_dPsum.producer_acquire(producer_state_dO_dPsum)
-                with cute.arch.elect_one():
-                    copy_stats(
-                        gdPsum[None, m_block_safe],
-                        sdPsum[None, producer_state_dO_dPsum.index],
-                        mbar_ptr=pipeline_dPsum.producer_get_barrier(producer_state_dO_dPsum),
-                    )
+                copy_stats(
+                    gdPsum[None, m_block_safe],
+                    sdPsum[None, producer_state_dO_dPsum.index],
+                    mbar_ptr=pipeline_dPsum.producer_get_barrier(producer_state_dO_dPsum),
+                )
                 producer_state_dO_dPsum.advance()
         else:
             # Subsequent blocks: just load Q/dO (K/V already loaded)
@@ -1119,24 +1117,22 @@ def produce_block_sparse_q_loads_bwd_sm100(
                 load_Q(m_block_safe, producer_state=producer_state_Q_LSE)
                 pipeline_Q.producer_commit(producer_state_Q_LSE)
                 pipeline_LSE.producer_acquire(producer_state_Q_LSE)
-                with cute.arch.elect_one():
-                    copy_stats(
-                        gLSE[None, m_block_safe],
-                        sLSE[None, producer_state_Q_LSE.index],
-                        mbar_ptr=pipeline_LSE.producer_get_barrier(producer_state_Q_LSE),
-                    )
+                copy_stats(
+                    gLSE[None, m_block_safe],
+                    sLSE[None, producer_state_Q_LSE.index],
+                    mbar_ptr=pipeline_LSE.producer_get_barrier(producer_state_Q_LSE),
+                )
                 producer_state_Q_LSE.advance()
             if const_expr(should_load_dO):
                 pipeline_dO.producer_acquire(producer_state_dO_dPsum)
                 load_dO(m_block_safe, producer_state=producer_state_dO_dPsum)
                 pipeline_dO.producer_commit(producer_state_dO_dPsum)
                 pipeline_dPsum.producer_acquire(producer_state_dO_dPsum)
-                with cute.arch.elect_one():
-                    copy_stats(
-                        gdPsum[None, m_block_safe],
-                        sdPsum[None, producer_state_dO_dPsum.index],
-                        mbar_ptr=pipeline_dPsum.producer_get_barrier(producer_state_dO_dPsum),
-                    )
+                copy_stats(
+                    gdPsum[None, m_block_safe],
+                    sdPsum[None, producer_state_dO_dPsum.index],
+                    mbar_ptr=pipeline_dPsum.producer_get_barrier(producer_state_dO_dPsum),
+                )
                 producer_state_dO_dPsum.advance()
 
     return producer_state_Q_LSE, producer_state_dO_dPsum

--- a/flash_attn/cute/flash_bwd_mla_sm100.py
+++ b/flash_attn/cute/flash_bwd_mla_sm100.py
@@ -1488,9 +1488,6 @@ class FlashAttentionSparseMLABackwardSm100:
         load_pipeline.producer_acquire(producer_state)
         mbar_ptr = load_pipeline.producer_get_barrier(producer_state)
         if const_expr(bulk_copy):
-            # Single-issue bulk-copy atoms (cpasync.CopyBulkG2SOp) get their lane election
-            # generated inside cute.copy; an explicit elect_one here nests and can deadlock.
-            # See #2677. (Relies on the cute-dsl build that elects inside cute.copy for bulk copies.)
             cute.copy(copy_atom, tXgX, tXsX, mbar_ptr=mbar_ptr)
         else:
             cute.copy(copy_atom, tXgX, tXsX, tma_bar_ptr=mbar_ptr)

--- a/flash_attn/cute/flash_bwd_mla_sm100.py
+++ b/flash_attn/cute/flash_bwd_mla_sm100.py
@@ -1488,8 +1488,10 @@ class FlashAttentionSparseMLABackwardSm100:
         load_pipeline.producer_acquire(producer_state)
         mbar_ptr = load_pipeline.producer_get_barrier(producer_state)
         if const_expr(bulk_copy):
-            with cute.arch.elect_one():
-                cute.copy(copy_atom, tXgX, tXsX, mbar_ptr=mbar_ptr)
+            # Single-issue bulk-copy atoms (cpasync.CopyBulkG2SOp) get their lane election
+            # generated inside cute.copy; an explicit elect_one here nests and can deadlock.
+            # See #2677. (Relies on the cute-dsl build that elects inside cute.copy for bulk copies.)
+            cute.copy(copy_atom, tXgX, tXsX, mbar_ptr=mbar_ptr)
         else:
             cute.copy(copy_atom, tXgX, tXsX, tma_bar_ptr=mbar_ptr)
         producer_state.advance()

--- a/flash_attn/cute/flash_bwd_sm100.py
+++ b/flash_attn/cute/flash_bwd_sm100.py
@@ -1969,12 +1969,11 @@ class FlashAttentionBackwardSm100:
                         producer_state_Q_Qt.advance()
                         # LSE
                         pipeline_LSE.producer_acquire(producer_state_LSE)
-                        with cute.arch.elect_one():
-                            copy_stats(
-                                gLSE[None, first_m_block],
-                                sLSE[None, producer_state_LSE.index],
-                                mbar_ptr=pipeline_LSE.producer_get_barrier(producer_state_LSE),
-                            )
+                        copy_stats(
+                            gLSE[None, first_m_block],
+                            sLSE[None, producer_state_LSE.index],
+                            mbar_ptr=pipeline_LSE.producer_get_barrier(producer_state_LSE),
+                        )
                         producer_state_LSE.advance()
 
                         # dOt + V, for dP.T = V @ dO.T
@@ -1988,12 +1987,11 @@ class FlashAttentionBackwardSm100:
                         producer_state_O_Ot.advance()
                         # dPsum
                         pipeline_dPsum.producer_acquire(producer_state_dPsum)
-                        with cute.arch.elect_one():
-                            copy_stats(
-                                gdPsum[None, first_m_block],
-                                sdPsum[None, producer_state_dPsum.index],
-                                mbar_ptr=pipeline_dPsum.producer_get_barrier(producer_state_dPsum),
-                            )
+                        copy_stats(
+                            gdPsum[None, first_m_block],
+                            sdPsum[None, producer_state_dPsum.index],
+                            mbar_ptr=pipeline_dPsum.producer_get_barrier(producer_state_dPsum),
+                        )
                         producer_state_dPsum.advance()
 
                         # Qt, for dK = dS.T @ Q
@@ -2017,12 +2015,11 @@ class FlashAttentionBackwardSm100:
                         for m_block in cutlass.range(m_block_min + 1, m_block_max, unroll=1):
                             # LSE
                             pipeline_LSE.producer_acquire(producer_state_LSE)
-                            with cute.arch.elect_one():
-                                copy_stats(
-                                    gLSE[None, m_block],
-                                    sLSE[None, producer_state_LSE.index],
-                                    mbar_ptr=pipeline_LSE.producer_get_barrier(producer_state_LSE),
-                                )
+                            copy_stats(
+                                gLSE[None, m_block],
+                                sLSE[None, producer_state_LSE.index],
+                                mbar_ptr=pipeline_LSE.producer_get_barrier(producer_state_LSE),
+                            )
                             producer_state_LSE.advance()
 
                             # Q
@@ -2033,14 +2030,13 @@ class FlashAttentionBackwardSm100:
 
                             # dPsum
                             pipeline_dPsum.producer_acquire(producer_state_dPsum)
-                            with cute.arch.elect_one():
-                                copy_stats(
-                                    gdPsum[None, m_block],
-                                    sdPsum[None, producer_state_dPsum.index],
-                                    mbar_ptr=pipeline_dPsum.producer_get_barrier(
-                                        producer_state_dPsum
-                                    ),
-                                )
+                            copy_stats(
+                                gdPsum[None, m_block],
+                                sdPsum[None, producer_state_dPsum.index],
+                                mbar_ptr=pipeline_dPsum.producer_get_barrier(
+                                    producer_state_dPsum
+                                ),
+                            )
                             producer_state_dPsum.advance()
 
                             # dOt, for dP.T = V @ dO.T
@@ -2076,14 +2072,13 @@ class FlashAttentionBackwardSm100:
 
                             # LSE
                             pipeline_LSE.producer_acquire(producer_state_Q_LSE)
-                            with cute.arch.elect_one():
-                                copy_stats(
-                                    gLSE[None, first_m_block],
-                                    sLSE[None, producer_state_Q_LSE.index],
-                                    mbar_ptr=pipeline_LSE.producer_get_barrier(
-                                        producer_state_Q_LSE
-                                    ),
-                                )
+                            copy_stats(
+                                gLSE[None, first_m_block],
+                                sLSE[None, producer_state_Q_LSE.index],
+                                mbar_ptr=pipeline_LSE.producer_get_barrier(
+                                    producer_state_Q_LSE
+                                ),
+                            )
                             producer_state_Q_LSE.advance()
 
                         if const_expr(should_load_dO):
@@ -2105,14 +2100,13 @@ class FlashAttentionBackwardSm100:
 
                             # dPsum
                             pipeline_dPsum.producer_acquire(producer_state_dO_dPsum)
-                            with cute.arch.elect_one():
-                                copy_stats(
-                                    gdPsum[None, first_m_block],
-                                    sdPsum[None, producer_state_dO_dPsum.index],
-                                    mbar_ptr=pipeline_dPsum.producer_get_barrier(
-                                        producer_state_dO_dPsum
-                                    ),
-                                )
+                            copy_stats(
+                                gdPsum[None, first_m_block],
+                                sdPsum[None, producer_state_dO_dPsum.index],
+                                mbar_ptr=pipeline_dPsum.producer_get_barrier(
+                                    producer_state_dO_dPsum
+                                ),
+                            )
                             producer_state_dO_dPsum.advance()
 
                         if const_expr(self.use_2cta_instrs):
@@ -2136,14 +2130,13 @@ class FlashAttentionBackwardSm100:
 
                                 # LSE
                                 pipeline_LSE.producer_acquire(producer_state_Q_LSE)
-                                with cute.arch.elect_one():
-                                    copy_stats(
-                                        gLSE[None, m_block],
-                                        sLSE[None, producer_state_Q_LSE.index],
-                                        mbar_ptr=pipeline_LSE.producer_get_barrier(
-                                            producer_state_Q_LSE
-                                        ),
-                                    )
+                                copy_stats(
+                                    gLSE[None, m_block],
+                                    sLSE[None, producer_state_Q_LSE.index],
+                                    mbar_ptr=pipeline_LSE.producer_get_barrier(
+                                        producer_state_Q_LSE
+                                    ),
+                                )
                                 producer_state_Q_LSE.advance()
 
                             if const_expr(should_load_dO):
@@ -2160,14 +2153,13 @@ class FlashAttentionBackwardSm100:
 
                                 # dPsum
                                 pipeline_dPsum.producer_acquire(producer_state_dO_dPsum)
-                                with cute.arch.elect_one():
-                                    copy_stats(
-                                        gdPsum[None, m_block],
-                                        sdPsum[None, producer_state_dO_dPsum.index],
-                                        mbar_ptr=pipeline_dPsum.producer_get_barrier(
-                                            producer_state_dO_dPsum
-                                        ),
-                                    )
+                                copy_stats(
+                                    gdPsum[None, m_block],
+                                    sdPsum[None, producer_state_dO_dPsum.index],
+                                    mbar_ptr=pipeline_dPsum.producer_get_barrier(
+                                        producer_state_dO_dPsum
+                                    ),
+                                )
                                 producer_state_dO_dPsum.advance()
 
                         #### Tail ####

--- a/flash_attn/cute/pyproject.toml
+++ b/flash_attn/cute/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "nvidia-cutlass-dsl==4.6.0",
+    "nvidia-cutlass-dsl==4.6.1",
     "torch",
     "einops",
     "typing_extensions",
@@ -32,7 +32,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-cu13 = ["nvidia-cutlass-dsl[cu13]==4.6.0"]
+cu13 = ["nvidia-cutlass-dsl[cu13]==4.6.1"]
 dev = [
     "pytest",
     "pytest-xdist",

--- a/flash_attn/cute/pyproject.toml
+++ b/flash_attn/cute/pyproject.toml
@@ -22,17 +22,17 @@ classifiers = [
 ]
 
 dependencies = [
-    "nvidia-cutlass-dsl==4.6.0.dev0",
+    "nvidia-cutlass-dsl==4.6.0",
     "torch",
     "einops",
     "typing_extensions",
     "apache-tvm-ffi>=0.1.12,<0.2",
     "torch-c-dlpack-ext",
-    "quack-kernels>=0.5.3",
+    "quack-kernels>=0.6.0",
 ]
 
 [project.optional-dependencies]
-cu13 = ["nvidia-cutlass-dsl[cu13]==4.6.0.dev0"]
+cu13 = ["nvidia-cutlass-dsl[cu13]==4.6.0"]
 dev = [
     "pytest",
     "pytest-xdist",


### PR DESCRIPTION
Follow-up to #2677 (Finding 2). #2686 fixed the stride-divisibility issue; this PR removes redundant caller-side thread elections and declares the coordinated CUTLASS DSL/Quack release floor.

## Root cause

CUTLASS DSL 4.6 performs the required single-lane election inside `cute.copy` for copy atoms such as `cpasync.CopyBulkG2SOp`. Wrapping those calls in an additional `with cute.arch.elect_one():` creates nested `elect.sync` regions and can deadlock.

## Changes

Removed the external election from all 17 affected bulk-copy sites:

- `flash_bwd_mla_sm100.py`: `load_inner` bulk-copy path ×1
- `flash_bwd_sm100.py`: LSE/dPsum `copy_stats` paths ×8
- `block_sparse_utils.py`: LSE/dPsum `copy_stats` paths ×8
  - default 1CTA/2CTA helper ×4
  - hdim-192 2CTA helper ×4

All of these use `cute.copy` with `CopyBulkG2SOp`. After #2661 rewrote block-sparse backward for 2CTA, the same rule is applied to its eight new `copy_stats` sites.

Explicit elections remain where the called operation does not elect internally: TMA descriptor prefetch, raw `cp.reduce.async.bulk` inline PTX, direct mbarrier operations, and pipeline/UMMA commit-release operations. TMA tensor copies were already unwrapped.

The dependencies in `flash_attn/cute/pyproject.toml` are updated to:

- `nvidia-cutlass-dsl==4.6.1`
- `nvidia-cutlass-dsl[cu13]==4.6.1`
- `quack-kernels>=0.6.0`

Quack 0.6.0 contains the coordinated fix from [Dao-AILab/quack#164](https://github.com/Dao-AILab/quack/pull/164).

## Validation

Validated on B200 using the published `nvidia-cutlass-dsl==4.6.1` and `quack-kernels==0.6.0` packages:

- SM100 block-sparse backward: four focused cases covering 1CTA, 2CTA, and hdim-192 2CTA
- standard SM100 forward/backward
- sparse MLA absorbed backward

All six focused pytest cases passed without stalls and matched their references.

A static audit also confirmed that the PR removes 17 external elections around bulk `cute.copy`, adds none, and retains 18 explicit elections only around operations that still require caller-side single-lane execution.