### PR TITLE
ci: add MLA absorbed coverage to FA4 CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,18 @@ permissions:
 
 env:
   CI_WORK_DIR: ${{ vars.CI_WORK_DIR || format('/scratch/user/{0}', github.actor) }}
+  # The mla_absorbed cases exercise the MLA backward kernels (flash_bwd_mla_sm100.py +
+  # dq_dqv + dk); without them CI runs no MLA test at all. We cover the distinct backward
+  # paths: sparse (kv_sparsity=True) non-causal + causal, dense (kv_sparsity=False), and
+  # shared_kv=True. (deterministic/hdim/mha_type are single-valued for this test.)
   FA4_TEST_FILTER: >-
     1024-1024-128-True-0-0.0-False-False-False-mha-dtype0
     or 1024-1024-128-False-0-0.0-False-False-False-mha-dtype0
     or test_flash_attn_ex2_emu_decode_prefill_consistency
+    or test_flash_attn_mla_absorbed and 256-256-False-True-64-False-0-False-False-mqa-dtype0
+    or test_flash_attn_mla_absorbed and 256-256-False-True-64-True-0-False-False-mqa-dtype0
+    or test_flash_attn_mla_absorbed and 256-256-False-False-64-False-0-False-False-mqa-dtype0
+    or test_flash_attn_mla_absorbed and 256-256-True-True-64-False-0-False-False-mqa-dtype0
 
 jobs:
   lint:


### PR DESCRIPTION

## Problem
`FA4_TEST_FILTER` (`.github/workflows/ci.yml`) selects only `test_flash_attn_output[1024-1024-128-…-mha]` (×2) and `test_flash_attn_ex2_emu_decode_prefill_consistency` — **no MLA case at all**. So both the MLA forward and the sparse / asymmetric-head-dim MLA backward kernels (`flash_bwd_mla_sm100.py` + `flash_bwd_mla_dq_dqv_sm100` + `flash_bwd_mla_dk_sm100`) currently have **zero CI coverage**. (The dense backward, including dense `192-128`, is already exercised by the existing suite — this PR is not about that path.)


## What this does
Add four `test_flash_attn_mla_absorbed` cases to `FA4_TEST_FILTER`, covering the distinct MLA backward paths:

```
or test_flash_attn_mla_absorbed and 256-256-False-True-64-False-0-False-False-mqa-dtype0
or test_flash_attn_mla_absorbed and 256-256-False-True-64-True-0-False-False-mqa-dtype0
or test_flash_attn_mla_absorbed and 256-256-False-False-64-False-0-False-False-mqa-dtype0
or test_flash_attn_mla_absorbed and 256-256-True-True-64-False-0-False-False-mqa-dtype0
```

All at seqlen 256 / hdim 64 / MQA:

| case | knob | path exercised |
|------|------|----------------|
| sparse, non-causal | `kv_sparsity=True` | sparse-MLA backward |
| sparse, causal | `kv_sparsity=True`, causal | sparse-MLA backward, causal mask |
| dense | `kv_sparsity=False` | dense-MLA backward |
| shared KV | `shared_kv=True` | shared-KV backward |

(`deterministic` / `hdim` / `mha_type` are single-valued for this test, so not expandable.) `--collect-only` confirms the filter now selects exactly **8 cases** (2 output + 4 MLA + 2 ex2), no over-selection.

## Cost
Cold-cache run on B200 over the full 8-case filter: pass-1 compile ~4:54 (builds `flash_bwd_mla_sm100` + `flash_bwd_mla_dq_dqv_sm100` + `flash_bwd_mla_dk_sm100`), GPU run ~1:03 — ≈ **+1.3 min** to the GPU job (~7 → ~8 min), well under the 60-min timeout.

