### PR TITLE
[FA3 ring attn support] Ring-attention primitives that keep partials & gradients in fp32, eliminating the per-hop bf16↔fp32 round-trips a naive ring pays (faster + more accurate)

### DIFF
--- a/benchmarks/benchmark_flash_ring_attention_fa3.py
+++ b/benchmarks/benchmark_flash_ring_attention_fa3.py
@@ -1,0 +1,726 @@
+"""
+================================================================================
+ Ring Flash Attention (FA3) benchmark: FA3 before/after (dense + varlen)
+================================================================================
+
+Measures what the optimized FA3 ring primitives buy, for BOTH dense and varlen
+(context-parallel) attention, by comparing an "optimized" ring against a "stock"
+ring that is IDENTICAL except for the FA3 part (the forward/backward primitive).
+
+The optimized ring drivers are NOT re-implemented here -- they are imported from
+`tests/ring_flash_attn_fa3.py` (the single source of truth):
+    _RingFlashAttnFunc / ring_flash_attn_func         # dense, optimized
+    _RingVarlenFunc    / ring_flash_attn_varlen_func   # varlen, optimized
+plus the shared ring machinery (DoubleBufRingComm, the fp32 online-merge kernels,
+sequence sharding). This file only adds the "stock" (before-optimization) rings and
+the before/after comparisons.
+
+--------------------------------------------------------------------------------
+ What differs between opt and stock (the FA3 part only)
+--------------------------------------------------------------------------------
+Dense (ring_opt vs ring_stock):
+  * forward:  opt = flash_attn_forward_ring (fp32 partial, no bf16 round-trip)
+              stock = full flash_attn_func per block (bf16 out -> cast to fp32 to merge)
+  * backward: opt = phased flash_attn_backward_ring (persistent fp32 dq_accum;
+              preprocess/convert once per rank)
+              stock = full flash_attn_3.bwd per hop (repeats preprocess+convert; dQ
+              round-trips to bf16 each hop and is accumulated in Python fp32)
+
+Varlen (ring_varlen_opt vs ring_varlen_stock):
+  * forward:  IDENTICAL -- both use per-hop flash_attn_varlen_func(out+lse) + the fused
+              fp32 merge (there is no varlen fwd_ring; the store-all path is unusable
+              under the dynamic varlen split scheduler). So varlen has no forward
+              before/after -- the only FA3 difference is the backward.
+  * backward: opt = phased flash_attn_backward_ring (varlen) ; stock = full
+              flash_attn_3.bwd (varlen) per hop.
+
+Everything else (ring communication, fp32 dK/dV ring reduction, sharding) is shared,
+so any difference reflects the FA3 primitives alone. Varlen CP splits each global
+sequence into W equal chunks along its length (every sequence length divisible by W).
+
+--------------------------------------------------------------------------------
+ How to run
+--------------------------------------------------------------------------------
+  torchrun --nproc_per_node=8 --standalone benchmark_flash_ring_attention_fa3.py
+  CUDA_VISIBLE_DEVICES=0,1 torchrun --nproc_per_node=2 --standalone benchmark_flash_ring_attention_fa3.py
+
+  Env overrides:
+    RING_HQ / RING_HKV        head counts for the speed stages (default 16 / 2)
+    RING_D_LIST               head dims for the dense speed grid (default "64,128,256")
+    RING_S_LIST               per-rank seqlens for the dense speed grid ("512,1024,2048,4096,8192")
+    RING_REPS                 median-of-N repeats per speed cell (default 3)
+    RING_SKIP_PRECISION       "1" skip the dense accuracy gate
+    RING_SKIP_PRECISION_DIFF  "1" skip the dense before/after accuracy table
+    RING_SKIP_SPEED           "1" skip the dense before/after speed grid
+    RING_SKIP_VARLEN_DIFF     "1" skip the varlen before/after accuracy table
+    RING_SKIP_VARLEN_SPEED    "1" skip the varlen before/after speed table
+"""
+
+import os
+import sys
+
+import torch
+import torch.distributed as dist
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_HOPPER_DIR = os.path.join(_REPO_ROOT, "hopper")   # exposes the built FA3 ring primitives
+_TESTS_DIR = os.path.join(_REPO_ROOT, "tests")     # exposes the optimized ring drivers
+for _p in (_HOPPER_DIR, _TESTS_DIR):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+# Optimized ring drivers + shared ring machinery (single source of truth). We do NOT
+# re-implement the optimized ring here; the "stock" rings below reuse the same comm /
+# merge / sharding and differ only in the FA3 forward/backward calls.
+from ring_flash_attn_fa3 import (  # tests/ring_flash_attn_fa3.py
+    DoubleBufRingComm, _merge, _merge_varlen,
+    shard_along_seq, shard_varlen_along_seq,
+    _RingFlashAttnFunc, ring_flash_attn_func as ring_opt,               # dense, optimized
+    _RingVarlenFunc, ring_flash_attn_varlen_func as ring_varlen_opt,    # varlen, optimized
+    _ring_forward_varlen,                                               # varlen fwd (shared by the stock varlen)
+)
+from flash_attn_interface import flash_attn_func, flash_attn_varlen_func  # stock full-block FA3
+
+# Stock (before-optimization) FA3 backward op -- the full backward, run per hop.
+_bwd = torch.ops.flash_attn_3.bwd
+
+
+# ############################################################################
+# Dense stock ring (ring_stock): full flash_attn_func forward + full flash_attn_3.bwd
+# per hop. IDENTICAL to the imported optimized ring_opt except for those two FA3 calls
+# (same DoubleBufRingComm / _merge / fp32 dK/dV reduction / shard_along_seq).
+# ############################################################################
+@torch.no_grad()
+def _stock_forward(process_group, q, k, v, softmax_scale, causal):
+    """Each hop: full flash_attn_func -> (bf16 out, fp32 lse); cast out to fp32 (the
+    per-hop bf16 round-trip) and merge online. Optimized ring_opt instead uses
+    flash_attn_forward_ring, whose partial is already fp32."""
+    q, k, v = q.contiguous(), k.contiguous(), v.contiguous()
+    comm = DoubleBufRingComm(process_group)
+    W, rank = comm.world_size, comm.rank
+    B, S, Hq, D = q.shape
+    dev = q.device
+    kv_bufs = [torch.empty((2,) + k.shape, device=dev, dtype=k.dtype) for _ in range(2)]
+    kv_send = torch.empty((2,) + k.shape, device=dev, dtype=k.dtype)
+    if W > 1:
+        kv_send[0].copy_(k); kv_send[1].copy_(v)
+    k_cur, v_cur = k, v
+    acc = torch.empty((B, Hq, S, D), device=dev, dtype=torch.float32)  # fp32 merge accumulator
+    lse = torch.empty((B, Hq, S), device=dev, dtype=torch.float32)
+    first = True
+    for step in range(W):
+        if step + 1 != W:
+            comm.send_recv_packed(kv_send, kv_bufs[step & 1])
+        if (not causal) or step <= rank:
+            block_causal = causal and step == 0
+            out_blk, lse_blk = flash_attn_func(
+                q, k_cur, v_cur, softmax_scale=softmax_scale, causal=block_causal,
+                return_attn_probs=True)                                    # out (B,S,Hq,D) bf16
+            o_i = out_blk.permute(0, 2, 1, 3).contiguous().float()         # bf16->fp32 (per-hop round-trip)
+            _merge(o_i, lse_blk.contiguous(), acc, lse, is_first=first)
+            first = False
+        if step + 1 != W:
+            comm.wait()
+            kv_send = kv_bufs[step & 1]
+            k_cur, v_cur = kv_bufs[step & 1][0], kv_bufs[step & 1][1]
+    out = acc.permute(0, 2, 1, 3).contiguous().to(q.dtype)
+    return out, lse
+
+
+@torch.no_grad()
+def _stock_backward(process_group, dout, q, k, v, out, softmax_lse, softmax_scale, causal):
+    """Each active hop: a FULL flash_attn_3.bwd (repeats preprocess+convert), producing a
+    bf16 block_dq accumulated in Python fp32 (the per-hop dQ bf16 round-trip). Optimized
+    ring_opt instead uses the phased flash_attn_backward_ring with a persistent fp32
+    dq_accum. The fp32 dK/dV ring reduction is identical to ring_opt."""
+    dout, q, k, v, out = [x.contiguous() for x in (dout, q, k, v, out)]
+    kv_comm = DoubleBufRingComm(process_group)
+    d_kv_comm = DoubleBufRingComm(process_group)
+    W, rank = kv_comm.world_size, kv_comm.rank
+    dev = q.device
+    dq_acc = torch.zeros(q.shape, device=dev, dtype=torch.float32)  # Python fp32 dQ accumulator
+    block_dq = torch.empty_like(q); block_dk = torch.empty_like(k); block_dv = torch.empty_like(k)
+    kv_bufs = [torch.empty((2,) + k.shape, device=dev, dtype=k.dtype) for _ in range(2)]
+    kv_send = torch.empty((2,) + k.shape, device=dev, dtype=k.dtype)
+    if W > 1:
+        kv_send[0].copy_(k); kv_send[1].copy_(v)
+    k_cur, v_cur = k, v
+    dkdv_bufs = [torch.empty((2,) + k.shape, device=dev, dtype=torch.float32) for _ in range(2)]
+    dk_bufs = [dkdv_bufs[0][0], dkdv_bufs[1][0]]
+    dv_bufs = [dkdv_bufs[0][1], dkdv_bufs[1][1]]
+    first_iter_done = False
+    for step in range(W):
+        if step + 1 != W:
+            kv_comm.send_recv_packed(kv_send, kv_bufs[step & 1])
+        active = step <= rank or not causal
+        prev_slot = (step - 1) & 1
+        if active:
+            _bwd(dout, q, k_cur, v_cur, out, softmax_lse,
+                 block_dq, block_dk, block_dv,
+                 None, None, None, None, None, None,
+                 softmax_scale, (causal and step == 0), -1, -1, 0.0, False, 0)
+            if not first_iter_done:
+                dq_acc.copy_(block_dq)
+            else:
+                dq_acc.add_(block_dq)
+            if first_iter_done:
+                d_kv_comm.wait()
+            if not first_iter_done:
+                dk_bufs[prev_slot].copy_(block_dk); dv_bufs[prev_slot].copy_(block_dv)
+            else:
+                dk_bufs[prev_slot].add_(block_dk); dv_bufs[prev_slot].add_(block_dv)
+            first_iter_done = True
+        elif step != 0:
+            d_kv_comm.wait()
+        if step + 1 != W:
+            kv_comm.wait()
+            kv_send = kv_bufs[step & 1]
+            k_cur, v_cur = kv_bufs[step & 1][0], kv_bufs[step & 1][1]
+        d_kv_comm.send_recv_packed(dkdv_bufs[prev_slot], dkdv_bufs[step & 1])
+    d_kv_comm.wait()
+    final_slot = (W - 1) & 1
+    return dq_acc.to(q.dtype), dk_bufs[final_slot].to(k.dtype), dv_bufs[final_slot].to(v.dtype)
+
+
+class _StockRingFunc(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, q, k, v, softmax_scale, causal, group):
+        if softmax_scale is None:
+            softmax_scale = q.shape[-1] ** -0.5
+        out, lse = _stock_forward(group, q, k, v, softmax_scale, causal)
+        ctx.save_for_backward(q, k.contiguous(), v.contiguous(), out, lse.contiguous())
+        ctx.softmax_scale, ctx.causal, ctx.group = softmax_scale, causal, group
+        return out
+
+    @staticmethod
+    def backward(ctx, dout):
+        q, k, v, out, lse = ctx.saved_tensors
+        dq, dk, dv = _stock_backward(ctx.group, dout, q, k, v, out, lse, ctx.softmax_scale, ctx.causal)
+        return dq, dk, dv, None, None, None
+
+
+def ring_stock(q, k, v, softmax_scale=None, causal=False, group=None):
+    """[before] Dense baseline ring (full flash_attn_func forward + full bwd per hop)."""
+    return _StockRingFunc.apply(q, k, v, softmax_scale, causal, group)
+
+
+# ############################################################################
+# Varlen stock ring (ring_varlen_stock): mimics _StockRingFunc for varlen. Forward is
+# IDENTICAL to the optimized _RingVarlenFunc (imported _ring_forward_varlen) -- varlen
+# has no forward FA3 alternative -- so the ONLY FA3 difference is the backward: a full
+# flash_attn_3.bwd (varlen) per hop vs the optimized phased bwd_ring.
+# ############################################################################
+@torch.no_grad()
+def _ring_backward_varlen_stock(process_group, dout, q, k, v, out, softmax_lse, cu, max_s, softmax_scale, causal):
+    """Varlen analog of _stock_backward: per active hop run a FULL varlen flash_attn_3.bwd
+    (repeats preprocess+convert; dQ->bf16 per hop, Python fp32 accum); fp32 dK/dV ring
+    reduction identical to the optimized varlen ring. q/k/v/out: (total,H,D); dout:
+    (total,Hq,D); softmax_lse: (Hq,total)."""
+    dout, q, k, v, out = [x.contiguous() for x in (dout, q, k, v, out)]
+    kv_comm = DoubleBufRingComm(process_group)
+    d_kv_comm = DoubleBufRingComm(process_group)
+    W, rank = kv_comm.world_size, kv_comm.rank
+    dev = q.device
+    dq_acc = torch.zeros(q.shape, device=dev, dtype=torch.float32)  # Python fp32 dQ accumulator
+    block_dq = torch.empty_like(q); block_dk = torch.empty_like(k); block_dv = torch.empty_like(k)
+    kv_bufs = [torch.empty((2,) + k.shape, device=dev, dtype=k.dtype) for _ in range(2)]
+    kv_send = torch.empty((2,) + k.shape, device=dev, dtype=k.dtype)
+    if W > 1:
+        kv_send[0].copy_(k); kv_send[1].copy_(v)
+    k_cur, v_cur = k, v
+    dkdv_bufs = [torch.empty((2,) + k.shape, device=dev, dtype=torch.float32) for _ in range(2)]
+    dk_bufs = [dkdv_bufs[0][0], dkdv_bufs[1][0]]
+    dv_bufs = [dkdv_bufs[0][1], dkdv_bufs[1][1]]
+    first_iter_done = False
+    for step in range(W):
+        if step + 1 != W:
+            kv_comm.send_recv_packed(kv_send, kv_bufs[step & 1])
+        active = step <= rank or not causal
+        prev_slot = (step - 1) & 1
+        if active:
+            # full varlen backward for the current K/V chunk
+            _bwd(dout, q, k_cur, v_cur, out, softmax_lse,
+                 block_dq, block_dk, block_dv,
+                 cu, cu, None, None, max_s, max_s,
+                 softmax_scale, (causal and step == 0), -1, -1, 0.0, False, 0)
+            if not first_iter_done:
+                dq_acc.copy_(block_dq)
+            else:
+                dq_acc.add_(block_dq)
+            if first_iter_done:
+                d_kv_comm.wait()
+            if not first_iter_done:
+                dk_bufs[prev_slot].copy_(block_dk); dv_bufs[prev_slot].copy_(block_dv)
+            else:
+                dk_bufs[prev_slot].add_(block_dk); dv_bufs[prev_slot].add_(block_dv)
+            first_iter_done = True
+        elif step != 0:
+            d_kv_comm.wait()
+        if step + 1 != W:
+            kv_comm.wait()
+            kv_send = kv_bufs[step & 1]
+            k_cur, v_cur = kv_bufs[step & 1][0], kv_bufs[step & 1][1]
+        d_kv_comm.send_recv_packed(dkdv_bufs[prev_slot], dkdv_bufs[step & 1])
+    d_kv_comm.wait()
+    final_slot = (W - 1) & 1
+    return dq_acc.to(q.dtype), dk_bufs[final_slot].to(k.dtype), dv_bufs[final_slot].to(v.dtype)
+
+
+class _StockRingVarlenFunc(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, q, k, v, cu, max_s, softmax_scale, causal, group):
+        if softmax_scale is None:
+            softmax_scale = q.shape[-1] ** -0.5
+        out, lse = _ring_forward_varlen(group, q, k, v, cu, max_s, softmax_scale, causal)  # SAME fwd as opt
+        ctx.save_for_backward(q, k.contiguous(), v.contiguous(), out, lse.contiguous(), cu)
+        ctx.softmax_scale, ctx.causal, ctx.group, ctx.max_s = softmax_scale, causal, group, max_s
+        return out
+
+    @staticmethod
+    def backward(ctx, dout):
+        q, k, v, out, lse, cu = ctx.saved_tensors
+        dq, dk, dv = _ring_backward_varlen_stock(ctx.group, dout, q, k, v, out, lse, cu, ctx.max_s,
+                                                 ctx.softmax_scale, ctx.causal)
+        return dq, dk, dv, None, None, None, None, None
+
+
+def ring_varlen_stock(q, k, v, cu_seqlens, max_seqlen, softmax_scale=None, causal=False, group=None):
+    """[before] Varlen baseline ring (Option A forward + full varlen bwd per hop)."""
+    return _StockRingVarlenFunc.apply(q, k, v, cu_seqlens, max_seqlen, softmax_scale, causal, group)
+
+
+# ============================================================================
+# fp32 eager references ("ground truth") for accuracy.
+# ============================================================================
+def _ref_attention_fp32(q, k, v, causal, scale):
+    """Dense fp32 eager attention. q (B,S,Hq,D)/k,v (B,S,Hkv,D) fp32 -> out (B,S,Hq,D)."""
+    B, S, Hq, D = q.shape
+    Hkv = k.shape[2]; g = Hq // Hkv
+    qf = q.transpose(1, 2)
+    kf = k.transpose(1, 2).repeat_interleave(g, dim=1)
+    vf = v.transpose(1, 2).repeat_interleave(g, dim=1)
+    scores = torch.matmul(qf, kf.transpose(-1, -2)) * scale
+    if causal:
+        mask = torch.ones(S, S, device=q.device, dtype=torch.bool).tril()
+        scores = scores.masked_fill(~mask, float("-inf"))
+    p = torch.softmax(scores, dim=-1)
+    return torch.matmul(p, vf).transpose(1, 2).contiguous()
+
+
+def _ref_attention_fp32_varlen(q, k, v, cu, causal, scale):
+    """Per-sequence fp32 eager varlen attention. q (total,Hq,D)/k,v (total,Hkv,D) fp32
+    (may require grad) -> out (total,Hq,D). GQA repeats kv heads; causal is lower-tri."""
+    Hq = q.shape[1]; Hkv = k.shape[1]; g = Hq // Hkv
+    seqlens = (cu[1:] - cu[:-1]).tolist()
+    outs = []
+    for i, s in enumerate(seqlens):
+        lo = int(cu[i]); hi = lo + s
+        qi = q[lo:hi].transpose(0, 1)                              # (Hq, s, D)
+        ki = k[lo:hi].transpose(0, 1).repeat_interleave(g, 0)      # (Hq, s, D)
+        vi = v[lo:hi].transpose(0, 1).repeat_interleave(g, 0)
+        sc = torch.matmul(qi, ki.transpose(-1, -2)) * scale        # (Hq, s, s)
+        if causal:
+            m = torch.ones(s, s, device=q.device, dtype=torch.bool).tril()
+            sc = sc.masked_fill(~m, float("-inf"))
+        outs.append(torch.matmul(torch.softmax(sc, dim=-1), vi).transpose(0, 1))  # (s, Hq, D)
+    return torch.cat(outs, 0)                                      # (total, Hq, D)
+
+
+def _make_global_varlen(nseq, W, hq, hkv, d, dtype, device, seed):
+    """Packed global varlen batch whose every sequence length is a multiple of 8*W (so
+    each of the W ring chunks is a multiple of 8). Returns qg,kg,vg,dog (total,H,D), cu,
+    max_s, total -- identical on every rank (seeded)."""
+    unit = 8 * W
+    g = torch.Generator(device="cpu").manual_seed(seed)
+    seqlens = [((x // unit) + 1) * unit for x in torch.randint(unit, unit * 4, (nseq,), generator=g).tolist()]
+    total = sum(seqlens)
+    cu = torch.tensor([0] + list(torch.tensor(seqlens).cumsum(0)), dtype=torch.int32, device=device)
+    torch.manual_seed(seed)
+    qg = torch.randn(total, hq, d, device=device, dtype=dtype)
+    kg = torch.randn(total, hkv, d, device=device, dtype=dtype)
+    vg = torch.randn(total, hkv, d, device=device, dtype=dtype)
+    dog = torch.randn_like(qg)
+    return qg, kg, vg, dog, cu, max(seqlens), total
+
+
+def _parse_int_list(env_name, default):
+    raw = os.environ.get(env_name, default)
+    return [int(x) for x in raw.replace(" ", "").split(",") if x]
+
+
+def _bench(fn, device, warmup=8, iters=30):
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    s = torch.cuda.Event(enable_timing=True); e = torch.cuda.Event(enable_timing=True)
+    s.record()
+    for _ in range(iters):
+        fn()
+    e.record(); torch.cuda.synchronize()
+    t = torch.tensor([s.elapsed_time(e) / iters], device=device, dtype=torch.float64)
+    dist.all_reduce(t, op=dist.ReduceOp.MAX)   # true wall-clock straggler
+    return t.item()
+
+
+def _median(xs):
+    xs = sorted(xs); n = len(xs)
+    return xs[n // 2] if n % 2 else 0.5 * (xs[n // 2 - 1] + xs[n // 2])
+
+
+# ============================================================================
+# 1) Dense accuracy gate: optimized ring vs single-GPU full-sequence flash, each vs the
+#    fp32 eager truth. Criterion: ring_max <= flash_max*2.5 + 2e-3.
+# ============================================================================
+def precision_test(device, rank, world_size, log):
+    log("=" * 104)
+    log("[dense accuracy] optimized ring vs single-GPU flash, each vs fp32 eager truth")
+    log("criterion: ring_max <= flash_max * 2.5 + 2e-3")
+    log("=" * 104)
+    log(f"{'dtype':>7} {'d':>4} {'Hq':>3} {'Hkv':>4} {'causal':>7} | "
+        f"{'ring_max':>10} {'flash_max':>10} {'ring/flash':>10}  status")
+    B = 1
+    S_global = max(world_size, (2048 // world_size) * world_size)
+    all_ok = True
+    for dtype in (torch.bfloat16, torch.float16):
+        for D in (64, 128):
+            for (Hq, Hkv) in ((8, 8), (16, 2)):
+                for causal in (False, True):
+                    scale = D ** -0.5
+                    torch.manual_seed(2024)
+                    qg = torch.randn(B, S_global, Hq, D, device=device, dtype=dtype)
+                    kg = torch.randn(B, S_global, Hkv, D, device=device, dtype=dtype)
+                    vg = torch.randn(B, S_global, Hkv, D, device=device, dtype=dtype)
+                    dog = torch.randn_like(qg)
+                    qf = qg.float().detach().requires_grad_(True)
+                    kf = kg.float().detach().requires_grad_(True)
+                    vf = vg.float().detach().requires_grad_(True)
+                    o_t = _ref_attention_fp32(qf, kf, vf, causal, scale)
+                    o_t.backward(dog.float())
+                    truth = {"out": o_t.detach(), "dq": qf.grad, "dk": kf.grad, "dv": vf.grad}
+                    ql = shard_along_seq(qg, rank, world_size).detach().clone().requires_grad_(True)
+                    kl = shard_along_seq(kg, rank, world_size).detach().clone().requires_grad_(True)
+                    vl = shard_along_seq(vg, rank, world_size).detach().clone().requires_grad_(True)
+                    o_r = ring_opt(ql, kl, vl, causal=causal, softmax_scale=scale)
+                    o_r.backward(shard_along_seq(dog, rank, world_size))
+                    ring = {"out": o_r.detach(), "dq": ql.grad, "dk": kl.grad, "dv": vl.grad}
+                    qF = qg.detach().clone().requires_grad_(True)
+                    kF = kg.detach().clone().requires_grad_(True)
+                    vF = vg.detach().clone().requires_grad_(True)
+                    o_f = flash_attn_func(qF, kF, vF, softmax_scale=scale, causal=causal)
+                    o_f.backward(dog)
+                    flash = {"out": o_f.detach(), "dq": qF.grad, "dk": kF.grad, "dv": vF.grad}
+                    ring_max = flash_max = 0.0
+                    for key in ("out", "dq", "dk", "dv"):
+                        t = shard_along_seq(truth[key], rank, world_size).float()
+                        ring_max = max(ring_max, (ring[key].float() - t).abs().max().item())
+                        flash_max = max(flash_max, (shard_along_seq(flash[key], rank, world_size).float() - t).abs().max().item())
+                    ok_local = ring_max <= flash_max * 2.5 + 2e-3
+                    ok_t = torch.tensor([int(ok_local)], device=device, dtype=torch.int32)
+                    dist.all_reduce(ok_t, op=dist.ReduceOp.MIN)
+                    ok = bool(ok_t.item()); all_ok = all_ok and ok
+                    log(f"{str(dtype).split('.')[-1]:>7} {D:>4} {Hq:>3} {Hkv:>4} {str(causal):>7} | "
+                        f"{ring_max:>10.2e} {flash_max:>10.2e} {ring_max / max(flash_max, 1e-9):>9.2f}x  "
+                        f"{'PASS' if ok else 'FAIL'}")
+    log()
+    log(f"dense accuracy: {'ALL PASSED' if all_ok else 'SOME FAILED'}")
+    log()
+    return all_ok
+
+
+# ============================================================================
+# 2) Dense before/after accuracy: opt vs stock, each vs the fp32 eager truth.
+# ============================================================================
+def precision_compare(device, rank, world_size, log):
+    log("=" * 118)
+    log("[dense before/after accuracy] opt (fwd_ring + bwd_ring) vs stock (flash_attn_func + full bwd), vs fp32 truth")
+    log("=" * 118)
+    log(f"{'dtype':>7} {'d':>4} {'Hq':>3} {'Hkv':>4} {'causal':>7} | "
+        f"{'out opt':>9} {'out old':>9} | {'dq opt':>9} {'dq old':>9} | "
+        f"{'dk opt':>9} {'dk old':>9} | {'dv opt':>9} {'dv old':>9}")
+    B = 1
+    S_global = max(world_size, (2048 // world_size) * world_size)
+    for dtype in (torch.bfloat16, torch.float16):
+        for D in (64, 128):
+            for (Hq, Hkv) in ((8, 8), (16, 2)):
+                for causal in (False, True):
+                    scale = D ** -0.5
+                    torch.manual_seed(2024)
+                    qg = torch.randn(B, S_global, Hq, D, device=device, dtype=dtype)
+                    kg = torch.randn(B, S_global, Hkv, D, device=device, dtype=dtype)
+                    vg = torch.randn(B, S_global, Hkv, D, device=device, dtype=dtype)
+                    dog = torch.randn_like(qg)
+                    qf = qg.float().detach().requires_grad_(True)
+                    kf = kg.float().detach().requires_grad_(True)
+                    vf = vg.float().detach().requires_grad_(True)
+                    o_t = _ref_attention_fp32(qf, kf, vf, causal, scale)
+                    o_t.backward(dog.float())
+                    truth = {"out": o_t.detach(), "dq": qf.grad, "dk": kf.grad, "dv": vf.grad}
+
+                    def run(ring_fn):
+                        ql = shard_along_seq(qg, rank, world_size).detach().clone().requires_grad_(True)
+                        kl = shard_along_seq(kg, rank, world_size).detach().clone().requires_grad_(True)
+                        vl = shard_along_seq(vg, rank, world_size).detach().clone().requires_grad_(True)
+                        o = ring_fn(ql, kl, vl, causal=causal, softmax_scale=scale)
+                        o.backward(shard_along_seq(dog, rank, world_size))
+                        return {"out": o.detach(), "dq": ql.grad, "dk": kl.grad, "dv": vl.grad}
+
+                    opt = run(ring_opt); old = run(ring_stock)
+                    e = {}
+                    for key in ("out", "dq", "dk", "dv"):
+                        t = shard_along_seq(truth[key], rank, world_size).float()
+                        pair = torch.tensor([(opt[key].float() - t).abs().max().item(),
+                                             (old[key].float() - t).abs().max().item()],
+                                            device=device, dtype=torch.float64)
+                        dist.all_reduce(pair, op=dist.ReduceOp.MAX)
+                        e[key] = (pair[0].item(), pair[1].item())
+                    log(f"{str(dtype).split('.')[-1]:>7} {D:>4} {Hq:>3} {Hkv:>4} {str(causal):>7} | "
+                        f"{e['out'][0]:>9.2e} {e['out'][1]:>9.2e} | {e['dq'][0]:>9.2e} {e['dq'][1]:>9.2e} | "
+                        f"{e['dk'][0]:>9.2e} {e['dk'][1]:>9.2e} | {e['dv'][0]:>9.2e} {e['dv'][1]:>9.2e}")
+    log()
+
+
+# ============================================================================
+# 3) Dense before/after speed: opt vs stock, fwd and fwd+bwd, (head_dim x per-rank S).
+# ============================================================================
+def speed_grid(device, rank, world_size, log):
+    Hq = int(os.environ.get("RING_HQ", 16))
+    Hkv = int(os.environ.get("RING_HKV", 2))
+    d_list = _parse_int_list("RING_D_LIST", "64,128,256")
+    s_list = _parse_int_list("RING_S_LIST", "512,1024,2048,4096,8192")
+    reps = int(os.environ.get("RING_REPS", 3))
+    B = 1
+    dtype = torch.bfloat16
+    log("=" * 120)
+    log(f"[dense before/after speed] causal=True, ws={world_size}, Hq={Hq} Hkv={Hkv}, bf16 | median of {reps}, all_reduce MAX")
+    log("old/opt > 1 => optimized ring is faster.  bwd = backward-only (fwd run once, untimed, then timed .backward on the retained graph)")
+    log("=" * 120)
+    log(f"{'D':>4} {'S_local':>8} {'S_glob':>8} | {'fwd opt':>9} {'fwd old':>9} {'o/o':>6} | "
+        f"{'bwd opt':>9} {'bwd old':>9} {'o/o':>6} | {'fbw opt':>9} {'fbw old':>9} {'o/o':>6}")
+    for D in d_list:
+        scale = D ** -0.5
+        for S_local in s_list:
+            S_global = S_local * world_size
+            try:
+                torch.manual_seed(7)
+                qg = torch.randn(B, S_global, Hq, D, device=device, dtype=dtype)
+                kg = torch.randn(B, S_global, Hkv, D, device=device, dtype=dtype)
+                vg = torch.randn(B, S_global, Hkv, D, device=device, dtype=dtype)
+                q = shard_along_seq(qg, rank, world_size)
+                k = shard_along_seq(kg, rank, world_size)
+                v = shard_along_seq(vg, rank, world_size)
+                dout = shard_along_seq(torch.randn_like(qg), rank, world_size)
+
+                def mk_fwd(fn):
+                    def r():
+                        with torch.no_grad():
+                            fn(q, k, v, causal=True, softmax_scale=scale)
+                    return r
+
+                def mk_fbw(fn):
+                    def r():
+                        qa = q.detach().clone().requires_grad_(True)
+                        ka = k.detach().clone().requires_grad_(True)
+                        va = v.detach().clone().requires_grad_(True)
+                        fn(qa, ka, va, causal=True, softmax_scale=scale).backward(dout)
+                    return r
+
+                def mk_bwd(fn):
+                    # forward ONCE (untimed), then time only repeated backward on the
+                    # retained graph -> isolates the backward from the shared forward.
+                    qa = q.detach().clone().requires_grad_(True)
+                    ka = k.detach().clone().requires_grad_(True)
+                    va = v.detach().clone().requires_grad_(True)
+                    out = fn(qa, ka, va, causal=True, softmax_scale=scale)
+
+                    def r():
+                        out.backward(dout, retain_graph=True)
+                    return r
+
+                # interleave opt/stock per rep so slow clock/thermal drift cancels
+                fwd_o, fwd_s, bwd_o, bwd_s, fbw_o, fbw_s = [], [], [], [], [], []
+                for _ in range(reps):
+                    fwd_o.append(_bench(mk_fwd(ring_opt), device))
+                    fwd_s.append(_bench(mk_fwd(ring_stock), device))
+                    bwd_o.append(_bench(mk_bwd(ring_opt), device))
+                    bwd_s.append(_bench(mk_bwd(ring_stock), device))
+                    fbw_o.append(_bench(mk_fbw(ring_opt), device))
+                    fbw_s.append(_bench(mk_fbw(ring_stock), device))
+                fo, fs = _median(fwd_o), _median(fwd_s)
+                do, ds = _median(bwd_o), _median(bwd_s)
+                bo, bs = _median(fbw_o), _median(fbw_s)
+                log(f"{D:>4} {S_local:>8} {S_global:>8} | {fo:>9.3f} {fs:>9.3f} {fs / fo:>5.2f}x | "
+                    f"{do:>9.3f} {ds:>9.3f} {ds / do:>5.2f}x | {bo:>9.3f} {bs:>9.3f} {bs / bo:>5.2f}x")
+            except Exception as ex:
+                torch.cuda.synchronize()
+                log(f"{D:>4} {S_local:>8} {S_global:>8} | FAILED: {type(ex).__name__}: {str(ex)[:80]}")
+                torch.cuda.empty_cache()
+    log()
+
+
+# ============================================================================
+# 4) Varlen before/after accuracy: opt vs stock, each vs the fp32 eager varlen truth.
+#    (varlen forward is identical opt==stock -> `out` columns match; the FA3 difference
+#    is the backward, so watch dq.)
+# ============================================================================
+def varlen_precision_compare(device, rank, world_size, log):
+    log("=" * 118)
+    log("[varlen before/after accuracy] opt (bwd_ring) vs stock (full varlen bwd/hop), vs fp32 varlen truth")
+    log("(varlen forward is shared -> out opt==old; the FA3 difference is the backward -> watch dq)")
+    log("=" * 118)
+    log(f"{'dtype':>7} {'d':>4} {'Hq':>3} {'Hkv':>4} {'causal':>7} | "
+        f"{'out opt':>9} {'out old':>9} | {'dq opt':>9} {'dq old':>9} | "
+        f"{'dk opt':>9} {'dk old':>9} | {'dv opt':>9} {'dv old':>9}")
+    nseq = 3
+    for dtype in (torch.bfloat16, torch.float16):
+        for D in (64, 128):
+            for (Hq, Hkv) in ((8, 8), (16, 2)):
+                for causal in (False, True):
+                    scale = D ** -0.5
+                    qg, kg, vg, dog, cu, max_s, total = _make_global_varlen(nseq, world_size, Hq, Hkv, D, dtype, device, seed=2024)
+                    qf = qg.float().detach().requires_grad_(True)
+                    kf = kg.float().detach().requires_grad_(True)
+                    vf = vg.float().detach().requires_grad_(True)
+                    o_t = _ref_attention_fp32_varlen(qf, kf, vf, cu, causal, scale)
+                    o_t.backward(dog.float())
+                    truth = {"out": o_t.detach(), "dq": qf.grad, "dk": kf.grad, "dv": vf.grad}
+                    cu_loc = shard_varlen_along_seq(qg, cu, rank, world_size)[1]
+                    max_loc = shard_varlen_along_seq(qg, cu, rank, world_size)[2]
+                    dol = shard_varlen_along_seq(dog, cu, rank, world_size)[0]
+
+                    def run(ring_fn):
+                        ql = shard_varlen_along_seq(qg, cu, rank, world_size)[0].detach().requires_grad_(True)
+                        kl = shard_varlen_along_seq(kg, cu, rank, world_size)[0].detach().requires_grad_(True)
+                        vl = shard_varlen_along_seq(vg, cu, rank, world_size)[0].detach().requires_grad_(True)
+                        o = ring_fn(ql, kl, vl, cu_loc, max_loc, softmax_scale=scale, causal=causal)
+                        o.backward(dol)
+                        return {"out": o.detach(), "dq": ql.grad, "dk": kl.grad, "dv": vl.grad}
+
+                    opt = run(ring_varlen_opt); old = run(ring_varlen_stock)
+                    e = {}
+                    for key in ("out", "dq", "dk", "dv"):
+                        t = shard_varlen_along_seq(truth[key], cu, rank, world_size)[0].float()
+                        pair = torch.tensor([(opt[key].float() - t).abs().max().item(),
+                                             (old[key].float() - t).abs().max().item()],
+                                            device=device, dtype=torch.float64)
+                        dist.all_reduce(pair, op=dist.ReduceOp.MAX)
+                        e[key] = (pair[0].item(), pair[1].item())
+                    log(f"{str(dtype).split('.')[-1]:>7} {D:>4} {Hq:>3} {Hkv:>4} {str(causal):>7} | "
+                        f"{e['out'][0]:>9.2e} {e['out'][1]:>9.2e} | {e['dq'][0]:>9.2e} {e['dq'][1]:>9.2e} | "
+                        f"{e['dk'][0]:>9.2e} {e['dk'][1]:>9.2e} | {e['dv'][0]:>9.2e} {e['dv'][1]:>9.2e}")
+    log()
+
+
+# ============================================================================
+# 5) Varlen before/after speed: opt vs stock, fwd and fwd+bwd, across per-rank chunk
+#    lengths. (fwd is shared -> ~parity; the win is the backward.)
+# ============================================================================
+def varlen_speed_compare(device, rank, world_size, log):
+    Hq = int(os.environ.get("RING_HQ", 16))
+    Hkv = int(os.environ.get("RING_HKV", 2))
+    reps = int(os.environ.get("RING_REPS", 3))
+    dtype = torch.bfloat16
+    causal = True
+    D = 128
+    scale = D ** -0.5
+    log("=" * 120)
+    log(f"[varlen before/after speed] causal=True, ws={world_size}, Hq={Hq} Hkv={Hkv} D={D}, bf16 | median of {reps}")
+    log("old/opt > 1 => optimized varlen ring is faster (fwd is shared -> ~1.0; the FA3 win is the backward -> read the bwd column)")
+    log("=" * 120)
+    log(f"{'nseq':>5} {'seqlen':>7} {'total':>8} | {'fwd opt':>9} {'fwd old':>9} {'o/o':>6} | "
+        f"{'bwd opt':>9} {'bwd old':>9} {'o/o':>6} | {'fbw opt':>9} {'fbw old':>9} {'o/o':>6}")
+    for nseq, per_seq in ((4, 512), (4, 2048), (8, 4096)):
+        try:
+            unit = 8 * world_size
+            per_seq = ((per_seq + unit - 1) // unit) * unit    # round up to a multiple of 8*W
+            seqlens = [per_seq] * nseq
+            total = per_seq * nseq
+            cu = torch.tensor([i * per_seq for i in range(nseq + 1)], dtype=torch.int32, device=device)
+            torch.manual_seed(7)
+            qg = torch.randn(total, Hq, D, device=device, dtype=dtype)
+            kg = torch.randn(total, Hkv, D, device=device, dtype=dtype)
+            vg = torch.randn(total, Hkv, D, device=device, dtype=dtype)
+            q, cu_loc, max_loc = shard_varlen_along_seq(qg, cu, rank, world_size)
+            k = shard_varlen_along_seq(kg, cu, rank, world_size)[0]
+            v = shard_varlen_along_seq(vg, cu, rank, world_size)[0]
+            dout = shard_varlen_along_seq(torch.randn_like(qg), cu, rank, world_size)[0]
+
+            def mk_fwd(fn):
+                def r():
+                    with torch.no_grad():
+                        fn(q, k, v, cu_loc, max_loc, softmax_scale=scale, causal=causal)
+                return r
+
+            def mk_fbw(fn):
+                def r():
+                    qa = q.detach().requires_grad_(True)
+                    ka = k.detach().requires_grad_(True)
+                    va = v.detach().requires_grad_(True)
+                    fn(qa, ka, va, cu_loc, max_loc, softmax_scale=scale, causal=causal).backward(dout)
+                return r
+
+            def mk_bwd(fn):
+                # forward ONCE (untimed), then time only repeated backward on the retained
+                # graph -> isolates the backward from the shared varlen forward.
+                qa = q.detach().requires_grad_(True)
+                ka = k.detach().requires_grad_(True)
+                va = v.detach().requires_grad_(True)
+                out = fn(qa, ka, va, cu_loc, max_loc, softmax_scale=scale, causal=causal)
+
+                def r():
+                    out.backward(dout, retain_graph=True)
+                return r
+
+            fwd_o, fwd_s, bwd_o, bwd_s, fbw_o, fbw_s = [], [], [], [], [], []
+            for _ in range(reps):
+                fwd_o.append(_bench(mk_fwd(ring_varlen_opt), device))
+                fwd_s.append(_bench(mk_fwd(ring_varlen_stock), device))
+                bwd_o.append(_bench(mk_bwd(ring_varlen_opt), device))
+                bwd_s.append(_bench(mk_bwd(ring_varlen_stock), device))
+                fbw_o.append(_bench(mk_fbw(ring_varlen_opt), device))
+                fbw_s.append(_bench(mk_fbw(ring_varlen_stock), device))
+            fo, fs = _median(fwd_o), _median(fwd_s)
+            do, ds = _median(bwd_o), _median(bwd_s)
+            bo, bs = _median(fbw_o), _median(fbw_s)
+            log(f"{nseq:>5} {per_seq:>7} {total:>8} | {fo:>9.3f} {fs:>9.3f} {fs / fo:>5.2f}x | "
+                f"{do:>9.3f} {ds:>9.3f} {ds / do:>5.2f}x | {bo:>9.3f} {bs:>9.3f} {bs / bo:>5.2f}x")
+        except Exception as ex:
+            torch.cuda.synchronize()
+            log(f"{nseq:>5} {per_seq:>7} | FAILED: {type(ex).__name__}: {str(ex)[:80]}")
+            torch.cuda.empty_cache()
+    log()
+
+
+def main():
+    dist.init_process_group("nccl")
+    try:
+        rank = dist.get_rank()
+        world_size = dist.get_world_size()
+        local_rank = int(os.environ.get("LOCAL_RANK", rank))
+        torch.cuda.set_device(local_rank)
+        device = torch.device("cuda", local_rank)
+
+        def log(*a):
+            if rank == 0:
+                print(*a, flush=True)
+
+        log(f"world_size={world_size}  device_name={torch.cuda.get_device_name(local_rank)}")
+        log(f"hopper: {_HOPPER_DIR}\ntests:  {_TESTS_DIR}")
+        log()
+
+        if os.environ.get("RING_SKIP_PRECISION", "0") != "1":
+            precision_test(device, rank, world_size, log)
+        if os.environ.get("RING_SKIP_PRECISION_DIFF", "0") != "1":
+            precision_compare(device, rank, world_size, log)
+        if os.environ.get("RING_SKIP_SPEED", "0") != "1":
+            speed_grid(device, rank, world_size, log)
+        if os.environ.get("RING_SKIP_VARLEN_DIFF", "0") != "1":
+            varlen_precision_compare(device, rank, world_size, log)
+        if os.environ.get("RING_SKIP_VARLEN_SPEED", "0") != "1":
+            varlen_speed_compare(device, rank, world_size, log)
+    finally:
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/hopper/flash.h
+++ b/hopper/flash.h
@@ -165,6 +165,14 @@ struct Flash_fwd_params : public Qkv_params {
 
     int arch;
     int num_sm;
+
+    // Ring-attention backward phase selector (additive; 0 for all existing paths
+    // since set_params_fprop does `params = {}`). Only read by run_flash_bwd:
+    // 0 = normal full backward (unchanged), 1 = preprocess only (compute D +
+    // softmax_lse_log2 + clear dQaccum), 2 = main seqk kernel only (accumulate dQ
+    // into a persistent fp32 dq_accum, write this K/V block's dK/dV), 3 = convert
+    // dQaccum -> dQ only.
+    int ring_bwd_phase;
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/hopper/flash_api.cpp
+++ b/hopper/flash_api.cpp
@@ -384,6 +384,20 @@ void run_mha_fwd(Flash_fwd_params &params, cudaStream_t stream) {
     });
 }
 
+// Ring-attention: run the forward kernel with Split forced true so it writes an
+// fp32 partial (oaccum + lseaccum) for ONE K/V block, and NO combine. Used by
+// mha_fwd's `skip_combine` path (dense; num_splits is caller-chosen and may be 1 for a
+// non-causal ring block -- Split is still forced so we get the fp32 partial).
+void run_mha_fwd_ring(Flash_fwd_params &params, cudaStream_t stream) {
+    TORCH_CHECK(params.num_splits >= 1);
+    ARCH_SWITCH(params.arch, Arch, [&] {
+        SOFTCAP_SWITCH(params.softcap > 0.0, Has_softcap, [&] {
+            // Split=true always enables PackGQA; no paged-KV for ring partials.
+            run_mha_fwd_constexpr<Arch, /*Split=*/true, /*PagedKVNonTMA=*/false, /*PackGQA=*/true, Has_softcap>(params, stream);
+        });
+    });
+}
+
 void run_mha_fwd_combine(Flash_fwd_params &params, cudaStream_t stream, bool enable_pdl=false) {
     #ifndef FLASHATTENTION_DISABLE_SPLIT
     // If hdim is 96 or 192, it's faster to round them to 128 or 256 respectively
@@ -704,7 +718,15 @@ mha_fwd(at::Tensor q,   // (b, s_q, h, d) or (total_q, h, d) if there is cu_seql
         std::optional<at::Tensor> scheduler_metadata_,  // (b + 1)
         int64_t num_splits,
         std::optional<bool> pack_gqa_,
-        int64_t sm_margin
+        int64_t sm_margin,
+        // Ring / context-parallel forward, folded in. skip_combine == false (default) is
+        // the standard forward, byte-identical to before. When skip_combine == true the
+        // Split kernel is forced on (even for num_splits==1) so it writes the fp32
+        // normalized partial + fp32 LSE into the CALLER-OWNED out_accum/lse_accum, and the
+        // combine is skipped (no bf16 round-trip). The ring driver merges partials in fp32.
+        bool skip_combine,
+        std::optional<at::Tensor> out_accum_,
+        std::optional<at::Tensor> lse_accum_
         ) {
 
     auto dprops = at::cuda::getCurrentDeviceProperties();
@@ -983,6 +1005,13 @@ mha_fwd(at::Tensor q,   // (b, s_q, h, d) or (total_q, h, d) if there is cu_seql
     params.num_splits = num_splits <= 0 ? get_num_splits(params) : num_splits;
     // Always enable PackGQA for Split, and get_pack_gqa requires params.num_splits to decide
     params.pack_gqa = pack_gqa_.has_value() ? pack_gqa_.value() : get_pack_gqa(params);
+    if (skip_combine) {
+        TORCH_CHECK(out_accum_.has_value() && lse_accum_.has_value(),
+                    "skip_combine (ring forward) requires out_accum and lse_accum");
+        TORCH_CHECK(!paged_KV && !k_new_.has_value() && !q_v_.has_value(),
+                    "ring forward (skip_combine) does not support paged-KV / appendKV / q_v");
+        params.pack_gqa = true;  // the forced-Split ring path always uses PackGQA
+    }
 
     // This needs to be set after get_num_splits
     at::Tensor tile_count_semaphore;  // Contains the semaphore and optionally num_splits_dynamic
@@ -1091,9 +1120,26 @@ mha_fwd(at::Tensor q,   // (b, s_q, h, d) or (total_q, h, d) if there is cu_seql
 
     at::Tensor out_accum, softmax_lse_accum;
     auto outaccum_type = at::ScalarType::Float;
-    if (params.num_splits > 1) {
+    if (params.num_splits > 1 || skip_combine) {
         TORCH_CHECK(params.num_splits <= 256, "num_splits > 256 not supported");
-        if (!is_varlen_q) {
+        if (out_accum_.has_value()) {
+            // Ring: caller owns the fp32 partial buffers; skip_combine writes into them.
+            out_accum = out_accum_.value();
+            softmax_lse_accum = lse_accum_.value();
+            TORCH_CHECK(out_accum.scalar_type() == at::kFloat && softmax_lse_accum.scalar_type() == at::kFloat,
+                        "out_accum/lse_accum must be fp32");
+            TORCH_CHECK(out_accum.stride(-1) == 1, "out_accum must have contiguous last dimension");
+            TORCH_CHECK(softmax_lse_accum.stride(-1) == 1, "lse_accum must have contiguous last dimension");
+            if (!is_varlen_q) {
+                CHECK_SHAPE(out_accum, (int)params.num_splits, batch_size, num_heads, seqlen_q, head_size_v);
+                CHECK_SHAPE(softmax_lse_accum, (int)params.num_splits, batch_size, num_heads, seqlen_q);
+                params.oaccum_batch_stride = out_accum.stride(1);
+                params.lseaccum_batch_stride = softmax_lse_accum.stride(1);
+            } else {
+                CHECK_SHAPE(out_accum, (int)params.num_splits, num_heads, total_q, head_size_v);
+                CHECK_SHAPE(softmax_lse_accum, (int)params.num_splits, num_heads, total_q);
+            }
+        } else if (!is_varlen_q) {
             out_accum = torch::empty({params.num_splits, batch_size, num_heads, seqlen_q, head_size_v}, opts.dtype(outaccum_type));
             softmax_lse_accum = torch::empty({params.num_splits, batch_size, num_heads, seqlen_q}, opts.dtype(at::kFloat));
             params.oaccum_batch_stride = out_accum.stride(1);
@@ -1166,36 +1212,49 @@ mha_fwd(at::Tensor q,   // (b, s_q, h, d) or (total_q, h, d) if there is cu_seql
 
     if (total_q > 0 && (total_k + params.total_knew) > 0 && num_heads_k > 0) {
         auto stream = at::cuda::getCurrentCUDAStream().stream();
-        run_mha_fwd(params, stream);
-        if (params.num_splits > 1) {
-            if (out_type == at::ScalarType::BFloat16) {
-                // Since we want output in BF16. Otherwise fwd_combine will output to FP16
-                params.is_bf16 = true;
+        if (skip_combine) {
+            // Ring: force the Split kernel (even for num_splits==1) to write fp32 partials
+            // into the caller-owned out_accum/lse_accum, and skip the combine.
+            run_mha_fwd_ring(params, stream);
+        } else {
+            run_mha_fwd(params, stream);
+            if (params.num_splits > 1) {
+                if (out_type == at::ScalarType::BFloat16) {
+                    // Since we want output in BF16. Otherwise fwd_combine will output to FP16
+                    params.is_bf16 = true;
+                }
+                // Unless there's seqused_q, for the purpose of attn_combine, we can just treat it as batch=1
+                // and seqlen = total_q, and don't need to dispatch to Varlen there.
+                // However, with dynamic split, each row needs to know which batch it belongs to
+                // to read the number of splits, so we just use the varlen version of combine kernel.
+                // if (is_varlen_q && !seqused_q_.has_value()) {
+                // if (is_varlen_q) {
+                //     params.b = 1;
+                //     params.seqlen_q = total_q;
+                // }
+                // This will zero out the semaphore if needed
+                run_mha_fwd_combine(params, stream, true /*enable_pdl*/);
+            } else if (scheduler_needs_semaphore && params.skip_scheduler_metadata_computation) {
+                // need to zero out the semaphore in this case
+                tile_count_semaphore.index({torch::indexing::Slice(params.tile_count_semaphore_offset, params.tile_count_semaphore_offset + 1)}).zero_();
             }
-            // Unless there's seqused_q, for the purpose of attn_combine, we can just treat it as batch=1
-            // and seqlen = total_q, and don't need to dispatch to Varlen there.
-            // However, with dynamic split, each row needs to know which batch it belongs to
-            // to read the number of splits, so we just use the varlen version of combine kernel.
-            // if (is_varlen_q && !seqused_q_.has_value()) {
-            // if (is_varlen_q) {
-            //     params.b = 1;
-            //     params.seqlen_q = total_q;
-            // }
-            // This will zero out the semaphore if needed
-            run_mha_fwd_combine(params, stream, true /*enable_pdl*/);
-        } else if (scheduler_needs_semaphore && params.skip_scheduler_metadata_computation) {
-            // need to zero out the semaphore in this case
-            tile_count_semaphore.index({torch::indexing::Slice(params.tile_count_semaphore_offset, params.tile_count_semaphore_offset + 1)}).zero_();
         }
     } else if (total_q > 0 && num_heads_k > 0) {
         // If seqlen_k == 0, then we have an empty tensor. We need to set the output to 0.
-        out.zero_();
-        softmax_lse.fill_(std::numeric_limits<float>::infinity());
+        if (skip_combine) {
+            out_accum.zero_();
+            softmax_lse_accum.fill_(-std::numeric_limits<float>::infinity());
+        } else {
+            out.zero_();
+            softmax_lse.fill_(std::numeric_limits<float>::infinity());
+        }
     }
 
-    // return {out, softmax_lse};
     return {out, softmax_lse, out_accum, softmax_lse_accum};
 }
+
+// ===========================================================================
+
 
 #ifdef FLASHATTENTION_DISABLE_BACKWARD
 void run_mha_bwd(Flash_bwd_params &params, cudaStream_t stream) {
@@ -1258,12 +1317,10 @@ void run_mha_bwd(Flash_bwd_params &params, cudaStream_t stream) {
 #endif
 
 
-// b: batch_size
-// s_q: seqlen_q
-// s_k: seqlen_k
-// h: num_heads
-// h_k: num_heads_k
-// d: head_size
+// Ring backward kBlockM/kBlockN (causal-independent; single source of truth for
+// sizing the persistent dq_accum). Defined below; forward-declared for mha_bwd.
+static std::tuple<int, int> ring_bwd_kblock_mn(int arch, int head_size_rounded, double softcap);
+
 std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor> mha_bwd(
     at::Tensor dout,  // (b, s_q, h, dv) or (total_q, h, dv) if there is cu_seqlens_q
     at::Tensor q,     // (b, s_q, h, d) or (total_q, h, d) if there is cu_seqlens_q
@@ -1286,7 +1343,17 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor> mha_bwd(
     int64_t window_size_right,
     double softcap,
     bool deterministic,
-    int64_t sm_margin
+    int64_t sm_margin,
+    // Ring / context-parallel backward, folded in. ring_phase == 0 (default) is the
+    // standard backward, byte-identical to before. When ring_phase != 0 the three
+    // fp32 buffers below are CALLER-OWNED and persist across phases:
+    //   1 = preprocess (clear dq_accum + write D/softmax_lse_log2, once per rank),
+    //   2 = step       (accumulate this K/V shard's dQ into dq_accum, emit dK/dV, per hop),
+    //   3 = convert    (dq_accum -> dq, once per rank).
+    int64_t ring_phase,
+    std::optional<at::Tensor> dq_accum_,
+    std::optional<at::Tensor> dsoftmax_sum_,
+    std::optional<at::Tensor> softmax_lse_log2_
 ) {
 
     #ifdef FLASHATTENTION_DISABLE_BACKWARD
@@ -1367,16 +1434,28 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor> mha_bwd(
     int const arch = at::cuda::getCurrentDeviceProperties()->major * 10 + at::cuda::getCurrentDeviceProperties()->minor;
     int const head_size_rounded = round_up_headdim(std::max(head_size, head_size_v));
     int const head_size_v_rounded = head_size_rounded;
+    bool const is_ring = ring_phase != 0;
+    if (is_ring) {
+        TORCH_CHECK(arch >= 90, "ring backward (ring_phase != 0) requires Hopper (sm90+).");
+        TORCH_CHECK(!(head_size_rounded <= 64 && softcap > 0.0),
+                    "ring backward does not support softcap for hdim<=64 (kBlockM would differ "
+                    "across causal/non-causal ring steps and break the persistent dq_accum).");
+        deterministic = false;  // ring path is always non-deterministic (dq_semaphore unused)
+    }
     TORCH_CHECK(!deterministic || head_size_rounded < 256, "Deterministic backward not supported for hdim 256.");
     // Very important that these match the kernel configs
     bool const is_local = (window_size_left >= 0 || window_size_right >= 0) && !is_causal;
+    TORCH_CHECK(!is_ring || !is_local,
+                "ring backward (ring_phase != 0) does not support local / sliding-window: the "
+                "hd128 ring pins kBlockM=80 for plain causal, which disagrees with the kernel's "
+                "local kBlockM=64 and would corrupt the persistent dq_accum layout.");
     int const kBlockM_sm90 = head_size_rounded <= 64 ? (is_causal && softcap > 0.0 ? 96 : 128)
         : (head_size_rounded <= 96 ? 64
            : (head_size_rounded <= 128 ? (is_causal || is_local || softcap > 0.0 ? 64 : 80)
               : 64));
     int const kBlockM_sm80 = head_size_rounded <= 64 ? 128 : 64;
     int const kBlockM_sm86 = head_size_rounded <= 192 ? 64 : 32;
-    int const kBlockM = arch >= 90 ? kBlockM_sm90 : (arch == 86 || arch == 89 ? kBlockM_sm86 : kBlockM_sm80);
+    int kBlockM = arch >= 90 ? kBlockM_sm90 : (arch == 86 || arch == 89 ? kBlockM_sm86 : kBlockM_sm80);
     int const kBlockN_sm90 = head_size_rounded <= 128
         ? 128
         : (head_size_rounded <= 192 ? 96 : 80);
@@ -1387,7 +1466,10 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor> mha_bwd(
         : (head_size_rounded <= 96 ? 128
            : (head_size_rounded <= 128 ? 96
               : (head_size_rounded <= 192 ? 64 : 64)));
-    int const kBlockN = arch >= 90 ? kBlockN_sm90 : (arch == 86 || arch == 89 ? kBlockN_sm86 : kBlockN_sm80);
+    int kBlockN = arch >= 90 ? kBlockN_sm90 : (arch == 86 || arch == 89 ? kBlockN_sm86 : kBlockN_sm80);
+    // Ring keeps ONE (causal-independent) block across mixed causal/non-causal steps so
+    // the persistent dq_accum layout stays consistent (hd128 -> tuned 80-block).
+    if (is_ring) { std::tie(kBlockM, kBlockN) = ring_bwd_kblock_mn(arch, head_size_rounded, softcap); }
     auto round_multiple = [](int x, int m) { return (x + m - 1) / m * m; };
     int const seqlen_q_rounded = round_multiple(seqlen_q, kBlockM);
     int const seqlen_k_rounded = round_multiple(seqlen_k, kBlockN);
@@ -1474,21 +1556,37 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor> mha_bwd(
     auto opts = q.options();
     // Need softmax_d to have total_q_padded_rounded since we want its address to be aligned by 16/8 bytes for TMA / LDG.64
     at::Tensor softmax_d, softmax_lse_log2;
-    if (!is_varlen) {
+    at::Tensor dq_accum, dk_accum, dv_accum;
+    if (is_ring) {
+        // Ring: the three fp32 buffers are caller-owned and persist across phases 1/2/3.
+        dq_accum = dq_accum_.value();
+        softmax_d = dsoftmax_sum_.value();
+        softmax_lse_log2 = softmax_lse_log2_.value();
+        TORCH_CHECK(dq_accum.dtype() == at::kFloat && softmax_d.dtype() == at::kFloat
+                    && softmax_lse_log2.dtype() == at::kFloat,
+                    "ring dq_accum / dsoftmax_sum / softmax_lse_log2 must be float32");
+        if (!is_varlen) {
+            CHECK_SHAPE(dq_accum, batch_size, num_heads, seqlen_q_rounded * head_size_rounded);
+            CHECK_SHAPE(softmax_d, batch_size, num_heads, seqlen_q_rounded);
+            CHECK_SHAPE(softmax_lse_log2, batch_size, num_heads, seqlen_q_rounded);
+        } else {
+            CHECK_SHAPE(dq_accum, num_heads, total_q_padded_rounded * head_size_rounded);
+            CHECK_SHAPE(softmax_d, num_heads, total_q_padded_rounded);
+            CHECK_SHAPE(softmax_lse_log2, num_heads, total_q_padded_rounded);
+        }
+    } else if (!is_varlen) {
         // Need softmax_d to have seqlen_q_rounded since we want its address to be aligned by 16/8 bytes for TMA / LDG.64
         softmax_d = torch::empty({batch_size, num_heads, seqlen_q_rounded}, opts.dtype(at::kFloat));
         softmax_lse_log2 = torch::empty({batch_size, num_heads, seqlen_q_rounded}, opts.dtype(at::kFloat));
+        dq_accum = torch::empty({batch_size, num_heads, seqlen_q_rounded * head_size_rounded}, opts.dtype(at::kFloat));
     } else {
         softmax_d = torch::empty({num_heads, total_q_padded_rounded}, opts.dtype(at::kFloat));
         softmax_lse_log2 = torch::empty({num_heads, total_q_padded_rounded}, opts.dtype(at::kFloat));
-    }
-    at::Tensor dq_accum, dk_accum, dv_accum;
-    if (!is_varlen) {
-        dq_accum = torch::empty({batch_size, num_heads, seqlen_q_rounded * head_size_rounded}, opts.dtype(at::kFloat));
-    } else {
         dq_accum = torch::empty({num_heads, total_q_padded_rounded * head_size_rounded}, opts.dtype(at::kFloat));
     }
-    if (num_heads_k != num_heads) {  // MQA / GQA
+    // MQA/GQA fp32 dk/dv accumulators. Ring only emits a shard's dK/dV in phase 2.
+    bool const use_kv_accum = (num_heads_k != num_heads) && (!is_ring || ring_phase == 2);
+    if (use_kv_accum) {
         if (!is_varlen) {
             dk_accum = torch::zeros({batch_size, num_heads_k, seqlen_k_rounded * head_size_rounded}, opts.dtype(at::kFloat));
             dv_accum = torch::zeros({batch_size, num_heads_k, seqlen_k_rounded * head_size_v_rounded}, opts.dtype(at::kFloat));
@@ -1512,8 +1610,8 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor> mha_bwd(
                      seqused_q_.has_value() ? seqused_q_.value().data_ptr() : nullptr,
                      seqused_k_.has_value() ? seqused_k_.value().data_ptr() : nullptr,
                      dq_accum.data_ptr(),
-                     num_heads_k != num_heads ? dk_accum.data_ptr() : nullptr,
-                     num_heads_k != num_heads ? dv_accum.data_ptr() : nullptr,
+                     use_kv_accum ? dk_accum.data_ptr() : nullptr,
+                     use_kv_accum ? dv_accum.data_ptr() : nullptr,
                      softmax_lse.data_ptr(),
                      softmax_d.data_ptr(),
                      /*p_dropout=*/0.f,
@@ -1529,12 +1627,20 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor> mha_bwd(
     params.softmax_lse_log2_ptr = softmax_lse_log2.data_ptr();
     params.dv = head_size_v;
     params.dv_rounded = head_size_v_rounded;
+    params.ring_bwd_phase = (int)ring_phase;  // 0 = standard backward (all phases run)
 
     // auto tile_count_semaphore = (params.is_causal || params.is_local) ? torch::zeros({1}, opts.dtype(torch::kInt32)) : torch::empty({1}, opts.dtype(torch::kInt32));
     // params.tile_count_semaphore = tile_count_semaphore.data_ptr<int>();
-    // Will be zero'ed out in the backward preprocess kernel
-    at::Tensor dq_semaphore = torch::empty({(seqlen_q + kBlockM - 1) / kBlockM, batch_size, num_heads}, opts.dtype(torch::kInt32));
-    params.dq_semaphore = dq_semaphore.data_ptr<int>();
+    // Will be zero'ed out in the backward preprocess kernel. Ring runs deterministic=false,
+    // so the semaphore is dead (main kernel takes lock_ptr=nullptr, preprocess clear is
+    // null-guarded): skip the per-call int32 allocation and leave the pointer null.
+    at::Tensor dq_semaphore;
+    if (is_ring) {
+        params.dq_semaphore = nullptr;
+    } else {
+        dq_semaphore = torch::empty({(seqlen_q + kBlockM - 1) / kBlockM, batch_size, num_heads}, opts.dtype(torch::kInt32));
+        params.dq_semaphore = dq_semaphore.data_ptr<int>();
+    }
     at::Tensor dk_semaphore, dv_semaphore;
     if (num_heads_k != num_heads && params.deterministic) {
         // TODO: maybe also zero'ed out dk_semaphore and dv_semaphore in the backward preprocess kernel
@@ -1558,13 +1664,51 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor> mha_bwd(
         // If seqlen_q == 0, then we have an empty tensor. We need to set the output to 0.
         dk.zero_();
         dv.zero_();
-        softmax_d.zero_();
+        if (!is_ring) softmax_d.zero_();  // ring: softmax_d is the caller's persistent D buffer
     } else if (total_q > 0 && num_heads_k > 0) {
-        dq.zero_();
-        softmax_d.zero_();
+        if (!is_ring) {
+            dq.zero_();
+            softmax_d.zero_();
+        } else {
+            // ring phase-2 with an empty K/V shard contributes nothing: zero only this
+            // shard's dK/dV; leave the persistent dq_accum / softmax_d (dsoftmax_sum) intact.
+            dk.zero_();
+            dv.zero_();
+        }
     }
 
     return { softmax_d, softmax_lse_log2, dq_accum, dk_accum, dv_accum };
+}
+
+// ===========================================================================
+// Ring-attention native backward (FA3): the phased context-parallel backward is
+// FOLDED INTO mha_bwd above via `ring_phase` (0 = standard backward, untouched).
+//   phase 1 (preprocess): D=rowsum(dO*O) -> dsoftmax_sum, softmax_lse_log2, and CLEAR
+//                         the caller-owned persistent fp32 dq_accum. Once per rank.
+//   phase 2 (step):       main bwd kernel for the CURRENT K/V shard -- accumulate its
+//                         dQ into dq_accum (no clear, no bf16 round-trip) and emit this
+//                         shard's dK/dV (h_k-headed; GQA reduced on-device). Per hop.
+//   phase 3 (convert):    dq_accum -> dq (bf16/fp16), scaled once. Once per rank.
+// ring_bwd_kblock_mn below is CAUSAL-INDEPENDENT so the persistent dq_accum keeps ONE
+// layout across mixed causal/non-causal steps (hd128 -> tuned 80-block). It sizes the
+// buffers the caller passes to mha_bwd (see ring_bwd_alloc in flash_attn_interface.py).
+// ===========================================================================
+
+// kBlockM/kBlockN the ring backward uses. Mirrors mha_bwd's selection but is
+// CAUSAL-INDEPENDENT (a persistent dq_accum must keep one layout across mixed
+// causal/non-causal ring steps): hd64 -> 128, hd96 -> 64, hd128 -> 80 (no-softcap;
+// matches the ring branch of run_mha_bwd_hdim128, which pins the causal diagonal to
+// the tuned 80-block too) or 64 with softcap (where non-causal also uses 64),
+// hd192/256 -> 64. hd64 + softcap>0 is rejected by mha_bwd's is_ring guard. Ring
+// backward is sm90-only (also enforced there), so only sm90 block sizes are reachable.
+// Single source of truth for sizing the persistent dq_accum.
+static std::tuple<int, int> ring_bwd_kblock_mn(int arch, int head_size_rounded, double softcap) {
+    (void)arch;  // sm90-only path
+    int kBlockM = head_size_rounded <= 64 ? 128
+        : (head_size_rounded <= 96 ? 64
+           : (head_size_rounded <= 128 ? (softcap > 0.0 ? 64 : 80) : 64));
+    int kBlockN = head_size_rounded <= 128 ? 128 : (head_size_rounded <= 192 ? 96 : 80);
+    return {kBlockM, kBlockN};
 }
 
 std::tuple<at::Tensor, at::Tensor>
@@ -1705,7 +1849,10 @@ TORCH_LIBRARY(flash_attn_3, m) {
         "Tensor? scheduler_metadata = None,"
         "int num_splits = 0,"
         "bool? pack_gqa = None,"
-        "int sm_margin = 0) -> (Tensor(out!), Tensor, Tensor, Tensor)");
+        "int sm_margin = 0,"
+        "bool skip_combine = False,"
+        "Tensor(oa!)? out_accum = None,"
+        "Tensor(la!)? lse_accum = None) -> (Tensor(out!), Tensor, Tensor, Tensor)");
     m.def("bwd("
         "Tensor dout,"
         "Tensor q,"
@@ -1728,7 +1875,11 @@ TORCH_LIBRARY(flash_attn_3, m) {
         "int window_size_right = -1,"
         "float softcap = 0.0,"
         "bool deterministic = False,"
-        "int sm_margin = 0) -> (Tensor, Tensor, Tensor, Tensor, Tensor)");
+        "int sm_margin = 0,"
+        "int ring_phase = 0,"
+        "Tensor(dq_accum!)? dq_accum = None,"
+        "Tensor(dsoftmax_sum!)? dsoftmax_sum = None,"
+        "Tensor(softmax_lse_log2!)? softmax_lse_log2 = None) -> (Tensor, Tensor, Tensor, Tensor, Tensor)");
     m.def("fwd_combine("
         "Tensor out_partial,"
         "Tensor lse_partial,"

--- a/hopper/flash_attn_interface.py
+++ b/hopper/flash_attn_interface.py
@@ -939,6 +939,74 @@ def flash_attn_combine(out_partial, lse_partial, out=None, out_dtype=None):
     return flash_attn_3_gpu.fwd_combine(out_partial, lse_partial, out, out_dtype)
 
 
+# ---------------------------------------------------------------------------
+# Ring-attention native backward (FA3, phased). The phased backward is the stock
+# `bwd` op with ring_phase != 0 (folded in -- there is NO separate op / wrapper): it
+# keeps a caller-owned persistent fp32 dq_accum across ring steps so dQ never round-trips
+# through bf16, and splits the backward into three separately-launchable phases.
+# ring_phase == 0 is the standard FA3 backward, untouched. ring_bwd_alloc (below) sizes
+# the three persistent fp32 buffers the driver passes to bwd(..., ring_phase=, dq_accum=,
+# dsoftmax_sum=, softmax_lse_log2=).
+#
+# Persistent buffers the ring driver allocates ONCE per rank (see ring_bwd_alloc):
+#   dq_accum:         (batch, nheads, seqlen_q_rounded * head_size_rounded) fp32
+#   dsoftmax_sum:     (batch, nheads, seqlen_q_rounded)                     fp32
+#   softmax_lse_log2: (batch, nheads, seqlen_q_rounded)                     fp32
+# Usage per rank:
+#   phase 1 (preprocess): once  -> D into dsoftmax_sum, softmax_lse_log2, clear dq_accum
+#   phase 2 (step):       per ring step -> atomicAdd this K/V shard's dQ into dq_accum,
+#                         write this shard's dk/dv (h_k-headed, GQA reduced); the driver
+#                         accumulates dk/dv in fp32 across ring steps.
+#   phase 3 (convert):    once  -> dq_accum -> dq (bf16/fp16), scaled once.
+# ---------------------------------------------------------------------------
+def _ring_round_up_headdim(d):
+    """Matches round_up_headdim in hopper/flash_api.cpp (64/96/128/192/256 steps)."""
+    for x in (64, 96, 128, 192, 256):
+        if d <= x:
+            return x
+    raise ValueError(f"head dim {d} too large (max 256)")
+
+
+def ring_bwd_alloc(batch, seqlen_q, nheads, head_size, head_size_v=None, device="cuda",
+                   total_q=None):
+    """Allocate the persistent (dq_accum, dsoftmax_sum, softmax_lse_log2) buffers for
+    the FA3 ring backward. Shapes match hopper/flash_api.cpp::mha_bwd (ring_phase!=0, sm90):
+    head_size_rounded = round_up_headdim(max(d, dv)); the ring kBlockM (see below) is
+    causal-independent so seqlen_q_rounded stays consistent across mixed causal/
+    non-causal steps.
+
+    Dense (total_q is None): dq_accum (batch, nheads, s_q_rounded*d_rounded) etc.
+    Varlen (total_q given): collapses the batch dim and uses total_q_padded_rounded =
+    round_up(total_q + batch*kBlockM, kBlockM) -> dq_accum (nheads, tqpr*d_rounded),
+    dsoftmax_sum / softmax_lse_log2 (nheads, tqpr). `seqlen_q` here is max_seqlen_q."""
+    if head_size_v is None:
+        head_size_v = head_size
+    d_rounded = _ring_round_up_headdim(max(head_size, head_size_v))
+    # kBlockM must match ring_bwd_kblock_mn (hopper/flash_api.cpp) for the no-softcap
+    # ring: hd<=64 -> 128, hd96 -> 64, hd128 -> 80 (tuned block, shared by the pinned
+    # causal diagonal), hd192/256 -> 64.
+    if d_rounded <= 64:
+        kBlockM = 128
+    elif d_rounded <= 96:
+        kBlockM = 64
+    elif d_rounded <= 128:
+        kBlockM = 80
+    else:
+        kBlockM = 64
+    if total_q is None:
+        s_q_rounded = ((seqlen_q + kBlockM - 1) // kBlockM) * kBlockM
+        lead = (batch, nheads)
+        n_rows = s_q_rounded
+    else:
+        tqpr = ((total_q + batch * kBlockM + kBlockM - 1) // kBlockM) * kBlockM
+        lead = (nheads,)
+        n_rows = tqpr
+    dq_accum = torch.empty(lead + (n_rows * d_rounded,), dtype=torch.float32, device=device)
+    dsoftmax_sum = torch.empty(lead + (n_rows,), dtype=torch.float32, device=device)
+    softmax_lse_log2 = torch.empty(lead + (n_rows,), dtype=torch.float32, device=device)
+    return dq_accum, dsoftmax_sum, softmax_lse_log2
+
+
 def flash_attn_with_kvcache(
     q,
     k_cache,

--- a/hopper/flash_bwd_launch_template.h
+++ b/hopper/flash_bwd_launch_template.h
@@ -46,6 +46,12 @@ void run_flash_bwd(Flash_bwd_params &params, cudaStream_t stream) {
     int batch_q = !is_varlen_q ? params.b : 1;
     int batch_k = !is_varlen_k ? params.b : 1;
 
+    // Ring-attention phased backward: 0 = normal full backward (byte-identical to
+    // before this field existed). Phases run a single stage per call so a ring
+    // driver keeps a persistent fp32 dq_accum across steps: 1 = preprocess only,
+    // 2 = main seqk kernel (+ GQA dK/dV convert) only, 3 = convert dQ only.
+    const int ring_phase = params.ring_bwd_phase;
+
     using TileShape_MK = cute::Shape<Int<kBlockM>, Int<kHeadDim>>;
     using PreprocessKernel = flash::FlashAttnBwdPreprocess<TileShape_MK, Element, ElementAccum, ArchTag, /*Clear_dQaccum=*/true, Varlen>;
     typename PreprocessKernel::Arguments preprocess_args {
@@ -72,7 +78,10 @@ void run_flash_bwd(Flash_bwd_params &params, cudaStream_t stream) {
     typename PreprocessKernel::Params preprocess_params = PreprocessKernel::to_underlying_arguments(preprocess_args);
     int num_m_block = cute::ceil_div(params.seqlen_q, kBlockM);
     dim3 grid_m(num_m_block, params.h, params.b);
-    CHECK_CUTLASS(cutlass::kernel_launch<PreprocessKernel>(grid_m, PreprocessKernel::MaxThreadsPerBlock, PreprocessKernel::SharedStorageSize, stream, preprocess_params, false /*launch_with_pdl*/));
+    if (ring_phase == 0 || ring_phase == 1) {
+        CHECK_CUTLASS(cutlass::kernel_launch<PreprocessKernel>(grid_m, PreprocessKernel::MaxThreadsPerBlock, PreprocessKernel::SharedStorageSize, stream, preprocess_params, false /*launch_with_pdl*/));
+        if (ring_phase == 1) { return; }
+    }
 
     using TileShape_MNK = cute::Shape<Int<kBlockM>, Int<kBlockN>, Int<kHeadDim>>;
     using ClusterShape = cute::Shape<_1, Int<1>, _1>;  // Currently doesn't not support cluster
@@ -207,6 +216,7 @@ void run_flash_bwd(Flash_bwd_params &params, cudaStream_t stream) {
     // int smem_size_lse = sizeof(decltype((typename CollectiveMainloop::TensorStorage{}).smem_lse));
     // int smem_size_dpsum = sizeof(decltype((typename CollectiveMainloop::TensorStorage{}).smem_dpsum));
     // printf("smem_size = %d, q = %d, k = %d, v = %d, do = %d, ds = %d, dqacc = %d, lse = %d, dpsum = %d\n", smem_size, smem_size_q, smem_size_k, smem_size_v, smem_size_do, smem_size_ds, smem_size_dqacc, smem_size_lse, smem_size_dpsum);
+    if (ring_phase == 0 || ring_phase == 2) {
     if constexpr (size(ClusterShape{}) > 1) {
         void const* kernel = (void const*) cutlass::device_kernel<AttnKernel>;
         if (smem_size >= 48 * 1024) {
@@ -220,6 +230,7 @@ void run_flash_bwd(Flash_bwd_params &params, cudaStream_t stream) {
             CHECK_CUDA(cudaFuncSetAttribute(cutlass::device_kernel<AttnKernel>, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
         }
         CHECK_CUTLASS(cutlass::kernel_launch<AttnKernel>(grid_dims, block_dims, smem_size, stream, kernel_params, false /*launch_with_pdl*/));
+    }
     }
 
     using PostprocessKernel = flash::FlashAttnBwdPostprocessConvertdQ<TileShape_MK, Element, ElementAccum, ArchTag,
@@ -245,9 +256,13 @@ void run_flash_bwd(Flash_bwd_params &params, cudaStream_t stream) {
     if (smem_size_postprocess >= 48 * 1024) {
         CHECK_CUDA(cudaFuncSetAttribute(cutlass::device_kernel<PostprocessKernel>, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size_postprocess));
     }
-    CHECK_CUTLASS(cutlass::kernel_launch<PostprocessKernel>(grid_m_postprocess, PostprocessKernel::MaxThreadsPerBlock, smem_size_postprocess, stream, postprocess_params, false /*launch_with_pdl*/));
+    if (ring_phase == 0 || ring_phase == 3) {
+        CHECK_CUTLASS(cutlass::kernel_launch<PostprocessKernel>(grid_m_postprocess, PostprocessKernel::MaxThreadsPerBlock, smem_size_postprocess, stream, postprocess_params, false /*launch_with_pdl*/));
+        if (ring_phase == 3) { return; }
+    }
 
     if constexpr (GQA) {
+      if (ring_phase == 0 || ring_phase == 2) {
         using TileShape_NK = cute::Shape<Int<kBlockN>, Int<kHeadDim>>;
         using PostprocessKerneldKV = flash::FlashAttnBwdPostprocessConvertdQ<TileShape_NK, Element, ElementAccum, ArchTag,
             AttnKernel::CollectiveEpilogue::NumEpilogueThreads,
@@ -286,6 +301,7 @@ void run_flash_bwd(Flash_bwd_params &params, cudaStream_t stream) {
         }
         CHECK_CUTLASS(cutlass::kernel_launch<PostprocessKerneldKV>(grid_n_postprocess, PostprocessKerneldKV::MaxThreadsPerBlock, smem_size_postprocess, stream, postprocess_dK_params, false /*launch_with_pdl*/));
         CHECK_CUTLASS(cutlass::kernel_launch<PostprocessKerneldKV>(grid_n_postprocess, PostprocessKerneldKV::MaxThreadsPerBlock, smem_size_postprocess, stream, postprocess_dV_params, false /*launch_with_pdl*/));
+      }
     }
 
 }
@@ -348,8 +364,20 @@ void run_mha_bwd_hdim128(Flash_bwd_params &params, cudaStream_t stream) {
     CAUSAL_LOCAL_SWITCH(params.is_causal, params.is_local, Is_causal, Is_local, [&] {
         if constexpr (Arch >= 90) {
             if constexpr (Is_causal || Is_local || Has_softcap) {
-                run_mha_bwd_dispatch<Arch, T, 64, 128, 128, Is_causal, Is_local, Has_softcap, 2, 2, true, false, false, 2, 1, 2, 1, false>(params, stream);
+                // Ring mode with PLAIN causal (no local/softcap) uses the tuned 80-block
+                // config so the causal diagonal hop shares the persistent dq_accum layout
+                // with the non-causal hops (which also use 80) -- lets hd128 rings run the
+                // fast 80-block on EVERY hop (matching v4's per-hop non-causal kernel) while
+                // still saving the per-hop preprocess/convert. Non-ring, or local/softcap
+                // (where non-causal also uses 64, so layouts already match), keep 64.
+                if (params.ring_bwd_phase != 0 && Is_causal && !Is_local && !Has_softcap) {
+                    run_mha_bwd_dispatch<Arch, T, 80, 128, 128, Is_causal, Is_local, Has_softcap, 2, 2, true, false, true, 2, 1, 2, 1, false>(params, stream);
+                } else {
+                    run_mha_bwd_dispatch<Arch, T, 64, 128, 128, Is_causal, Is_local, Has_softcap, 2, 2, true, false, false, 2, 1, 2, 1, false>(params, stream);
+                }
             } else {
+                // Non-causal, no softcap: always the tuned 80-block (ring or not). The ring's
+                // causal diagonal is pinned to 80 above so the shared dq_accum stays consistent.
                 run_mha_bwd_dispatch<Arch, T, 80, 128, 128, Is_causal, Is_local, Has_softcap, 2, 2, true, false, true, 2, 1, 2, 1, false>(params, stream);
             }
         } else if constexpr (Arch == 86 || Arch == 89) {

--- a/tests/ring_flash_attn_fa3.py
+++ b/tests/ring_flash_attn_fa3.py
@@ -1,0 +1,780 @@
+"""
+================================================================================
+ Ring / context-parallel Flash Attention on the optimized FA3 primitives
+================================================================================
+
+A self-contained, autograd-enabled ring (context-parallel) attention driver built
+directly on the FA3 (Hopper / sm90) ops via their FOLDED-IN ring parameters -- there
+are NO separate ring ops/wrappers; the ring path is the stock fwd/bwd with a flag:
+
+    _fwd_op = torch.ops.flash_attn_3.fwd   # forward: fwd(..., skip_combine=True, out_accum=,
+                                           #   lse_accum=) -> fp32 normalized partial + fp32 LSE, no combine
+    _bwd_op = torch.ops.flash_attn_3.bwd   # backward: bwd(..., ring_phase=1/2/3, dq_accum=,
+                                           #   dsoftmax_sum=, softmax_lse_log2=) -> phased backward
+    from flash_attn_interface import ring_bwd_alloc  # allocate the 3 persistent fp32 buffers
+
+Thin private `_fwd_ring` / `_bwd_ring` wrappers (below) adapt those ops. They keep every
+ring intermediate in fp32 across ring hops and cast to bf16 exactly once, instead of
+round-tripping through bf16 on every hop (which a naive ring built on the plain
+flash_attn_func / an un-phased flash_attn_3.bwd pays). See the
+`### Why these ops` section below.
+
+--------------------------------------------------------------------------------
+ The ring algorithm in one paragraph
+--------------------------------------------------------------------------------
+A long sequence is split into W shards (W = number of GPUs); each rank permanently
+owns one shard of Q (Q is NEVER communicated) and, initially, the matching shard of
+K/V. K/V then rotate around a ring one hop at a time; after W hops every rank has
+seen every K/V shard. A single query's attention over the whole key set equals the
+online-softmax merge of its attention over each key block, so computing block by
+block and merging is numerically identical to full-sequence attention.
+
+Forward (`_ring_forward`): each hop runs `_fwd_ring` (= fwd with skip_combine=True) on
+the current K/V block to get an fp32 normalized partial + fp32 LSE (CUTLASS speed, no
+bf16 round-trip), and streams it into a persistent fp32 accumulator with an online
+softmax merge; after W hops the accumulator is cast to bf16 once. Under causal
+masking only the diagonal block (step 0) carries the mask.
+
+Backward (`_ring_backward`, phased via `_bwd_ring` (= bwd with ring_phase=…) + `ring_bwd_alloc`):
+  * phase 1 (once/rank): compute D = rowsum(dO*O), softmax_lse_log2, and clear the
+    persistent fp32 dq_accum;
+  * phase 2 (per hop): run only the main kernel, atomicAdd this K/V block's dQ into
+    the persistent fp32 dq_accum (never leaving fp32), and write this block's dK/dV;
+    dK/dV are reduced in fp32 along a SECOND ring back to their owner rank;
+  * phase 3 (once/rank): convert the accumulated fp32 dq_accum to bf16 dQ.
+Compared with running a full backward per hop, this drops W-1 preprocess + W-1
+convert passes per rank and keeps dQ resident in fp32.
+
+--------------------------------------------------------------------------------
+ Why the folded ring flags (vs a naive ring on the public FA3 entry points)
+--------------------------------------------------------------------------------
+  * A naive forward calls flash_attn_func per block: it runs a full split+combine
+    and returns a bf16 block output, so the ring must cast back to fp32 before its
+    own merge (one bf16 round-trip per hop) and the internal combine is wasted.
+    `fwd(skip_combine=True)` emits the fp32 partial directly and skips the combine.
+  * A naive backward calls the full flash_attn_3.bwd per hop: it recomputes
+    preprocess and convert every hop and rounds dQ to bf16 each hop. The phased
+    `bwd(ring_phase=…)` runs preprocess/convert once per rank and keeps dQ in fp32.
+
+--------------------------------------------------------------------------------
+ Supported configuration
+--------------------------------------------------------------------------------
+  * dtype: fp16 / bf16.
+  * head_dim: 64, 96, 128, 192, 256 (sm90).
+  * MHA (hq == hkv) and GQA/MQA (hq a multiple of hkv).
+  * causal and non-causal. causal uses the plain causal ring: rank r computes steps
+    0..r; step 0 is its own diagonal block (the only masked one). This is load-
+    imbalanced by design (later ranks do more work); a zigzag shard assignment would
+    balance it and is intentionally not implemented here to keep the driver simple.
+  * varlen (cu_seqlens) via `ring_flash_attn_varlen_func`: each global sequence is split
+    into W equal chunks along its length (every sequence length must be divisible by W)
+    and rank r owns chunk r; forward = per-hop flash_attn_varlen_func + online merge
+    (Option A), backward = phased bwd_ring. See `shard_varlen_along_seq`.
+ NOT supported: sliding-window / local, deterministic backward, sequence lengths not
+  divisible by W, and a ragged varlen CP where a sequence's chunking differs across
+  ranks. sm90 (Hopper) only.
+
+--------------------------------------------------------------------------------
+ Requirements / how to run
+--------------------------------------------------------------------------------
+  * The in-tree hopper FA3 extension must be built (it exposes the ring primitives);
+    it is resolved relative to this file (../hopper), so no absolute path is needed.
+  * q/k/v layout: (batch, seqlen_local, nheads, head_dim), last dim contiguous,
+    16-byte aligned, bf16/fp16.
+
+  # run the built-in example (forward+backward + a single-GPU correctness check):
+  torchrun --nproc_per_node=8 --standalone ring_flash_attn_fa3.py
+  # 2 GPUs:
+  CUDA_VISIBLE_DEVICES=0,1 torchrun --nproc_per_node=2 --standalone ring_flash_attn_fa3.py
+"""
+
+import os
+import sys
+
+import torch
+import torch.distributed as dist
+import triton
+import triton.language as tl
+
+# Resolve the in-tree hopper build (which exposes the ring primitives) relative to
+# this file: <repo>/tests/this_file.py -> <repo>/hopper. No absolute path baked in.
+_HOPPER_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "hopper")
+if _HOPPER_DIR not in sys.path:
+    sys.path.insert(0, _HOPPER_DIR)
+
+from flash_attn_interface import (  # in-tree hopper build
+    ring_bwd_alloc,
+    flash_attn_varlen_func,    # stock FA3 varlen forward -- used per-hop by the varlen ring (Option A)
+)
+
+# Ring forward/backward are the stock `fwd`/`bwd` ops with a flag flipped (folded in; NO
+# separate ops or wrappers) -- thin call-throughs, no duplicated logic.
+#   forward:  fwd(..., skip_combine=True, out_accum=, lse_accum=) forces the Split kernel to
+#             write fp32 partials into caller-owned buffers and skips the combine.
+#   backward: bwd(..., ring_phase=1/2/3, dq_accum=, dsoftmax_sum=, softmax_lse_log2=) is the
+#             phased backward; the three fp32 buffers are caller-owned (see ring_bwd_alloc).
+_fwd_op = torch.ops.flash_attn_3.fwd
+_bwd_op = torch.ops.flash_attn_3.bwd
+
+
+def _fwd_ring(q, k, v, out_accum, lse_accum, softmax_scale=None, causal=False,
+              window_size=(-1, -1), softcap=0.0, num_splits=2,
+              cu_seqlens_q=None, cu_seqlens_k=None, seqused_q=None, seqused_k=None,
+              max_seqlen_q=None, max_seqlen_k=None):
+    q, k, v = (x.contiguous() for x in (q, k, v))
+    _fwd_op(q, k, v,
+            softmax_scale=softmax_scale, is_causal=causal,
+            window_size_left=window_size[0], window_size_right=window_size[1],
+            softcap=softcap, num_splits=num_splits,
+            cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=cu_seqlens_k,
+            seqused_q=seqused_q, seqused_k=seqused_k,
+            max_seqlen_q=max_seqlen_q, max_seqlen_k=max_seqlen_k,
+            skip_combine=True, out_accum=out_accum, lse_accum=lse_accum)
+
+
+def _bwd_ring(phase, dout, q, k, v, out, softmax_lse, dq, dk, dv,
+              dq_accum, dsoftmax_sum, softmax_lse_log2, softmax_scale=None, causal=False,
+              cu_seqlens_q=None, cu_seqlens_k=None, max_seqlen_q=None, max_seqlen_k=None):
+    dout, q, k, v, out = (x.contiguous() for x in (dout, q, k, v, out))
+    _bwd_op(dout, q, k, v, out, softmax_lse, dq, dk, dv,
+            cu_seqlens_q, cu_seqlens_k, None, None, max_seqlen_q, max_seqlen_k,
+            softmax_scale, causal, -1, -1, 0.0, False, 0,
+            phase, dq_accum, dsoftmax_sum, softmax_lse_log2)
+
+
+# ============================================================================
+# Ring communication: double-buffered. K/V (or the in-flight dK/dV accumulator) are
+# packed into one [2, ...] tensor and exchanged with a single batch_isend_irecv
+# ("send to the next rank, receive from the previous rank"). The sends/recvs are
+# non-blocking, so a hop's communication overlaps with that hop's compute; a matched
+# wait() drains the oldest outstanding exchange.
+# ============================================================================
+class DoubleBufRingComm:
+    def __init__(self, process_group):
+        self._pg = process_group
+        self.rank = dist.get_rank(process_group)
+        self.world_size = dist.get_world_size(process_group)
+        # Ring topology: send to rank+1, receive from rank-1. Map to GLOBAL ranks so
+        # this works when `process_group` is a sub-group of WORLD.
+        self.send_rank = (self.rank + 1) % self.world_size
+        self.recv_rank = (self.rank - 1) % self.world_size
+        if process_group is not None:
+            self.send_rank = dist.get_global_rank(process_group, self.send_rank)
+            self.recv_rank = dist.get_global_rank(process_group, self.recv_rank)
+        self._pending = []  # FIFO of issued isend/irecv handle batches
+
+    def send_recv_packed(self, send_buf, recv_buf):
+        """Send `send_buf` to the next rank while receiving into `recv_buf` from the
+        previous rank. Non-blocking: returns immediately, pairs with a later wait()."""
+        self._pending.append(dist.batch_isend_irecv([
+            dist.P2POp(dist.isend, send_buf, self.send_rank, group=self._pg),
+            dist.P2POp(dist.irecv, recv_buf, self.recv_rank, group=self._pg)]))
+
+    def wait(self):
+        """Wait on the earliest still-outstanding exchange (one-to-one with a
+        preceding send_recv_packed call)."""
+        if self._pending:
+            for req in self._pending.pop(0):
+                req.wait()
+
+
+# ============================================================================
+# Online softmax merge -- an inlined fused Triton kernel that merges one NORMALIZED
+# partial (blk_o, blk_lse) into a persistent fp32 accumulator (acc, lse) IN PLACE:
+#   blk_o/acc: (B, Hq, S, D) fp32 (each already normalized over its own key block);
+#   blk_lse/lse: (B, Hq, S) fp32
+# Both sides are normalized, so the merge weights sum to 1:
+#   new = max(lse, blk_lse); a = exp(lse - new); b = exp(blk_lse - new)
+#   acc = (acc*a + blk_o*b) / (a + b);  lse = new + log(a + b)
+# is_first=True just seeds the accumulator (nothing to merge with yet). Tensors are
+# indexed as a flat [B*Hq, S, D] / [B*Hq, S] contiguous layout; the grid parallelizes
+# over (sequence tiles, B*Hq). Everything stays in fp32 -- no bf16 round-trip.
+# ============================================================================
+def _next_pow2(x):
+    return 1 << (x - 1).bit_length()
+
+
+@triton.jit
+def _merge_kernel(blk_o_ptr, blk_lse_ptr, acc_ptr, lse_ptr, s, d,
+                  is_first: tl.constexpr, BLOCK_S: tl.constexpr, BLOCK_D: tl.constexpr):
+    pid_s = tl.program_id(0)        # tile along the sequence dim
+    pid_bh = tl.program_id(1)       # one program per (batch*head)
+    offs_s = pid_s * BLOCK_S + tl.arange(0, BLOCK_S)
+    offs_d = tl.arange(0, BLOCK_D)
+    s_mask = offs_s < s
+    d_mask = offs_d < d
+    o_ptrs = pid_bh * s * d + offs_s[:, None] * d + offs_d[None, :]   # element offsets for acc/blk_o
+    lse_ptrs = pid_bh * s + offs_s                                    # element offsets for lse/blk_lse
+    blk_o = tl.load(blk_o_ptr + o_ptrs, mask=s_mask[:, None] & d_mask[None, :], other=0.0)
+    blk_lse = tl.load(blk_lse_ptr + lse_ptrs, mask=s_mask, other=-float("inf"))
+    if is_first:
+        tl.store(acc_ptr + o_ptrs, blk_o, mask=s_mask[:, None] & d_mask[None, :])
+        tl.store(lse_ptr + lse_ptrs, blk_lse, mask=s_mask)
+    else:
+        acc = tl.load(acc_ptr + o_ptrs, mask=s_mask[:, None] & d_mask[None, :], other=0.0)
+        old = tl.load(lse_ptr + lse_ptrs, mask=s_mask, other=-float("inf"))
+        new = tl.maximum(old, blk_lse)
+        a = tl.exp(old - new)
+        b = tl.exp(blk_lse - new)
+        denom = a + b
+        tl.store(acc_ptr + o_ptrs, (acc * a[:, None] + blk_o * b[:, None]) / denom[:, None],
+                 mask=s_mask[:, None] & d_mask[None, :])
+        tl.store(lse_ptr + lse_ptrs, new + tl.log(denom), mask=s_mask)
+
+
+def _merge(blk_o, blk_lse, acc, lse, is_first):
+    """Merge a normalized partial (blk_o, blk_lse) into (acc, lse) in place. All
+    tensors must be (B,Hq,S,D)/(B,Hq,S) contiguous fp32."""
+    b, h, s, d = acc.shape
+    BLOCK_D = _next_pow2(d)
+    BLOCK_S = max(1, min(128, 8192 // BLOCK_D))
+    grid = (triton.cdiv(s, BLOCK_S), b * h)
+    _merge_kernel[grid](blk_o, blk_lse, acc, lse, s, d, is_first,
+                        BLOCK_S=BLOCK_S, BLOCK_D=BLOCK_D, num_warps=4, num_stages=2)
+
+
+# ============================================================================
+# Dedicated varlen merge: fuses (a) the token-major -> head-major transpose, (b) the
+# bf16/fp16 -> fp32 cast, and (c) the online-softmax merge into ONE kernel pass, so the
+# per-hop block output from flash_attn_varlen_func is consumed IN ITS NATIVE bf16 layout
+# with no intermediate `.permute().contiguous().float()` materialization. Layouts:
+#   blk_o: (total, Hq, D) bf16/fp16, contiguous (flash_attn_varlen_func output)
+#   blk_lse: (Hq, total) fp32 ; acc: (Hq, total, D) fp32 ; lse: (Hq, total) fp32
+# One program per (token tile, head); the bf16 load is promoted to fp32 in registers.
+# ============================================================================
+@triton.jit
+def _merge_varlen_kernel(blk_o_ptr, blk_lse_ptr, acc_ptr, lse_ptr, total, Hq, D,
+                         is_first: tl.constexpr, BLOCK_T: tl.constexpr, BLOCK_D: tl.constexpr):
+    pid_t = tl.program_id(0)        # tile along the (packed) token dim
+    pid_h = tl.program_id(1)        # one program per head
+    offs_t = pid_t * BLOCK_T + tl.arange(0, BLOCK_T)
+    offs_d = tl.arange(0, BLOCK_D)
+    t_mask = offs_t < total
+    d_mask = offs_d < D
+    bo_ptrs = offs_t[:, None] * (Hq * D) + pid_h * D + offs_d[None, :]   # blk_o[t, h, d] token-major
+    acc_ptrs = pid_h * (total * D) + offs_t[:, None] * D + offs_d[None, :]  # acc[h, t, d] head-major
+    l_ptrs = pid_h * total + offs_t                                      # blk_lse/lse[h, t]
+    blk_o = tl.load(blk_o_ptr + bo_ptrs, mask=t_mask[:, None] & d_mask[None, :], other=0.0).to(tl.float32)
+    blk_lse = tl.load(blk_lse_ptr + l_ptrs, mask=t_mask, other=-float("inf"))
+    if is_first:
+        tl.store(acc_ptr + acc_ptrs, blk_o, mask=t_mask[:, None] & d_mask[None, :])
+        tl.store(lse_ptr + l_ptrs, blk_lse, mask=t_mask)
+    else:
+        acc = tl.load(acc_ptr + acc_ptrs, mask=t_mask[:, None] & d_mask[None, :], other=0.0)
+        old = tl.load(lse_ptr + l_ptrs, mask=t_mask, other=-float("inf"))
+        new = tl.maximum(old, blk_lse)
+        a = tl.exp(old - new)
+        b = tl.exp(blk_lse - new)
+        denom = a + b
+        tl.store(acc_ptr + acc_ptrs, (acc * a[:, None] + blk_o * b[:, None]) / denom[:, None],
+                 mask=t_mask[:, None] & d_mask[None, :])
+        tl.store(lse_ptr + l_ptrs, new + tl.log(denom), mask=t_mask)
+
+
+def _merge_varlen(blk_o, blk_lse, acc, lse, is_first):
+    """Merge one varlen block output into the fp32 accumulator IN PLACE, fusing the
+    bf16->fp32 cast + layout transpose (see kernel comment). blk_o: (total, Hq, D)
+    bf16/fp16 contiguous; blk_lse: (Hq, total) fp32; acc: (Hq, total, D) fp32;
+    lse: (Hq, total) fp32."""
+    Hq, total, D = acc.shape
+    BLOCK_D = _next_pow2(D)
+    BLOCK_T = max(1, min(128, 8192 // BLOCK_D))
+    grid = (triton.cdiv(total, BLOCK_T), Hq)
+    _merge_varlen_kernel[grid](blk_o, blk_lse, acc, lse, total, Hq, D, is_first,
+                               BLOCK_T=BLOCK_T, BLOCK_D=BLOCK_D, num_warps=4, num_stages=2)
+
+
+# Number of sub-splits `_fwd_ring` (fwd with skip_combine) writes for a block. A single-split
+# causal block needs num_splits>=2 (FA3 convention); a non-causal block needs 1.
+_NS_FULL = 1     # non-causal (off-diagonal) block
+_NS_CAUSAL = 2   # causal diagonal block
+
+
+# ============================================================================
+# Forward: rotate K/V around the ring; each hop emits an fp32 partial via
+# `_fwd_ring` (fwd with skip_combine) and merges it online into the accumulator. Returns
+# out (B,S,Hq,D) in the input dtype, and lse (B,Hq,S) fp32 (already the [b,h,s]
+# layout the FA3 backward wants). Runs under no_grad -- autograd is wired up by
+# _RingFlashAttnFunc below.
+# ============================================================================
+@torch.no_grad()
+def _ring_forward(process_group, q, k, v, softmax_scale, causal):
+    q, k, v = q.contiguous(), k.contiguous(), v.contiguous()
+    comm = DoubleBufRingComm(process_group)
+    W, rank = comm.world_size, comm.rank
+    B, S, Hq, D = q.shape
+    dev = q.device
+
+    # Double buffer for received K/V (each slot holds packed [k; v], shape
+    # (2,)+k.shape), plus one "to send" buffer seeded with the local K/V.
+    kv_bufs = [torch.empty((2,) + k.shape, device=dev, dtype=k.dtype) for _ in range(2)]
+    kv_send = torch.empty((2,) + k.shape, device=dev, dtype=k.dtype)
+    if W > 1:
+        kv_send[0].copy_(k); kv_send[1].copy_(v)
+    k_cur, v_cur = k, v
+
+    # Partial output buffers (up to _NS_CAUSAL sub-splits) and the PERSISTENT fp32
+    # accumulator that everything is merged into in place.
+    part_o = torch.empty((_NS_CAUSAL, B, Hq, S, D), device=dev, dtype=torch.float32)
+    part_lse = torch.empty((_NS_CAUSAL, B, Hq, S), device=dev, dtype=torch.float32)
+    acc = torch.empty((B, Hq, S, D), device=dev, dtype=torch.float32)
+    lse = torch.empty((B, Hq, S), device=dev, dtype=torch.float32)
+    first = True
+
+    for step in range(W):
+        # Kick off the NEXT hop's K/V transfer before computing on the current block,
+        # so communication overlaps compute.
+        if step + 1 != W:
+            comm.send_recv_packed(kv_send, kv_bufs[step & 1])
+        # Causal ring: rank r only processes steps 0..r. step 0 is its own diagonal
+        # block (the only masked block); later steps are full (unmasked) blocks.
+        if (not causal) or step <= rank:
+            block_causal = causal and step == 0
+            ns = _NS_CAUSAL if block_causal else _NS_FULL
+            # Emit `ns` normalized fp32 partials + fp32 LSE for the current K/V block.
+            _fwd_ring(
+                q, k_cur, v_cur, part_o[:ns], part_lse[:ns],
+                softmax_scale=softmax_scale, causal=block_causal, num_splits=ns)
+            for j in range(ns):
+                _merge(part_o[j], part_lse[j], acc, lse, is_first=first)
+                first = False
+        # Wait for this hop's K/V to arrive, switch to the other buffer half, and use
+        # it as the next hop's send source.
+        if step + 1 != W:
+            comm.wait()
+            kv_send = kv_bufs[step & 1]
+            k_cur, v_cur = kv_bufs[step & 1][0], kv_bufs[step & 1][1]
+
+    out = acc.permute(0, 2, 1, 3).contiguous().to(q.dtype)  # (B,Hq,S,D)->(B,S,Hq,D), one fp32->bf16
+    return out, lse
+
+
+# ============================================================================
+# Backward: phased FA3 backward. dQ stays in a local PERSISTENT fp32 dq_accum (never
+# communicated); dK/dV are reduced in fp32 along a SECOND ring back to their owner
+# rank. Order: phase 1 once -> phase 2 per hop -> phase 3 once. Runs under no_grad.
+# ============================================================================
+@torch.no_grad()
+def _ring_backward(process_group, dout, q, k, v, out, softmax_lse, softmax_scale, causal):
+    dout, q, k, v, out = [x.contiguous() for x in (dout, q, k, v, out)]
+    kv_comm = DoubleBufRingComm(process_group)     # rotates K/V
+    d_kv_comm = DoubleBufRingComm(process_group)   # rotates the in-flight dK/dV accumulator
+    W, rank = kv_comm.world_size, kv_comm.rank
+    B, S, Hq, D = q.shape
+    dev = q.device
+
+    # The three PERSISTENT fp32 buffers: dq_accum (accumulates dQ across hops),
+    # dsoftmax_sum (holds D), and softmax_lse_log2. ring_bwd_alloc sizes them with the
+    # block rounding the phased backward expects (hd128 uses the tuned 80-block).
+    # NOTE: pass `device` as a keyword (its positional slot is head_size_v).
+    dq_accum, dsoftmax, lse_log2 = ring_bwd_alloc(B, S, Hq, D, device=dev)
+
+    dq = torch.empty_like(q)          # written by phase 3 (bf16)
+    block_dk = torch.empty_like(k)    # this hop's dK contribution (bf16, h_kv heads)
+    block_dv = torch.empty_like(k)
+
+    # phase 1 (once per rank): D + softmax_lse_log2 + clear dq_accum. dO/O/LSE are
+    # fixed for this rank across all ring steps, so this runs exactly once.
+    _bwd_ring(
+        1, dout, q, k, v, out, softmax_lse,
+        dq, block_dk, block_dv, dq_accum, dsoftmax, lse_log2,
+        softmax_scale=softmax_scale, causal=causal)
+
+    # K/V double buffer + an fp32 dK/dV double buffer (packed [dk; dv], shape
+    # (2,)+k.shape) that carries the running dK/dV reduction around the ring.
+    kv_bufs = [torch.empty((2,) + k.shape, device=dev, dtype=k.dtype) for _ in range(2)]
+    kv_send = torch.empty((2,) + k.shape, device=dev, dtype=k.dtype)
+    if W > 1:
+        kv_send[0].copy_(k); kv_send[1].copy_(v)
+    k_cur, v_cur = k, v
+    dkdv_bufs = [torch.empty((2,) + k.shape, device=dev, dtype=torch.float32) for _ in range(2)]
+    dk_bufs = [dkdv_bufs[0][0], dkdv_bufs[1][0]]
+    dv_bufs = [dkdv_bufs[0][1], dkdv_bufs[1][1]]
+    first_iter_done = False
+
+    for step in range(W):
+        if step + 1 != W:
+            kv_comm.send_recv_packed(kv_send, kv_bufs[step & 1])
+        active = step <= rank or not causal
+        prev_slot = (step - 1) & 1
+        if active:
+            # phase 2 (per hop): atomicAdd this block's dQ into the persistent
+            # dq_accum, and write this block's dK/dV (h_kv-headed, GQA-reduced).
+            _bwd_ring(
+                2, dout, q, k_cur, v_cur, out, softmax_lse,
+                dq, block_dk, block_dv, dq_accum, dsoftmax, lse_log2,
+                softmax_scale=softmax_scale, causal=(causal and step == 0))
+            # Fold this block's dK/dV into the rotating fp32 accumulator slot (copy the
+            # first time, add afterwards). Wait for the slot arriving from the previous
+            # hop before adding into it.
+            if first_iter_done:
+                d_kv_comm.wait()
+            if not first_iter_done:
+                dk_bufs[prev_slot].copy_(block_dk); dv_bufs[prev_slot].copy_(block_dv)
+            else:
+                dk_bufs[prev_slot].add_(block_dk); dv_bufs[prev_slot].add_(block_dv)
+            first_iter_done = True
+        elif step != 0:
+            d_kv_comm.wait()  # inactive steps still drain the second ring to stay in sync
+        if step + 1 != W:
+            kv_comm.wait()
+            kv_send = kv_bufs[step & 1]
+            k_cur, v_cur = kv_bufs[step & 1][0], kv_bufs[step & 1][1]
+        # Forward the current dK/dV accumulator slot to the next rank; it keeps
+        # accumulating on other ranks and returns to this K/V's owner after W hops.
+        d_kv_comm.send_recv_packed(dkdv_bufs[prev_slot], dkdv_bufs[step & 1])
+
+    # phase 3 (once per rank): persistent fp32 dq_accum -> bf16 dQ, scaled once.
+    # Launched BEFORE the final dK/dV wait: the convert only reads dq_accum and writes
+    # dq (it never touches dk_bufs/dv_bufs), so it overlaps the exposed tail dK/dV
+    # exchange on the comm stream instead of serializing strictly after it.
+    _bwd_ring(
+        3, dout, q, k, v, out, softmax_lse,
+        dq, block_dk, block_dv, dq_accum, dsoftmax, lse_log2,
+        softmax_scale=softmax_scale, causal=causal)
+
+    d_kv_comm.wait()  # now block on the final dK/dV slot before reading it below
+    final_slot = (W - 1) & 1  # after W hops the complete dK/dV for this rank lands here
+    return dq.to(q.dtype), dk_bufs[final_slot].to(k.dtype), dv_bufs[final_slot].to(v.dtype)
+
+
+# ============================================================================
+# autograd.Function: the forward saves (q, k, v, out, lse) for the backward, which
+# calls the phased _ring_backward. Only q/k/v receive gradients.
+# ============================================================================
+class _RingFlashAttnFunc(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, q, k, v, softmax_scale, causal, group):
+        if softmax_scale is None:
+            softmax_scale = q.shape[-1] ** -0.5
+        out, lse = _ring_forward(group, q, k, v, softmax_scale, causal)
+        ctx.save_for_backward(q, k.contiguous(), v.contiguous(), out, lse.contiguous())
+        ctx.softmax_scale, ctx.causal, ctx.group = softmax_scale, causal, group
+        return out
+
+    @staticmethod
+    def backward(ctx, dout):
+        q, k, v, out, lse = ctx.saved_tensors
+        dq, dk, dv = _ring_backward(ctx.group, dout, q, k, v, out, lse, ctx.softmax_scale, ctx.causal)
+        return dq, dk, dv, None, None, None  # match forward's 6 inputs (last 3 are non-tensors)
+
+
+def ring_flash_attn_func(q, k, v, softmax_scale=None, causal=False, group=None):
+    """Optimized FA3 ring / context-parallel attention (autograd-enabled).
+
+    q/k/v are THIS rank's sequence shard: (B, S_local, H, D), bf16/fp16, last dim
+    contiguous. Returns out (B, S_local, Hq, D) in the input dtype.
+
+    softmax_scale: defaults to head_dim**-0.5.
+    causal:        plain causal ring (rank r attends key shards 0..r; the diagonal
+                   block carries the mask).
+    group:         a torch.distributed process group defining the ring; defaults to
+                   WORLD. World size = number of shards the sequence was split into.
+    """
+    return _RingFlashAttnFunc.apply(q, k, v, softmax_scale, causal, group)
+
+
+# ---------------------------------------------------------------------------
+# Convenience helpers for context-parallel sharding.
+# ---------------------------------------------------------------------------
+def shard_along_seq(x_global, rank, world_size):
+    """Split (B, S_global, H, D) along the sequence dim into `world_size` contiguous
+    chunks and return this rank's chunk. S_global must be divisible by world_size."""
+    assert x_global.shape[1] % world_size == 0, "global sequence length must be divisible by world_size"
+    return torch.chunk(x_global, world_size, dim=1)[rank].contiguous()
+
+
+def ring_attention(q_local, k_local, v_local, causal=False, softmax_scale=None, group=None):
+    """Alias of ring_flash_attn_func for inputs already sharded to this rank -- the
+    single call you drop into a context-parallel training/inference step."""
+    return ring_flash_attn_func(q_local, k_local, v_local,
+                                softmax_scale=softmax_scale, causal=causal, group=group)
+
+
+# ############################################################################
+# Varlen (context-parallel) ring: forward = Option A (per-hop flash_attn_varlen_func
+# + online fp32 merge), backward = phased bwd_ring. Each GLOBAL sequence is split
+# into W equal chunks along its length (every sequence length must be divisible by
+# W); rank r owns chunk r of every sequence, packed. Chunk sizes are therefore
+# uniform across ranks (fixed-size ring comm), and the per-hop K/V block is itself a
+# valid varlen batch with the SAME cu_seqlens as Q. The plain causal-ring logic
+# carries over per sequence: at hop h rank r sees chunk (r-h) of each sequence, which
+# is entirely in the past for h>0 (full block) and the diagonal for h==0 (masked).
+# (the forced-Split ring forward is not used for varlen: its store-all path is unusable
+# under the dynamic varlen split scheduler -- see the module docstring.)
+# ############################################################################
+def shard_varlen_along_seq(x_global, cu_global, rank, world_size):
+    """Split each sequence (delimited by cu_global) into `world_size` EQUAL chunks
+    along its length and return (this rank's chunk-r packed tensor, local cu_seqlens,
+    local max_seqlen). x_global: (total_global, H, D) packed varlen. Every sequence
+    length must be divisible by world_size. The local cu_seqlens is identical on every
+    rank (all chunks of sequence i have length seqlen_i / world_size)."""
+    seqlens = (cu_global[1:] - cu_global[:-1]).tolist()
+    lens_loc, chunks = [], []
+    for i, s in enumerate(seqlens):
+        assert s % world_size == 0, "each sequence length must be divisible by world_size"
+        c = s // world_size
+        base = int(cu_global[i]) + rank * c
+        chunks.append(x_global[base:base + c])
+        lens_loc.append(c)
+    x_loc = torch.cat(chunks, 0).contiguous()
+    cu_loc = torch.tensor([0] + list(torch.tensor(lens_loc).cumsum(0)), dtype=torch.int32, device=x_global.device)
+    return x_loc, cu_loc, max(lens_loc)
+
+
+@torch.no_grad()
+def _ring_forward_varlen(process_group, q, k, v, cu, max_s, softmax_scale, causal):
+    """Option A varlen forward: each hop runs flash_attn_varlen_func on the current K/V
+    chunk (out+lse) and merges online in fp32. q/k/v: (total, H, D) packed varlen; cu:
+    local cu_seqlens (same per-seq lengths on every rank). Returns out (total, Hq, D) in
+    q.dtype and lse (Hq, total) fp32 (the layout the FA3 backward wants)."""
+    q, k, v = q.contiguous(), k.contiguous(), v.contiguous()
+    comm = DoubleBufRingComm(process_group)
+    W, rank = comm.world_size, comm.rank
+    total, Hq, D = q.shape
+    dev = q.device
+    kv_bufs = [torch.empty((2,) + k.shape, device=dev, dtype=k.dtype) for _ in range(2)]
+    kv_send = torch.empty((2,) + k.shape, device=dev, dtype=k.dtype)
+    if W > 1:
+        kv_send[0].copy_(k); kv_send[1].copy_(v)
+    k_cur, v_cur = k, v
+    acc = torch.empty((Hq, total, D), device=dev, dtype=torch.float32)      # head-major fp32 accumulator
+    lse = torch.empty((Hq, total), device=dev, dtype=torch.float32)
+    first = True
+    for step in range(W):
+        if step + 1 != W:
+            comm.send_recv_packed(kv_send, kv_bufs[step & 1])
+        if (not causal) or step <= rank:
+            block_causal = causal and step == 0
+            out_blk, lse_blk = flash_attn_varlen_func(
+                q, k_cur, v_cur, cu, cu, max_s, max_s, softmax_scale=softmax_scale,
+                causal=block_causal, return_attn_probs=True)  # out (total,Hq,D) bf16 ; lse (Hq,total) fp32
+            # fused: consumes bf16 out_blk directly (bf16->fp32 cast + transpose + merge in one pass)
+            _merge_varlen(out_blk, lse_blk, acc, lse, is_first=first); first = False
+        if step + 1 != W:
+            comm.wait()
+            kv_send = kv_bufs[step & 1]
+            k_cur, v_cur = kv_bufs[step & 1][0], kv_bufs[step & 1][1]
+    out = acc.permute(1, 0, 2).contiguous().to(q.dtype)      # (Hq,total,D) -> (total, Hq, D), one fp32->bf16
+    return out, lse                                          # lse (Hq, total) fp32
+
+
+@torch.no_grad()
+def _ring_backward_varlen(process_group, dout, q, k, v, out, softmax_lse, cu, max_s, softmax_scale, causal):
+    """Phased bwd_ring varlen backward (mirrors _ring_backward, varlen-threaded). dQ
+    stays in a persistent fp32 dq_accum; dK/dV are reduced in fp32 along a second ring.
+    q/k/v/out: (total, H, D); dout: (total, Hq, D); softmax_lse: (Hq, total)."""
+    dout, q, k, v, out = [x.contiguous() for x in (dout, q, k, v, out)]
+    kv_comm = DoubleBufRingComm(process_group)
+    d_kv_comm = DoubleBufRingComm(process_group)
+    W, rank = kv_comm.world_size, kv_comm.rank
+    total, Hq, D = q.shape
+    batch = cu.numel() - 1
+    dev = q.device
+    dq_accum, dsoftmax, lse_log2 = ring_bwd_alloc(batch, max_s, Hq, D, device=dev, total_q=total)
+    dq = torch.empty_like(q); block_dk = torch.empty_like(k); block_dv = torch.empty_like(k)
+
+    def _bwd(phase, kk, vv, blk_causal):
+        _bwd_ring(
+            phase, dout, q, kk, vv, out, softmax_lse, dq, block_dk, block_dv,
+            dq_accum, dsoftmax, lse_log2, softmax_scale=softmax_scale, causal=blk_causal,
+            cu_seqlens_q=cu, cu_seqlens_k=cu, max_seqlen_q=max_s, max_seqlen_k=max_s)
+
+    _bwd(1, k, v, causal)  # phase 1 (once/rank)
+
+    kv_bufs = [torch.empty((2,) + k.shape, device=dev, dtype=k.dtype) for _ in range(2)]
+    kv_send = torch.empty((2,) + k.shape, device=dev, dtype=k.dtype)
+    if W > 1:
+        kv_send[0].copy_(k); kv_send[1].copy_(v)
+    k_cur, v_cur = k, v
+    dkdv_bufs = [torch.empty((2,) + k.shape, device=dev, dtype=torch.float32) for _ in range(2)]
+    dk_bufs = [dkdv_bufs[0][0], dkdv_bufs[1][0]]
+    dv_bufs = [dkdv_bufs[0][1], dkdv_bufs[1][1]]
+    first_iter_done = False
+    for step in range(W):
+        if step + 1 != W:
+            kv_comm.send_recv_packed(kv_send, kv_bufs[step & 1])
+        active = step <= rank or not causal
+        prev_slot = (step - 1) & 1
+        if active:
+            _bwd(2, k_cur, v_cur, causal and step == 0)  # phase 2 (per hop): dQ into dq_accum + this chunk's dK/dV
+            if first_iter_done:
+                d_kv_comm.wait()
+            if not first_iter_done:
+                dk_bufs[prev_slot].copy_(block_dk); dv_bufs[prev_slot].copy_(block_dv)
+            else:
+                dk_bufs[prev_slot].add_(block_dk); dv_bufs[prev_slot].add_(block_dv)
+            first_iter_done = True
+        elif step != 0:
+            d_kv_comm.wait()
+        if step + 1 != W:
+            kv_comm.wait()
+            kv_send = kv_bufs[step & 1]
+            k_cur, v_cur = kv_bufs[step & 1][0], kv_bufs[step & 1][1]
+        d_kv_comm.send_recv_packed(dkdv_bufs[prev_slot], dkdv_bufs[step & 1])
+    _bwd(3, k, v, causal)  # phase 3 (once/rank): dq_accum -> dQ; launched BEFORE the
+    d_kv_comm.wait()       # final wait so the convert overlaps the exposed tail dK/dV recv
+    final_slot = (W - 1) & 1
+    return dq.to(q.dtype), dk_bufs[final_slot].to(k.dtype), dv_bufs[final_slot].to(v.dtype)
+
+
+class _RingVarlenFunc(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, q, k, v, cu, max_s, softmax_scale, causal, group):
+        if softmax_scale is None:
+            softmax_scale = q.shape[-1] ** -0.5
+        out, lse = _ring_forward_varlen(group, q, k, v, cu, max_s, softmax_scale, causal)
+        ctx.save_for_backward(q, k.contiguous(), v.contiguous(), out, lse.contiguous(), cu)
+        ctx.softmax_scale, ctx.causal, ctx.group, ctx.max_s = softmax_scale, causal, group, max_s
+        return out
+
+    @staticmethod
+    def backward(ctx, dout):
+        q, k, v, out, lse, cu = ctx.saved_tensors
+        dq, dk, dv = _ring_backward_varlen(ctx.group, dout, q, k, v, out, lse, cu, ctx.max_s,
+                                           ctx.softmax_scale, ctx.causal)
+        return dq, dk, dv, None, None, None, None, None  # 8 forward inputs; only q/k/v get grads
+
+
+def ring_flash_attn_varlen_func(q, k, v, cu_seqlens, max_seqlen, softmax_scale=None,
+                                causal=False, group=None):
+    """Varlen ring / context-parallel attention (autograd-enabled). Forward = Option A
+    (per-hop flash_attn_varlen_func + online fp32 merge); backward = phased bwd_ring.
+
+    q/k/v: THIS rank's per-sequence CHUNK, packed varlen -> (total_local, H, D), bf16/fp16.
+    cu_seqlens / max_seqlen: the LOCAL chunk lengths (identical on every rank). Each
+    global sequence is split into world_size equal chunks along its length, so every
+    global sequence length must be divisible by world_size -- see shard_varlen_along_seq.
+    Returns out (total_local, Hq, D) in the input dtype."""
+    return _RingVarlenFunc.apply(q, k, v, cu_seqlens, max_seqlen, softmax_scale, causal, group)
+
+
+
+# ============================================================================
+# Runnable example: run the optimized ring attention (forward + backward) across the
+# GPUs launched by torchrun, and sanity-check it against a single-GPU full-sequence
+# FA3 flash reference on the same inputs. Every rank builds the SAME global tensors
+# (seeded), shards them, runs the ring on its shard, and compares its shard of the
+# result with the reference. Errors are max-reduced across ranks; rank 0 prints.
+#
+#   torchrun --nproc_per_node=8 --standalone ring_flash_attn_fa3.py
+# ============================================================================
+if __name__ == "__main__":
+    dist.init_process_group("nccl")
+    try:
+        rank = dist.get_rank()
+        world_size = dist.get_world_size()
+        local_rank = int(os.environ.get("LOCAL_RANK", rank))
+        torch.cuda.set_device(local_rank)
+        device = torch.device("cuda", local_rank)
+
+        def log(*a):
+            if rank == 0:
+                print(*a, flush=True)
+
+        # ---- config (override via env if you like) ----
+        B = int(os.environ.get("B", 1))
+        S_global = int(os.environ.get("S", 8192))          # total sequence length across all ranks
+        Hq = int(os.environ.get("HQ", 16))                 # query heads
+        Hkv = int(os.environ.get("HKV", 2))                # key/value heads (GQA if < Hq)
+        D = int(os.environ.get("D", 128))                  # head dim
+        causal = os.environ.get("CAUSAL", "1") == "1"
+        dtype = torch.bfloat16
+        scale = D ** -0.5
+        assert S_global % world_size == 0, "S must be divisible by the number of GPUs"
+        S_local = S_global // world_size
+
+        log(f"world_size={world_size}  device={torch.cuda.get_device_name(local_rank)}")
+        log(f"config: B={B} S_global={S_global} (S_local={S_local}) Hq={Hq} Hkv={Hkv} D={D} "
+            f"causal={causal} {dtype}")
+
+        # ---- build identical global Q/K/V on every rank, then shard along the seq dim ----
+        torch.manual_seed(2024)
+        qg = torch.randn(B, S_global, Hq, D, device=device, dtype=dtype)
+        kg = torch.randn(B, S_global, Hkv, D, device=device, dtype=dtype)
+        vg = torch.randn(B, S_global, Hkv, D, device=device, dtype=dtype)
+        dog = torch.randn_like(qg)                          # upstream gradient for the backward
+
+        # local shards this rank owns (require grad so we can run the ring backward)
+        q = shard_along_seq(qg, rank, world_size).detach().requires_grad_(True)
+        k = shard_along_seq(kg, rank, world_size).detach().requires_grad_(True)
+        v = shard_along_seq(vg, rank, world_size).detach().requires_grad_(True)
+
+        # ---- the actual usage: one call for the forward, autograd for the backward ----
+        out = ring_attention(q, k, v, causal=causal, softmax_scale=scale)
+        out.backward(shard_along_seq(dog, rank, world_size))
+        log(f"ring output shape (this rank's shard): {tuple(out.shape)}")
+
+        # ---- sanity check vs a single-GPU full-sequence FA3 flash on the same inputs ----
+        from flash_attn_interface import flash_attn_func  # stock FA3 (whole sequence, one GPU)
+        qf = qg.detach().requires_grad_(True)
+        kf = kg.detach().requires_grad_(True)
+        vf = vg.detach().requires_grad_(True)
+        ref = flash_attn_func(qf, kf, vf, softmax_scale=scale, causal=causal)
+        ref.backward(dog)
+
+        def err(a, b):
+            return (a.float() - b.float()).abs().max().item()
+
+        # Per-tensor max abs error vs the reference (this rank's shard), max-reduced
+        # across ranks. Both sides are bf16; the ring keeps out/dQ in fp32 so those
+        # track flash tightly, while dK/dV differ only by bf16 rounding (a few 1e-2 on
+        # a long causal sequence -- expected, not a bug).
+        errs = torch.tensor([
+            err(out, shard_along_seq(ref.detach(), rank, world_size)),
+            err(q.grad, shard_along_seq(qf.grad, rank, world_size)),
+            err(k.grad, shard_along_seq(kf.grad, rank, world_size)),
+            err(v.grad, shard_along_seq(vf.grad, rank, world_size)),
+        ], device=device, dtype=torch.float64)
+        dist.all_reduce(errs, op=dist.ReduceOp.MAX)
+        o_e, dq_e, dk_e, dv_e = errs.tolist()
+        log(f"max abs error vs single-GPU flash (all ranks): "
+            f"out={o_e:.2e} dq={dq_e:.2e} dk={dk_e:.2e} dv={dv_e:.2e}")
+        ok = o_e < 2e-2 and max(dq_e, dk_e, dv_e) < 1.2e-1  # generous bf16 backward tolerance
+        log("OK: ring matches single-GPU flash within bf16 tolerance"
+            if ok else "WARNING: error larger than the bf16 tolerance -- check the build/config")
+
+        # ---- varlen ring example: shard each sequence into W chunks, run the varlen ring,
+        #      compare to a single-GPU full-sequence flash_attn_varlen_func ----
+        log()
+        VB = int(os.environ.get("VB", 3))                       # number of (variable-length) sequences
+        unit = 8 * world_size                                   # seqlens are multiples of this so each chunk is a multiple of 8
+        gcpu = torch.Generator(device="cpu").manual_seed(11)
+        vseqlens = [((x // unit) + 1) * unit for x in torch.randint(unit, 12 * unit, (VB,), generator=gcpu).tolist()]
+        vtotal = sum(vseqlens)
+        vcu = torch.tensor([0] + list(torch.tensor(vseqlens).cumsum(0)), dtype=torch.int32, device=device)
+        vmax = max(vseqlens)
+        torch.manual_seed(11)
+        vqg = torch.randn(vtotal, Hq, D, device=device, dtype=dtype)
+        vkg = torch.randn(vtotal, Hkv, D, device=device, dtype=dtype)
+        vvg = torch.randn(vtotal, Hkv, D, device=device, dtype=dtype)
+        vdog = torch.randn_like(vqg)
+        # reference: full-sequence varlen attention on one GPU (+ autograd)
+        vqf = vqg.detach().requires_grad_(True); vkf = vkg.detach().requires_grad_(True); vvf = vvg.detach().requires_grad_(True)
+        vref = flash_attn_varlen_func(vqf, vkf, vvf, vcu, vcu, vmax, vmax, softmax_scale=scale, causal=causal)
+        vref.backward(vdog)
+        # this rank owns chunk `rank` of every sequence
+        vq, vcu_loc, vmax_loc = shard_varlen_along_seq(vqg, vcu, rank, world_size)
+        vk, _, _ = shard_varlen_along_seq(vkg, vcu, rank, world_size)
+        vv, _, _ = shard_varlen_along_seq(vvg, vcu, rank, world_size)
+        vdo, _, _ = shard_varlen_along_seq(vdog, vcu, rank, world_size)
+        vq = vq.detach().requires_grad_(True); vk = vk.detach().requires_grad_(True); vv = vv.detach().requires_grad_(True)
+        vout = ring_flash_attn_varlen_func(vq, vk, vv, vcu_loc, vmax_loc, softmax_scale=scale, causal=causal)
+        vout.backward(vdo)
+        log(f"varlen ring: {VB} seqs, global total={vtotal}, this rank's chunk total={vout.shape[0]}; out shape {tuple(vout.shape)}")
+        # compare this rank's chunk of {out, dq, dk, dv} to the reference's chunk
+        vref_loc, _, _ = shard_varlen_along_seq(vref.detach(), vcu, rank, world_size)
+        vdq_loc, _, _ = shard_varlen_along_seq(vqf.grad, vcu, rank, world_size)
+        vdk_loc, _, _ = shard_varlen_along_seq(vkf.grad, vcu, rank, world_size)
+        vdv_loc, _, _ = shard_varlen_along_seq(vvf.grad, vcu, rank, world_size)
+        verrs = torch.tensor([err(vout, vref_loc), err(vq.grad, vdq_loc), err(vk.grad, vdk_loc), err(vv.grad, vdv_loc)],
+                             device=device, dtype=torch.float64)
+        dist.all_reduce(verrs, op=dist.ReduceOp.MAX)
+        vo, vdq, vdk, vdv = verrs.tolist()
+        log(f"[varlen] max abs error vs single-GPU flash_attn_varlen_func (all ranks): "
+            f"out={vo:.2e} dq={vdq:.2e} dk={vdk:.2e} dv={vdv:.2e}")
+        log("[varlen] OK: varlen ring matches single-GPU varlen flash within bf16 tolerance"
+            if (vo < 2e-2 and max(vdq, vdk, vdv) < 1.2e-1) else "[varlen] WARNING: error larger than the bf16 tolerance")
+    finally:
+        if dist.is_initialized():
+            dist.destroy_process_group()


### PR DESCRIPTION
# FA3 ring / context-parallel attention: fold fp32 ring partials & gradients into the stock fwd/bwd (no per-hop bf16<->fp32 round-trips)

Ring / context-parallel (CP) support for the FA3 (Hopper / sm90) attention ops,
added by **folding it into the existing `fwd` / `bwd` ops behind default-off flags**
— there are no separate ring ops. This lets a ring driver keep every intermediate in
**fp32** across ring hops and cast to bf16 exactly once, instead of round-tripping
through bf16 on every hop. With the flags at their defaults the standard
forward/backward is byte-for-byte untouched (identical speed and numerics); the ring
path reuses the existing kernels. A complete multi-GPU reference driver (dense **and**
true variable-length CP) and a before/after benchmark ship alongside.

## Problem

**A ring attention built on the public FA3 entry points is forced to round-trip
through bf16 on every ring hop — which both wastes work and loses precision on
`out` and `dQ`.**

Concretely, per K/V hop:

- **Forward** — `flash_attn_func` runs a full split **+ combine** and returns a
  **bf16** block output; the ring must cast it back to fp32 before its own online
  merge. That is one bf16 round-trip per hop, and the internal combine is wasted
  work (the ring merges the partials itself).
- **Backward** — the full `flash_attn_3.bwd` recomputes **preprocess**
  (`D = rowsum(dO∘O)`, `softmax_lse_log2`) and **convert** (`dQ_accum → dQ`) on
  every hop, and rounds dQ to **bf16** each hop before it is accumulated in Python
  fp32 — another per-hop round-trip.

These per-hop overheads dominate the regime where ring attention is used most
(many ranks, moderate per-rank sequence length, GQA), and the repeated bf16
rounding degrades `out` / `dQ` accuracy.

## Our solution

- **Forward → emit an fp32 partial and skip the combine.** The `fwd` op gains a
  **`skip_combine`** flag (+ caller-owned `out_accum` / `lse_accum`). With it set, the
  forward is run with the Split kernel forced on (even `num_splits==1`) to write the
  block's **fp32 normalized partial + fp32 LSE** directly into the caller's buffers,
  with no combine and no downcast. The ring merges partials online in fp32 and casts
  to bf16 once, at the very end. *(removes the forward bf16 round-trip and the wasted
  per-hop combine.)*
- **Backward → one persistent fp32 dQ accumulator, computed once.** The `bwd` op
  gains a **`ring_phase`** flag (+ caller-owned `dq_accum` / `dsoftmax_sum` /
  `softmax_lse_log2`). With `ring_phase != 0` it keeps dQ in the **persistent fp32
  buffer** the main kernel reduce-adds into (fp32 TMA `SM90_BULK_REDUCE_ADD` on
  hd128), and splits the pass so **preprocess and convert run once per rank** while
  only the main kernel runs per hop. *(removes the dQ bf16 round-trip and the `W-1`
  repeated preprocess/convert passes.)*
- **hd128 → pin one block size so the fp32 accumulator layout stays consistent.**
  hd128's backward `kBlockM` is causal-dependent (causal → 64, non-causal → 80); a
  ring mixes causal (diagonal) and non-causal (off-diagonal) hops into one
  persistent `dq_accum`, so ring mode pins every hop to the tuned **80-block**.
  *(gives the fast kernel on non-causal hops without breaking the shared layout.)*
- **Two zero-risk driver/host cleanups.** (a) the phased convert (phase 3) is
  launched **before** the final dK/dV `wait()` so it overlaps the exposed tail
  exchange (it only touches `dq_accum`/`dQ`); (b) the ring backward (`ring_phase != 0`)
  no longer allocates the `dq_semaphore` int32 buffer — it is dead when
  `deterministic=false` (main kernel takes `lock_ptr=nullptr`; the preprocess clear is
  null-guarded). Both are numerically inert (grads bit-identical) — pure housekeeping.

## What this adds

Ring support is exposed as **new default-off parameters on the existing `fwd` / `bwd`
ops** (in the `flash_attn_3` torch library) plus one Python allocation helper — no new
ops, no new public wrappers:

1. **`fwd(..., skip_combine=False, out_accum=None, lse_accum=None)`** — `skip_combine=True`
   forces the Split kernel on and writes the fp32 normalized partial + fp32 LSE (into
   `num_splits` caller-owned sub-splits in `out_accum`/`lse_accum`) with no combine.
   Default `False` = the standard forward.
2. **`bwd(..., ring_phase=0, dq_accum=None, dsoftmax_sum=None, softmax_lse_log2=None)`** —
   `ring_phase` selects one phase per call (buffers are caller-owned, persist across
   phases):
   - phase 1 `preprocess` — compute `D`, `softmax_lse_log2`, clear `dq_accum` (**once per rank**);
   - phase 2 `step` — main kernel only: accumulate this shard's dQ into `dq_accum`, write its dK/dV (**per hop**);
   - phase 3 `convert` — `dq_accum → dQ`, scaled once (**once per rank**).
   Default `ring_phase=0` = the standard backward (all phases, internal buffers).
3. **`ring_bwd_alloc`** (`flash_attn_interface`) — allocates the three persistent fp32
   buffers (`dq_accum`, `dsoftmax_sum`, `softmax_lse_log2`) with the exact shapes /
   block rounding the phased backward expects (dense **and** varlen layouts).

Internal helpers kept for the ring path: `run_mha_fwd_ring` (the forced-Split, no-combine
launcher) and `ring_bwd_kblock_mn` (causal-independent block sizing) in `flash_api.cpp`.

**The complete, ready-to-use ring flash-attention lives in
`tests/ring_flash_attn_fa3.py`** — a self-contained, autograd-enabled multi-GPU driver
that is the single source of truth for the ring logic (double-buffered comm, fused fp32
online merge, sequence sharding). This is the file you import to run context-parallel
attention; `benchmarks/benchmark_flash_ring_attention_fa3.py` only imports it and adds the
before/after comparison. The driver calls the folded ops through thin private
`_fwd_ring` / `_bwd_ring` glue (no public op wrappers). Its two public entry points:

- **`ring_flash_attn_func(q, k, v, causal=…, softmax_scale=…, group=…)`** — **dense** ring:
  forward via `fwd(skip_combine=True)` + phased `bwd(ring_phase=…)`, `DoubleBufRingComm`,
  fused fp32 online merge, fp32 dK/dV ring reduction, autograd.
- **`ring_flash_attn_varlen_func(q, k, v, cu_seqlens, max_seqlen, causal=…, …)`** — **true
  varlen CP** ring: each global sequence is split into `W` equal chunks and rank `r` holds
  chunk `r` of every sequence (zhuzilin-style per-sequence-equal sharding). Forward is
  per-hop `flash_attn_varlen_func(out+lse)` + fp32 merge; backward is the phased
  `bwd(ring_phase=…)`.

## Files changed

Additive delta on top of the current `hopper/` FA3 (base `2409214`): **~301
insertions, 50 deletions** across 4 source files, plus two new files (driver +
benchmark). The ring paths are folded into `mha_fwd` / `mha_bwd` behind default-off
flags, so the un-flagged (`skip_combine=false` / `ring_phase==0`) paths stay
byte-identical to the original.

| File | +/- | What |
|---|---|---|
| `hopper/flash.h` | +8 | `int ring_bwd_phase` field on `Flash_fwd_params` (0 = normal; only read by `run_flash_bwd`). |
| `hopper/flash_bwd_launch_template.h` | +31 / -3 | `run_flash_bwd` gates preprocess / main / convert / dK-dV-convert launches by `ring_bwd_phase`; `run_mha_bwd_hdim128` pins the ring's hd128 hops to the tuned 80-block. |
| `hopper/flash_api.cpp` | +194 / -47 | `mha_fwd` gains `skip_combine` + caller-owned `out_accum`/`lse_accum` (routes to `run_mha_fwd_ring`, skips combine); `mha_bwd` gains `ring_phase` + caller-owned `dq_accum`/`dsoftmax_sum`/`softmax_lse_log2` (+ hd128 pin via `ring_bwd_kblock_mn`, `dq_semaphore` left null); `fwd`/`bwd` schemas extended. Kept: `run_mha_fwd_ring`, `ring_bwd_kblock_mn`. |
| `hopper/flash_attn_interface.py` | +68 | `ring_bwd_alloc` (dense + varlen). No new op wrappers — the stock `_flash_attn_forward` / `_flash_attn_backward` are untouched. |
| `tests/ring_flash_attn_fa3.py` | new (~750) | Reference multi-GPU ring driver — dense + true varlen CP, comm/merge/shard machinery, autograd; private `_fwd_ring`/`_bwd_ring` glue over the folded ops. Single source of truth. |
| `benchmarks/benchmark_flash_ring_attention_fa3.py` | new (726) | Imports the driver, adds the "stock" (before-optimization) rings, and runs 5 stages: dense accuracy gate, dense before/after accuracy, dense before/after speed grid, varlen before/after accuracy, varlen before/after speed. |

No new ops, no new `.cu` kernels, no changes to the mainloop/kernel headers: the
forward ring path reuses the existing split-KV forward (`run_mha_fwd_ring`), and the
backward reuses the existing preprocess / main / convert / dK-dV kernels — only the
folded-in flags, the launch gating, and the ring `kBlockM` selection are new.

## Usage

Build the Hopper extension in place (sm90), then use the ring flags / driver:

```bash
cd hopper
python setup.py build_ext --inplace
# Optional fast build (skip unused features): prepend
#   FLASH_ATTENTION_DISABLE_SM80=TRUE FLASH_ATTENTION_DISABLE_FP8=TRUE \
#   FLASH_ATTENTION_DISABLE_HDIMDIFF64=TRUE FLASH_ATTENTION_DISABLE_HDIMDIFF192=TRUE \
#   FLASH_ATTENTION_DISABLE_PAGEDKV=TRUE FLASH_ATTENTION_DISABLE_APPENDKV=TRUE
```

Easiest path — use the reference driver directly:

```python
# tests/ on PYTHONPATH; sequence sharded along dim 1 across the process group
from ring_flash_attn_fa3 import ring_flash_attn_func, ring_flash_attn_varlen_func
out = ring_flash_attn_func(q_local, k_local, v_local, causal=True, softmax_scale=scale)
out.backward(dout_local)          # phased fp32 backward, all autograd-wired
```

Or drive the raw ops yourself (the folded ring flags). Minimal forward (one ring hop):

```python
import torch
from flash_attn_interface import ring_bwd_alloc  # (registers the ops on import)
fwd = torch.ops.flash_attn_3.fwd
# out_accum: (num_splits, B, H, S_q, Dv) fp32 ; lse_accum: (num_splits, B, H, S_q) fp32 (caller-owned)
fwd(q, k_block, v_block, softmax_scale=scale, is_causal=block_is_diagonal,
    num_splits=ns, skip_combine=True, out_accum=out_accum, lse_accum=lse_accum)
# merge out_accum/lse_accum into your running fp32 (acc, lse) with online softmax
```

Minimal backward (phased, per rank):

```python
bwd = torch.ops.flash_attn_3.bwd
dq_accum, dsoftmax, lse_log2 = ring_bwd_alloc(B, S_local, H, D, device=q.device)
# common positional args: (dout,q,k,v,out,lse, dq,dk,dv, cu_q,cu_k,su_q,su_k, mq,mk,
#                          scale, is_causal, wsl, wsr, softcap, deterministic, sm_margin,
#                          ring_phase, dq_accum, dsoftmax_sum, softmax_lse_log2)
bwd(dout, q, k, v, out, lse, dq, dk, dv, None, None, None, None, None, None,
    scale, causal, -1, -1, 0.0, False, 0, 1, dq_accum, dsoftmax, lse_log2)   # phase 1 preprocess (once)
for hop in ring:                                                             # phase 2 step (per hop)
    bwd(dout, q, k_hop, v_hop, out, lse, dq, dk, dv, None, None, None, None, None, None,
        scale, (causal and hop == 0), -1, -1, 0.0, False, 0, 2, dq_accum, dsoftmax, lse_log2)
bwd(dout, q, k, v, out, lse, dq, dk, dv, None, None, None, None, None, None,
    scale, causal, -1, -1, 0.0, False, 0, 3, dq_accum, dsoftmax, lse_log2)   # phase 3 convert (once)
```

(The reference driver's private `_fwd_ring` / `_bwd_ring` in `tests/ring_flash_attn_fa3.py`
wrap exactly these calls.)

Run the benchmark (accuracy + before/after speed, dense + varlen):

```bash
torchrun --nproc_per_node=8 --standalone benchmarks/benchmark_flash_ring_attention_fa3.py
# knobs: RING_D_LIST, RING_S_LIST, RING_HQ, RING_HKV, RING_REPS, and per-stage skips
#   RING_SKIP_PRECISION / RING_SKIP_PRECISION_DIFF / RING_SKIP_SPEED /
#   RING_SKIP_VARLEN_DIFF / RING_SKIP_VARLEN_SPEED
```

## Supported configuration

- **dtype:** fp16 / bf16. **sm90 (Hopper) only.**
- **head_dim:** 64, 96, 128, 192, 256 (Q/K and V head dim equal).
- **heads:** MHA (`hq == hkv`) and GQA / MQA (`hq` a multiple of `hkv`).
- **masking:** causal and non-causal. The causal ring uses the plain schedule — rank `r`
  attends key shards `0..r`, and only its diagonal (step-0) block is masked.
- **dense CP ring — `ring_flash_attn_func`:** the global sequence is split into `W`
  contiguous shards along seqlen (`S_global` divisible by `W`); each rank permanently owns
  one Q shard, K/V rotate around the ring. Forward `fwd(skip_combine=True)` + phased
  `bwd(ring_phase=…)`, fused fp32 online merge, fp32 dK/dV ring reduction, autograd.
- **varlen CP ring — `ring_flash_attn_varlen_func`:** **per-sequence-equal sharding** —
  each global (packed) sequence is split into `W` **equal** chunks along its length (every
  sequence length divisible by `W`) and rank `r` holds chunk `r` of every sequence, packed;
  the local `cu_seqlens` is then identical on every rank. Forward = per-hop
  `flash_attn_varlen_func(out+lse)` + online fp32 merge (Option A — **not**
  `fwd(skip_combine)`, whose store-all path is unusable under the dynamic varlen split
  scheduler); backward = the phased `bwd(ring_phase=…)`. Validated multi-GPU against a
  single-GPU `flash_attn_varlen_func` reference (all grads within bf16/fp16 tolerance).

## Limitations (not yet supported)

- **window_size / local / sliding-window.** The driver implements only the plain
  causal / non-causal ring (no cross-rank window remapping); the hd128 `kBlockM=80` pin
  also assumes plain causal (`Is_causal && !Is_local && !Has_softcap`), so a local window
  would disagree with the `dq_accum` layout that `ring_bwd_alloc` sizes. The ring backward
  **rejects `is_local` with a clear error** rather than silently producing wrong gradients.
- **Causal load-balancing (zigzag).** The causal ring is naive (`active = step <= rank`),
  so the straggler rank runs `W` hops vs rank 0's 1 — the collective is straggler-bound.
  A zigzag split would rebalance every rank to ~`(W+1)/2` hops (~1.8× at `W=8`) and is the
  main remaining perf lever, especially in the large-S compute-bound regime where the
  phased amortization already washes out; composing it with the phased backward needs two
  `kBlockM`-aligned `dq_accum` sub-regions (the hd128 80-block makes the `S_local/2` split
  un-aligned). A planned follow-up (dense first) — **not implemented yet.**
- **Arbitrary / ragged varlen CP.** Only per-sequence-equal sharding is supported; a
  varlen ring where a sequence's chunking differs across ranks (llama3-style ragged CP),
  or varlen zigzag, is out of scope. Sequence lengths not divisible by `W` are rejected.
- **hdim ≤ 64 + softcap.** Rejected: its `kBlockM` would differ across causal /
  non-causal ring steps and break the shared `dq_accum`. (`hd128 + softcap` is fine at a
  consistent `kBlockM=64`.)
- **Differing Q/K vs V head dim, deterministic backward, paged-KV / appendKV / FP8 / sm80.**
  Out of scope: the ring keeps `dv == d`; deterministic uses a `dq_semaphore` path the ring
  leaves unallocated; and paged-KV / appendKV / FP8 / sm80 are unrelated to CP (this fast
  build also compiles with FP8 / HDIMDIFF / paged-KV / appendKV disabled).

## Test results (8× H100 80GB, bf16 & fp16)

### Stock forward/backward unaffected (folded flags default off)

The whole point of folding behind default-off flags is that the standard FA3 path stays
untouched. Verified against the **upstream stock test** `hopper/test_flash_attn.py`
(`test_flash_attn_output` / `test_flash_attn_varlen_output`, which check the forward **and**
the backward via `autograd.grad`) on this build's supported configs — d=128 (dv == d),
bf16 & fp16, MHA/MQA/GQA, causal & non-causal, softcap ∈ {0, 15}, local on/off, seqlen
1024×1024:

- dense (`test_flash_attn_output`): **48 passed / 0 failed**
- varlen (`test_flash_attn_varlen_output`): **192 passed / 0 failed**
- → **240 / 0** — the stock path is bit-for-bit intact.

(In a broader sweep the only failures are configs this fast build compiles **out** — FP8
and differing-V-dim hd64 — which error because those kernels aren't built, unrelated to the
ring changes. The ring touches zero forward-kernel code, and the `skip_combine=false` /
`ring_phase==0` default paths are byte-identical to the original.)

### Dense accuracy — `precision_test`

Optimized ring vs the fp32 eager reference, gated against a single-GPU
full-sequence FA3 flash on the same reference:
`ring_max ≤ flash_max × 2.5 + 2e-3` (flash-attention's testing style). Swept over
`dtype ∈ {bf16, fp16} × D ∈ {64,128} × {MHA(8,8), GQA(16,2)} × {causal, non-causal}`:
**all 16 configurations PASS.**

### Dense before/after accuracy — `precision_compare`

Max abs error of optimized (`opt`) vs naive baseline (`old`) against the fp32
truth. The optimized ring is **≤** the baseline on `out` and `dQ` (dropping the
per-hop bf16 round-trip), and identical on `dK`/`dV` (same fp32 ring reduction).
Representative rows:

| dtype | d | Hq | Hkv | causal | out opt | out old | dq opt | dq old |
|---|---|---|---|---|---|---|---|---|
| bf16 | 64 | 8 | 8 | True | 7.98e-03 | 7.98e-03 | **7.81e-03** | 2.16e-02 |
| bf16 | 128 | 8 | 8 | False | **6.61e-04** | 9.89e-04 | **1.41e-03** | 2.32e-03 |
| bf16 | 64 | 16 | 2 | False | **6.37e-04** | 8.83e-04 | **1.40e-03** | 2.10e-03 |

### Dense before/after speed — `speed_grid`

Wall-clock (ms, all_reduce MAX across ranks, median of 3), causal=True, GQA
Hq=16 / Hkv=2, bf16, 8 ranks. `old/opt > 1` means the optimized ring is faster.
`bwd` is the **backward in isolation** (forward run once untimed, then only
`.backward()` timed on the retained graph); `fbw` is the bundled forward+backward.

```
   D  S_local  S_global | fwd o/o | bwd o/o | fbw o/o
  64      512      4096  |  2.03x  |  1.08x  |  1.44x
  64     1024      8192  |  1.95x  |  1.08x  |  1.45x
  64     2048     16384  |  2.01x  |  1.03x  |  1.36x
  64     4096     32768  |  1.34x  |  1.10x  |  1.09x
  64     8192     65536  |  1.03x  |  1.05x  |  1.04x
 128      512      4096  |  2.11x  |  1.08x  |  1.44x
 128     1024      8192  |  1.95x  |  1.04x  |  1.40x
 128     2048     16384  |  2.06x  |  1.21x  |  1.36x
 128     4096     32768  |  1.11x  |  1.12x  |  1.07x
 128     8192     65536  |  1.02x  |  1.04x  |  1.06x
 256      512      4096  |  2.03x  |  1.01x  |  1.42x
 256     1024      8192  |  1.99x  |  1.25x  |  1.38x
 256     2048     16384  |  1.38x  |  1.16x  |  1.15x
 256     4096     32768  |  1.08x  |  1.08x  |  1.08x
 256     8192     65536  |  1.02x  |  1.04x  |  1.04x
```

The optimized ring is **faster in every cell**: forward wins ~2× in the launch /
overhead-bound regime (`fwd(skip_combine)` drops the combine + bf16 round-trip); the isolated
backward is 1.01–1.25× everywhere. Both converge toward parity — but never invert
— as the workload becomes compute-bound (large S), where the main kernel dominates
and the phased amortization has little left to save (this is what a zigzag schedule
would attack next).

### Varlen — `varlen_precision_compare` / `varlen_speed_compare`

Multi-GPU validation of the full varlen CP path (per-sequence-equal sharding, 8
ranks) against the fp32 eager varlen truth, swept over
`dtype ∈ {bf16, fp16} × d ∈ {64,128} × {MHA(8,8), GQA(16,2)} × {causal, non-causal}`
— **all rows match** (the forward is shared, so `out opt == out old`; the FA3
difference is the backward, and `dq opt` is ≤ `dq old`, e.g. bf16 d64 non-causal
`5.11e-03` vs `1.30e-02`).

Speed (causal, ws=8, D=128, bf16). The varlen forward is shared → `fwd ≈ 1.0×`;
the FA3 difference is the backward, which is **1.05–1.21× faster in isolation**.
On the bundled `fbw` metric the win is diluted to ~parity because the shared
forward is the larger half at these sizes:

```
 nseq  seqlen   total | fwd o/o | bwd o/o | fbw o/o
    4     512    2048  |  1.01x  |  1.05x  |  1.01x
    4    2048    8192  |  1.02x  |  1.12x  |  0.98x
    8    4096   32768  |  0.98x  |  1.21x  |  1.00x
```

The varlen backward's value is precision + memory/comm (dQ never round-trips bf16,
`dq_accum` resident) and a modest isolated speedup; it is at parity on bundled
wall-clock at these sizes.

Environment: 8× NVIDIA H100 80GB HBM3, CUDA 12.x, PyTorch 2.5, sm90 build.
