### PR TITLE
Different numerics

### DIFF
--- a/flash_attn/cute/flash_fwd_sm100.py
+++ b/flash_attn/cute/flash_fwd_sm100.py
@@ -2035,6 +2035,11 @@ class FlashAttentionForwardSm100:
                 8 if cutlass.const_expr(self.q_dtype.width == 8) else
                 0
             )
+            max_offset_scale = (
+                Float32(16.0) if cutlass.const_expr(self.q_dtype is cutlass.Float8E4M3FN) else
+                Float32(256.0) if cutlass.const_expr(self.q_dtype.width == 8) else
+                Float32(1.0)
+            )
             if const_expr(self.score_mod is None):
                 softmax_scale_log2_eff = softmax_scale_log2 * qk_descale
                 softmax_scale_eff = None
@@ -2058,8 +2063,7 @@ class FlashAttentionForwardSm100:
             if const_expr(
                 self.q_dtype.width != Float32.width
                 and not self.is_split_kv
-                and learnable_sink is None
-                and not self.use_block_sparsity
+                and (learnable_sink is None or not self.use_block_sparsity)
             ):
                 l_i_lowp = cute.make_rmem_tensor(1, Float32)
                 l_i_lowp.fill(0.0)
@@ -2151,11 +2155,35 @@ class FlashAttentionForwardSm100:
                     self.kv_subtile_factor,
                 )
                 if not empty_tile:
-                    sScale[tidx + stage * self.m_block_size] = softmax.row_sum[0]
+                    l_i_fp32 = softmax.row_sum[0]
+                    sScale[tidx + stage * self.m_block_size] = (
+                        l_i_lowp[0] if const_expr(l_i_lowp is not None) else l_i_fp32
+                    )
                     if const_expr(mLSE is not None or learnable_sink is not None):
-                        sScale[
-                            tidx + stage * self.m_block_size + self.q_stage * self.m_block_size
-                        ] = softmax.row_max[0]
+                        if const_expr(l_i_lowp is not None):
+                            l_i_out = l_i_lowp[0]
+                            l_i_out_is_zero_or_nan = l_i_out == 0.0 or l_i_out != l_i_out
+                            LN2 = math.log(2.0)
+                            sScale[
+                                tidx
+                                + stage * self.m_block_size
+                                + self.q_stage * self.m_block_size
+                            ] = (
+                                (
+                                    softmax.row_max[0] * softmax_scale_log2_eff
+                                    + cute.math.log2(l_i_out, fastmath=True)
+                                    - max_offset
+                                )
+                                * LN2
+                                if not l_i_out_is_zero_or_nan
+                                else -Float32.inf
+                            )
+                        else:
+                            sScale[
+                                tidx
+                                + stage * self.m_block_size
+                                + self.q_stage * self.m_block_size
+                            ] = softmax.row_max[0]
                     # if tidx == 0:
                     #     cute.printf("softmax row sum stage %d: %f, row_max = %f\n", stage, softmax.row_sum[0], softmax.row_max[0])
                     # See block_sparse_utils.py NOTE [SM100 block-sparse empty tiles: mbarrier contract].
@@ -2223,33 +2251,78 @@ class FlashAttentionForwardSm100:
 
                     # Dense path always writes scale / signals
                     l_i_fp32 = softmax.row_sum[0]
