### PR TITLE
[CuTe] Fix fp8 P saturation in sm100 forward: reduce softmax max_offset 8 -> 4

### DIFF
--- a/flash_attn/cute/flash_fwd_sm100.py
+++ b/flash_attn/cute/flash_fwd_sm100.py
@@ -2011,7 +2011,9 @@ class FlashAttentionForwardSm100:
 
             qk_descale, _ = self._load_effective_descales(descale_tensors, batch_idx, kv_head_idx)
 
-            max_offset = 8 if cutlass.const_expr(self.q_dtype.width == 8) else 0
+            # 8 leaves only 448/2^8 = 1.75x headroom before e4m3 saturates when
+            # P transiently exceeds 1 (running max lagging by a tile); 4 keeps 28x.
+            max_offset = 4 if cutlass.const_expr(self.q_dtype.width == 8) else 0
             if const_expr(self.score_mod is None):
                 softmax_scale_log2_eff = softmax_scale_log2 * qk_descale
                 softmax_scale_eff = None
@@ -2427,7 +2429,7 @@ class FlashAttentionForwardSm100:
             else:
                 softmax_scale_log2_eff = softmax_scale_log2
 
-            max_offset = Float32(8.0) if cutlass.const_expr(self.q_dtype.width == 8) else Float32(0.0)
+            max_offset = Float32(4.0) if cutlass.const_expr(self.q_dtype.width == 8) else Float32(0.0)
             max_offset_scale = (
                 Float32(256.0) if cutlass.const_expr(self.q_dtype.width == 8) else Float32(1.0)
             )


### PR DESCRIPTION
The sm100 fp8 fwd computes P against a running max that can lag by a tile, so P transiently exceeds 1. With `max_offset = 8` (P scaled by 2^8) e4m3 only has 448/256 = 1.75x headroom, so any tile that raises the max by more than ~0.56 silently clips the P entries computed against the stale max. This doesn't show up with sharp (LLM-like) attention where the max is found early, but with wide logit distributions (video DiTs over 10k+ tokens) the error gets large.

Repro on B300, exactly-representable fp8 inputs with descale=1, error vs the bf16 kernel on the same values, S=8192:

| logit std | 0.25 | 0.5 | 1.0 | 1.5 | 2.0 |
|---|---|---|---|---|---|
| offset 8 | 0.027 | 0.031 | 0.136 | 0.305 | 0.361 |
| offset 4 | 0.027 | 0.028 | 0.027 | 0.024 | 0.022 |

Offset 4 matches an exact-math fp8 simulation at every scale (one-hot / two-hot / uniform-attention probes are exact before and after, so this only affects the overshoot case). On real video DiT activations (Cosmos3, ~10k tokens) kernel error goes 0.237 -> 0.069, which was the difference between visibly degraded and floor-quality output for us.

```python
import torch
from flash_attn.cute import flash_attn_func
from flash_attn.cute.interface import _flash_attn_fwd
torch.manual_seed(0)
q8 = torch.randn(1, 2048, 1, 128, device="cuda").clamp(-3, 3).to(torch.float8_e4m3fn)
k8 = torch.randn(1, 8192, 1, 128, device="cuda").clamp(-3, 3).to(torch.float8_e4m3fn)
v8 = torch.randn(1, 8192, 1, 128, device="cuda").clamp(-3, 3).to(torch.float8_e4m3fn)
one = torch.ones(1, 1, device="cuda", dtype=torch.float32)
ref = flash_attn_func(q8.to(torch.bfloat16), k8.to(torch.bfloat16), v8.to(torch.bfloat16))
ref = (ref[0] if isinstance(ref, tuple) else ref).float()
out, *_ = _flash_attn_fwd(q8, k8, v8, softmax_scale=None, causal=False,
                          q_descale=one, k_descale=one, v_descale=one)
print(((out.float() - ref).abs().mean() / ref.abs().mean()).item())  # 0.137 -> 0.027
```

An exact alternative would be rescaling already-written P tiles when the max updates; happy to look at that instead if you'd rather keep offset 8.
