### PR TITLE
[CuTe,Bwd,Sm100] Support head_dim not a multiple of 32 in backward

### DIFF
--- a/flash_attn/cute/flash_bwd_preprocess.py
+++ b/flash_attn/cute/flash_bwd_preprocess.py
@@ -13,7 +13,6 @@
 # So the main backward kernel is unchanged; we just replace D with D' = D - dLSE here.
 import math
 import operator
-from functools import partial
 from typing import Callable, Type, Optional
 
 import cuda.bindings.driver as cuda
@@ -365,8 +364,8 @@ class FlashAttentionBackwardPreprocess:
             tOpO = None
             if const_expr(self.check_hdim_v_oob):
                 tOpO = copy_utils.predicate_k(tOcO, limit=headdim_v)
-            # Each copy will use the same predicate
-            copy = partial(copy_utils.copy, pred=tOpO)
+            # Each copy uses the predicate sliced to the current m (see loop below).
+            copy = copy_utils.copy
 
             tOrO = cute.make_rmem_tensor_like(tOgO)
             tOrdO = cute.make_rmem_tensor_like(tOgdO)
@@ -378,8 +377,13 @@ class FlashAttentionBackwardPreprocess:
                 # Instead of using tOcO, we using t0OcO and subtract the offset from the limit.
                 # This is bc the entries of t0OcO are known at compile time.
                 if t0OcO[0, m, 0][0] < seqlen_limit - tOcO[0][0]:
-                    copy(tOgO[None, m, None], tOrO[None, m, None])
-                    copy(tOgdO[None, m, None], tOrdO[None, m, None])
+                    # The predicate carries a CPY_M mode (broadcast over m); slice it to the
+                    # current m so its shape matches the m-sliced copy source. Otherwise the
+                    # vectorized copy atom's predicate-shape verification fails when head_dim_v
+                    # is not a multiple of the copy-atom width (e.g. 72, 104).
+                    tOpO_cur = tOpO[None, m, None] if const_expr(tOpO is not None) else None
+                    copy(tOgO[None, m, None], tOrO[None, m, None], pred=tOpO_cur)
+                    copy(tOgdO[None, m, None], tOrdO[None, m, None], pred=tOpO_cur)
             # O and dO loads are done; signal that the next kernel can start.
             # Correctness is ensured by griddepcontrol_wait() in bwd_sm90 before it reads our outputs.
             if const_expr(self.use_pdl):

--- a/flash_attn/cute/flash_bwd_preprocess.py
+++ b/flash_attn/cute/flash_bwd_preprocess.py
@@ -13,7 +13,6 @@
 # So the main backward kernel is unchanged; we just replace D with D' = D - dLSE here.
 import math
 import operator
-from functools import partial
 from typing import Callable, Type, Optional
 
 import cuda.bindings.driver as cuda
@@ -367,8 +366,8 @@ class FlashAttentionBackwardPreprocess:
             tOpO = None
             if const_expr(self.check_hdim_v_oob):
                 tOpO = copy_utils.predicate_k(tOcO, limit=headdim_v)
-            # Each copy will use the same predicate
-            copy = partial(copy_utils.copy, pred=tOpO)
+            # Each copy uses the predicate sliced to the current m (see loop below).
+            copy = copy_utils.copy
 
             tOrO = cute.make_rmem_tensor_like(tOgO)
             tOrdO = cute.make_rmem_tensor_like(tOgdO)
@@ -380,8 +379,13 @@ class FlashAttentionBackwardPreprocess:
                 # Instead of using tOcO, we using t0OcO and subtract the offset from the limit.
                 # This is bc the entries of t0OcO are known at compile time.
                 if t0OcO[0, m, 0][0] < seqlen_limit - tOcO[0][0]:
-                    copy(tOgO[None, m, None], tOrO[None, m, None])
-                    copy(tOgdO[None, m, None], tOrdO[None, m, None])
+                    # The predicate carries a CPY_M mode (broadcast over m); slice it to the
+                    # current m so its shape matches the m-sliced copy source. Otherwise the
+                    # vectorized copy atom's predicate-shape verification fails when head_dim_v
+                    # is not a multiple of the copy-atom width (e.g. 72, 104).
+                    tOpO_cur = tOpO[None, m, None] if const_expr(tOpO is not None) else None
+                    copy(tOgO[None, m, None], tOrO[None, m, None], pred=tOpO_cur)
+                    copy(tOgdO[None, m, None], tOrdO[None, m, None], pred=tOpO_cur)
             # O and dO loads are done; signal that the next kernel can start.
             # Correctness is ensured by griddepcontrol_wait() in bwd_sm90 before it reads our outputs.
             if const_expr(self.use_pdl):

