### PR TITLE
[CuTe, SM100, bwd] fix: SM100 backward for padded head dimensions

### DIFF
--- a/flash_attn/cute/flash_bwd_postprocess.py
+++ b/flash_attn/cute/flash_bwd_postprocess.py
@@ -166,7 +166,7 @@ class FlashAttentionBackwardPostprocess:
                 (self.tile_m * self.tile_hdim // num_wg_mma, num_wg_mma)
             )
         else:
-            self.dQ_reduce_ncol = 32
+            self.dQ_reduce_ncol = math.gcd(32, self.tile_hdim)
             dQaccum_reduce_stage = self.tile_hdim // self.dQ_reduce_ncol
             assert self.num_threads == 128  # TODO: currently hard-coded
             self.s2r_tiled_copy_dQaccum = copy_utils.tiled_copy_1d(

--- a/flash_attn/cute/flash_bwd_postprocess.py
+++ b/flash_attn/cute/flash_bwd_postprocess.py
@@ -56,8 +56,8 @@ class FlashAttentionBackwardPostprocess:
             "Only Ampere (8.x), Hopper (9.x), and Blackwell (10.x, 11.x, 12.x) are supported"
         )
         self.arch = arch
-        # padding head_dim to a multiple of 32 as k_block_size
-        hdim_multiple_of = 32
+        # SM100/SM110 backward accumulates packed 16-column head-dimension tiles.
+        hdim_multiple_of = 16 if arch // 10 in [10, 11] else 32
         self.tile_hdim = int(math.ceil(head_dim / hdim_multiple_of) * hdim_multiple_of)
         self.check_hdim_oob = head_dim != self.tile_hdim
         self.num_threads = num_threads

--- a/flash_attn/cute/flash_bwd_preprocess.py
+++ b/flash_attn/cute/flash_bwd_preprocess.py
@@ -13,7 +13,6 @@
 # So the main backward kernel is unchanged; we just replace D with D' = D - dLSE here.
 import math
 import operator
-from functools import partial
 from typing import Callable, Type, Optional
 
 import cuda.bindings.driver as cuda
@@ -365,8 +364,6 @@ class FlashAttentionBackwardPreprocess:
             tOpO = None
             if const_expr(self.check_hdim_v_oob):
                 tOpO = copy_utils.predicate_k(tOcO, limit=headdim_v)
-            # Each copy will use the same predicate
-            copy = partial(copy_utils.copy, pred=tOpO)
 
             tOrO = cute.make_rmem_tensor_like(tOgO)
             tOrdO = cute.make_rmem_tensor_like(tOgdO)
@@ -378,8 +375,9 @@ class FlashAttentionBackwardPreprocess:
                 # Instead of using tOcO, we using t0OcO and subtract the offset from the limit.
                 # This is bc the entries of t0OcO are known at compile time.
                 if t0OcO[0, m, 0][0] < seqlen_limit - tOcO[0][0]:
-                    copy(tOgO[None, m, None], tOrO[None, m, None])
-                    copy(tOgdO[None, m, None], tOrdO[None, m, None])
+                    pred = tOpO[None, m, None] if const_expr(self.check_hdim_v_oob) else None
+                    copy_utils.copy(tOgO[None, m, None], tOrO[None, m, None], pred=pred)
+                    copy_utils.copy(tOgdO[None, m, None], tOrdO[None, m, None], pred=pred)
             # O and dO loads are done; signal that the next kernel can start.
             # Correctness is ensured by griddepcontrol_wait() in bwd_sm90 before it reads our outputs.
             if const_expr(self.use_pdl):

--- a/flash_attn/cute/flash_bwd_preprocess.py
+++ b/flash_attn/cute/flash_bwd_preprocess.py
@@ -48,6 +48,7 @@ class FlashAttentionBackwardPreprocess:
         pack_gqa: bool = False,
         qhead_per_kvhead: int = 1,
         nheads_kv: int = 1,
