### PR TITLE
Numeric tweaks to fp8

### DIFF
--- a/flash_attn/cute/flash_fwd_sm100.py
+++ b/flash_attn/cute/flash_fwd_sm100.py
@@ -80,6 +80,22 @@ from flash_attn.cute.utils import AuxData
 #   num_regs_correction: int — register count for correction warps (multiple of 8)
 #   num_regs_other is derived: 512 - num_regs_softmax * 2 - num_regs_correction
 #                  (hd256 exception: num_regs_other is fixed at 32, not derived)
+
+# Note [Low Precision Scaling]
+# P is in (0, 1] and is cast to the input dtype before P @ V, so scaling it by 2^max_offset
+# spends the dtype's unused upper code points on the probability tail. A positive
+# rescale_threshold lets the row max lag by that many log2 units, so P can reach
+# 2^(max_offset + rescale_threshold); above the dtype max the top probabilities saturate
+# while the FP32 denominator still counts them in full, shrinking the output (#2716).
+
+# log2 of the largest finite value representable in each supported input dtype.
+_LOG2_DTYPE_MAX = {
+    cutlass.Float8E4M3FN: math.log2(448.0),
+    cutlass.Float8E5M2: math.log2(57344.0),
+    cutlass.Float16: math.log2(65504.0),
+    cutlass.BFloat16: math.log2(3.3895313892515355e38),
+}
+
 _TUNING_CONFIG = {
     (True, False, 128, False): {"ex2_emu_freq": 10, "ex2_emu_start_frg": 1, "num_regs_softmax": 176, "num_regs_correction": 88},
     (False, True, 128, False): {"ex2_emu_freq": 16, "ex2_emu_start_frg": 1, "num_regs_softmax": 192, "num_regs_correction": 72},
@@ -2027,16 +2043,8 @@ class FlashAttentionForwardSm100:
 
             qk_descale, _ = self._load_effective_descales(descale_tensors, batch_idx, kv_head_idx)
 
-            # P is scaled by 2^max_offset before the FP8 conversion. With rescale_threshold > 0
-            # the row max can be stale by up to rescale_threshold (in log2 units), so P can reach
-            # 2^(max_offset + rescale_threshold). max_offset + rescale_threshold must stay within
-            # log2(fp8_max) (448 = 2^8.8 for e4m3fn, 57344 = 2^15.8 for e5m2), otherwise the
-            # largest probabilities saturate and accuracy degrades (#2716).
-            max_offset = (
-                4 if cutlass.const_expr(self.q_dtype is cutlass.Float8E4M3FN) else
-                8 if cutlass.const_expr(self.q_dtype.width == 8) else
-                0
-            )
+            # See Note [Low Precision Scaling]
+            max_offset = 8 if cutlass.const_expr(self.q_dtype.width == 8) else 0
             if const_expr(self.score_mod is None):
                 softmax_scale_log2_eff = softmax_scale_log2 * qk_descale
                 softmax_scale_eff = None
@@ -2044,10 +2052,11 @@ class FlashAttentionForwardSm100:
                 softmax_scale_log2_eff = softmax_scale_log2
                 softmax_scale_eff = softmax_scale * qk_descale
 
-            rescale_threshold = (
-                8.0 if const_expr(self.q_dtype.width == 16) else
-                4.0 if const_expr(self.q_dtype.width == 8) else
-                0.0
+            rescale_threshold = 8.0 if const_expr(self.q_dtype.width == 16) else 0.0
+            # See Note [Low Precision Scaling]
+            assert max_offset + rescale_threshold < _LOG2_DTYPE_MAX[self.q_dtype], (
+                f"max_offset ({max_offset}) + rescale_threshold ({rescale_threshold}) must stay "
+                f"below log2(max {self.q_dtype} value) to avoid saturating P"
             )
             softmax = SoftmaxSm100.create(
                 softmax_scale_log2_eff,
@@ -2468,17 +2477,10 @@ class FlashAttentionForwardSm100:
             else:
                 softmax_scale_log2_eff = softmax_scale_log2
 
-            # Must match the softmax warp's max_offset (see comment there; #2716);
-            # max_offset_scale = 2^max_offset.
-            max_offset = (
-                Float32(4.0) if cutlass.const_expr(self.q_dtype is cutlass.Float8E4M3FN) else
-                Float32(8.0) if cutlass.const_expr(self.q_dtype.width == 8) else
-                Float32(0.0)
-            )
+            # Must match the softmax warp's max_offset; max_offset_scale = 2^max_offset.
+            max_offset = Float32(8.0) if cutlass.const_expr(self.q_dtype.width == 8) else Float32(0.0)
             max_offset_scale = (
-                Float32(16.0) if cutlass.const_expr(self.q_dtype is cutlass.Float8E4M3FN) else
-                Float32(256.0) if cutlass.const_expr(self.q_dtype.width == 8) else
-                Float32(1.0)
+                Float32(256.0) if cutlass.const_expr(self.q_dtype.width == 8) else Float32(1.0)
             )
             seqlen = SeqlenInfoCls(batch_idx)
             n_block_min, n_block_max = block_info.get_n_block_min_max(seqlen, m_block, split_idx, num_splits)

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -1835,6 +1835,78 @@ def _generate_block_kvcache(
     return k_cache, v_cache, page_table, k_cache_paged, v_cache_paged, num_blocks
 
 
+def _run_fp8_paged_decode(q, k, v, page_size=128):
+    """Run a single-sequence FP8 paged decode with unit descales."""
+    seqlen_k, nheads_kv, d = k.shape
+    num_pages = math.ceil(seqlen_k / page_size)
+    k_cache = torch.zeros(num_pages, page_size, nheads_kv, d, device=k.device, dtype=k.dtype)
+    v_cache = torch.zeros_like(k_cache)
+    k_cache.view(-1, nheads_kv, d)[:seqlen_k].copy_(k)
+    v_cache.view(-1, nheads_kv, d)[:seqlen_k].copy_(v)
+    page_table = torch.arange(num_pages, dtype=torch.int32, device=k.device).unsqueeze(0)
+    descale = torch.ones(1, nheads_kv, dtype=torch.float32, device=k.device)
+    return _flash_attn_fwd(
+        q,
+        k_cache,
+        v_cache,
+        cu_seqlens_q=torch.tensor([0, 1], dtype=torch.int32, device=q.device),
+        seqused_k=torch.tensor([seqlen_k], dtype=torch.int32, device=q.device),
+        page_table=page_table,
+        softmax_scale=d**-0.5,
+        causal=True,
+        q_descale=descale,
+        k_descale=descale,
+        v_descale=descale,
+    )[0]
+
+
+def _fp8_decode_reference(q, k, v):
+    """Compute FP32 attention over dequantized FP8 decode inputs."""
+    nheads = q.shape[1]
+    k = k.float().repeat_interleave(nheads // k.shape[1], dim=1)
+    v = v.float().repeat_interleave(nheads // v.shape[1], dim=1)
+    scores = torch.einsum("qhd,khd->hqk", q.float(), k) * q.shape[-1] ** -0.5
+    return torch.einsum("hqk,khd->qhd", torch.softmax(scores, dim=-1), v)
+
+
+@pytest.mark.skipif(not IS_SM100, reason="FP8 paged decode is SM100-only")
+@maybe_fake_tensor_mode(USE_FAKE_TENSOR)
+def test_flash_attn_fp8_paged_decode_tile_boundary():
+    """A second KV tile must not saturate e4m3 softmax probabilities."""
+    torch.manual_seed(0)
+    q = torch.randn(1, 6, 128, device="cuda", dtype=torch.bfloat16).to(torch.float8_e4m3fn)
+    k = torch.randn(129, 1, 128, device="cuda", dtype=torch.bfloat16).to(torch.float8_e4m3fn)
+    v = torch.randn(129, 1, 128, device="cuda", dtype=torch.bfloat16).to(torch.float8_e4m3fn)
+
+    out = _run_fp8_paged_decode(q, k, v)
+    if is_fake_mode():
+        return
+
+    ref = _fp8_decode_reference(q, k, v)
+    cosine = torch.nn.functional.cosine_similarity(out.float().flatten(), ref.flatten(), dim=0)
+    assert cosine > 0.99, f"FP8 paged decode lost accuracy at the tile boundary: {cosine=}"
+
+
+@pytest.mark.skipif(not IS_SM100, reason="FP8 paged decode is SM100-only")
+@maybe_fake_tensor_mode(USE_FAKE_TENSOR)
+def test_flash_attn_fp8_paged_decode_preserves_tail_mass():
+    """Collectively significant e4m3 softmax tails must not flush to zero."""
+    q = torch.zeros(1, 6, 128, device="cuda", dtype=torch.float8_e4m3fn)
+    q[..., 0] = 16.0
+    k = torch.zeros(1024, 1, 128, device="cuda", dtype=torch.float8_e4m3fn)
+    # Decode visits KV blocks right-to-left, so k[-1] establishes the max before the tails.
+    k[:-1, ..., 0] = -7.0
+    v = torch.ones_like(k)
+    v[-1] = 0.0
+
+    out = _run_fp8_paged_decode(q, k, v)
+    if is_fake_mode():
+        return
+
+    ref = _fp8_decode_reference(q, k, v)
+    torch.testing.assert_close(out.float(), ref, atol=0.01, rtol=0.1)
+
+
 @pytest.mark.parametrize("page_size", [16, 64, 256])
 @pytest.mark.parametrize("seqlen_q", [64, 128, 256])
 @maybe_fake_tensor_mode(USE_FAKE_TENSOR)


### PR DESCRIPTION
Numeric tweaks to fp8 rescale and offset

Addressing: https://github.com/Dao-AILab/flash-attention/issues/2577 

This however has some tradeoffs ill show. And this is choice is not yet finalized;

## Summary

The summary in that issue is pretty much spot on and I agree with its fix although there is some interesting perf/ numeric trade offs, and fundamentally the optimal choice is data dependent so we might wanna think about exposing this somehow.

TLDR: With `offset=8` and `rescale_threshold=4`, the max intermediate value in the first `P` block is `2^8 = 256`. A later block can have an unshifted max up to 3.999 log2 units above the tracked max. Because this increase is below the threshold, we keep the old `M` and skip rescaling the accumulator. The second block's max intermediate `P` value can then approach `2^(8+4) = 4096`.

This exceeds E4M3's max value of 448. The denominator `l_i` is accumulated in FP32, but `P` is cast to E4M3 before `P @ V`, causing these large values to saturate. The denominator includes the original values while the numerator includes only their clipped contributions. Final normalization therefore can destroy these values that should contribute to the output

lets say we set rescale threshold to zero,  then any increase in the block max also updates `M`. The  previous accumulator and `l_i` are rescaled by `alpha = 2^(M_old - M_new)`, and the new block is evaluated relative to `M_new`. Its max intermediate `P` value is therefore `2^8 = 256`, rather than 4096.

The current Pr uses a threshold of `0.75`; it allows the maximum to reach `2^8.75 ≈ 431`, which remains below 448, while still avoiding some accumulator rescales, but there are many ways to accomplish the same affect


### Perf Numeric Summary

-- agent notes -- 

#### Pareto frontier

![E4M3 offset-threshold Pareto](https://raw.githubusercontent.com/drisspg/flash-attention/8690cd53d13f7c6de766ff2814068d051adb70a6/issue2577/pareto-overview.png)

The full confirmation supports **`max_offset=8, rescale_threshold=0`** as the best global policy measured. Relative to upstream `(4,4)`:

| Path | Median latency | Time-weighted latency | Median relative-L2 / upstream |
| --- | ---: | ---: | ---: |
| Production decode, auto-SplitKV | +0.11% | +0.01% | 0.9945 |
| Decode diagnostic, forced one split | +0.94% | +0.94% | 0.8917 |
| Paged causal prefill | -2.70% | -3.80% | 0.9382 |

Lower is better. Threshold zero produced the stable prefill improvement. Offsets 6–8 had no reproducible performance ordering in the focused recheck, so offset 8 is preferred for its wider retained probability-tail range and slightly better aggregate prefill numerics. The tradeoff is roughly 1% slower forced-one-split decode; production auto-SplitKV decode remained neutral.

> **Implementation note:** the current diff uses `(8, 0)` for FP8 inputs, matching the measured global policy.

#### Why `(8, 0)` vs `(8, 0.75)`

`0.75` does genuinely help decode: it skips accumulator corrections when the running maximum increases by less than the threshold. Relative to `(8,0)`, `(8,0.75)` was **0.12% faster time-weighted** across the broad 72-case auto-SplitKV decode set and **0.61% faster** across the 72 forced-one-split cases. In a focused two-case long-context recheck, the gains were larger—**1.67%** and **4.26%**, respectively—showing that correction cost can be exposed in long unsplit decode.

Threshold zero, however, is a distinct compile-time specialization that removes the positive-threshold compare/select sequence. A codegen isolation test compared `0` with `1e-6`: their BF16 outputs matched bit-for-bit in **8/8** cases, but `1e-6` was **7.66% slower time-weighted** for prefill. `0.75` recovered some work by skipping real corrections, but remained **6.24% slower** than zero for prefill. It also had slightly worse aggregate numerics than zero.

I am going to stick with (8, 0) for now but int eh future this should maybe be user configurable .. 

#### Methodology

- **Discovery:** 38 distinct offset/threshold pairs, 54 matched cases each — **2,052 cells**.
- **Confirmation:** 9 selected pairs, 216 matched cases each — **1,944 cells**.
- **Focused recheck:** 5 finalists across 8 long-context cases with rotated policy order — **40 cells**.
- **Total:** **4,036 matched policy/workload cells**.
- Captured Qwen2.5-1.5B and Qwen2.5-7B attention tensors using C4 and instruction/GSM8K text, layers 0/16/27, and realistic MHA/GQA geometry.
- Paged causal decode used `Q=1`, `SK={129,512,2048,8192}`, both auto-SplitKV and forced one split. Paged causal prefill used `Q=K`, `S={512,2048,4096,8192}`.
- NVIDIA B200 with SM clock locked to 1500 MHz. Warm fixed-pointer CUDA-graph timing; quantization/setup excluded.
- Numerics compare FA4 against FP32 attention over the exact dequantized vLLM-style E4M3 inputs. This measures isolated FA4 attention, not end-to-end vLLM serving.

<details>
<summary>Full 2D discovery heatmaps</summary>

Green is better than upstream `(4,4)`. Unsafe pairs are retained as diagnostic controls and show the expected rapid saturation.

![E4M3 offset-threshold heatmaps](https://raw.githubusercontent.com/drisspg/flash-attention/8690cd53d13f7c6de766ff2814068d051adb70a6/issue2577/pair-grid-heatmaps.png)

</details>

## E5M2 follow-up

![E5M2 offset-threshold Pareto](https://raw.githubusercontent.com/drisspg/flash-attention/773da26c7381359ee09b1983759dfdd4c88f5d47/issue2577/e5m2-pareto-overview.png)

I repeated the performance/numerics sweep with the captured inputs quantized to E5M2. This supports retaining `max_offset=8` and changing E5M2 from `rescale_threshold=4` to **`rescale_threshold=0`**. Relative to inherited `(8,4)`:

| Path | Median latency | Time-weighted latency | Median relative-L2 / `(8,4)` |
| --- | ---: | ---: | ---: |
| Production decode, auto-SplitKV | -0.52% | -0.55% | 1.0000 |
| Decode diagnostic, forced one split | +0.08% | +0.11% | 0.9191 |
| Paged causal prefill | -3.49% | -4.17% | 0.9270 |

Threshold zero again removes the positive-threshold compare/select path and improves prefill while remaining slightly faster for production auto-SplitKV decode. A focused 8K forced-one-split decode recheck exposed the path-specific downside more clearly: `(8,0)` was about **3.1% slower** than `(8,4)` there.

E5M2's extra exponent range is still being used at offset 8: its effective probability floor is `2^-24`, versus `2^-17` for E4M3 at the same offset. Threshold-zero offsets 8, 12, and 15 produced essentially identical numerics, so spending more saturation headroom on a larger offset did not help. The grid did not test offsets below 8; this supports retaining the existing offset, not claiming that 8 is the global E5M2 optimum for every context length.

#### E5M2 methodology

- **Discovery:** 40 pairs (34 safe candidates plus 6 saturation controls) × 54 cases — **2,160 cells**.
- **Confirmation:** 8 selected pairs × 216 cases — **1,728 cells**.
- **Focused recheck:** 6 policies × 8 long-context cases — **48 cells**.
- **Total:** **3,936 matched policy/workload cells**.
- Same Qwen2.5-1.5B/Qwen2.5-7B captures, prefill/decode shapes, B200 timing contract, and FP32-reference methodology as the E4M3 study; only the input quantization format changed to E5M2.

<details>
<summary>Full E5M2 2D discovery heatmaps</summary>

![E5M2 offset-threshold heatmaps](https://raw.githubusercontent.com/drisspg/flash-attention/773da26c7381359ee09b1983759dfdd4c88f5d47/issue2577/e5m2-pair-grid-heatmaps.png)

</details>