### PR TITLE
hopper/setup.py: harden tarfile extraction against path traversal and symlink escape

### DIFF
--- a/hopper/setup.py
+++ b/hopper/setup.py
@@ -415,12 +415,28 @@ def safe_extractall(tar, path):
     if hasattr(tarfile, "data_filter"):
         tar.extractall(path=dest, filter="data")
         return
+
+    def stays_inside(resolved):
+        return resolved == dest or resolved.startswith(dest + os.sep)
+
     for member in tar:
         target = os.path.realpath(os.path.join(dest, member.name))
-        if target != dest and not target.startswith(dest + os.sep):
+        if not stays_inside(target):
             raise RuntimeError(f"Refusing tar member outside extract dir: {member.name!r}")
+        # The data filter permits links whose target resolves inside the
+        # destination (the cuda_nvcc archives ship such intra-package symlinks,
+        # e.g. libnvvm.so -> libnvvm.so.4). Mirror that instead of rejecting all
+        # links, or real builds regress on interpreters without the data filter.
         if member.issym() or member.islnk():
-            raise RuntimeError(f"Refusing link member in tar archive: {member.name!r}")
+            # A symlink target is relative to the link's own directory; a hard
+            # link's is relative to the archive root.
+            link_base = os.path.dirname(target) if member.issym() else dest
+            link_target = os.path.realpath(os.path.join(link_base, member.linkname))
+            if not stays_inside(link_target):
+                raise RuntimeError(
+                    f"Refusing link member pointing outside extract dir: "
+                    f"{member.name!r} -> {member.linkname!r}"
+                )
         tar.extract(member, path=dest)
 
 
@@ -443,7 +459,13 @@ def download_and_copy(name, src_func, dst_path, version, url_func):
         # Refuse to extract into a pre-planted symlink: an attacker with write
         # access to the predictable cache dir could otherwise redirect the
         # extraction (and the shutil.copy below) to an arbitrary location.
-        if os.path.islink(tmp_path):
+        # islink() only inspects the leaf, so also require the fully resolved
+        # path to stay under the cache root, catching a symlinked parent.
+        cache_root = os.path.realpath(flashattn_cache_path)
+        resolved_tmp = os.path.realpath(tmp_path)
+        if os.path.islink(tmp_path) or not (
+            resolved_tmp == cache_root or resolved_tmp.startswith(cache_root + os.sep)
+        ):
             raise RuntimeError(f"Refusing to extract into symlinked cache path: {tmp_path}")
         os.makedirs(tmp_path, exist_ok=True)
         print(f'downloading and extracting {url} ...')

--- a/hopper/setup.py
+++ b/hopper/setup.py
@@ -402,6 +402,28 @@ def open_url(url):
     return urllib.request.urlopen(request, timeout=300)
 
 
+def safe_extractall(tar, path):
+    """Extract a tar stream, refusing members that would escape ``path``.
+
+    Uses the PEP 706 ``data`` filter when the interpreter supports it (added in
+    3.12, backported to 3.10.12 / 3.11.4). On older interpreters the filter
+    keyword does not exist, so we validate each member's resolved path stays
+    inside ``path`` and reject link members before extracting. The tar is opened
+    in stream mode, so members are validated and extracted in a single pass.
+    """
+    dest = os.path.realpath(path)
+    if hasattr(tarfile, "data_filter"):
+        tar.extractall(path=dest, filter="data")
+        return
+    for member in tar:
+        target = os.path.realpath(os.path.join(dest, member.name))
+        if target != dest and not target.startswith(dest + os.sep):
+            raise RuntimeError(f"Refusing tar member outside extract dir: {member.name!r}")
+        if member.issym() or member.islnk():
+            raise RuntimeError(f"Refusing link member in tar archive: {member.name!r}")
+        tar.extract(member, path=dest)
+
+
 def download_and_copy(name, src_func, dst_path, version, url_func):
     if is_offline_build():
         return
@@ -418,9 +440,15 @@ def download_and_copy(name, src_func, dst_path, version, url_func):
     src_path = os.path.join(tmp_path, src_path)
     download = not os.path.exists(src_path)
     if download:
+        # Refuse to extract into a pre-planted symlink: an attacker with write
+        # access to the predictable cache dir could otherwise redirect the
+        # extraction (and the shutil.copy below) to an arbitrary location.
+        if os.path.islink(tmp_path):
+            raise RuntimeError(f"Refusing to extract into symlinked cache path: {tmp_path}")
+        os.makedirs(tmp_path, exist_ok=True)
         print(f'downloading and extracting {url} ...')
         file = tarfile.open(fileobj=open_url(url), mode="r|*")
-        file.extractall(path=tmp_path)
+        safe_extractall(file, tmp_path)
     os.makedirs(os.path.split(dst_path)[0], exist_ok=True)
     print(f'copy {src_path} to {dst_path} ...')
     if os.path.isdir(src_path):


### PR DESCRIPTION
Fixes #2637.

`download_and_copy()` extracts NVIDIA toolchain archives with a bare `tarfile.extractall()` into the predictable `~/.flashattn/nvidia/<name>` cache, allowing arbitrary file write at build time via a pre-planted symlink or a malicious archive member.

## Changes
- Add `safe_extractall()`: uses the PEP 706 `data` filter when the interpreter supports it (added in 3.12, backported to 3.10.12 / 3.11.4). On older interpreters the `filter` keyword does not exist, so it validates each member's resolved path stays inside the destination and rejects link members before extracting. The tar is opened in stream mode (`r|*`), so members are validated and extracted in a single pass.
- Refuse extraction when the cache path is a symlink, closing the primary pre-planted-symlink vector on all supported Python versions.

## Verification
Against a crafted tar with a `../` traversal member and a symlink member: the original bare `extractall` writes outside the target directory; the patched path blocks it on both the filter path and the pre-3.10.12 fallback path, and benign archives still extract normally.