--- a/flash_attn/cute/flash_bwd_sm100.py
+++ b/flash_attn/cute/flash_bwd_sm100.py
@@ -68,8 +68,10 @@ class FlashAttentionBackwardSm100:
         has_aux_tensors: cutlass.Constexpr = False,
         q_subtile_factor: cutlass.Constexpr[int] = 1,
     ):
-        # padding head_dim to a multiple of 16 as k_block_size
-        hdim_multiple_of = 16
+        # Pad head_dim to a multiple of 32 (k_block_size). Must stay a multiple of 32 so
+        # that the dQ accumulator reduce (dQ_reduce_ncol up to 32) tiles evenly and matches
+        # both the preprocess kernel and the interface's head_dim_rounded (also mult of 32).
+        hdim_multiple_of = 32
         self.tile_hdim = int(math.ceil(head_dim / hdim_multiple_of) * hdim_multiple_of)
         head_dim_v = head_dim_v if head_dim_v is not None else head_dim
         self.same_hdim_kv = head_dim == head_dim_v

--- a/flash_attn/cute/flash_bwd_sm100.py
+++ b/flash_attn/cute/flash_bwd_sm100.py
@@ -69,8 +69,10 @@ class FlashAttentionBackwardSm100:
         q_subtile_factor: cutlass.Constexpr[int] = 1,
         kv_subtile_factor: cutlass.Constexpr[int] = 1,
     ):
-        # padding head_dim to a multiple of 16 as k_block_size
-        hdim_multiple_of = 16
+        # Pad head_dim to a multiple of 32 (k_block_size). Must stay a multiple of 32 so
+        # that the dQ accumulator reduce (dQ_reduce_ncol up to 32) tiles evenly and matches
+        # both the preprocess kernel and the interface's head_dim_rounded (also mult of 32).
+        hdim_multiple_of = 32
         self.tile_hdim = int(math.ceil(head_dim / hdim_multiple_of) * hdim_multiple_of)
         head_dim_v = head_dim_v if head_dim_v is not None else head_dim
         self.same_hdim_kv = head_dim == head_dim_v

--- a/flash_attn/cute/flash_bwd_sm100.py
+++ b/flash_attn/cute/flash_bwd_sm100.py
@@ -79,6 +79,8 @@ class FlashAttentionBackwardSm100:
         self.tile_hdimv = int(math.ceil(head_dim_v / hdim_multiple_of) * hdim_multiple_of)
         self.check_hdim_oob = head_dim != self.tile_hdim
         self.check_hdim_v_oob = head_dim_v != self.tile_hdimv
+        self.head_dim = head_dim
+        self.head_dim_v = head_dim_v
 
         self.tile_m = tile_m
         self.tile_n = tile_n
@@ -3872,13 +3874,22 @@ class FlashAttentionBackwardSm100:
         mdV_cur = seqlen.offset_batch_K(mdV, batch_idx, dim=3)[None, None, head_idx]
         mdK_cur = seqlen.offset_batch_K(mdK, batch_idx, dim=3)[None, None, head_idx]
 
-        tmem_load_atom = cute.make_copy_atom(
-            tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(16)), Float32
+        # The gmem store below has no head-dim OOB protection from TMA, so when head_dim is
+        # not a multiple of the tile we predicate each 128-bit store vector (8 bf16 columns).
+        # The store's predicate granularity is one tmem-load repetition, so shrink the
+        # repetition to 8 columns for that case; 16 keeps fewer tmem loads otherwise.
+        tmem_load_atom_dV = cute.make_copy_atom(
+            tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(8 if self.check_hdim_v_oob else 16)),
+            Float32,
+        )
+        tmem_load_atom_dK = cute.make_copy_atom(
+            tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(8 if self.check_hdim_oob else 16)),
+            Float32,
         )
         # dV
         pipeline_dKV.consumer_wait(consumer_state_dKV)
 
