### PR TITLE
Validate VisionTransformer norm_layer

### DIFF
--- a/flash_attn/models/vit.py
+++ b/flash_attn/models/vit.py
@@ -161,7 +161,10 @@ class VisionTransformer(nn.Module):
         # pre_norm seems redundant, as there's a LayerNorm right at the start of each block, idk
         assert not pre_norm
         use_fc_norm = global_pool == "avg" if fc_norm is None else fc_norm
-        norm_layer = norm_layer or partial(nn.LayerNorm, eps=1e-6)
+        if norm_layer is None:
+            norm_layer = partial(nn.LayerNorm, eps=1e-6)
+        elif not callable(norm_layer):
+            raise TypeError(f"norm_layer must be a callable or None, got {type(norm_layer)}")
         act_layer = act_layer or nn.GELU
 
         self.num_classes = num_classes

--- a/tests/models/test_vit.py
+++ b/tests/models/test_vit.py
@@ -2,8 +2,25 @@ import re
 
 import pytest
 import torch
-from flash_attn.models.vit import vit_base_patch16_224 as flash_vit_base_patch16_224
+from flash_attn.models.vit import (
+    VisionTransformer,
+    vit_base_patch16_224 as flash_vit_base_patch16_224,
+)
 from timm.models.vision_transformer import vit_base_patch16_224
+
+
+def test_vit_rejects_non_callable_norm_layer():
+    with pytest.raises(TypeError, match="norm_layer must be a callable or None"):
+        VisionTransformer(
+            img_size=32,
+            patch_size=16,
+            in_chans=3,
+            num_classes=10,
+            embed_dim=64,
+            depth=2,
+            num_heads=4,
+            norm_layer=False,
+        )
 
 
 @pytest.mark.parametrize("fused_mlp", [False, True])


### PR DESCRIPTION
Fixes #1855.

`VisionTransformer` currently treats any falsy `norm_layer` value as a request for the default `LayerNorm`, so `norm_layer=False` is silently ignored. This changes the constructor to use the default only when `norm_layer is None`, and to raise a clear `TypeError` for non-callable values.

I added a regression test that covers `norm_layer=False` so the unsupported value fails before model construction proceeds.

Validation:
- `python3 -m py_compile flash_attn/models/vit.py tests/models/test_vit.py`
- `git diff --check`

I could not run `pytest tests/models/test_vit.py -k rejects_non_callable_norm_layer -q` locally because this Python environment does not have `pytest`, `torch`, `timm`, or `torchvision` installed.
