### PR TITLE
hopper: expose seqused_q for KV-cache decode

### DIFF
--- a/hopper/flash_attn_interface.py
+++ b/hopper/flash_attn_interface.py
@@ -954,6 +954,7 @@ def flash_attn_with_kvcache(
     page_table: Optional[torch.Tensor] = None,
     cu_seqlens_q: Optional[torch.Tensor] = None,
     cu_seqlens_k_new: Optional[torch.Tensor] = None,
+    seqused_q: Optional[torch.Tensor] = None,
     max_seqlen_q: Optional[int] = None,
     rotary_seqlens: Optional[torch.Tensor] = None,
     q_descale: Optional[torch.Tensor] = None,
@@ -1029,6 +1030,9 @@ def flash_attn_with_kvcache(
         rotary_sin [optional]: (seqlen_ro, rotary_dim / 2). Similar to rotary_cos.
         cache_seqlens: int, or (batch_size,), dtype torch.int32. The sequence lengths of the
             KV cache.
+        seqused_q: Optional[torch.Tensor]: Per-batch number of query tokens to
+            execute. Query rows beyond this length are not written and may be
+            left uninitialized.
         cache_batch_idx: (batch_size,), dtype torch.int32. The indices used to index into the KV cache.
             If None, we assume that the batch indices are [0, 1, 2, ..., batch_size - 1].
             If the indices are not distinct, and k and v are provided, the values updated in the cache
@@ -1076,7 +1080,7 @@ def flash_attn_with_kvcache(
         cu_seqlens_q,
         None,  # cu_seqlens_k
         cu_seqlens_k_new,
-        None,  # seqused_q
+        seqused_q,
         cache_seqlens,
         max_seqlen_q,
         None,  # max_seqlen_k
@@ -1110,6 +1114,7 @@ def get_scheduler_metadata(
     headdim_v=None,
     cu_seqlens_q: Optional[torch.Tensor] = None,
     cu_seqlens_k_new: Optional[torch.Tensor] = None,
+    seqused_q: Optional[torch.Tensor] = None,
     cache_leftpad: Optional[torch.Tensor] = None,
     page_size: Optional[int] = None,
     max_seqlen_k_new=0,
@@ -1131,7 +1136,7 @@ def get_scheduler_metadata(
         cu_seqlens_q,
         None,  # cu_seqlens_k
         cu_seqlens_k_new,
-        None,  # seqused_q
+        seqused_q,
         cache_leftpad,
         page_size,
         max_seqlen_k_new,

--- a/hopper/test_attn_kvcache.py
+++ b/hopper/test_attn_kvcache.py
@@ -482,5 +482,35 @@ def test_flash_attn_kvcache_output_fp8(nheads_kv, gqa_ratio, num_requests, query
                 assert ((lse_mean_ref == math.inf and lse_mean_fa3 == math.inf) or lse_mean_diff <= 1e-4)
 
 
+@pytest.mark.parametrize("causal", [True, False])
+def test_flash_attn_kvcache_seqused_q_skips_inactive_queries(causal):
+    device = "cuda"
+    q = torch.randn((2, 4, 2, 64), device=device, dtype=torch.bfloat16)
+    k_cache = torch.randn((2, 128, 2, 64), device=device, dtype=torch.bfloat16)
+    v_cache = torch.randn((2, 128, 2, 64), device=device, dtype=torch.bfloat16)
+
+    out, lse = flash_attn_interface.flash_attn_with_kvcache(
+        q=q,
+        k_cache=k_cache,
+        v_cache=v_cache,
+        cache_seqlens=torch.tensor([32, 0], dtype=torch.int32, device=device),
+        seqused_q=torch.tensor([2, 0], dtype=torch.int32, device=device),
+        causal=causal,
+        num_splits=1,
+        return_softmax_lse=True,
+    )
+    ref_out, ref_lse = flash_attn_interface.flash_attn_with_kvcache(
+        q=q[:1, :2],
+        k_cache=k_cache[:1],
+        v_cache=v_cache[:1],
+        cache_seqlens=torch.tensor([32], dtype=torch.int32, device=device),
+        causal=causal,
+        num_splits=1,
+        return_softmax_lse=True,
+    )
+
+    torch.testing.assert_close(out[0, :2], ref_out[0], atol=2e-3, rtol=2e-3)
+    torch.testing.assert_close(lse[0, :, :2], ref_lse[0], atol=2e-3, rtol=2e-3)
+
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary

- expose the existing FA3 `seqused_q` scheduler input through `flash_attn_with_kvcache`
- forward it through `get_scheduler_metadata`
- add a correctness regression test for padded decode queries

## Motivation

FA3 already supports `seqused_q` internally and uses it to avoid scheduling work for inactive query rows. The KV-cache wrapper currently hard-codes this input to `None`, forcing static padded query rows to run during packed decode workloads.

## Related issue

Addresses #2015.

## Verification

- `python3 -m py_compile hopper/flash_attn_interface.py hopper/test_attn_kvcache.py`
- `git diff --check`
- Hopper CUDA test not run locally because this machine has no CUDA toolkit/GPU.