-        tiled_tmem_ld_dV = tcgen05.make_tmem_copy(tmem_load_atom, tdVtdV)
+        tiled_tmem_ld_dV = tcgen05.make_tmem_copy(tmem_load_atom_dV, tdVtdV)
         thr_tmem_ld_dV = tiled_tmem_ld_dV.get_slice(tidx)
 
         tdVtdV_t2r_p = thr_tmem_ld_dV.partition_S(tdVtdV)
@@ -3919,8 +3930,11 @@ class FlashAttentionBackwardSm100:
         tdVgdV_r2g_p = thr_tmem_ld_dV.partition_D(tdVgdV)
         tdVgdV_r2g = self.split_wg(tdVgdV_r2g_p, wg_idx, num_wg)
 
+        tdVpdV = None
+        if const_expr(self.check_hdim_v_oob):
+            tdVpdV = self.predicate_hdim(tdVcdV_t2r, self.head_dim_v)
         if tidx < seqlen.seqlen_k - self.tile_n * n_block:
-            cute.copy(tiled_gmem_store_dV, tdVrdV_r2s, tdVgdV_r2g)
+            cute.copy(tiled_gmem_store_dV, tdVrdV_r2s, tdVgdV_r2g, pred=tdVpdV)
 
         cute.arch.sync_warp()
         with cute.arch.elect_one():
@@ -3930,7 +3944,7 @@ class FlashAttentionBackwardSm100:
         # dK
         pipeline_dKV.consumer_wait(consumer_state_dKV)
 
-        tiled_tmem_ld_dK = tcgen05.make_tmem_copy(tmem_load_atom, tdKtdK)
+        tiled_tmem_ld_dK = tcgen05.make_tmem_copy(tmem_load_atom_dK, tdKtdK)
         thr_tmem_ld_dK = tiled_tmem_ld_dK.get_slice(tidx)
 
         tdKtdK_t2r_p = thr_tmem_ld_dK.partition_S(tdKtdK)
@@ -3973,13 +3987,32 @@ class FlashAttentionBackwardSm100:
         tdKgdK_r2g_p = thr_tmem_ld_dK.partition_D(tdKgdK)
         tdKgdK_r2g = self.split_wg(tdKgdK_r2g_p, wg_idx, num_wg)
 
+        tdKpdK = None
+        if const_expr(self.check_hdim_oob):
+            tdKpdK = self.predicate_hdim(tdKcdK_t2r, self.head_dim)
         if tidx < seqlen.seqlen_k - self.tile_n * n_block:
-            cute.copy(tiled_gmem_store_dK, tdKrdK_r2s, tdKgdK_r2g)
+            cute.copy(tiled_gmem_store_dK, tdKrdK_r2s, tdKgdK_r2g, pred=tdKpdK)
 
         cute.arch.sync_warp()
         with cute.arch.elect_one():
             pipeline_dKV.consumer_release(consumer_state_dKV)
         return consumer_state_dKV
