### PR TITLE
Fa4 return lse consistency

### DIFF
--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -2489,14 +2489,13 @@ class FlashAttnFunc(torch.autograd.Function):
         ctx.aux_scalars = aux_scalars
         ctx.block_sparse_tensors_bwd = block_sparse_tensors_bwd
         ctx.set_materialize_grads(False)
-        return out, lse
+        return (out, lse) if return_lse else out
 
     @staticmethod
-    def backward(ctx, dout, dlse):
+    def backward(ctx, dout, *args):
         q, k, v, qv, out, lse, p, row_max, gather_kv_indices, *aux = ctx.saved_tensors
         aux_tensors = aux if aux else None
-        if not ctx.return_lse:
-            dlse = None
+        dlse = args[0] if ctx.return_lse else None
         if dout is None:
             dout = torch.zeros_like(out)
         if qv is not None:
@@ -2644,14 +2643,13 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
         ctx.mask_mod = mask_mod
         ctx.aux_scalars = aux_scalars
         ctx.set_materialize_grads(False)
-        return out, lse
+        return (out, lse) if return_lse else out
 
     @staticmethod
-    def backward(ctx, dout, dlse):
+    def backward(ctx, dout, *args):
         q, k, v, qv, out, lse, p, row_max, gather_kv_indices, cu_seqlens_q, cu_seqlens_k, seqused_q, seqused_k, *aux = ctx.saved_tensors
         aux_tensors = aux if aux else None
-        if not ctx.return_lse:
-            dlse = None
+        dlse = args[0] if ctx.return_lse else None
         if dout is None:
             dout = torch.zeros_like(out)
         if qv is not None:
@@ -2733,6 +2731,7 @@ def flash_attn_func(
     block_sparse_tensors_bwd: Optional[BlockSparseTensorsTorch] = None,
     return_lse: bool = False,
 ):
