### PR TITLE
[CuTe,Sm100,Fwd] fp8: bound lazy-rescale threshold by e4m3 range (fixes silent O corruption on peaked softmax rows)

### DIFF
--- a/flash_attn/cute/flash_fwd_sm100.py
+++ b/flash_attn/cute/flash_fwd_sm100.py
@@ -2033,9 +2033,13 @@ class FlashAttentionForwardSm100:
                 softmax_scale_log2_eff = softmax_scale_log2
                 softmax_scale_eff = softmax_scale * qk_descale
 
+            # fp8: the threshold must keep exp2(threshold + max_offset) within
+            # e4m3's finite range, else the P convert saturates at 448 while
+            # row_sum accumulates the unsaturated fp32 value and dominant keys
+            # on peaked rows are underweighted. Bound: log2(448) - 8 = 0.807.
             rescale_threshold = (
                 8.0 if const_expr(self.q_dtype.width == 16) else
-                4.0 if const_expr(self.q_dtype.width == 8) else
+                0.75 if const_expr(self.q_dtype.width == 8) else
                 0.0
             )
             softmax = SoftmaxSm100.create(

--- a/tests/cute/test_fp8_rescale_saturation.py
+++ b/tests/cute/test_fp8_rescale_saturation.py
@@ -1,0 +1,67 @@
+# Regression test for the fp8 lazy-rescale saturation bug: with a rescale
+# threshold above log2(448) - max_offset(8) = 0.807, P values overflow e4m3's
+# finite range (448) at the P convert while row_sum accumulates the
+# unsaturated fp32 value, underweighting dominant keys on peaked softmax rows.
+# The trigger is the logit distribution (std >~ 0.8), not shape -- so this
+# test sweeps logit std and compares against an fp32 reference computed from
+# the dequantized inputs (isolating kernel numerics from quantization noise).
+import math
+
+import pytest
+import torch
+
+from flash_attn.cute.interface import _flash_attn_fwd
+
+B, H, S, D = 1, 4, 4096, 128
+SCALE = 1.0 / math.sqrt(D)
+E4M3 = torch.float8_e4m3fn
+
+
+def _sm100_available():
+    return torch.cuda.is_available() and torch.cuda.get_device_capability()[0] >= 10
+
+
+def _ref_fp32(qf, kf, vf):
+    logits = torch.einsum("bshd,bthd->bhst", qf, kf) * SCALE
+    p = torch.softmax(logits.float(), dim=-1)
+    return torch.einsum("bhst,bthd->bshd", p, vf.float())
+
+
+def _quant_per_tensor(x):
+    amax = x.abs().amax().clamp(min=1e-8)
+    scale = 448.0 / amax
+    xq = (x * scale).clamp(-448, 448).to(E4M3)
+    descale = torch.full((B, H), 1.0 / scale, device=x.device, dtype=torch.float32)
+    return xq, descale
+
+
+def _pearson(a, b):
+    a, b = a.flatten().float(), b.flatten().float()
+    a, b = a - a.mean(), b - b.mean()
+    return (a @ b / (a.norm() * b.norm() + 1e-12)).item()
+
+
+@pytest.mark.skipif(not _sm100_available(), reason="requires SM100/SM103")
+@pytest.mark.parametrize("logit_std", [0.1, 0.5, 0.8, 1.0, 1.5, 2.5, 5.0])
+def test_fp8_no_rescale_saturation(logit_std):
+    torch.manual_seed(0)
+    q = torch.randn(B, S, H, D, device="cuda", dtype=torch.bfloat16)
+    k = torch.randn(B, S, H, D, device="cuda", dtype=torch.bfloat16)
+    v = torch.randn(B, S, H, D, device="cuda", dtype=torch.bfloat16)
+    # calibrate q so the attention logits have the target std
+    sample = torch.einsum("bshd,bthd->bhst", q[:, :256].float(), k[:, :256].float()) * SCALE
+    q = q * (logit_std / sample.std().clamp(min=1e-6)).to(torch.bfloat16)
+
+    q8, qs = _quant_per_tensor(q.float())
+    k8, ks = _quant_per_tensor(k.float())
+    v8, vs = _quant_per_tensor(v.float())
+    # dequantized-exact reference: quantization error cancels on both sides
+    ref = _ref_fp32(q8.float() * qs[0, 0], k8.float() * ks[0, 0], v8.float() * vs[0, 0])
+
+    out = _flash_attn_fwd(
+        q8, k8, v8, causal=False, q_descale=qs, k_descale=ks, v_descale=vs
+    )[0]
+    p = _pearson(out, ref)
+    # stock threshold 4.0 fails std >= 0.8 cells (pearson 0.92-0.99);
+    # any threshold <= 0.807 passes all cells at fp8-noise residuals.
+    assert p >= 0.999, f"logit_std={logit_std}: pearson {p:.6f} < 0.999"


### PR DESCRIPTION
> **Disclaimer:** this investigation, fix, and validation are **fully AI-agent-driven** (kernel-level bisect, probes, and the tables below included). The mechanism and numbers have been verified end-to-end on our side, but we'd appreciate a close look from someone familiar with the lazy-rescale logic before merging — in particular whether you'd prefer the dtype-derived bound or row_sum-side saturation over the constant (see Alternatives).

## What

One-line change: the fp8 lazy-rescale threshold in `flash_attn/cute/flash_fwd_sm100.py` goes from `4.0` to `0.75`, keeping `exp2(threshold + max_offset)` within e4m3's finite range (`log2(448) − 8 ≈ 0.807`), plus a regression test.

## Why

With threshold `4.0` and the fp8 `max_offset` of 8, a row whose running max lags the true tile max by up to the threshold produces P values up to `exp2(4 + 8) = 4096`. The e4m3 P conversion saturates those at **448**, but `row_sum` is accumulated from the **unsaturated** fp32 values — numerator (P@V) and denominator disagree, and the *dominant* keys of peaked softmax rows lose up to `1 − 448/4096 ≈ 89%` of their weight. LSE stays exact (max and row_sum are fp32), so only O is wrong — silently.

The trigger is the logit distribution, not shape: logits with std ≳ 0.8 make per-tile max jumps exceed 0.807 log2 units. Low-variance random payloads (e.g. `randn * 0.1`) never trip it, which is presumably why existing tests pass. The failure is independent of seqlen (identical at S≈4k and S≈68k), 2CTA mode, and descale configuration; bf16/fp16 and e5m2 are unaffected (no saturation at their ranges). The MLA fwd kernel already ships `0.0` for fp8, consistent with this bound.

## Verified repro (`flash-attn-4==4.0.0b22`, GB300/sm103)

`tests/cute/test_fp8_rescale_saturation.py` (added in this PR) sweeps logit std at B=1 H=4 S=4096 D=128 non-causal, comparing against an fp32 reference computed from the *dequantized* inputs (quantization error cancels; only kernel numerics differ).

Stock b22:

```
 logit_std  pearson_fp8  max_abs_err
      0.10     0.999715       0.0021
      0.30     0.999645       0.0023
      0.50     0.999554       0.0071
      0.80     0.996126       0.0656   <- onset, as predicted by log2(448)-8
      1.00     0.987032       0.0842
      1.50     0.931440       0.3713
      2.50     0.918562       1.9175
      5.00     0.934590       3.6577
```

Same install, only this patch applied:

```
      0.10     0.999715       0.0021
      0.30     0.999646       0.0023
      0.50     0.999656       0.0023
      0.80     0.999649       0.0029
      1.00     0.999670       0.0038
      1.50     0.999750       0.0108
      2.50     0.999892       0.0509
      5.00     0.999954       0.0857   (residual = fp8 quantization noise)
```

## Cost

≤2% forward time measured at S=68k / hdim128 / sm103 (throughput ~flat at long S — the extra rescales concentrate in the first tiles of each row while the running max climbs). fp16/bf16 paths untouched.

## Alternatives (happy to switch this PR to either)

- **Dtype-derived bound**: `log2(dtype_max) − max_offset` instead of the constant — preserves e5m2's headroom (~7.8) if P ever converts to e5m2. Slightly more code; arguably the principled form.
- **Saturate `row_sum` consistently with P** (accumulate `min(P, 448)`): keeps threshold 4.0's rescale frequency, but subtly changes softmax semantics and adds a clamp on the accumulation path; not pursued.