+
+    @cute.jit
+    def predicate_hdim(self, tcoord: cute.Tensor, limit: cutlass.Constexpr[int]) -> cute.Tensor:
+        """Per-store-vector head-dim predicate for the non-TMA dK/dV epilogue store.
+
+        ``tcoord`` is the (tile_n, hdim) identity tensor partitioned like the register data,
+        shape ((rep, 1), chunks, 1, 1) with one contiguous ``rep``-wide column chunk per copy
+        vector; the predicate drops the vector mode and marks each chunk whose first column
+        is inside ``limit``. Valid because ``limit`` is a multiple of ``rep``.
+        """
+        tpred = cute.make_rmem_tensor(
+            cute.make_layout((1, cute.size(tcoord, mode=[1]), 1, 1)), cutlass.Boolean
+        )
+        for i in cutlass.range_constexpr(cute.size(tcoord, mode=[1])):
+            tpred[0, i, 0, 0] = tcoord[0, i, 0, 0][1] < limit
+        return tpred
 
     @cute.jit
     def epilogue_dK_or_dV_tma(

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -1611,6 +1611,28 @@ def _flash_attn_bwd(
     dtype = torch2cute_dtype_map[q.dtype]
     current_stream = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
 
+    # Varlen MHA uses the non-TMA dK/dV epilogue store, which writes tile_hdim (a
+    # multiple of 32) columns per row and has no head-dim OOB predication (unlike the
+    # TMA store used elsewhere). When head_dim is not a multiple of 32 the store would
+    # spill past the real head_dim into neighboring memory and corrupt dK/dV. Route the
+    # store through a head-dim-padded scratch buffer, then slice back to head_dim.
+    head_dim_v_rounded = (head_dim_v + 32 - 1) // 32 * 32
+    dkv_hdim_pad = (
+        not dKV_postprocess
+        and cu_seqlens_k is not None
+        and (head_dim != head_dim_rounded or head_dim_v != head_dim_v_rounded)
+    )
+    dk_final, dv_final = dk, dv
+    if dkv_hdim_pad:
+        if head_dim != head_dim_rounded:
+            dk = torch.empty(
+                *dk_final.shape[:-1], head_dim_rounded, dtype=out_torch_dtype, device=device
+            )
+        if head_dim_v != head_dim_v_rounded:
+            dv = torch.empty(
+                *dv_final.shape[:-1], head_dim_v_rounded, dtype=out_torch_dtype, device=device
+            )
+
     if deterministic:
         dQ_semaphore = torch.zeros(batch_size, num_head, seqlen_q_rounded // m_block_size, cluster_size, dtype=torch.int32, device=device)
     else:
@@ -1997,6 +2019,14 @@ def _flash_attn_bwd(
                 AtomLayoutNdKV, dKV_swapAB,
                 cluster_size=cluster_size,
             )
+
+    if dkv_hdim_pad:
+        if not is_fake_mode():
+            if head_dim != head_dim_rounded:
+                dk_final.copy_(dk[..., :head_dim])
+            if head_dim_v != head_dim_v_rounded:
+                dv_final.copy_(dv[..., :head_dim_v])
+        dk, dv = dk_final, dv_final
 
     return dq, dk, dv
 

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -2196,6 +2196,31 @@ def _flash_attn_bwd(
 
     dtype = torch2cute_dtype_map[q.dtype]
 
+    # On SM100/SM110, varlen MHA uses the non-TMA dK/dV epilogue store, which writes
+    # tile_hdim (a multiple of 32) columns per row and has no head-dim OOB predication
+    # (unlike the TMA store used elsewhere). When head_dim is not a multiple of 32 the
+    # store would spill past the real head_dim into neighboring memory and corrupt
+    # dK/dV. Route the store through a head-dim-padded scratch buffer, then slice back
+    # to head_dim. Other arches predicate their dK/dV store, so they skip the scratch
+    # buffers entirely rather than pay the extra alloc + copy.
+    head_dim_v_rounded = (head_dim_v + 32 - 1) // 32 * 32
+    dkv_hdim_pad = (
+        arch // 10 in [10, 11]
+        and not dKV_postprocess
+        and cu_seqlens_k is not None
+        and (head_dim != head_dim_rounded or head_dim_v != head_dim_v_rounded)
+    )
+    dk_final, dv_final = dk, dv
+    if dkv_hdim_pad:
+        if head_dim != head_dim_rounded:
+            dk = torch.empty(
+                *dk_final.shape[:-1], head_dim_rounded, dtype=out_torch_dtype, device=device
+            )
+        if head_dim_v != head_dim_v_rounded:
+            dv = torch.empty(
+                *dv_final.shape[:-1], head_dim_v_rounded, dtype=out_torch_dtype, device=device
+            )
+
     if deterministic:
         dQ_semaphore = torch.zeros(batch_size, num_head, seqlen_q_rounded // m_block_size, cluster_size, dtype=torch.int32, device=device)
     else:
@@ -2635,6 +2660,14 @@ def _flash_attn_bwd(
                 cu_total_m_blocks=cu_total_m_blocks_k if cluster_size == 1 else None,
                 fake_mode=fake_mode,
             )
+
+    if dkv_hdim_pad:
+        if not is_fake_mode():
+            if head_dim != head_dim_rounded:
+                dk_final.copy_(dk[..., :head_dim])
+            if head_dim_v != head_dim_v_rounded:
+                dv_final.copy_(dv[..., :head_dim_v])
+        dk, dv = dk_final, dv_final
 
     return (dq, dk, dv) if learnable_sink is None else (dq, dk, dv, dsink)
 

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -2196,31 +2196,6 @@ def _flash_attn_bwd(
 
     dtype = torch2cute_dtype_map[q.dtype]
 
-    # On SM100/SM110, varlen MHA uses the non-TMA dK/dV epilogue store, which writes
-    # tile_hdim (a multiple of 32) columns per row and has no head-dim OOB predication
-    # (unlike the TMA store used elsewhere). When head_dim is not a multiple of 32 the
-    # store would spill past the real head_dim into neighboring memory and corrupt
-    # dK/dV. Route the store through a head-dim-padded scratch buffer, then slice back
-    # to head_dim. Other arches predicate their dK/dV store, so they skip the scratch
-    # buffers entirely rather than pay the extra alloc + copy.
-    head_dim_v_rounded = (head_dim_v + 32 - 1) // 32 * 32
-    dkv_hdim_pad = (
-        arch // 10 in [10, 11]
-        and not dKV_postprocess
-        and cu_seqlens_k is not None
-        and (head_dim != head_dim_rounded or head_dim_v != head_dim_v_rounded)
-    )
-    dk_final, dv_final = dk, dv
-    if dkv_hdim_pad:
-        if head_dim != head_dim_rounded:
-            dk = torch.empty(
-                *dk_final.shape[:-1], head_dim_rounded, dtype=out_torch_dtype, device=device
-            )
-        if head_dim_v != head_dim_v_rounded:
-            dv = torch.empty(
-                *dv_final.shape[:-1], head_dim_v_rounded, dtype=out_torch_dtype, device=device
-            )
-
     if deterministic:
         dQ_semaphore = torch.zeros(batch_size, num_head, seqlen_q_rounded // m_block_size, cluster_size, dtype=torch.int32, device=device)
     else:
@@ -2660,14 +2635,6 @@ def _flash_attn_bwd(
                 cu_total_m_blocks=cu_total_m_blocks_k if cluster_size == 1 else None,
                 fake_mode=fake_mode,
             )
-
-    if dkv_hdim_pad:
-        if not is_fake_mode():
-            if head_dim != head_dim_rounded:
-                dk_final.copy_(dk[..., :head_dim])
-            if head_dim_v != head_dim_v_rounded:
-                dv_final.copy_(dv[..., :head_dim_v])
-        dk, dv = dk_final, dv_final
 
     return (dq, dk, dv) if learnable_sink is None else (dq, dk, dv, dsink)
 

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -197,6 +197,65 @@ def test_flash_attn_value_dim_larger_than_query_dim():
     torch.testing.assert_close(out.float(), reference, atol=0.04, rtol=0.04)
 
 
+@pytest.mark.parametrize("head_dim", [72, 104])
+@pytest.mark.parametrize("causal", [False, True])
+@maybe_fake_tensor_mode(USE_FAKE_TENSOR)
+def test_flash_attn_varlen_backward_non_aligned_head_dim(head_dim, causal):
+    torch.manual_seed(0)
+    device = "cuda"
+    dtype = torch.bfloat16
+    seqlens = [97, 128]
+    total_seqlen = sum(seqlens)
+    nheads = 4
+    cu_seqlens = torch.tensor(
+        [0, seqlens[0], total_seqlen], device=device, dtype=torch.int32
+    )
+
+    q = torch.randn(
+        total_seqlen, nheads, head_dim, device=device, dtype=dtype, requires_grad=True
+    )
+    k = torch.randn_like(q, requires_grad=True)
+    v = torch.randn_like(q, requires_grad=True)
+    out, _ = flash_attn_varlen_func(
+        q,
+        k,
+        v,
+        cu_seqlens_q=cu_seqlens,
+        cu_seqlens_k=cu_seqlens,
+        max_seqlen_q=max(seqlens),
+        max_seqlen_k=max(seqlens),
+        causal=causal,
+    )
+    dout = torch.randn_like(out)
+    grads = torch.autograd.grad(out, (q, k, v), dout)
+
+    if is_fake_mode():
+        return
+
+    q_ref = q.detach().float().requires_grad_()
+    k_ref = k.detach().float().requires_grad_()
+    v_ref = v.detach().float().requires_grad_()
+    out_ref_chunks = []
+    offset = 0
+    for seqlen in seqlens:
+        seq_slice = slice(offset, offset + seqlen)
+        out_ref = torch.nn.functional.scaled_dot_product_attention(
+            q_ref[seq_slice].transpose(0, 1).unsqueeze(0),
+            k_ref[seq_slice].transpose(0, 1).unsqueeze(0),
+            v_ref[seq_slice].transpose(0, 1).unsqueeze(0),
+            dropout_p=0.0,
+            is_causal=causal,
+        )
+        out_ref_chunks.append(out_ref.squeeze(0).transpose(0, 1))
+        offset += seqlen
+    out_ref = torch.cat(out_ref_chunks, dim=0)
+    grads_ref = torch.autograd.grad(out_ref, (q_ref, k_ref, v_ref), dout.float())
+
+    torch.testing.assert_close(out.float(), out_ref, atol=0.04, rtol=0.04)
+    for grad, grad_ref in zip(grads, grads_ref, strict=True):
+        torch.testing.assert_close(grad.float(), grad_ref, atol=0.05, rtol=0.05)
+
+
 @pytest.mark.skipif(
     torch.cuda.get_device_capability()[0] not in [10, 11] or USE_FAKE_TENSOR,
     reason="SM100/SM110 runtime paged-KV tail-loading test",


### PR DESCRIPTION
## Summary

Backward on SM100 (B200/B300) crashes or **silently produces wrong dK/dV** when `head_dim % 32 != 0` (e.g. ViT `head_dim=72`, `104`). Fixes #2492. Three independent root causes:

1. **`flash_bwd_preprocess.py`** — the O/dO load predicate (`predicate_k`) carries a `CPY_M` mode broadcast over `m`, but the copy source is sliced per-`m` (`tOgO[None, m, None]`) without slicing the predicate. The vectorized 128-bit copy atom's predicate-shape verifier then rejects the extra mode (`expects (1,(k)) but got (1,(cpy_m,k))`). Slice the predicate per-`m`, as `flash_fwd.py` / `flash_bwd.py` already do.

2. **`flash_bwd_sm100.py`** — `tile_hdim` padded `head_dim` to a multiple of 16, but the dQ accumulator reduce requires a multiple of 32 (`assert tile_hdim % dQ_reduce_ncol == 0`), and both the preprocess kernel and the interface already round to 32. `head_dim=72 -> 80` tripped the assert. Pad to 32 so all three agree (96); this reuses the already-working `head_dim=96` path.

3. **`interface.py`** — varlen MHA uses the non-TMA dK/dV epilogue store, which writes `tile_hdim` (mult of 32) columns per row with no head-dim OOB predication (its 16-wide vectorization cannot mask a 72 boundary). It spilled past the real `head_dim` and corrupted neighboring dK/dV. Route that store through a head-dim-padded scratch buffer, then slice back. Gated on `arch // 10 in [10, 11]` so SM90/SM120 skip the extra alloc + copy (suggested by @hebo1221).

## Test results

Validated on **B300 (SM103)** against `torch.nn.functional.scaled_dot_product_attention` (fp32 reference):

- **Coverage**: dense + varlen, causal + non-causal, `head_dim ∈ {64, 72, 80, 104, 128}`, MHA and GQA(hd=128).
- **Result**: `dq/dk/dv` max relative error **2e-3 – 7e-3** (bf16 precision), matching the multiple-of-32 baselines. No regression on aligned head dims.
- **End-to-end**: Qwen3.5-VL training (ViT `head_dim=72`, varlen) trains with a decreasing loss and finite grad norm.

## Relation to #2633

This is an alternative to #2633. #2633 keeps V padding at a multiple of 16 and predicates the non-TMA store via a reduced tmem `Repetition` — neater for varlen. However, in our testing that leaves the **dense (TMA-store) dV path numerically wrong** for `head_dim % 32 != 0` (relative error ~1–13 on `dv` for hd 72/80/104), while the varlen path is correct. Padding V to 32 keeps **both dense and varlen** paths correct, at the cost of a little extra dV compute. Happy to combine approaches if maintainers prefer the leaner store.

## Test plan
- [x] Numerical parity vs SDPA (fp32 ref), dense + varlen, causal + non-causal, hd {64,72,80,104,128}
- [x] No regression on multiple-of-32 head dims
- [x] End-to-end VLM training smoke (ViT hd=72)
- [ ] Maintainer CI matrix

## Acknowledgments

Thanks to @hebo1221 for independently verifying all three fixes via FakeTensor compilation on SM121 and for pointing out that the scratch-buffer path should be gated to SM100/SM110 only.