-                    sScale[tidx + stage * self.m_block_size] = (
-                        l_i_lowp[0] if const_expr(l_i_lowp is not None) else l_i_fp32
-                    )
-                    if const_expr(mLSE is not None or learnable_sink is not None):
-                        if const_expr(l_i_lowp is not None):
-                            l_i_fp32_is_zero_or_nan = l_i_fp32 == 0.0 or l_i_fp32 != l_i_fp32
-                            LN2 = math.log(2.0)
-                            sScale[
-                                tidx
-                                + stage * self.m_block_size
-                                + self.q_stage * self.m_block_size
-                            ] = (
+                    l_i_out = l_i_lowp[0] if const_expr(l_i_lowp is not None) else l_i_fp32
+                    if const_expr(l_i_lowp is not None):
+                        full_lse = Float32.zero
+                        l_i_fp32_is_zero_or_nan = l_i_fp32 == 0.0 or l_i_fp32 != l_i_fp32
+                        if const_expr(learnable_sink is not None):
+                            if const_expr(not self.pack_gqa):
+                                sink_val = Float32(learnable_sink[head_idx])
+                            else:
+                                mma_tile_coord_v = thr_mma_qk.thr_idx
+                                q_head_idx = (
+                                    (
+                                        (m_block * self.q_stage + stage) * self.cta_group_size
+                                        + mma_tile_coord_v
+                                    )
+                                    * self.m_block_size
+                                    + tidx
+                                ) % self.qhead_per_kvhead + head_idx * self.qhead_per_kvhead
+                                sink_val = Float32(learnable_sink[q_head_idx])
+                            if l_i_fp32_is_zero_or_nan:
+                                l_i_out = (
+                                    Float32.zero
+                                    if sink_val == -Float32.inf
+                                    else max_offset_scale
+                                )
+                                full_lse = (
+                                    -Float32.inf if sink_val == -Float32.inf else sink_val
+                                )
+                            else:
+                                LOG2_E = math.log2(math.e)
+                                sink_mass = cute.math.exp2(
+                                    sink_val * LOG2_E
+                                    - softmax.row_max[0] * softmax_scale_log2_eff
+                                    + max_offset,
+                                    fastmath=True,
+                                )
+                                l_i_out += sink_mass
+                                l_i_fp32 += sink_mass
+                        LN2 = math.log(2.0)
+                        l_i_out_is_zero_or_nan = l_i_out == 0.0 or l_i_out != l_i_out
+                        if const_expr(learnable_sink is None):
+                            full_lse = (
                                 (
                                     softmax.row_max[0] * softmax_scale_log2_eff
-                                    + cute.math.log2(l_i_fp32, fastmath=True)
+                                    + cute.math.log2(l_i_out, fastmath=True)
                                     - max_offset
                                 )
                                 * LN2
-                                if not l_i_fp32_is_zero_or_nan
+                                if not l_i_out_is_zero_or_nan
                                 else -Float32.inf
                             )
-                        else:
-                            sScale[
-                                tidx
-                                + stage * self.m_block_size
-                                + self.q_stage * self.m_block_size
-                            ] = softmax.row_max[0]
+                        elif not l_i_fp32_is_zero_or_nan:
+                            full_lse = (
+                                (
+                                    softmax.row_max[0] * softmax_scale_log2_eff
+                                    + cute.math.log2(l_i_out, fastmath=True)
+                                    - max_offset
+                                )
+                                * LN2
+                                if not l_i_out_is_zero_or_nan
+                                else -Float32.inf
+                            )
+                    sScale[tidx + stage * self.m_block_size] = l_i_out
+                    if const_expr(mLSE is not None or learnable_sink is not None):
+                        sScale[
+                            tidx
+                            + stage * self.m_block_size
+                            + self.q_stage * self.m_block_size
+                        ] = (
+                            full_lse
+                            if const_expr(l_i_lowp is not None)
+                            else softmax.row_max[0]
+                        )
                     # pipeline_sm_stats.producer_commit_w_index(stage)
                     sm_stats_barrier.arrive_w_index(index=stage * 4 + warp_idx)
 
@@ -2544,8 +2617,7 @@ class FlashAttentionForwardSm100:
             use_lowp_row_sum = const_expr(
                 self.q_dtype.width != Float32.width
                 and not self.is_split_kv
-                and learnable_sink is None
-                and not self.use_block_sparsity
+                and (learnable_sink is None or not self.use_block_sparsity)
             )
             seqlen = SeqlenInfoCls(batch_idx)
             n_block_min, n_block_max = block_info.get_n_block_min_max(seqlen, m_block, split_idx, num_splits)
@@ -2647,7 +2719,7 @@ class FlashAttentionForwardSm100:
                     else:
                         row_max = None
                     pipeline_sm_stats.consumer_release_w_index(stage)
-                    if const_expr(learnable_sink is not None):
+                    if const_expr(learnable_sink is not None and not use_lowp_row_sum):
                         LOG2_E = math.log2(math.e)
                         sink_val = learnable_sink_val[stage]
                         if const_expr(not self.is_split_kv) or split_idx == 0:

--- a/flash_attn/cute/flash_fwd_sm100.py
+++ b/flash_attn/cute/flash_fwd_sm100.py
@@ -2054,6 +2054,15 @@ class FlashAttentionForwardSm100:
                 max_offset=max_offset,
             )
             softmax.reset()