+    # Returns just out if return_lse is False (default), else (out, lse).
     return FlashAttnFunc.apply(
         q,
         k,
@@ -2801,6 +2800,8 @@ def flash_attn_varlen_func(
         page_table: (batch, max_num_pages_per_seq)
     
     Return:
+       If return_lse is False (default), returns just out. Otherwise returns
+       the tuple (out, lse).
        out: (total_q, nheads, hdim) or (batch, seqlen_q, nheads, hdim)
        lse: (nheads, total_q)       or (batch, nheads, seqlen_q) if not has_qv (standard)
             (total_q, nheads)       or (batch, seqlen_q, nheads) if has_qv

--- a/tests/cute/test_clc_fuzz.py
+++ b/tests/cute/test_clc_fuzz.py
@@ -61,7 +61,7 @@ def clc_scheduler_enabled():
 
 def check_output(q, k, v, *, causal=False, window_size=(None, None), num_splits=1, assert_clc=True, assert_2cta=False):
     _captured_schedulers.clear()
-    out, _ = flash_attn_func(q, k, v, causal=causal, window_size=window_size, num_splits=num_splits)
+    out = flash_attn_func(q, k, v, causal=causal, window_size=window_size, num_splits=num_splits)
     torch.cuda.synchronize()
     if assert_clc and _captured_schedulers:
         sched_cls, sched_mode, use_2cta = _captured_schedulers[-1]
@@ -272,7 +272,7 @@ class TestCLCFallback:
         q = torch.randn(total, heads, d, device="cuda", dtype=torch.bfloat16)
         k = torch.randn(total, heads, d, device="cuda", dtype=torch.bfloat16)
         v = torch.randn(total, heads, d, device="cuda", dtype=torch.bfloat16)
-        out, _ = flash_attn_varlen_func(
+        out = flash_attn_varlen_func(
             q, k, v,
             cu_seqlens_q=cu_seqlens,
             cu_seqlens_k=cu_seqlens,
@@ -312,7 +312,7 @@ def check_varlen_output(seqlens, heads, d, *, causal=False, kv_heads=None, num_s
     v = torch.randn(total, kv_heads, d, device="cuda", dtype=torch.bfloat16)
 
     _captured_schedulers.clear()
-    out, _ = flash_attn_varlen_func(
+    out = flash_attn_varlen_func(
         q, k, v,
         cu_seqlens_q=cu_seqlens,
         cu_seqlens_k=cu_seqlens,
@@ -357,7 +357,7 @@ def check_varlen_output_seqused(seqlens, heads, d, *, causal=False, kv_heads=Non
     k_mask = q_mask
 
     _captured_schedulers.clear()
-    out, _ = flash_attn_varlen_func(
+    out = flash_attn_varlen_func(
         q,
         k,
         v,

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -345,7 +345,7 @@ def test_flash_attn_output(
                     continue
                 if pack_gqa is None and mha_type != "mha":
                     continue
-            out, lse = flash_attn_func(
+            out = flash_attn_func(
                 q,
                 k,
                 v,
@@ -506,7 +506,7 @@ def test_flash_attn_small_head_dim(seqlen_q, seqlen_k, d, causal, dtype):
     out_pt, _ = attention_ref(
         q_ref, k_ref, v_ref, None, None, causal=causal, upcast=False, reorder_ops=True
     )
-    out, _ = flash_attn_func(q, k, v, causal=causal)
+    out = flash_attn_func(q, k, v, causal=causal)
     if is_fake_mode():
         return
     fwd_atol = 2 * (out_ref + 0.3 - 0.3 - out_ref).abs().max().item()
@@ -527,8 +527,8 @@ def test_flash_attn_hd256_sm100_noncontiguous_transpose():
     k = torch.randn(batch_size, nheads, seqlen, d, device="cuda", dtype=dtype).transpose(1, 2)
     v = torch.randn(batch_size, nheads, seqlen, d, device="cuda", dtype=dtype).transpose(1, 2)
 
-    out, _ = flash_attn_func(q, k, v)
-    out_contig, _ = flash_attn_func(q.contiguous(), k.contiguous(), v.contiguous())
+    out = flash_attn_func(q, k, v)
+    out_contig = flash_attn_func(q.contiguous(), k.contiguous(), v.contiguous())
 
     if is_fake_mode():
         return
@@ -876,7 +876,7 @@ def test_flash_attn_varlen_output(
                     continue
                 if pack_gqa is None and mha_type != "mha":
                     continue
-            out_unpad, lse = flash_attn_varlen_func(
+            out_unpad = flash_attn_varlen_func(
                 q_unpad if unpad_q else q,
                 k_unpad if unpad_kv else k,
                 v_unpad if unpad_kv else v,
@@ -1512,7 +1512,7 @@ def test_flash_attn_kvcache(
                     k_cache_paged.copy_(k_cache_saved)
                     v_cache_paged.copy_(v_cache_saved)
                 # out, lse, *rest = flash_attn_with_kvcache(
-                out, lse, *rest = flash_attn_varlen_func(
+                out = flash_attn_varlen_func(
                     q if not varlen_q else q_unpad,
                     k_cache if page_size is None else k_cache_paged,
                     v_cache if page_size is None else v_cache_paged,
@@ -1770,8 +1770,8 @@ def test_flash_attn_lse_grad_unused(seqlen_q, seqlen_k, d, causal, dtype):
     v = torch.randn(batch_size, seqlen_k, nheads, d, device=device, dtype=dtype, requires_grad=True)
     g = torch.randn(batch_size, seqlen_q, nheads, d, device=device, dtype=dtype)
 
-    # Case 1: return_lse=False (standard path, lse marked non-differentiable)
-    out1, lse1 = flash_attn_func(q, k, v, causal=causal, return_lse=False)
+    # Case 1: return_lse=False (standard path, lse not returned / not differentiable)
+    out1 = flash_attn_func(q, k, v, causal=causal, return_lse=False)
     if is_fake_mode():
         return
     dq1, dk1, dv1 = torch.autograd.grad(out1, (q, k, v), g)
@@ -1857,7 +1857,7 @@ def test_flash_attn_paged_deepseek(seqlen_q, page_size):
     cu_seqlens = torch.tensor([0, seqlen_q], dtype=torch.int32, device=device)
 
     # Non-paged reference
-    out_ref, _ = flash_attn_varlen_func(
+    out_ref = flash_attn_varlen_func(
         q, k, v, cu_seqlens_q=cu_seqlens, cu_seqlens_k=cu_seqlens,
         max_seqlen_q=seqlen_q, max_seqlen_k=seqlen_q, causal=True,
     )
@@ -1872,7 +1872,7 @@ def test_flash_attn_paged_deepseek(seqlen_q, page_size):
     page_table = torch.arange(num_pages, dtype=torch.int32, device=device).unsqueeze(0)
     cache_seqlens = torch.tensor([seqlen_q], dtype=torch.int32, device=device)
 
-    out, _ = flash_attn_varlen_func(
+    out = flash_attn_varlen_func(
         q, k_cache_paged, v_cache_paged,
         cu_seqlens_q=cu_seqlens, cu_seqlens_k=None,
         max_seqlen_q=seqlen_q, max_seqlen_k=None,
@@ -1914,7 +1914,7 @@ def test_flash_attn_paged_hd256_sm100_tma(seqlen_q):
     cu_seqlens_k = cu_seqlens_q.clone()
 
     # Non-paged reference (varlen).
-    out_ref, _ = flash_attn_varlen_func(
+    out_ref = flash_attn_varlen_func(
         q, k, v,
         cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=cu_seqlens_k,
         max_seqlen_q=seqlen_q, max_seqlen_k=seqlen_q,
@@ -1936,13 +1936,13 @@ def test_flash_attn_paged_hd256_sm100_tma(seqlen_q):
     )
 
     # Paged via hd256 2CTA TMA paged path — run twice for determinism.
-    out_paged_0, _ = flash_attn_varlen_func(
+    out_paged_0 = flash_attn_varlen_func(
         q, k_paged, v_paged,
         cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=None,
         max_seqlen_q=seqlen_q, max_seqlen_k=seqlen_q,
         page_table=page_table,
     )
-    out_paged_1, _ = flash_attn_varlen_func(
+    out_paged_1 = flash_attn_varlen_func(
         q, k_paged, v_paged,
         cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=None,
         max_seqlen_q=seqlen_q, max_seqlen_k=seqlen_q,
@@ -1985,7 +1985,7 @@ def test_flash_attn_paged_hd256_sm100_tma_gqa(nheads_kv):
     cu_seqlens_q = torch.arange(0, batch_size + 1, dtype=torch.int32, device=device) * seqlen_q
     cu_seqlens_k = cu_seqlens_q.clone()
 
-    out_ref, _ = flash_attn_varlen_func(
+    out_ref = flash_attn_varlen_func(
         q, k, v,
         cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=cu_seqlens_k,
         max_seqlen_q=seqlen_q, max_seqlen_k=seqlen_q,
@@ -2005,7 +2005,7 @@ def test_flash_attn_paged_hd256_sm100_tma_gqa(nheads_kv):
         batch_size, num_pages_per_seq
     )
 
-    out_paged, _ = flash_attn_varlen_func(
+    out_paged = flash_attn_varlen_func(
         q, k_paged, v_paged,
         cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=None,
         max_seqlen_q=seqlen_q, max_seqlen_k=seqlen_q,
@@ -2049,7 +2049,7 @@ def test_flash_attn_paged_hd256_sm100_tma_shuffled():
     cu_seqlens_q = torch.arange(0, batch_size + 1, dtype=torch.int32, device=device) * seqlen_q
     cu_seqlens_k = cu_seqlens_q.clone()
 
-    out_ref, _ = flash_attn_varlen_func(
+    out_ref = flash_attn_varlen_func(
         q, k, v,
         cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=cu_seqlens_k,
         max_seqlen_q=seqlen_q, max_seqlen_k=seqlen_q,
@@ -2072,7 +2072,7 @@ def test_flash_attn_paged_hd256_sm100_tma_shuffled():
             k_paged[phys, po] = k[b * seqlen_q + s]
             v_paged[phys, po] = v[b * seqlen_q + s]
 
-    out_paged, _ = flash_attn_varlen_func(
+    out_paged = flash_attn_varlen_func(
         q, k_paged, v_paged,
         cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=None,
         max_seqlen_q=seqlen_q, max_seqlen_k=seqlen_q,
@@ -2248,6 +2248,7 @@ def test_flash_attn_mla_absorbed(
                 pack_gqa=pack_gqa,
                 num_splits=num_splits,
                 deterministic=deterministic,
+                return_lse=True,
             )
             if is_fake_mode():
                 # no more flash_attn cutedsl calls for the rest of the loop
@@ -2266,7 +2267,7 @@ def test_flash_attn_mla_absorbed(
 
             repeats = 10 if check_fwd_deterministic else 0
             for iter in range(repeats):
-                out2, lse2 = flash_attn_func(
+                out2 = flash_attn_func(
                     q,
                     k,
                     v,
@@ -2592,6 +2593,7 @@ def test_flash_attn_mla_absorbed_varlen(
                 pack_gqa=pack_gqa,
                 deterministic=deterministic,
                 gather_kv_indices=gather_kv_indices_unpad if unpad_q else gather_kv_indices,
+                return_lse=True,
             )
             out = output_pad_fn(out_unpad) if unpad_q else out_unpad
             if is_fake_mode():
@@ -2628,7 +2630,7 @@ def test_flash_attn_mla_absorbed_varlen(
 
             repeats = 10 if check_fwd_deterministic else 0
             for iter in range(repeats):
-                out_unpad2, lse = flash_attn_varlen_func(
+                out_unpad2 = flash_attn_varlen_func(
                     q_unpad if unpad_q else q,
                     k_unpad if unpad_kv else k,
                     v_unpad if unpad_kv else v,
@@ -2779,7 +2781,7 @@ def test_flash_attn_mla_paged(dtype, seqlen_q, seqlen_k, page_size, causal, has_
     )
 
     # Non-paged reference
-    out_ref, _ = flash_attn_varlen_func(
+    out_ref = flash_attn_varlen_func(
         q, k, v, qv=qv,
         cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=cu_seqlens_k,
         max_seqlen_q=seqlen_q, max_seqlen_k=seqlen_k,
@@ -2811,7 +2813,7 @@ def test_flash_attn_mla_paged(dtype, seqlen_q, seqlen_k, page_size, causal, has_
     seqused_k = torch.full((batch_size,), seqlen_k, dtype=torch.int32, device=device)
 
     # Paged output (triggers cp.async path if page_size != 128)
-    out, _ = flash_attn_varlen_func(
+    out = flash_attn_varlen_func(
         q, k_paged, v_paged, qv=qv,
         cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=None,
         max_seqlen_q=seqlen_q, max_seqlen_k=None,
@@ -2873,7 +2875,7 @@ def test_flash_attn_seqlen_k_zero(seqlen_q, d, causal):
     k = torch.empty(batch_size, 0, nheads_kv, d, device=device, dtype=dtype)
     v = torch.empty(batch_size, 0, nheads_kv, dv, device=device, dtype=dtype)
 
-    out, lse = flash_attn_func(q, k, v, causal=causal)
+    out, lse = flash_attn_func(q, k, v, causal=causal, return_lse=True)
 
     if is_fake_mode():
         return
@@ -2928,7 +2930,7 @@ def test_flash_attn_empty_q_dense(shape, causal):
     k = torch.randn(batch_size, seqlen_k, nheads_kv, d, device=device, dtype=dtype)
     v = torch.randn(batch_size, seqlen_k, nheads_kv, d, device=device, dtype=dtype)
 
-    out, lse = flash_attn_func(q, k, v, causal=causal)
+    out, lse = flash_attn_func(q, k, v, causal=causal, return_lse=True)
 
     if is_fake_mode():
         return
@@ -2978,6 +2980,7 @@ def test_flash_attn_empty_q_varlen(causal):
         cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=cu_seqlens_k,
         max_seqlen_q=0, max_seqlen_k=seqlen_k_per_batch,
         causal=causal,
+        return_lse=True,
     )
 
     if is_fake_mode():
@@ -3013,7 +3016,7 @@ def test_flash_attn_ex2_emu_decode_prefill_consistency(seqlen_k):
 
     # Prefill: full sequence, non-paged, causal
     cu = torch.tensor([0, seqlen_k], dtype=torch.int32, device=device)
-    out_prefill, _ = flash_attn_varlen_func(
+    out_prefill = flash_attn_varlen_func(
         q, k, v,
         cu_seqlens_q=cu, cu_seqlens_k=cu,
         max_seqlen_q=seqlen_k, max_seqlen_k=seqlen_k,
@@ -3031,7 +3034,7 @@ def test_flash_attn_ex2_emu_decode_prefill_consistency(seqlen_k):
     page_table = torch.arange(num_pages, dtype=torch.int32, device=device).unsqueeze(0)
     cache_seqlens = torch.tensor([seqlen_k], dtype=torch.int32, device=device)
 
-    out_decode, _ = flash_attn_varlen_func(
+    out_decode = flash_attn_varlen_func(
         q[-1:], k_cache, v_cache,
         cu_seqlens_q=torch.tensor([0, 1], dtype=torch.int32, device=device),
         cu_seqlens_k=None,

--- a/tests/cute/test_flash_attn_fast.py
+++ b/tests/cute/test_flash_attn_fast.py
@@ -71,7 +71,7 @@ def test_flash_attn_output(seqlen_q, seqlen_k, d, causal, num_splits, mha_type, 
         q_ref, k_ref, v_ref, None, None, causal=causal, upcast=False, reorder_ops=True,
     )
 
-    out, lse = flash_attn_func(q, k, v, causal=causal, num_splits=num_splits)
+    out = flash_attn_func(q, k, v, causal=causal, num_splits=num_splits)
 
     if is_fake_mode():
         return
@@ -138,7 +138,7 @@ def test_flash_attn_varlen_output(seqlen, d, causal, mha_type, dtype):
     k_varlen = rearrange(k_ref.detach(), "b s h d -> (b s) h d").requires_grad_()
     v_varlen = rearrange(v_ref.detach(), "b s h d -> (b s) h d").requires_grad_()
 
-    out_varlen, lse = flash_attn_varlen_func(
+    out_varlen = flash_attn_varlen_func(
         q_varlen, k_varlen, v_varlen,
         cu_seqlens_q=cu_seqlens, cu_seqlens_k=cu_seqlens,
         max_seqlen_q=seqlen, max_seqlen_k=seqlen,
@@ -239,7 +239,7 @@ def test_flash_attn_varlen_unpad_output(seqlen, d, causal, mha_type, unpad_q, un
         k_in = k.detach().to(dtype).requires_grad_()
         v_in = v.detach().to(dtype).requires_grad_()
 
-    out_unpad, lse = flash_attn_varlen_func(
+    out_unpad = flash_attn_varlen_func(
         q_in, k_in, v_in,
         cu_seqlens_q=cu_seqlens_q if unpad_q else None,
         cu_seqlens_k=cu_seqlens_k if unpad_kv else None,

--- a/tests/cute/test_flash_attn_race_condition.py
+++ b/tests/cute/test_flash_attn_race_condition.py
@@ -228,6 +228,7 @@ def test_flash_attn_output(
                 pack_gqa=pack_gqa,
                 num_splits=num_splits,
                 deterministic=deterministic,
+                return_lse=True,
             )
             print(f"Output max diff: {(out - out_ref).abs().max().item()}")
             print(f"Output mean diff: {(out - out_ref).abs().mean().item()}")
@@ -628,6 +629,7 @@ def test_flash_attn_varlen_output(
             num_splits=1,
             pack_gqa=False,
             deterministic=deterministic,
+            return_lse=True,
         )
         out = output_pad_fn(out_unpad)
         if query_unused_mask is not None:

--- a/tests/cute/test_flash_attn_varlen.py
+++ b/tests/cute/test_flash_attn_varlen.py
@@ -86,7 +86,7 @@ def check_varlen_vs_torch_flash(
         cu_seqlens_k_fa = None
         cu_seqlens_k_t = None
 
-    out_fa, lse_fa = flash_attn_varlen_func(
+    out_fa = flash_attn_varlen_func(
         q_fa, k_fa, v_fa,
         cu_seqlens_q=cu_seqlens_q_fa,
         cu_seqlens_k=cu_seqlens_k_fa,

--- a/tests/cute/test_score_mod.py
+++ b/tests/cute/test_score_mod.py
@@ -810,7 +810,7 @@ def run_cute_flash_bwd(
         q_t = q_t.detach().requires_grad_(True)
         k_t = k_t.detach().requires_grad_(True)
         v_t = v_t.detach().requires_grad_(True)
-        out, lse = flash_attn_func(
+        out = flash_attn_func(
             q_t, 
             k_t, 
             v_t, 


### PR DESCRIPTION
## Make `flash_attn_func` return LSE only when `return_lse=True` (CuTe / FA4)

### Problem

The FA4 (CuTe) Python interface always returns the tuple `(out, lse)` from
[`flash_attn_func` / `flash_attn_varlen_func`](https://github.com/Dao-AILab/flash-attention/blob/main/flash_attn/cute/interface.py#L2492),
regardless of the `return_lse` argument. The flag therefore has no effect on the
output signature and every caller is forced to unpack a tuple and discard the LSE.

This is inconsistent with the FA2/FA3 Python interfaces, which return a bare `out`
tensor unless the LSE is explicitly requested:

- FA2: [`return out if not return_softmax else (out, softmax_lse, S_dmask)`](https://github.com/Dao-AILab/flash-attention/blob/main/flash_attn/flash_attn_interface.py#L878)
- FA3 (hopper): [`return (out, softmax_lse) if return_softmax else out`](https://github.com/Dao-AILab/flash-attention/blob/main/hopper/flash_attn_interface.py#L608)

### Change

Bring the CuTe interface in line with FA3:

- `FlashAttnFunc.forward` / `FlashAttnVarlenFunc.forward` now
  `return (out, lse) if return_lse else out`.
- Their `backward` methods accept `*args` so autograd works with either the
  1-output (`out`) or 2-output (`out, lse`) forward. `dlse` is only read from
  `args` when `return_lse` was set (behavior preserved via
  `set_materialize_grads(False)`).
- Documented the conditional return in both public wrappers.
- Updated all in-repo callers under `tests/cute/` and `benchmarks/`: sites that
  consume the LSE now pass `return_lse=True`; sites that discarded it stop
  unpacking a tuple. No behavioral change to any test's assertions.

### Why the current behavior exists (and why change it anyway)

This is intentionally called out so it can be gated to a breaking release. The
always-return-tuple behavior is not obviously a bug:

- In FA4 the LSE is a **free byproduct** — `_flash_attn_fwd` allocates it
  whenever `requires_grad or return_lse`, so during training it is materialized
  regardless of the flag (backward needs it). Returning it costs nothing.
- `return_lse` in FA4 is slightly overloaded vs FA3's `return_softmax`: besides
  the output signature it also forces LSE computation at inference and makes the
  returned LSE **differentiable** (`dlse` flows in backward). The output-arity
  effect reads almost like a side detail.
- A fixed 2-output arity is also marginally friendlier to tracing/compile of an
  `autograd.Function`.

The case *for* this PR: the FA4 signature is clearly modeled on FA3 (same
`return_lse` name, same `False` default), so users reasonably expect FA3's
return contract. Aligning them removes a real foot-gun (`return_lse=False`
currently still hands back an `lse`/`None` second value). This belongs in a
**major/breaking release with a changelog note**, not a patch.

### ⚠️ Breaking change

Callers of the CuTe `flash_attn_func` / `flash_attn_varlen_func` that relied on
always receiving `(out, lse)` must now either pass `return_lse=True` or stop
unpacking the second value:

```python
# before
out, lse = flash_attn_func(q, k, v)          # lse always returned

# after
out = flash_attn_func(q, k, v)               # out only (default)
out, lse = flash_attn_func(q, k, v, return_lse=True)
```

### Verification

- All modified files pass `python -m py_compile`.
- AST sweep over `tests/cute/` + `benchmarks/` confirms every tuple-unpacked
  call now passes `return_lse=True`, and no `return_lse=True` call is bound to a
  single target.