+        dq_accum_hdim_multiple: int = 32,
     ):
         """
         All contiguous dimensions must be at least 16 bytes aligned which indicates the head dimension
@@ -63,10 +64,13 @@ class FlashAttentionBackwardPreprocess:
         self.use_pdl = BaseDSL._get_dsl().get_arch_enum() >= Arch.sm_90a
         self.dtype = dtype
         self.tile_m = tile_m
-        # padding head_dim to a multiple of 32 as k_block_size
-        hdim_multiple_of = 32
-        self.head_dim_padded = int(math.ceil(head_dim / hdim_multiple_of) * hdim_multiple_of)
-        self.head_dim_v_padded = int(math.ceil(head_dim_v / hdim_multiple_of) * hdim_multiple_of)
+        self.head_dim_padded = int(
+            math.ceil(head_dim / dq_accum_hdim_multiple) * dq_accum_hdim_multiple
+        )
+        hdim_v_multiple_of = 32
+        self.head_dim_v_padded = int(
+            math.ceil(head_dim_v / hdim_v_multiple_of) * hdim_v_multiple_of
+        )
         self.check_hdim_v_oob = head_dim_v != self.head_dim_v_padded
         self.num_threads = num_threads
         self.use_padded_offsets = use_padded_offsets

--- a/flash_attn/cute/flash_bwd_sm100.py
+++ b/flash_attn/cute/flash_bwd_sm100.py
@@ -252,7 +252,7 @@ class FlashAttentionBackwardSm100:
                 self.sdQaccum_stage = 2 if self.deterministic else 4
                 self.dQ_reduce_ncol_t2r = 32
             else:
-                self.dQ_reduce_ncol = 32
+                self.dQ_reduce_ncol = math.gcd(32, self.tile_hdim)
                 self.sdQaccum_stage = 64 // self.dQ_reduce_ncol
                 self.dQ_reduce_ncol_t2r = self.dQ_reduce_ncol
         assert (self.tile_hdim // self.cta_group_size) % self.dQ_reduce_ncol == 0

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -1183,6 +1183,7 @@ def _compile_bwd_preprocess(
     pack_gqa,
     qhead_per_kvhead,
     nheads_kv,
+    dq_accum_hdim_multiple,
 ):
     """Compile bwd preprocess kernel using cute fake tensors (no real GPU tensors needed)."""
     mQ, mK, mV, mO, mdO, mdQ, mdK, mdV, mLSE, mLSElog2, mPdPsum, mdQaccum, mdKaccum, mdVaccum, mScaleP = make_fake_bwd_tensors(
@@ -1205,6 +1206,7 @@ def _compile_bwd_preprocess(
         pack_gqa=pack_gqa,
         qhead_per_kvhead=qhead_per_kvhead,
         nheads_kv=nheads_kv,
+        dq_accum_hdim_multiple=dq_accum_hdim_multiple,
     )
     return cute.compile(
         fa_bwd_pre, mO, mdO, mPdPsum, mLSE, mLSElog2, mdQaccum, mCuSeqlensQ, mSequsedQ, mdLSE,
@@ -1225,6 +1227,7 @@ def _bwd_preprocess(
     pack_gqa=False,
     qhead_per_kvhead=1,  # only used with pack_gqa
     nheads_kv=1,         # only used with pack_gqa
+    dq_accum_hdim_multiple=32,
     softmax_scale=1.0,   # only used with scale_p
 ):
     """Backward preprocess: compute (o * dout).sum(dim=-1) - dLSE, lse * log2_e, and zero out dq_accum."""
@@ -1242,6 +1245,7 @@ def _bwd_preprocess(
         pack_gqa,
         qhead_per_kvhead,
         nheads_kv,
+        dq_accum_hdim_multiple,
     )
     if compile_key not in _bwd_preprocess.compile_cache:
         _bwd_preprocess.compile_cache[compile_key] = _compile_bwd_preprocess(*compile_key)
@@ -1580,7 +1584,8 @@ def _flash_attn_bwd(
     else:
         _validate_tensor(dv, "dv", v.shape, out_torch_dtype, device)
 
-    head_dim_rounded = (head_dim + 32 - 1) // 32 * 32
+    accum_hdim_multiple = 16 if arch // 10 in [10, 11] else 32
+    head_dim_rounded = (head_dim + accum_hdim_multiple - 1) // accum_hdim_multiple * accum_hdim_multiple
 
     if cu_seqlens_q is None:
         dq_accum = (
@@ -1620,7 +1625,11 @@ def _flash_attn_bwd(
     # hd=256 2CTA backward has its own internal postprocess for dK/dV.
     dKV_postprocess = qhead_per_kvhead > 1 and not use_dedicated_hd256_kernel
     if dKV_postprocess:
-        head_dim_v_rounded = (head_dim_v + 32 - 1) // 32 * 32
+        head_dim_v_rounded = (
+            (head_dim_v + accum_hdim_multiple - 1)
+            // accum_hdim_multiple
+            * accum_hdim_multiple
+        )
         if cu_seqlens_k is None:
             dk_accum = torch.zeros(
                 batch_size,
@@ -1675,6 +1684,7 @@ def _flash_attn_bwd(
         out, dout, dpsum, lse, lse_log2, dq_accum,
         cu_seqlens_q, seqused_q, dlse,
         dtype, head_dim, head_dim_v, m_block_size,
+        dq_accum_hdim_multiple=accum_hdim_multiple,
     )
     # num_threads: SM90 derives from BwdConfig.num_wg, SM120 is set to 128 above,
     # SM100/SM110 uses default from function signature (384).

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -540,6 +540,32 @@ def test_flash_attn_hd256_sm100_noncontiguous_transpose():
     )
 
 
+@maybe_fake_tensor_mode(USE_FAKE_TENSOR)
+def test_flash_attn_sm100_head_dim_72_backward():
+    """Regression test for the backward preprocess O/dO predicate shape."""
+    if not IS_SM100:
+        pytest.skip("SM100-specific backward preprocess regression test")
+
+    torch.manual_seed(0)
+    shape = (1, 16, 1, 72)
+    q_ref, k_ref, v_ref = (
+        torch.randn(shape, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+        for _ in range(3)
+    )
+    q, k, v = (x.detach().clone().requires_grad_() for x in (q_ref, k_ref, v_ref))
+    out_ref, _ = attention_ref(q_ref, k_ref, v_ref)
+    out, _ = flash_attn_func(q, k, v)
+    if is_fake_mode():
+        return
+
+    grad = torch.randn_like(out)
+    grads_ref = torch.autograd.grad(out_ref, (q_ref, k_ref, v_ref), grad)
+    grads = torch.autograd.grad(out, (q, k, v), grad)
+    torch.testing.assert_close(out, out_ref, rtol=5e-2, atol=1e-2)
+    for actual, expected in zip(grads, grads_ref):
+        torch.testing.assert_close(actual, expected, rtol=1e-1, atol=2e-2)
+
+
 # @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float8_e4m3fn])
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 @pytest.mark.parametrize("mha_type", ["mha", "mqa", "gqa"])

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -541,13 +541,18 @@ def test_flash_attn_hd256_sm100_noncontiguous_transpose():
 
 
 @maybe_fake_tensor_mode(USE_FAKE_TENSOR)
-def test_flash_attn_sm100_head_dim_72_backward():
-    """Cover predicate and multi-block dQ accumulator padding for head_dim=72."""
+@pytest.mark.parametrize(
+    ("seqlen", "head_dim"),
+    [(16, 8), (256, 72)],
+    ids=["head_dim_8", "head_dim_72_multiblock"],
+)
+def test_flash_attn_sm100_padded_head_dim_backward(seqlen, head_dim):
+    """Cover small and multi-block padded head dimensions in SM100 backward."""
     if not IS_SM100:
         pytest.skip("SM100-specific backward preprocess regression test")
 
     torch.manual_seed(0)
-    shape = (1, 256, 1, 72)
+    shape = (1, seqlen, 1, head_dim)
     q_ref, k_ref, v_ref = (
         torch.randn(shape, device="cuda", dtype=torch.bfloat16, requires_grad=True)
         for _ in range(3)

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -571,6 +571,103 @@ def test_flash_attn_sm100_padded_head_dim_backward(seqlen, head_dim):
         torch.testing.assert_close(actual, expected, rtol=1e-1, atol=2e-2)
 
 
+@maybe_fake_tensor_mode(USE_FAKE_TENSOR)
+def test_flash_attn_sm100_varlen_gqa_padded_head_dim_backward():
+    """Cover varlen offsets and GQA dK/dV accumulation with 16-column padding."""
+    if not IS_SM100:
+        pytest.skip("SM100-specific backward accumulator regression test")
+
+    torch.manual_seed(0)
+    batch_size, seqlen_q, seqlen_k = 2, 129, 97
+    nheads, nheads_kv, head_dim = 4, 2, 72
+    q_ref = torch.randn(
+        batch_size,
+        seqlen_q,
+        nheads,
+        head_dim,
+        device="cuda",
+        dtype=torch.bfloat16,
+        requires_grad=True,
+    )
+    k_ref, v_ref = (
+        torch.randn(
+            batch_size,
+            seqlen_k,
+            nheads_kv,
+            head_dim,
+            device="cuda",
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+        for _ in range(2)
+    )
+    query_padding_mask = torch.arange(seqlen_q, device="cuda")[None, :] < torch.tensor(
+        [129, 65], device="cuda"
+    )[:, None]
+    key_padding_mask = torch.arange(seqlen_k, device="cuda")[None, :] < torch.tensor(
+        [97, 33], device="cuda"
+    )[:, None]
+    (
+        q_unpad,
+        k_unpad,
+        v_unpad,
+        _,
+        cu_seqlens_q,
+        cu_seqlens_k,
+        _,
+        _,
+        max_seqlen_q,
+        max_seqlen_k,
+        _,
+        _,
+        _,
+        _,
+        output_pad_fn,
+        dq_pad_fn,
+        dk_pad_fn,
+    ) = generate_qkv(
+        q_ref,
+        k_ref,
+        v_ref,
+        query_padding_mask,
+        key_padding_mask,
+    )
+
+    out_unpad, _ = flash_attn_varlen_func(
+        q_unpad,
+        k_unpad,
+        v_unpad,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        max_seqlen_q=max_seqlen_q,
+        max_seqlen_k=max_seqlen_k,
+        pack_gqa=False,
+    )
+    if is_fake_mode():
+        return
+
+    out_ref, _ = attention_ref(
+        q_ref,
+        k_ref,
+        v_ref,
+        query_padding_mask,
+        key_padding_mask,
+    )
+    grad_unpad = torch.randn_like(out_unpad)
+    grads_unpad = torch.autograd.grad(out_unpad, (q_unpad, k_unpad, v_unpad), grad_unpad)
+    grad = output_pad_fn(grad_unpad)
+    grads_ref = torch.autograd.grad(out_ref, (q_ref, k_ref, v_ref), grad)
+    grads = (
+        dq_pad_fn(grads_unpad[0]),
+        dk_pad_fn(grads_unpad[1]),
+        dk_pad_fn(grads_unpad[2]),
+    )
+
+    torch.testing.assert_close(output_pad_fn(out_unpad), out_ref, rtol=5e-2, atol=1e-2)
+    for actual, expected in zip(grads, grads_ref):
+        torch.testing.assert_close(actual, expected, rtol=1e-1, atol=2e-2)
+
+
 # @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float8_e4m3fn])
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 @pytest.mark.parametrize("mha_type", ["mha", "mqa", "gqa"])

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -542,12 +542,12 @@ def test_flash_attn_hd256_sm100_noncontiguous_transpose():
 
 @maybe_fake_tensor_mode(USE_FAKE_TENSOR)
 def test_flash_attn_sm100_head_dim_72_backward():
-    """Regression test for the backward preprocess O/dO predicate shape."""
+    """Cover predicate and multi-block dQ accumulator padding for head_dim=72."""
     if not IS_SM100:
         pytest.skip("SM100-specific backward preprocess regression test")
 
     torch.manual_seed(0)
-    shape = (1, 16, 1, 72)
+    shape = (1, 256, 1, 72)
     q_ref, k_ref, v_ref = (
         torch.randn(shape, device="cuda", dtype=torch.bfloat16, requires_grad=True)
         for _ in range(3)


### PR DESCRIPTION
## Summary

- slice the backward preprocess O/dO predicate along the same `CPY_M` dimension as the source and destination tensors
- choose a non-2CTA dQ reduction width that divides the padded head dimension
- add an SM100 head-dim-72 regression covering forward and backward correctness

## Root cause

For head dimension 72, SM100 pads the kernel head dimension to 80. The backward preprocess created an O/dO predicate for the full `(CPY_Atom, CPY_M, CPY_K)` partition, but reused it after slicing the source and destination by `CPY_M`. CuTeDSL therefore rejected a predicate of shape `(1, (2, 3))` for a copy of shape `(1, (3))`.

After slicing the predicate consistently, the main backward kernel also needs a dQ reduction width compatible with the padded width. Using `gcd(32, tile_hdim)` preserves 32 columns for existing aligned configurations and selects 16 for an 80-column tile.

Issue #1909 provides broader context for B200 backward IR verification failures. This change addresses the padded-head-dimension predicate and reduction configuration described above; it does not claim to resolve the distinct pointer-alignment failure in that report.

## Testing

On an NVIDIA B200:

```text
pytest -q tests/cute/test_flash_attn.py::test_flash_attn_sm100_head_dim_72_backward -s
1 passed
```

The regression compares the FA4 output and dQ/dK/dV gradients with the reference implementation.
