### PR TITLE
Migrate deprecated cutlass.utils spellings to canonical namespaces

### DIFF
--- a/AI/racecheck_repro_1d_bulk.py
+++ b/AI/racecheck_repro_1d_bulk.py
@@ -22,7 +22,7 @@ N_STG = 2
 
 @cute.kernel
 def kernel(g_src: cute.Tensor, g_dst: cute.Tensor):
-    smem = cutlass.utils.SmemAllocator()
+    smem = cutlass.memory.SmemAllocator()
     s = smem.allocate_tensor(Float32, cute.make_layout((TILE, N_STG)), byte_alignment=128)
     s_mbar = smem.allocate_tensor(cutlass.Int64, cute.make_layout(2 * N_STG), byte_alignment=8)
     tidx, _, _ = cute.arch.thread_idx()

--- a/AI/racecheck_repro_1d_tensor.py
+++ b/AI/racecheck_repro_1d_tensor.py
@@ -22,7 +22,7 @@ N_STG = 2
 
 @cute.kernel
 def kernel(g_dst: cute.Tensor, tma_atom: cute.CopyAtom, tma_tensor: cute.Tensor):
-    smem = cutlass.utils.SmemAllocator()
+    smem = cutlass.memory.SmemAllocator()
     s = smem.allocate_tensor(Float32, cute.make_layout((TILE, N_STG)), byte_alignment=128)
     s_mbar = smem.allocate_tensor(cutlass.Int64, cute.make_layout(2 * N_STG), byte_alignment=8)
     tidx, _, _ = cute.arch.thread_idx()

--- a/flash_attn/cute/compute_block_sparsity.py
+++ b/flash_attn/cute/compute_block_sparsity.py
@@ -144,7 +144,7 @@ class BlockSparsityKernel:
                 cute.struct.MemRange[cutlass.Int8, 2 * self.num_warps], 1024
             ]
 
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(SharedStorage, 16)
 
         reduction_buffer = storage.reduction_buffer_smem.get_tensor(

--- a/flash_attn/cute/cu_blocks_kernel.py
+++ b/flash_attn/cute/cu_blocks_kernel.py
@@ -73,7 +73,7 @@ class CuSeqlensToBlocksKernel:
         lane_idx = cute.arch.lane_idx()
         warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
 
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(SharedStorage)
         warp_block_count = storage.warp_block_count.get_tensor(cute.make_layout(self.num_warps))
         warp_split_count = storage.warp_split_count.get_tensor(cute.make_layout(self.num_warps))

--- a/flash_attn/cute/flash_bwd.py
+++ b/flash_attn/cute/flash_bwd.py
@@ -12,7 +12,6 @@ import cutlass
 import cutlass.cute as cute
 from cutlass.cute.nvgpu import cpasync, warp
 from cutlass import Int32
-import cutlass.utils as utils_basic
 
 from quack import layout_utils
 from flash_attn.cute import ampere_helpers as sm80_utils
@@ -143,7 +142,7 @@ class FlashAttentionBackwardSm80:
         smem_usage_V = n_block_size * head_dim_v * 2
         smem_usage_QV = (smem_usage_Q + smem_usage_V) if not V_in_regs else max(smem_usage_Q, smem_usage_V)
         smem_usage = smem_usage_QV + smem_usage_dO + smem_usage_K
-        smem_capacity = utils_basic.get_smem_capacity_in_bytes("sm_80")
+        smem_capacity = cutlass.memory.get_smem_capacity_in_bytes("sm_80")
         if smem_usage > smem_capacity:
             return False
         return True
@@ -604,7 +603,7 @@ class FlashAttentionBackwardSm80:
             # ///////////////////////////////////////////////////////////////////////////////
             # Get shared memory buffer
             # ///////////////////////////////////////////////////////////////////////////////
-            smem = cutlass.utils.SmemAllocator()
+            smem = cutlass.memory.SmemAllocator()
             storage = smem.allocate(SharedStorage)
             sQ = storage.sQ.get_tensor(sQ_layout)
             sK = storage.sK.get_tensor(sK_layout)

--- a/flash_attn/cute/flash_bwd.py
+++ b/flash_attn/cute/flash_bwd.py
@@ -12,7 +12,6 @@ import cutlass
 import cutlass.cute as cute
 from cutlass.cute.nvgpu import cpasync, warp
 from cutlass import Int32
-import cutlass.utils as utils_basic
 
 from quack import layout_utils
 from flash_attn.cute import ampere_helpers as sm80_utils
@@ -143,7 +142,7 @@ class FlashAttentionBackwardSm80:
         smem_usage_V = n_block_size * head_dim_v * 2
         smem_usage_QV = (smem_usage_Q + smem_usage_V) if not V_in_regs else max(smem_usage_Q, smem_usage_V)
         smem_usage = smem_usage_QV + smem_usage_dO + smem_usage_K
-        smem_capacity = utils_basic.get_smem_capacity_in_bytes("sm_80")
+        smem_capacity = cutlass.memory.get_smem_capacity_in_bytes("sm_80")
         if smem_usage > smem_capacity:
             return False
         return True
@@ -606,7 +605,7 @@ class FlashAttentionBackwardSm80:
             # ///////////////////////////////////////////////////////////////////////////////
             # Get shared memory buffer
             # ///////////////////////////////////////////////////////////////////////////////
-            smem = cutlass.utils.SmemAllocator()
+            smem = cutlass.memory.SmemAllocator()
             storage = smem.allocate(SharedStorage)
             sQ = storage.sQ.get_tensor(sQ_layout)
             sK = storage.sK.get_tensor(sK_layout)

--- a/flash_attn/cute/flash_bwd_mla_dk_sm100.py
+++ b/flash_attn/cute/flash_bwd_mla_dk_sm100.py
@@ -85,7 +85,7 @@ class dKGemmKernel:
 
         # Output dKaccum: (total_q, seqlen_k, dim), dim-major
         self.c_dtype = cutlass.Float32
-        self.c_layout = utils.LayoutEnum.ROW_MAJOR
+        self.c_layout = cutlass.tensor_utils.LayoutEnum.ROW_MAJOR
 
         self.acc_dtype = cutlass.Float32
 
@@ -214,7 +214,7 @@ class dKGemmKernel:
             self.c_dtype, self.c_layout, self.epi_tile_dK, 1
         )
 
