### PR TITLE
PR: [CuTe, Bwd, SM100] Remove unneeded proxy fences in postprocess kernel

### DIFF
--- a/flash_attn/cute/flash_bwd_postprocess.py
+++ b/flash_attn/cute/flash_bwd_postprocess.py
@@ -450,7 +450,6 @@ class FlashAttentionBackwardPostprocess:
                             sdQaccum_g2s[None, None, smem_buf],
                         )
 
-                    cute.arch.fence_view_async_shared()
                     cute.arch.barrier(barrier_id=6, number_of_threads=num_reduce_threads)
 
                     # S -> R
@@ -465,7 +464,6 @@ class FlashAttentionBackwardPostprocess:
                             tdQrdQ_s2r_cpy.iterator, cute.make_layout(sdQaccum_src.shape)
                         )
                         cute.copy(s2r_thr_copy, sdQaccum_src, tdQrdQ_r2s_cpy)
-                        cute.arch.fence_view_async_shared()
                         cute.arch.barrier(barrier_id=7, number_of_threads=num_reduce_threads)
 
                         # R -> S
@@ -486,7 +484,6 @@ class FlashAttentionBackwardPostprocess:
                     tdQrdQ_r2s[None, None, None, 0],
                     tdQsdQ_r2s[None, None, None, 0],
                 )
-                cute.arch.fence_view_async_shared()
                 cute.arch.barrier(barrier_id=8, number_of_threads=num_reduce_threads)
             else:
                 # Step 1: load dQaccum from gmem to smem


### PR DESCRIPTION
Related: #2718

## What

Removes the three `cute.arch.fence_view_async_shared()` calls (`fence.proxy.async.shared::cta`) in the 2-CTA dQ reduce path of the backward postprocess kernel, as suggested by @pchen7e2 in #2718. The named barriers next to them are kept unchanged.

## Why they are not needed

`fence.proxy.async` only orders smem accesses between the **generic proxy** and the **async proxy** (TMA, UMMA smem descriptors, tensormap). Every copy this kernel actually executes is generic-proxy:

| site | copy | instructions |
|---|---|---|
| G2S (`:447`) | `tiled_copy_1d` → `CopyUniversalOp` | `LDG` + `STS` |
| S2R (`:467`) | same universal atom | `LDS` |
| R2S (`:484`) | `get_smem_store_op` → `SmemStoreMatrix`/`SimtSyncCopy` | `stmatrix`/`STS` |
| epilogue (`:575`, `:582`) | autovec + universal | `LDS` + `STG` |

No TMA or tcgen05 instruction touches smem anywhere in this kernel: the `tcgen05` tmem-load atoms created at `:384-393`/`:520-527` are used only to derive thread/value partitioning layouts (so threads read `gdQaccum` in the main bwd kernel's TMEM accumulator order) — no tmem copy is ever issued, and no TMEM is allocated. With only generic-proxy traffic, the `bar.sync` named barriers already provide CTA-wide ordering/visibility (PTX memory model), covering both the G2S→S2R RAW and the loop-carried WAR when smem buffers are reused.

Two supporting observations:

- The non-2-CTA branch of this same kernel (SM80/90/120 and non-2CTA SM100) performs the identical G2S→S2R→R2S→S2G sequence with no proxy fences.
- The fences arrived with the 2-CTA bwd PR #2202, matching the pattern in `flash_bwd_sm100.py` where they **are** required (generic stores consumed by UMMA / "visible to TMA store"). The postprocess kernel has no such consumer.

The `:468` fence sits inside the per-stage loop, so it executes several times per tile — consistent with the nonzero cost @pchen7e2 measured in ncu.

## Validation (B200, cu130)

- CI 8-case filter (includes both `hdim128` fp16 bwd cases that execute the modified 2-CTA path): **8/8 passed**.
- Full `test_flash_attn_output and -128-` sweep (all dtypes / mha types / seqlens / causal / local through the postprocess kernel): [PENDING — fill in result before opening PR]

---

## Notes for us (not part of PR body)

- Issue author @pchen7e2 offered to send a PR themselves ("I'll be glad to put up a PR if we agree they're not needed") — consider commenting on the issue with the analysis + this branch instead of opening the PR immediately, or coordinate to avoid stepping on their contribution.
- Optional strengthening: ncu before/after of the postprocess kernel to quantify the saving.
- Leftover micro-cleanup (NOT in this PR, keep diff minimal): barrier 8 (`:488`) and the step-4 `barrier()` (`:567`) are back-to-back in the 2-CTA path.
