### PR TITLE
chore: set stable cutlass 4.6.0 version for FA4

### DIFF
--- a/flash_attn/cute/pyproject.toml
+++ b/flash_attn/cute/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "nvidia-cutlass-dsl==4.6.0.dev0",
+    "nvidia-cutlass-dsl==4.6.0",
     "torch",
     "einops",
     "typing_extensions",
@@ -32,7 +32,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-cu13 = ["nvidia-cutlass-dsl[cu13]==4.6.0.dev0"]
+cu13 = ["nvidia-cutlass-dsl[cu13]==4.6.0"]
 dev = [
     "pytest",
     "pytest-xdist",


### PR DESCRIPTION
There's upstream 4.6.0 for cutlass now. This also makes it compatible with latest sonicmoe which has also integrated 4.6.0. This will also then not require `pre-release` flag if using with `uv`.


Note: I've only done some light test with this (for run with Axolotl downstream) and not full expansive checks across whole FA4.