+            l_i_lowp = None
+            if const_expr(
+                self.q_dtype.width != Float32.width
+                and not self.is_split_kv
+                and learnable_sink is None
+                and not self.use_block_sparsity
+            ):
+                l_i_lowp = cute.make_rmem_tensor(1, Float32)
+                l_i_lowp.fill(0.0)
 
             if const_expr(self.use_block_sparsity):
                 tile_block_count = get_total_block_count(
@@ -2076,6 +2085,7 @@ class FlashAttentionForwardSm100:
             softmax_step = partial(
                 self.softmax_step,
                 softmax=softmax,
+                l_i_lowp=l_i_lowp,
                 thr_mma_qk=thr_mma_qk,
                 pipeline_s_p_o=pipeline_s_p_o,
                 pipeline_p_lastsplit=pipeline_p_lastsplit,
@@ -2212,11 +2222,34 @@ class FlashAttentionForwardSm100:
                             # Now that we no longer already have the 1st iteration, need mask_seqlen=True here
 
                     # Dense path always writes scale / signals
-                    sScale[tidx + stage * self.m_block_size] = softmax.row_sum[0]
+                    l_i_fp32 = softmax.row_sum[0]
+                    sScale[tidx + stage * self.m_block_size] = (
+                        l_i_lowp[0] if const_expr(l_i_lowp is not None) else l_i_fp32
+                    )
                     if const_expr(mLSE is not None or learnable_sink is not None):
-                        sScale[
-                            tidx + stage * self.m_block_size + self.q_stage * self.m_block_size
-                        ] = softmax.row_max[0]
+                        if const_expr(l_i_lowp is not None):
+                            l_i_fp32_is_zero_or_nan = l_i_fp32 == 0.0 or l_i_fp32 != l_i_fp32
+                            LN2 = math.log(2.0)
+                            sScale[
+                                tidx
+                                + stage * self.m_block_size
+                                + self.q_stage * self.m_block_size
+                            ] = (
+                                (
+                                    softmax.row_max[0] * softmax_scale_log2_eff
+                                    + cute.math.log2(l_i_fp32, fastmath=True)
+                                    - max_offset
+                                )
+                                * LN2
+                                if not l_i_fp32_is_zero_or_nan
+                                else -Float32.inf
+                            )
+                        else:
+                            sScale[
+                                tidx
+                                + stage * self.m_block_size
+                                + self.q_stage * self.m_block_size
+                            ] = softmax.row_max[0]
                     # pipeline_sm_stats.producer_commit_w_index(stage)
                     sm_stats_barrier.arrive_w_index(index=stage * 4 + warp_idx)
 
@@ -2258,6 +2291,7 @@ class FlashAttentionForwardSm100:
         s0_s1_sequence_phase: Int32,
         n_block: Int32,
         softmax: SoftmaxSm100,
+        l_i_lowp: Optional[cute.Tensor],
         thr_mma_qk: cute.ThrMma,
         pipeline_s_p_o: pipeline.PipelineAsync,
         pipeline_p_lastsplit: pipeline.PipelineAsync,
@@ -2375,6 +2409,16 @@ class FlashAttentionForwardSm100:
             ex2_emu_freq=self.ex2_emu_freq,
             ex2_emu_start_frg=self.ex2_emu_start_frg,
         )
+        use_fhadd_lowp_sum = const_expr(l_i_lowp is not None and self.q_dtype.width == 16)
+        lowp_acc = None
+        if const_expr(use_fhadd_lowp_sum):
+            lowp_suffix = "bf16" if const_expr(self.q_dtype is cutlass.BFloat16) else "f16"
+            lowp_acc = [
+                l_i_lowp[0] * acc_scale if const_expr(not is_first) else Float32.zero,
+                Float32.zero,
+                Float32.zero,
+                Float32.zero,
+            ]
         # Sequence barrier arrive
         if const_expr(self.s0_s1_barrier):
             pipeline_s0_s1_sequence.sync_object_full.arrive(1 - stage, dst=None)
@@ -2382,6 +2426,17 @@ class FlashAttentionForwardSm100:
         # cute.copy(thr_tmem_store, tSrP_r2t_f32, tStP_r2t)
         for i in cutlass.range_constexpr(cute.size(tStP_r2t.shape[2])):
             cute.copy(thr_tmem_store, tSrP_r2t_f32[None, None, i], tStP_r2t[None, None, i])
+            if const_expr(use_fhadd_lowp_sum):
+                lowp_acc[0], lowp_acc[1], lowp_acc[2], lowp_acc[3] = (
+                    utils.accum_packed_lowp_fragment(
+                        cute.recast_tensor(tSrP_r2t_f32[None, None, i], Int32),
+                        lowp_acc[0],
+                        lowp_acc[1],
+                        lowp_acc[2],
+                        lowp_acc[3],
+                        lowp_suffix,
+                    )
+                )
             if const_expr(self.split_P_arrive > 0):
                 split_P_arrive_idx = cute.size(tStP_r2t.shape[2]) * self.split_P_arrive // self.n_block_size
                 if const_expr(i + 1 == split_P_arrive_idx):
@@ -2398,6 +2453,14 @@ class FlashAttentionForwardSm100:
             pipeline_s_p_o.consumer_release_w_index(stage)
         pipeline_sm_stats.producer_acquire_w_index_phase(stage, sm_stats_producer_phase)
         softmax.update_row_sum(tSrS_t2r.load(), acc_scale, is_first)
+        if const_expr(use_fhadd_lowp_sum):
+            l_i_lowp[0] = (lowp_acc[0] + lowp_acc[1]) + (lowp_acc[2] + lowp_acc[3])
+        elif const_expr(l_i_lowp is not None):
+            l_i_lowp[0] = utils.fadd_reduce(
+                tSrP_r2t.load().to(Float32),
+                init_val=l_i_lowp[0] * acc_scale if const_expr(not is_first) else None,
+                arch=100,
+            )
         # acc_scale = cute.math.exp2(acc_scale_, fastmath=True)
         return mma_si_consumer_phase ^ 1, sm_stats_producer_phase ^ 1, s0_s1_sequence_phase ^ 1
 
@@ -2477,6 +2540,12 @@ class FlashAttentionForwardSm100:
                 Float32(16.0) if cutlass.const_expr(self.q_dtype is cutlass.Float8E4M3FN) else
                 Float32(256.0) if cutlass.const_expr(self.q_dtype.width == 8) else
                 Float32(1.0)
+            )
+            use_lowp_row_sum = const_expr(
+                self.q_dtype.width != Float32.width
+                and not self.is_split_kv
+                and learnable_sink is None
+                and not self.use_block_sparsity
             )
             seqlen = SeqlenInfoCls(batch_idx)
             n_block_min, n_block_max = block_info.get_n_block_min_max(seqlen, m_block, split_idx, num_splits)
