### PR TITLE
[CuTe, FA4] Preserve first-tile flag during scheduler reconstruction

### DIFF
--- a/flash_attn/cute/pyproject.toml
+++ b/flash_attn/cute/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "nvidia-cutlass-dsl==4.6.0.dev0",
+    "nvidia-cutlass-dsl==4.7.0",
     "torch",
     "einops",
     "typing_extensions",
@@ -32,7 +32,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-cu13 = ["nvidia-cutlass-dsl[cu13]==4.6.0.dev0"]
+cu13 = ["nvidia-cutlass-dsl[cu13]==4.7.0"]
 dev = [
     "pytest",
     "pytest-xdist",

--- a/flash_attn/cute/pyproject.toml
+++ b/flash_attn/cute/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "nvidia-cutlass-dsl==4.7.0",
+    "nvidia-cutlass-dsl==4.6.0.dev0",
     "torch",
     "einops",
     "typing_extensions",
@@ -32,7 +32,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-cu13 = ["nvidia-cutlass-dsl[cu13]==4.7.0"]
+cu13 = ["nvidia-cutlass-dsl[cu13]==4.6.0.dev0"]
 dev = [
     "pytest",
     "pytest-xdist",

--- a/flash_attn/cute/tile_scheduler.py
+++ b/flash_attn/cute/tile_scheduler.py
@@ -281,7 +281,10 @@ class SingleTileScheduler:
         for obj, n_items in zip([self.params, self._blk_coord], self._values_pos):
             obj_list.append(cutlass.new_from_mlir_values(obj, values[:n_items]))
             values = values[n_items:]
-        return SingleTileScheduler(*(tuple(obj_list)), loc=self._loc)
+        scheduler = SingleTileScheduler(*(tuple(obj_list)), loc=self._loc)
+        # Preserve the Python-only first-tile flag across CuTe reconstruction.
+        scheduler._is_first_block = self._is_first_block
+        return scheduler
 
 
 class StaticPersistentTileScheduler:
@@ -1114,7 +1117,10 @@ class SingleTileVarlenScheduler:
         for obj, n_items in zip(objs, self._values_pos):
             obj_list.append(cutlass.new_from_mlir_values(obj, values[:n_items]))
             values = values[n_items:]
-        return self.__class__(*obj_list, loc=self._loc)
+        scheduler = self.__class__(*obj_list, loc=self._loc)
+        # Preserve the Python-only first-tile flag across CuTe reconstruction.
+        scheduler._is_first_block = self._is_first_block
+        return scheduler
 
 
 # -----------------------------------------------------------------------------
@@ -1367,9 +1373,12 @@ class Sm100FmhaStaticTileScheduler:
         )
         new_blk_coord = new_from_mlir_values(self._blk_coord, values[4:7])
         new_grid_shape = new_from_mlir_values(self._grid_shape, values[7:])
-        return Sm100FmhaStaticTileScheduler(
+        scheduler = Sm100FmhaStaticTileScheduler(
             new_params, new_current_work_linear_idx, new_blk_coord, new_grid_shape
         )
+        # Preserve the Python-only first-tile flag across CuTe reconstruction.
+        scheduler._is_first_block = self._is_first_block
+        return scheduler
 
 
 def compute_sm100_fmha_grid(

--- a/flash_attn/cute/tile_scheduler.py
+++ b/flash_attn/cute/tile_scheduler.py
@@ -343,7 +343,8 @@ class SingleTileScheduler:
             obj_list.append(cutlass.new_from_mlir_values(obj, values[:n_items]))
             values = values[n_items:]
         scheduler = SingleTileScheduler(*(tuple(obj_list)), loc=self._loc)
-        # Preserve the Python-only first-tile flag across CuTe reconstruction.
+        # Note: _is_first_block is a Python-only attribute omitted from MLIR values,
+        # so it must be restored explicitly after reconstruction.
         scheduler._is_first_block = self._is_first_block
         return scheduler
 
@@ -1389,7 +1390,7 @@ class SingleTileVarlenScheduler:
             obj_list.append(cutlass.new_from_mlir_values(obj, values[:n_items]))
             values = values[n_items:]
         scheduler = self.__class__(*obj_list, loc=self._loc)
-        # Preserve the Python-only first-tile flag across CuTe reconstruction.
+        # See the note on Python-only attributes in SingleTileScheduler.
         scheduler._is_first_block = self._is_first_block
         return scheduler
 
@@ -1836,7 +1837,7 @@ class Sm100FmhaStaticTileScheduler:
         scheduler = Sm100FmhaStaticTileScheduler(
             new_params, new_current_work_linear_idx, new_blk_coord, new_grid_shape
         )
-        # Preserve the Python-only first-tile flag across CuTe reconstruction.
+        # See the note on Python-only attributes in SingleTileScheduler.
         scheduler._is_first_block = self._is_first_block
         return scheduler
 


### PR DESCRIPTION
## Summary

Preserve the Python-only `_is_first_block` flag when CuTe reconstructs FlashAttention single-tile schedulers from their MLIR values.

## Root cause

These schedulers omit `_is_first_block` from their MLIR representation, but their constructors initialize it to `True`.

After `advance_to_next_work()` marks the first tile consumed, reconstruction therefore resets the omitted flag and makes the first tile valid again. The kernel can repeat that tile and deadlock its producer/consumer pipeline.

## Change

Copy `_is_first_block` from the original object after reconstructing:

- `SingleTileScheduler`
- `SingleTileVarlenScheduler`
- `Sm100FmhaStaticTileScheduler`

## Validation
Main branch and cutlass-4.7.0 could pass with this change