-        smem_capacity = utils.get_smem_capacity_in_bytes()
+        smem_capacity = cutlass.memory.get_smem_capacity_in_bytes()
 
         # TMEM pipeline stages
         # 64 TMEM columns per stage, 8 stages can fit in TMEM
@@ -458,7 +458,7 @@ class dKGemmKernel:
         # Alloc and init: a+b full/empty, accumulator full/empty, tensor memory dealloc barrier
         #
 
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(SharedStorage)
 
         # Initialize mainloop ab_pipeline (barrier) and states
@@ -528,7 +528,7 @@ class dKGemmKernel:
             num_threads=32 * len((self.mma_warp_id, *self.epilogue_warp_id)),
         )
         # Tensor memory dealloc barrier init
-        tmem = utils.TmemAllocator(
+        tmem = cutlass.memory.TmemAllocator(
             storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=tmem_alloc_barrier,
             allocator_warp_id=self.epilogue_warp_id[0],

--- a/flash_attn/cute/flash_bwd_mla_dq_dqv_sm100.py
+++ b/flash_attn/cute/flash_bwd_mla_dq_dqv_sm100.py
@@ -196,11 +196,11 @@ class dQdQvGemmKernel:
             mK = static_reshape(mK, self.head_dim_k)
 
         # ---- layout info ----
-        self.ds_major_mode = utils.LayoutEnum.from_tensor(mdS).mma_major_mode()
-        self.kv_major_mode = utils.LayoutEnum.from_tensor(mV).mma_major_mode()
-        self.dq_layout = utils.LayoutEnum.from_tensor(mdQv)
+        self.ds_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(mdS).mma_major_mode()
+        self.kv_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(mV).mma_major_mode()
+        self.dq_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(mdQv)
         if const_expr(self.compute_dQ):
-            assert self.dq_layout == utils.LayoutEnum.from_tensor(mdQ)
+            assert self.dq_layout == cutlass.tensor_utils.LayoutEnum.from_tensor(mdQ)
 
         # ------------------------------------------------------------------ #
         # Setup attributes that depend on kernel inputs                      #
@@ -255,7 +255,7 @@ class dQdQvGemmKernel:
             )
 
         # ---- Device-specific attributes ----
-        self.smem_capacity = utils.get_smem_capacity_in_bytes()
+        self.smem_capacity = cutlass.memory.get_smem_capacity_in_bytes()
 
         self.num_tmem_alloc_cols = 512
 
@@ -492,7 +492,7 @@ class dQdQvGemmKernel:
         # ------------------------------------------------------------------ #
         # Shared storage allocation                                          #
         # ------------------------------------------------------------------ #
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(self.shared_storage)
 
         # ------------------------------------------------------------------ #
@@ -568,7 +568,7 @@ class dQdQvGemmKernel:
             num_threads=32 * len((self.mma_warp_id, *self.epilogue_warp_ids)),
         )
         # ---- Tensor memory dealloc barrier init ----