@@ -2686,9 +2755,13 @@ class FlashAttentionForwardSm100:
                     #     cute.printf("row_sum = {}, row_max = {}, acc_O_mn_row_is_zero_or_nan = {}\n", row_sum, row_max, acc_O_mn_row_is_zero_or_nan)
                     LN2 = math.log(2.0)
                     lse = (
-                        (row_max * softmax_scale_log2_eff + (cute.math.log2(row_sum, fastmath=True) - max_offset)) * LN2
-                        if not acc_O_mn_row_is_zero_or_nan
-                        else -Float32.inf
+                        row_max
+                        if const_expr(use_lowp_row_sum)
+                        else (
+                            (row_max * softmax_scale_log2_eff + (cute.math.log2(row_sum, fastmath=True) - max_offset)) * LN2
+                            if not acc_O_mn_row_is_zero_or_nan
+                            else -Float32.inf
+                        )
                     )
                     seqlen_q = (
                         seqlen.seqlen_q

--- a/flash_attn/cute/utils.py
+++ b/flash_attn/cute/utils.py
@@ -414,6 +414,60 @@ def fmax_reduce(
         return fmax(local_max[0], local_max[2], local_max[3])
 
 
+@dsl_user_op
+def accum_lowp_pair_into_f32(
+    packed: Int32,
+    acc0: Float32,
+    acc1: Float32,
+    lowp_suffix: str,
+    *,
+    loc=None,
+    ip=None,
+) -> Tuple[Float32, Float32]:
+    """Accumulate both lowp lanes of one packed word into two FP32 sums."""
+    out = llvm.inline_asm(
+        llvm.StructType.get_literal([T.f32(), T.f32()]),
+        [
+            Int32(packed).ir_value(loc=loc, ip=ip),
+            Float32(acc0).ir_value(loc=loc, ip=ip),
+            Float32(acc1).ir_value(loc=loc, ip=ip),
+        ],
+        "{\n\t"
+        ".reg .b16 lo, hi;\n\t"
+        "mov.b32 {lo, hi}, $2;\n\t"
+        f"add.rn.f32.{lowp_suffix} $0, lo, $0;\n\t"
+        f"add.rn.f32.{lowp_suffix} $1, hi, $1;\n\t"
+        "}\n",
+        "=f,=f,r,0,1",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+    return (
+        Float32(llvm.extractvalue(T.f32(), out, [0], loc=loc, ip=ip)),
+        Float32(llvm.extractvalue(T.f32(), out, [1], loc=loc, ip=ip)),
+    )
+
+
+@cute.jit
+def accum_packed_lowp_fragment(
+    x: cute.Tensor,
+    acc0: Float32,
+    acc1: Float32,
+    acc2: Float32,
+    acc3: Float32,
+    lowp_suffix: cutlass.Constexpr[str],
+) -> Tuple[Float32, Float32, Float32, Float32]:
+    """Accumulate one packed lowp P fragment into four FP32 chains."""
+    assert x.element_type is Int32, "x must contain packed lowp pairs"
+    n = cute.size(x.shape)
+    assert n % 2 == 0, "packed fragment size must be a multiple of 2 words"
+    for i in cutlass.range_constexpr(0, n, 2):
+        acc0, acc1 = accum_lowp_pair_into_f32(x[i], acc0, acc1, lowp_suffix)
+        acc2, acc3 = accum_lowp_pair_into_f32(x[i + 1], acc2, acc3, lowp_suffix)
+    return acc0, acc1, acc2, acc3
+
+
 @cute.jit
 def fadd_reduce(
     x: cute.TensorSSA, init_val: float | Float32 | None = None, arch: cutlass.Constexpr[int] = 80

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -110,8 +110,8 @@ def test_flash_attn_bf16_row_sum_matches_pv():
 
 @pytest.mark.skipif(not IS_SM100, reason="SM100-only probability rounding behavior")
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
-def test_flash_attn_lowp_pv_row_sum_preserves_lse(dtype):
-    """Keep LSE tied to the FP32 exponential mass used by backward."""
+def test_flash_attn_lowp_pv_row_sum_uses_lowp_lse(dtype):
+    """Use the same rounded exponential mass for output and backward LSE."""
     torch.manual_seed(0)
     q = torch.zeros(1, 1, 1, 128, device="cuda", dtype=dtype)
     k = torch.zeros(1, 8192, 1, 128, device="cuda", dtype=dtype)
@@ -122,7 +122,68 @@ def test_flash_attn_lowp_pv_row_sum_preserves_lse(dtype):
 
     _, lse = flash_attn_func(q, k, v, softmax_scale=1.0, return_lse=True)
 
-    assert torch.equal(lse[0, 0, 0], torch.logsumexp(logits.float(), dim=0))
+    row_max = logits.float().max()
+    p_lowp = torch.exp(logits.float() - row_max).to(dtype).float()
+    expected_lse = row_max + torch.log(p_lowp.sum())
+
+    torch.testing.assert_close(lse[0, 0, 0], expected_lse, atol=1e-5, rtol=0.0)
+
+
+@pytest.mark.skipif(not IS_SM100, reason="SM100-only probability rounding behavior")
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("q_heads,kv_heads", [(1, 1), (4, 2)])
+def test_flash_attn_lowp_negative_inf_sink_matches_no_sink(dtype, q_heads, kv_heads):
+    """A zero-mass sink must not change lowp output normalization."""
+    torch.manual_seed(0)
+    q = torch.randn(1, 8, q_heads, 128, device="cuda", dtype=dtype) * 1000
+    k = torch.randn(1, 1024, kv_heads, 128, device="cuda", dtype=dtype) * 1000
+    v = torch.ones_like(k)
+    sink = torch.full((q_heads,), -torch.inf, device="cuda", dtype=torch.bfloat16)
+
+    out, lse = flash_attn_func(q, k, v, return_lse=True)
+    out_sink, lse_sink = flash_attn_func(
+        q, k, v, learnable_sink=sink, return_lse=True
+    )
+
+    assert torch.equal(out_sink, out)
+    assert torch.equal(lse_sink, lse)
+
+
+@pytest.mark.skipif(not IS_SM100, reason="SM100-only probability rounding behavior")
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_flash_attn_lowp_finite_sink_uses_lowp_mass(dtype):
+    """Use rounded P mass for both output and sink-inclusive LSE."""
+    torch.manual_seed(0)
+    q = torch.zeros(1, 1, 1, 128, device="cuda", dtype=dtype)
+    k = torch.zeros(1, 8192, 1, 128, device="cuda", dtype=dtype)
+    q[..., 0] = 1
+    logits = torch.randn(8192, device="cuda", dtype=dtype)
+    k[0, :, 0, 0] = logits
+    v = torch.ones_like(k)
+    sink = torch.tensor([0.5], device="cuda", dtype=torch.bfloat16)
+
+    out, lse = flash_attn_func(
+        q,
+        k,
+        v,
+        softmax_scale=1.0,
+        learnable_sink=sink,
+        return_lse=True,
+    )
+
+    row_max = torch.maximum(logits.float().max(), sink.float()[0])
+    p_lowp = torch.exp(logits.float() - row_max).to(dtype).float()
+    sink_mass = torch.exp(sink.float()[0] - row_max)
+    expected_out = (p_lowp.sum() / (p_lowp.sum() + sink_mass)).to(dtype)
+    expected_lse = row_max + torch.log(p_lowp.sum() + sink_mass)
+
+    torch.testing.assert_close(
+        out,
+        torch.full_like(out, expected_out),
+        atol=torch.finfo(dtype).eps,
+        rtol=0.0,
+    )
+    torch.testing.assert_close(lse[0, 0, 0], expected_lse, atol=1e-5, rtol=0.0)
 
 
 # @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float8_e4m3fn])

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -96,6 +96,35 @@ def test_flash_attn_sm120_rejects_splitkv():
         flash_attn_func(q, k, v, num_splits=3)
 
 
+@pytest.mark.skipif(not IS_SM100, reason="SM100-only probability rounding behavior")
+def test_flash_attn_bf16_row_sum_matches_pv():
+    torch.manual_seed(0)
+    q = torch.randn(4, 8192, 1, 128, device="cuda", dtype=torch.bfloat16) * 1000
+    k = torch.randn(4, 8192, 1, 128, device="cuda", dtype=torch.bfloat16) * 1000
+    v = torch.ones(4, 8192, 1, 128, device="cuda", dtype=torch.bfloat16)
+
+    out, _ = flash_attn_func(q, k, v, causal=True)
+
+    assert torch.equal(out, v)
+
+
+@pytest.mark.skipif(not IS_SM100, reason="SM100-only probability rounding behavior")
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_flash_attn_lowp_pv_row_sum_preserves_lse(dtype):
+    """Keep LSE tied to the FP32 exponential mass used by backward."""
+    torch.manual_seed(0)
+    q = torch.zeros(1, 1, 1, 128, device="cuda", dtype=dtype)
+    k = torch.zeros(1, 8192, 1, 128, device="cuda", dtype=dtype)
+    q[..., 0] = 1
+    logits = torch.randn(8192, device="cuda", dtype=dtype)
+    k[0, :, 0, 0] = logits
+    v = torch.ones_like(k)
+
+    _, lse = flash_attn_func(q, k, v, softmax_scale=1.0, return_lse=True)
+
+    assert torch.equal(lse[0, 0, 0], torch.logsumexp(logits.float(), dim=0))
+
+
 # @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float8_e4m3fn])
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 @pytest.mark.parametrize("mha_type", ["mha", "mqa", "gqa"])


### PR DESCRIPTION
# Different numerics

There is a current source of bias, the denominator for our iterative softmax is using `p` in essence than what is computed by the p@v. It is sum(p_fp32) but the p@v numerator is casted to p_bf16. This can show up as a negative bias in the forward (look at the v= 1) test.

The updated variant has two stats, l_i_bf16 and l_i_fp32 where you use the fp32 for LSE and backward and then l_i_bf16 for the final output_scaling. 


Howerver; Rip super slow - we must weight for vera :( 

| Causal | Head dim | Seq. length | Baseline (µs) | FHADD row sum (µs) | Change |
|:------:|---------:|------------:|--------------:|---------------------:|-------:|
| No | 32 | 512 | 95.360 | 108.512 | **+13.79%** |
| No | 32 | 2,048 | 308.448 | 371.872 | **+20.56%** |
| No | 32 | 8,192 | 1,207.312 | 1,423.424 | **+17.90%** |
| No | 64 | 512 | 63.680 | 62.816 | **-1.36%** |
| No | 64 | 2,048 | 217.024 | 208.832 | **-3.77%** |
| No | 64 | 8,192 | 852.560 | 816.512 | **-4.23%** |
| No | 128 | 512 | 52.544 | 44.992 | **-14.37%** |
| No | 128 | 2,048 | 171.936 | 148.384 | **-13.70%** |
| No | 128 | 8,192 | 640.960 | 567.712 | **-11.43%** |
| Yes | 32 | 512 | 121.152 | 128.960 | **+6.44%** |
| Yes | 32 | 2,048 | 228.864 | 253.920 | **+10.95%** |
| Yes | 32 | 8,192 | 668.144 | 758.912 | **+13.59%** |
| Yes | 64 | 512 | 69.984 | 75.072 | **+7.27%** |
| Yes | 64 | 2,048 | 130.320 | 140.992 | **+8.19%** |
| Yes | 64 | 8,192 | 402.048 | 440.080 | **+9.46%** |
| Yes | 128 | 512 | 47.008 | 49.600 | **+5.51%** |
| Yes | 128 | 2,048 | 87.904 | 92.288 | **+4.99%** |
| Yes | 128 | 8,192 | 268.736 | 286.656 | **+6.67%** |