-        tmem = utils.TmemAllocator(
+        tmem = cutlass.memory.TmemAllocator(
             storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=tmem_alloc_barrier,
             allocator_warp_id=self.epilogue_warp_ids[0],

--- a/flash_attn/cute/flash_bwd_mla_sm100.py
+++ b/flash_attn/cute/flash_bwd_mla_sm100.py
@@ -472,7 +472,7 @@ class FlashAttentionSparseMLABackwardSm100:
             setattr(self, attr, cute.select(staged, mode=[0, 1, 2]))
 
         # Prepare additional SMEM load layouts
-        self.P_layout_major = cutlass.utils.LayoutEnum.from_tensor(mP)
+        self.P_layout_major = cutlass.tensor_utils.LayoutEnum.from_tensor(mP)
         self.sP_layout_staged = sm100_utils.make_smem_layout_epi(
             self.dtype, self.P_layout_major, self.tile_P, self.num_stages_P
         )
@@ -534,8 +534,8 @@ class FlashAttentionSparseMLABackwardSm100:
         # ==== TMA store ====
         tma_store_op = cpasync.CopyBulkTensorTileS2GOp()  
 
-        self.dS_layout_major = cutlass.utils.LayoutEnum.from_tensor(mdS)
-        self.dV_layout_major = cutlass.utils.LayoutEnum.from_tensor(mdV)
+        self.dS_layout_major = cutlass.tensor_utils.LayoutEnum.from_tensor(mdS)
+        self.dV_layout_major = cutlass.tensor_utils.LayoutEnum.from_tensor(mdV)
         # (tile_m, tile_n, dS_stages) = (nheads, 64, dS_stage)
         sdS_layout_staged = sm100_utils.make_smem_layout_epi(
             self.dtype, self.dS_layout_major, self.tile_dS, self.num_stages_dSt
@@ -702,7 +702,7 @@ class FlashAttentionSparseMLABackwardSm100:
         is_leader_cta = mma_tile_coord_v == 0
 
         # ==== Allocate SMEM ====
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(SharedStorage)
 
         # ==== Prepare TMEM allocator ====
@@ -710,7 +710,7 @@ class FlashAttentionSparseMLABackwardSm100:
             barrier_id=int(NamedBarrierBwdSm100_MLA2CTA.TmemPtr),
             num_threads=self.num_mma_threads + self.num_softmax_threads + self.num_epilogue_threads,
         )
-        tmem = cutlass.utils.TmemAllocator(
+        tmem = cutlass.memory.TmemAllocator(
             storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=tmem_alloc_barrier,
             allocator_warp_id=self.mma_warp_id,

--- a/flash_attn/cute/flash_bwd_postprocess.py
+++ b/flash_attn/cute/flash_bwd_postprocess.py
@@ -12,7 +12,7 @@ import cutlass.utils.hopper_helpers as sm90_utils_basic
 import cutlass.utils.blackwell_helpers as sm100_utils_basic
 from cutlass.cute.nvgpu import cpasync, warp, warpgroup
 from cutlass import Float32, const_expr
-from cutlass.utils import LayoutEnum
+from cutlass.tensor_utils import LayoutEnum
 
 from quack import copy_utils
 from quack import layout_utils
@@ -307,7 +307,7 @@ class FlashAttentionBackwardPostprocess:
         # ///////////////////////////////////////////////////////////////////////////////
         # Get shared memory buffer
         # ///////////////////////////////////////////////////////////////////////////////
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         sdQaccum = smem.allocate_tensor(cutlass.Float32, sdQaccum_layout, byte_alignment=1024)
         sdQaccum_flat = cute.make_tensor(sdQaccum.iterator, cute.make_layout(cute.size(sdQaccum)))
         if const_expr(self.arch // 10 in [8, 9, 12]):

--- a/flash_attn/cute/flash_bwd_postprocess.py
+++ b/flash_attn/cute/flash_bwd_postprocess.py
@@ -13,7 +13,7 @@ import cutlass.utils.hopper_helpers as sm90_utils_basic
 import cutlass.utils.blackwell_helpers as sm100_utils_basic
 from cutlass.cute.nvgpu import cpasync, warp, warpgroup
 from cutlass import Float32, const_expr
-from cutlass.utils import LayoutEnum
+from cutlass.tensor_utils import LayoutEnum
 
 from quack import copy_utils
 from quack import layout_utils
@@ -336,7 +336,7 @@ class FlashAttentionBackwardPostprocess:
         # ///////////////////////////////////////////////////////////////////////////////
         # Get shared memory buffer
         # ///////////////////////////////////////////////////////////////////////////////
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         sdQaccum = smem.allocate_tensor(cutlass.Float32, sdQaccum_layout, byte_alignment=1024)
         sdQaccum_flat = cute.make_tensor(sdQaccum.iterator, cute.make_layout(cute.size(sdQaccum)))
         if const_expr(self.arch // 10 in [8, 9, 12]):

--- a/flash_attn/cute/flash_bwd_sm100.py
+++ b/flash_attn/cute/flash_bwd_sm100.py
@@ -9,7 +9,7 @@ import cutlass
 import cutlass.cute as cute
 from cutlass.cute import FastDivmodDivisor
 from cutlass import Float32, Int32, Int64, const_expr
-from cutlass.utils import LayoutEnum
+from cutlass.tensor_utils import LayoutEnum
 from cutlass.cute.nvgpu import cpasync, tcgen05
 import cutlass.utils.blackwell_helpers as sm100_utils_basic
 from cutlass.pipeline import PipelineAsync
@@ -1112,7 +1112,7 @@ class FlashAttentionBackwardSm100:
         )
 
         # Alloc
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(self.shared_storage)
 
         dQ_cluster_full_mbar_ptr = storage.dQ_cluster_full_mbar_ptr.data_ptr()
@@ -1153,7 +1153,7 @@ class FlashAttentionBackwardSm100:
             num_threads=cute.arch.WARP_SIZE
             * len((self.mma_warp_id, *self.compute_warp_ids, *self.reduce_warp_ids)),
         )
-        tmem = cutlass.utils.TmemAllocator(
+        tmem = cutlass.memory.TmemAllocator(
             storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=tmem_alloc_barrier,
             allocator_warp_id=self.mma_warp_id,

--- a/flash_attn/cute/flash_bwd_sm100.py
+++ b/flash_attn/cute/flash_bwd_sm100.py
@@ -9,7 +9,7 @@ import cutlass
 import cutlass.cute as cute
 from cutlass.cute import FastDivmodDivisor
 from cutlass import Float32, Int32, Int64, const_expr
-from cutlass.utils import LayoutEnum
+from cutlass.tensor_utils import LayoutEnum
 from cutlass.cute.nvgpu import cpasync, tcgen05
 import cutlass.utils.blackwell_helpers as sm100_utils_basic
 from cutlass.pipeline import PipelineAsync
@@ -1117,7 +1117,7 @@ class FlashAttentionBackwardSm100:
         )
 
         # Alloc
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(self.shared_storage)
 
         dQ_cluster_full_mbar_ptr = storage.dQ_cluster_full_mbar_ptr.data_ptr()
@@ -1158,7 +1158,7 @@ class FlashAttentionBackwardSm100:
             num_threads=cute.arch.WARP_SIZE
             * len((self.mma_warp_id, *self.compute_warp_ids, *self.reduce_warp_ids)),
         )
-        tmem = cutlass.utils.TmemAllocator(
+        tmem = cutlass.memory.TmemAllocator(
             storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=tmem_alloc_barrier,
             allocator_warp_id=self.mma_warp_id,

--- a/flash_attn/cute/flash_bwd_sm120.py
+++ b/flash_attn/cute/flash_bwd_sm120.py
@@ -6,7 +6,6 @@
 # FlashAttentionBackwardSm80 and overrides the SMEM capacity check accordingly.
 
 import cutlass
-import cutlass.utils as utils_basic
 
 from flash_attn.cute.flash_bwd import FlashAttentionBackwardSm80
 
@@ -49,7 +48,7 @@ class FlashAttentionBackwardSm120(FlashAttentionBackwardSm80):
         )
         smem_usage = smem_usage_QV + smem_usage_dO + smem_usage_K
         # SM120 has 99 KB shared memory (vs 163 KB on SM80)
-        smem_capacity = utils_basic.get_smem_capacity_in_bytes("sm_120")
+        smem_capacity = cutlass.memory.get_smem_capacity_in_bytes("sm_120")
         if smem_usage > smem_capacity:
             return False
         return True

--- a/flash_attn/cute/flash_bwd_sm90.py
+++ b/flash_attn/cute/flash_bwd_sm90.py
@@ -10,7 +10,7 @@ import cutlass.utils.hopper_helpers as sm90_utils_basic
 from cutlass.cute.nvgpu import cpasync, warpgroup
 from cutlass.cute import FastDivmodDivisor
 from cutlass import Float32, Int32, Boolean, const_expr
-from cutlass.utils import LayoutEnum
+from cutlass.tensor_utils import LayoutEnum
 
 from quack import copy_utils
 from quack import layout_utils
@@ -682,7 +682,7 @@ class FlashAttentionBackwardSm90:
                 if const_expr(atom is not None):
                     cpasync.prefetch_descriptor(atom)
 
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(SharedStorage)
 
         pipeline_producer_group = cutlass.pipeline.CooperativeGroup(cutlass.pipeline.Agent.Thread)

--- a/flash_attn/cute/flash_bwd_sm90.py
+++ b/flash_attn/cute/flash_bwd_sm90.py
@@ -10,7 +10,7 @@ import cutlass.utils.hopper_helpers as sm90_utils_basic
 from cutlass.cute.nvgpu import cpasync, warpgroup
 from cutlass.cute import FastDivmodDivisor
 from cutlass import Float32, Int32, Boolean, const_expr
-from cutlass.utils import LayoutEnum
+from cutlass.tensor_utils import LayoutEnum
 
 from quack import copy_utils
 from quack import layout_utils
@@ -684,7 +684,7 @@ class FlashAttentionBackwardSm90:
                 if const_expr(atom is not None):
                     cpasync.prefetch_descriptor(atom)
 
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(SharedStorage)
 
         pipeline_producer_group = cutlass.pipeline.CooperativeGroup(cutlass.pipeline.Agent.Thread)

--- a/flash_attn/cute/flash_fwd.py
+++ b/flash_attn/cute/flash_fwd.py
@@ -16,7 +16,6 @@ import cutlass
 import cutlass.cute as cute
 from cutlass import Float32, Int32, const_expr
 from cutlass.cute.nvgpu import cpasync, warp
-import cutlass.utils as utils_basic
 from cutlass.base_dsl.arch import Arch
 from cutlass.cutlass_dsl import BaseDSL
 
@@ -166,7 +165,7 @@ class FlashAttentionForwardBase:
         )
         smem_usage = smem_usage_QV + smem_usage_K
         # TODO: sm86 and sm89
-        smem_capacity = utils_basic.get_smem_capacity_in_bytes("sm_80")
+        smem_capacity = cutlass.memory.get_smem_capacity_in_bytes("sm_80")
         if smem_usage > smem_capacity:
             return False
         # Check if twice the block size is divisible by the number of threads
@@ -835,7 +834,7 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
         # ///////////////////////////////////////////////////////////////////////////////
         # Get shared memory buffer
         # ///////////////////////////////////////////////////////////////////////////////
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(SharedStorage)
         sQ = storage.sQ.get_tensor(sQ_layout)
         sK = storage.sK.get_tensor(sK_layout)

--- a/flash_attn/cute/flash_fwd.py
+++ b/flash_attn/cute/flash_fwd.py
@@ -16,7 +16,6 @@ import cutlass
 import cutlass.cute as cute
 from cutlass import Float32, Int32, const_expr
 from cutlass.cute.nvgpu import cpasync, warp
-import cutlass.utils as utils_basic
 from cutlass.base_dsl.arch import Arch
 from cutlass.cutlass_dsl import BaseDSL
 
@@ -166,7 +165,7 @@ class FlashAttentionForwardBase:
         )
         smem_usage = smem_usage_QV + smem_usage_K
         # TODO: sm86 and sm89
-        smem_capacity = utils_basic.get_smem_capacity_in_bytes("sm_80")
+        smem_capacity = cutlass.memory.get_smem_capacity_in_bytes("sm_80")
         if smem_usage > smem_capacity:
             return False
         # Check if twice the block size is divisible by the number of threads
@@ -839,7 +838,7 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
         # ///////////////////////////////////////////////////////////////////////////////
         # Get shared memory buffer
         # ///////////////////////////////////////////////////////////////////////////////
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(SharedStorage)
         sQ = storage.sQ.get_tensor(sQ_layout)
         sK = storage.sK.get_tensor(sK_layout)

--- a/flash_attn/cute/flash_fwd_combine.py
+++ b/flash_attn/cute/flash_fwd_combine.py
@@ -357,7 +357,7 @@ class FlashAttentionForwardCombine:
         # ///////////////////////////////////////////////////////////////////////////////
         # Get shared memory buffer
         # ///////////////////////////////////////////////////////////////////////////////
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(SharedStorage)
         sLSE = storage.sLSE.get_tensor(smem_layout_lse)
         sMaxValidSplit = storage.sMaxValidSplit.get_tensor((self.tile_m,))

--- a/flash_attn/cute/flash_fwd_combine.py
+++ b/flash_attn/cute/flash_fwd_combine.py
@@ -391,7 +391,7 @@ class FlashAttentionForwardCombine:
         # ///////////////////////////////////////////////////////////////////////////////
         # Get shared memory buffer
         # ///////////////////////////////////////////////////////////////////////////////
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(SharedStorage)
         sLSE = storage.sLSE.get_tensor(smem_layout_lse)
         sMaxValidSplit = storage.sMaxValidSplit.get_tensor((self.tile_m,))

--- a/flash_attn/cute/flash_fwd_mla_sm100.py
+++ b/flash_attn/cute/flash_fwd_mla_sm100.py
@@ -448,10 +448,10 @@ class FlashAttentionMLAForwardSm100:
 
         topk_length_dynamic = mIndexTopk.shape[0] if mIndexTopk is not None else None
 
-        self.o_layout = cutlass.utils.LayoutEnum.from_tensor(mO)
-        self.p_layout = cutlass.utils.LayoutEnum.ROW_MAJOR
+        self.o_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(mO)
+        self.p_layout = cutlass.tensor_utils.LayoutEnum.ROW_MAJOR
         if const_expr(self.store_P):
-            assert cutlass.utils.LayoutEnum.from_tensor(mP) == self.p_layout
+            assert cutlass.tensor_utils.LayoutEnum.from_tensor(mP) == self.p_layout
 
         mO_og = mO
         mP_og = mP
@@ -811,7 +811,7 @@ class FlashAttentionMLAForwardSm100:
         is_leader_cta = mma_tile_coord_v == 0
 
         # ==== Allocate SMEM ====
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(SharedStorage)
 
         # ==== TMEM stuff ====
@@ -819,7 +819,7 @@ class FlashAttentionMLAForwardSm100:
             barrier_id=int(NamedBarrierFwdSm100_MLA2CTA.TmemPtr),
             num_threads=self.num_mma_threads + self.num_softmax_threads + self.num_epilogue_threads,
         )
-        tmem = cutlass.utils.TmemAllocator(
+        tmem = cutlass.memory.TmemAllocator(
             storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=tmem_alloc_barrier,
             allocator_warp_id=self.mma_warp_id,

--- a/flash_attn/cute/flash_fwd_sm100.py
+++ b/flash_attn/cute/flash_fwd_sm100.py
@@ -484,7 +484,7 @@ class FlashAttentionForwardSm100:
         q_major_mode = tcgen05.OperandMajorMode.K
         k_major_mode = tcgen05.OperandMajorMode.K
         v_major_mode = tcgen05.OperandMajorMode.MN
-        self.o_layout = cutlass.utils.LayoutEnum.from_tensor(mO)
+        self.o_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(mO)
         # the intermediate tensor p is from tmem & mK-major
         p_source = tcgen05.OperandSource.TMEM
         p_major_mode = tcgen05.OperandMajorMode.K
@@ -876,7 +876,7 @@ class FlashAttentionForwardSm100:
         is_leader_cta = mma_tile_coord_v == 0
 
         # Alloc
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(self.shared_storage)
 
         tmem_alloc_barrier = pipeline.NamedBarrier(
@@ -889,7 +889,7 @@ class FlashAttentionForwardSm100:
             ),
         )
         # Tensor memory dealloc barrier init
-        tmem = cutlass.utils.TmemAllocator(
+        tmem = cutlass.memory.TmemAllocator(
             storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=tmem_alloc_barrier,
             allocator_warp_id=self.mma_warp_id,

--- a/flash_attn/cute/flash_fwd_sm100.py
+++ b/flash_attn/cute/flash_fwd_sm100.py
@@ -535,7 +535,7 @@ class FlashAttentionForwardSm100:
         q_major_mode = tcgen05.OperandMajorMode.K
         k_major_mode = tcgen05.OperandMajorMode.K
         v_major_mode = tcgen05.OperandMajorMode.MN
-        self.o_layout = cutlass.utils.LayoutEnum.from_tensor(mO)
+        self.o_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(mO)
         # the intermediate tensor p is from tmem & mK-major
         p_source = tcgen05.OperandSource.TMEM
         p_major_mode = tcgen05.OperandMajorMode.K
@@ -950,7 +950,7 @@ class FlashAttentionForwardSm100:
         is_leader_cta = mma_tile_coord_v == 0
 
         # Alloc
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(self.shared_storage)
 
         tmem_alloc_barrier = pipeline.NamedBarrier(
@@ -963,7 +963,7 @@ class FlashAttentionForwardSm100:
             ),
         )
         # Tensor memory dealloc barrier init
-        tmem = cutlass.utils.TmemAllocator(
+        tmem = cutlass.memory.TmemAllocator(
             storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=tmem_alloc_barrier,
             allocator_warp_id=self.mma_warp_id,

--- a/flash_attn/cute/flash_fwd_sm120.py
+++ b/flash_attn/cute/flash_fwd_sm120.py
@@ -6,7 +6,6 @@
 # FlashAttentionForwardSm80 and overrides the SMEM capacity check accordingly.
 
 import cutlass
-import cutlass.utils as utils_basic
 from cutlass.base_dsl.arch import Arch
 
 from flash_attn.cute.flash_fwd import FlashAttentionForwardSm80
@@ -53,7 +52,7 @@ class FlashAttentionForwardSm120(FlashAttentionForwardSm80):
         )
         smem_usage = smem_usage_QV + smem_usage_K
         # SM120 has 99 KB shared memory (vs 163 KB on SM80)
-        smem_capacity = utils_basic.get_smem_capacity_in_bytes("sm_120")
+        smem_capacity = cutlass.memory.get_smem_capacity_in_bytes("sm_120")
         if smem_usage > smem_capacity:
             return False
         if (tile_m * 2) % num_threads != 0:

--- a/flash_attn/cute/flash_fwd_sm90.py
+++ b/flash_attn/cute/flash_fwd_sm90.py
@@ -11,7 +11,7 @@ import cutlass
 import cutlass.cute as cute
 from cutlass import Float32, Int32, const_expr
 from cutlass.cute.nvgpu import cpasync, warpgroup
-from cutlass.utils import LayoutEnum
+from cutlass.tensor_utils import LayoutEnum
 import cutlass.utils.hopper_helpers as sm90_utils_basic
 from cutlass import pipeline
 from cutlass.pipeline import pipeline_init_arrive, pipeline_init_wait
@@ -445,7 +445,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                 if const_expr(tma_atom is not None):
                     cpasync.prefetch_descriptor(tma_atom)
 
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(SharedStorage)
 
         # Mbarrier / pipeline init

--- a/flash_attn/cute/flash_fwd_sm90.py
+++ b/flash_attn/cute/flash_fwd_sm90.py
@@ -11,7 +11,7 @@ import cutlass
 import cutlass.cute as cute
 from cutlass import Float32, Int32, const_expr
 from cutlass.cute.nvgpu import cpasync, warpgroup
-from cutlass.utils import LayoutEnum
+from cutlass.tensor_utils import LayoutEnum
 import cutlass.utils.hopper_helpers as sm90_utils_basic
 from cutlass import pipeline
 from cutlass.pipeline import pipeline_init_arrive, pipeline_init_wait
@@ -450,7 +450,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
                 if const_expr(tma_atom is not None):
                     cpasync.prefetch_descriptor(tma_atom)
 
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(SharedStorage)
 
         # Mbarrier / pipeline init

--- a/flash_attn/cute/prepare_scheduler.py
+++ b/flash_attn/cute/prepare_scheduler.py
@@ -180,7 +180,7 @@ class FlashPrepareScheduler:
         warp_idx = cute.arch.warp_idx()
         lane_idx = cute.arch.lane_idx()
 
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(self.shared_storage)
         total_blocks_smem = storage.total_blocks_smem.get_tensor((1,))
 

--- a/flash_attn/cute/sm100_hd256_2cta_fmha_backward_dkdvkernel.py
+++ b/flash_attn/cute/sm100_hd256_2cta_fmha_backward_dkdvkernel.py
@@ -16,7 +16,6 @@ import cuda.bindings.driver as cuda
 import cutlass
 import cutlass.cute as cute
 from cutlass.cute.nvgpu import cpasync, tcgen05
-import cutlass.utils as utils
 import cutlass.pipeline as pipeline
 import cutlass.utils.blackwell_helpers as sm100_utils
 from cutlass.cute.typing import Int32
@@ -350,12 +349,12 @@ class BlackwellFusedMultiHeadAttentionBackwardDKDVKernel:
             ),
         )
 
-        self.Q_major_mode = utils.LayoutEnum.from_tensor(Q).mma_major_mode()
-        self.K_major_mode = utils.LayoutEnum.from_tensor(K).mma_major_mode()
-        self.dK_major_mode = utils.LayoutEnum.from_tensor(dK).mma_major_mode()
-        self.V_major_mode = utils.LayoutEnum.from_tensor(V).mma_major_mode()
-        self.dV_major_mode = utils.LayoutEnum.from_tensor(dV).mma_major_mode()
-        self.dO_major_mode = utils.LayoutEnum.from_tensor(dO).mma_major_mode()
+        self.Q_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(Q).mma_major_mode()
+        self.K_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(K).mma_major_mode()
+        self.dK_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(dK).mma_major_mode()
+        self.V_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(V).mma_major_mode()
+        self.dV_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(dV).mma_major_mode()
+        self.dO_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(dO).mma_major_mode()
 
         if cutlass.const_expr(self.Q_major_mode != tcgen05.OperandMajorMode.K):
             raise RuntimeError(f"The layout of q is not supported: {self.Q_major_mode}")
@@ -602,8 +601,8 @@ class BlackwellFusedMultiHeadAttentionBackwardDKDVKernel:
         num_epi_stages_dKV = (self.cta_tiler[2] // num_compute_wgs) // epi_cols_dKV
         epi_tile_dKV = (self.cta_tiler[1], epi_cols_dKV)
         total_epi_stages = num_compute_wgs * num_epi_stages_dKV
-        dK_layout_enum = utils.LayoutEnum.from_tensor(dK)
-        dV_layout_enum = utils.LayoutEnum.from_tensor(dV)
+        dK_layout_enum = cutlass.tensor_utils.LayoutEnum.from_tensor(dK)
+        dV_layout_enum = cutlass.tensor_utils.LayoutEnum.from_tensor(dV)
         sdK_epi_layout = sm100_utils.make_smem_layout_epi(
             dK.element_type,
             dK_layout_enum,
@@ -853,7 +852,7 @@ class BlackwellFusedMultiHeadAttentionBackwardDKDVKernel:
             cpasync.prefetch_descriptor(tma_atom_dO)
             cpasync.prefetch_descriptor(tma_atom_dOT)
 
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(self.shared_storage)
 
         load_mma_Q_producer, load_mma_Q_consumer = pipeline.PipelineTmaUmma.create(
@@ -1028,7 +1027,7 @@ class BlackwellFusedMultiHeadAttentionBackwardDKDVKernel:
             num_threads=self.threads_per_cta,
         )
 
-        tmem = utils.TmemAllocator(
+        tmem = cutlass.memory.TmemAllocator(
             storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=tmem_alloc_barrier,
             allocator_warp_id=self.load_warp_id,

--- a/flash_attn/cute/sm100_hd256_2cta_fmha_backward_dqkernel.py
+++ b/flash_attn/cute/sm100_hd256_2cta_fmha_backward_dqkernel.py
@@ -9,7 +9,6 @@ import cutlass
 import cutlass.cute as cute
 import cutlass.cute.nvgpu.tcgen05 as tcgen05
 from cutlass.cute.nvgpu import cpasync
-import cutlass.utils as utils
 import cutlass.pipeline as pipeline
 import cutlass.utils.blackwell_helpers as sm100_utils
 from cutlass.cute.typing import Int32, Int64, Float32
@@ -307,11 +306,11 @@ class BlackwellFusedMultiHeadAttentionBackwardDQKernel:
                 self.is_persistent,
             )
 
-        self.q_major_mode = utils.LayoutEnum.from_tensor(q).mma_major_mode()
-        self.do_major_mode = utils.LayoutEnum.from_tensor(do).mma_major_mode()
-        self.k_major_mode = utils.LayoutEnum.from_tensor(k).mma_major_mode()
-        self.v_major_mode = utils.LayoutEnum.from_tensor(v).mma_major_mode()
-        self.dq_layout = utils.LayoutEnum.from_tensor(dq)
+        self.q_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(q).mma_major_mode()
+        self.do_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(do).mma_major_mode()
+        self.k_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(k).mma_major_mode()
+        self.v_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(v).mma_major_mode()
+        self.dq_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(dq)
 
         if cutlass.const_expr(self.q_major_mode != tcgen05.OperandMajorMode.K):
             raise RuntimeError("The layout of q is not supported")
@@ -643,7 +642,7 @@ class BlackwellFusedMultiHeadAttentionBackwardDQKernel:
         block_in_cluster_coord_vmnk = cluster_layout_vmnk.get_flat_coord(cta_rank_in_cluster)
 
         # Alloc
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(self.shared_storage)
 
         load_q_producer, load_q_consumer = pipeline.PipelineTmaUmma.create(
@@ -750,7 +749,7 @@ class BlackwellFusedMultiHeadAttentionBackwardDQKernel:
         ).make_participants()
 
         # Tensor memory dealloc barrier init
-        tmem = utils.TmemAllocator(
+        tmem = cutlass.memory.TmemAllocator(
             storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=self.tmem_alloc_barrier,
             allocator_warp_id=self.epilogue_warp_ids[0],

--- a/flash_attn/cute/sm100_hd256_2cta_fmha_forward.py
+++ b/flash_attn/cute/sm100_hd256_2cta_fmha_forward.py
@@ -8,7 +8,6 @@ import cuda.bindings.driver as cuda
 import cutlass
 import cutlass.cute as cute
 import cutlass.cute.nvgpu.tcgen05 as tcgen05
-import cutlass.utils as utils
 import cutlass.pipeline as pipeline
 import cutlass.utils.blackwell_helpers as sm100_utils
 from cutlass.cute.typing import Int32, Int64, Float32
@@ -401,10 +400,10 @@ class BlackwellFusedMultiHeadAttentionForward:
                 self.is_persistent,
             )
 
-        self.q_major_mode = utils.LayoutEnum.from_tensor(q).mma_major_mode()
-        self.k_major_mode = utils.LayoutEnum.from_tensor(k).mma_major_mode()
-        self.v_major_mode = utils.LayoutEnum.from_tensor(v).mma_major_mode()
-        self.o_layout = utils.LayoutEnum.from_tensor(o)
+        self.q_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(q).mma_major_mode()
+        self.k_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(k).mma_major_mode()
+        self.v_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(v).mma_major_mode()
+        self.o_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(o)
 
         if cutlass.const_expr(self.q_major_mode != tcgen05.OperandMajorMode.K):
             raise RuntimeError("The layout of q is not supported")
@@ -626,7 +625,7 @@ class BlackwellFusedMultiHeadAttentionForward:
         block_in_cluster_coord_vmnk = cluster_layout_vmnk.get_flat_coord(cta_rank_in_cluster)
 
         # Alloc
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(self.shared_storage)
 
         load_q_producer, load_q_consumer = pipeline.PipelineTmaUmma.create(
@@ -700,7 +699,7 @@ class BlackwellFusedMultiHeadAttentionForward:
             defer_sync=True,
         ).make_participants()
         # Tensor memory dealloc barrier init
-        tmem = utils.TmemAllocator(
+        tmem = cutlass.memory.TmemAllocator(
             storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=self.tmem_alloc_barrier,
             allocator_warp_id=self.correction_warp_ids[0],

--- a/flash_attn/cute/sm100_hd256_2cta_fmha_forward.py
+++ b/flash_attn/cute/sm100_hd256_2cta_fmha_forward.py
@@ -8,7 +8,6 @@ import cuda.bindings.driver as cuda
 import cutlass
 import cutlass.cute as cute
 import cutlass.cute.nvgpu.tcgen05 as tcgen05
-import cutlass.utils as utils
 import cutlass.pipeline as pipeline
 import cutlass.utils.blackwell_helpers as sm100_utils
 from cutlass.cute.typing import Int32, Int64, Float32
@@ -407,10 +406,10 @@ class BlackwellFusedMultiHeadAttentionForward:
                 self.is_persistent,
             )
 
-        self.q_major_mode = utils.LayoutEnum.from_tensor(q).mma_major_mode()
-        self.k_major_mode = utils.LayoutEnum.from_tensor(k).mma_major_mode()
-        self.v_major_mode = utils.LayoutEnum.from_tensor(v).mma_major_mode()
-        self.o_layout = utils.LayoutEnum.from_tensor(o)
+        self.q_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(q).mma_major_mode()
+        self.k_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(k).mma_major_mode()
+        self.v_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(v).mma_major_mode()
+        self.o_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(o)
 
         if cutlass.const_expr(self.q_major_mode != tcgen05.OperandMajorMode.K):
             raise RuntimeError("The layout of q is not supported")
@@ -632,7 +631,7 @@ class BlackwellFusedMultiHeadAttentionForward:
         block_in_cluster_coord_vmnk = cluster_layout_vmnk.get_flat_coord(cta_rank_in_cluster)
 
         # Alloc
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(self.shared_storage)
 
         load_q_producer, load_q_consumer = pipeline.PipelineTmaUmma.create(
@@ -706,7 +705,7 @@ class BlackwellFusedMultiHeadAttentionForward:
             defer_sync=True,
         ).make_participants()
         # Tensor memory dealloc barrier init
-        tmem = utils.TmemAllocator(
+        tmem = cutlass.memory.TmemAllocator(
             storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=self.tmem_alloc_barrier,
             allocator_warp_id=self.correction_warp_ids[0],


### PR DESCRIPTION
Memory allocators and capacity queries:

- cutlass.utils.SmemAllocator -> cutlass.memory.SmemAllocator
- cutlass.utils.SmemPartition -> cutlass.memory.SmemPartition
- cutlass.utils.TmemAllocator -> cutlass.memory.TmemAllocator
- cutlass.utils.TmemBufferPool -> cutlass.memory.TmemBufferPool
- cutlass.utils.VirtualMemoryManager -> cutlass.memory.VirtualMemoryManager
- cutlass.utils.get_smem_capacity_in_bytes -> cutlass.memory.get_smem_capacity_in_bytes
- cutlass.utils.get_kernel_smem_size -> cutlass.memory.get_kernel_smem_size
- cutlass.utils.get_num_tmem_alloc_cols -> cutlass.memory.get_num_tmem_alloc_cols
- cutlass.utils.compute_tmem_cols_from_layout -> cutlass.memory.compute_tmem_cols_from_layout

Tensor description utilities:

- cutlass.utils.LayoutEnum -> cutlass.tensor_utils.LayoutEnum
- cutlass.utils.TensorMapManager -> cutlass.tensor_utils.TensorMapManager
- cutlass.utils.TensorMapUpdateMode -> cutlass.tensor_utils.TensorMapUpdateMode

Block copy:

- cutlass.utils.block_copy -> cutlass.block.block_copy

Layout visualization:

- cutlass.utils.print_latex -> cutlass.cute.viz.print_latex
- cutlass.utils.print_latex_tv -> cutlass.cute.viz.print_latex_tv
- cutlass.utils.PALETTES / Band / tikz_* -> cutlass.cute.viz.*