### PR TITLE
[CuTe] Add typed forward configurations

### DIFF
--- a/flash_attn/cute/config.py
+++ b/flash_attn/cute/config.py
@@ -1,0 +1,846 @@
+# Copyright (c) 2025, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+
+"""Typed forward configuration, selection, validation, and compile keys.
+
+`FwdHeuristicInputs` contains immutable host-visible metadata. `FwdConfig` is
+fully resolved: one split means the nonsplit path and larger values are exact
+SplitKV counts. Explicit configs are validated without ranking or normalization.
+The main and combine kernel specs independently project only codegen-changing
+values. Selection must not read tensor contents, synchronize CUDA, or allocate.
+"""
+
+import math
+from dataclasses import dataclass, replace
+from functools import lru_cache
+from typing import NamedTuple
+
+
+class FwdSm90RegisterAllocation(NamedTuple):
+    """SM90 per-thread register allocation by warp-group role."""
+
+    mma: int
+    producer: int
+
+
+class FwdSm100RegisterAllocation(NamedTuple):
+    """SM100 per-thread register allocation by warp-group role."""
+
+    softmax: int
+    correction: int
+    other: int
+
+
+FwdRegisterAllocation = FwdSm90RegisterAllocation | FwdSm100RegisterAllocation
+
+
+@dataclass(frozen=True)
+class FwdConfig:
+    """Fully resolved forward launch and algorithm configuration.
+
+    ``is_static_persistent`` controls static persistence; dynamic persistence is
+    derived from scheduler metadata. ``registers`` names the warp-group roles
+    exposed by the selected architecture and is ``None`` for other kernels.
+    """
+
+    device_capacity: int
+    tile_m: int
+    tile_n: int
+    num_stages: int
+    num_threads: int
+    mma_pv_is_rs: bool
+    intra_wg_overlap: bool
+    q_stage: int
+    use_clc_scheduler: bool
+    is_static_persistent: bool
+    use_tma_o: bool
+    num_splits: int
+    use_2cta_instrs: bool
+    registers: FwdRegisterAllocation | None
+
+    def __post_init__(self) -> None:
+        # JSON turns NamedTuple into a list; campaign YAML may use a mapping.
+        if self.registers is None or isinstance(
+            self.registers, (FwdSm90RegisterAllocation, FwdSm100RegisterAllocation)
+        ):
+            return
+        register_type = {
+            9: FwdSm90RegisterAllocation,
+            10: FwdSm100RegisterAllocation,
+            11: FwdSm100RegisterAllocation,
+        }.get(self.device_capacity)
+        if register_type is None:
+            raise ValueError(f"SM{self.device_capacity} does not expose register allocation")
+        registers = (
+            register_type(**self.registers)
+            if isinstance(self.registers, dict)
+            else register_type(*self.registers)
+        )
+        object.__setattr__(self, "registers", registers)
+
+
+class FwdHeuristicInputs(NamedTuple):
+    """Host-visible metadata used to select and validate a forward config."""
+
+    device_arch: int
+    num_sms: int
+    dtype: str
+    head_dim: int
+    head_dim_v: int
+    num_heads: int
+    num_heads_kv: int
+    batch_size: int
+    total_q: int
+    total_k: int
+    max_seqlen_q: int
+    max_seqlen_k: int
+    seqlen_k_per_split: int | None
+    causal: bool
+    local: bool
+    window_size_left: int | None
+    window_size_right: int | None
+    is_varlen_q: bool
+    has_cu_seqlens_q: bool
+    has_cu_seqlens_k: bool
+    has_seqused: bool
+    pack_gqa: bool
+    page_size: int | None
+    use_block_sparsity: bool
+    sparse_q_block_size: int | None
+    has_qv: bool
+    has_gather_kv: bool
+    has_score_mod: bool
+    has_mask_mod: bool
+    has_learnable_sink: bool
+    has_lse: bool
+    requested_tile_m: int | None
+    requested_tile_n: int | None
+    requested_mma_pv_is_rs: bool | None
+    requested_intra_wg_overlap: bool | None
+    requested_num_splits: int | None
+    requested_use_clc_scheduler: bool
+    disable_2cta: bool
+
+    @property
+    def device_capacity(self) -> int:
+        return self.device_arch // 10
+
+    @property
+    def qhead_per_kvhead(self) -> int:
+        return self.num_heads // self.num_heads_kv
+
+    @property
+    def head_dim_padded(self) -> int:
+        return math.ceil(self.head_dim / 16) * 16
+
+    @property
+    def head_dim_v_padded(self) -> int:
+        return math.ceil(self.head_dim_v / 16) * 16
+
+
+class FwdMainKernelSpec(NamedTuple):
+    """Typed cache key for one generated forward main kernel."""
+
+    kernel_family: str
+    dtype: object
+    head_dim: int
+    head_dim_v: int
+    qhead_per_kvhead: int
+    num_heads_kv: int | None
+    causal: bool
+    score_mod_hash: object
+    mask_mod_hash: object
+    use_block_sparsity: bool
+    block_sparse_broadcast_pattern: object
+    tensor_broadcast_patterns: object
+    aux_tensor_metadata: object
+    aux_scalar_metadata: object
+    has_lse: bool
+    has_cu_seqlens_q: bool
+    has_cu_seqlens_k: bool
+    has_seqused_q: bool
+    has_seqused_k: bool
+    has_page_table: bool
+    has_window_size_left: bool
+    has_window_size_right: bool
+    learnable_sink_dtype: object
+    has_q_descale: bool
+    has_k_descale: bool
+    has_v_descale: bool
+    has_cu_total_m_blocks: bool
+    has_cu_block_idx_offsets: bool
+    tile_m: int | None
+    tile_n: int | None
+    num_stages: int | None
+    num_threads: int | None
+    q_stage: int | None
+    is_split_kv: bool | None
+    pack_gqa: bool
+    arch: int
+    paged_kv_non_tma: bool | None
+    use_2cta_instrs: bool | None
+    q_subtile_factor: int | None
+    kv_subtile_factor: int | None
+    mma_pv_is_rs: bool | None
+    intra_wg_overlap: bool | None
+    use_clc_scheduler: bool | None
+    is_static_persistent: bool | None
+    use_tma_o: bool | None
+    registers: FwdRegisterAllocation | None
+    has_q: bool
+    has_p: bool
+    has_row_max: bool
+    gather_kv_length: int | None
+    sparse_kv: bool | None
+    disable_sparse_kv_bitmask: bool | None
+    log_level: int
+
+    @classmethod
+    def from_config(
+        cls,
+        config: FwdConfig,
+        *,
+        kernel_family: str,
+        arch: int,
+        pack_gqa: bool,
+        page_size: int | None,
+        q_subtile_factor: int,
+        kv_subtile_factor: int,
+        **kernel: object,
+    ) -> "FwdMainKernelSpec":
+        """Build a main-kernel key without irrelevant config fields."""
+        is_standard = kernel_family in ("sm8", "sm9", "sm10", "sm11", "sm12")
+        is_sm90 = kernel_family == "sm9"
+        is_sm100 = kernel_family in ("sm10", "sm11")
+        return cls(
+            kernel_family=kernel_family,
+            tile_m=config.tile_m if is_standard else None,
+            tile_n=config.tile_n if is_standard else None,
+            num_stages=(config.num_stages if kernel_family in ("sm8", "sm9", "sm12") else None),
+            num_threads=(config.num_threads if kernel_family in ("sm8", "sm12") else None),
+            q_stage=config.q_stage if is_sm100 else None,
+            is_split_kv=config.num_splits > 1 if is_sm100 else None,
+            pack_gqa=pack_gqa,
+            arch=arch,
+            paged_kv_non_tma=(
+                page_size not in (None, config.tile_n)
+                if is_sm90 or is_sm100 or kernel_family == "mla_sm100"
+                else None
+            ),
+            use_2cta_instrs=config.use_2cta_instrs if is_sm100 else None,
+            q_subtile_factor=q_subtile_factor if is_sm90 or is_sm100 else None,
+            kv_subtile_factor=kv_subtile_factor if is_sm100 else None,
+            mma_pv_is_rs=config.mma_pv_is_rs if is_sm90 else None,
+            intra_wg_overlap=config.intra_wg_overlap if is_sm90 else None,
+            use_clc_scheduler=config.use_clc_scheduler if is_sm100 else None,
+            is_static_persistent=config.is_static_persistent if is_sm100 else None,
+            use_tma_o=config.use_tma_o if is_sm100 else None,
+            registers=(
+                config.registers if is_sm90 or is_sm100 or kernel_family == "sm100_hd256" else None
+            ),
+            **kernel,
+        )
+
+
+class FwdCombineKernelSpec(NamedTuple):
+    """Typed cache key for one generated SplitKV combine kernel."""
+
+    dtype: object
+    dtype_partial: object
+    head_dim: int
+    log_max_splits: int
+    has_cu_seqlens: bool
+    has_seqused: bool
+    has_lse: bool
+    has_num_splits_dynamic_ptr: bool
+    has_varlen_batch_idx: bool
+    has_semaphore_to_reset: bool
+
+
+def fwd_combine_tile(head_dim: int) -> tuple[int, int]:
+    """Return the combine kernel's tile and padded head-dimension block."""
+    # Rounding D96 and D192 up gives a smaller M tile and more parallelism.
+    k_block_size = 64 if head_dim <= 64 else 128
+    return (16 if k_block_size == 64 else 8), k_block_size
+
+
+def combine_log_max_splits(num_splits: int, tile_m: int) -> int:
+    """Project an exact split count into the combine kernel's codegen bucket."""
+    if num_splits < 1:
+        raise ValueError(f"num_splits must be positive, got {num_splits}")
+    # An 8-row M tile requires at least 32 splits; other tiles require 16.
+    return max((num_splits - 1).bit_length(), 5 if tile_m == 8 else 4)
+
+
+def fwd_config_compile_bucket(config: FwdConfig, head_dim_v: int) -> tuple[FwdConfig, int | None]:
+    """Deduplicate exact split counts that share main and combine codegen."""
+    main = replace(config, num_splits=2 if config.num_splits > 1 else 1)
+    if config.num_splits == 1:
+        return main, None
+    tile_m, _ = fwd_combine_tile(head_dim_v)
+    return main, combine_log_max_splits(config.num_splits, tile_m)
+
+
+def num_splits_heuristic(
+    total_mblocks: int,
+    num_sms: int,
+    num_n_blocks: int,
+    max_splits: int,
+) -> int:
+    """Resolve automatic SplitKV to a concrete positive split count."""
+    if num_n_blocks <= 4 or total_mblocks == 0:
+        return 1
+    return max(1, min(num_sms // total_mblocks, max_splits, num_n_blocks))
+
+
+def fixed_seqlen_k_num_splits(inputs: FwdHeuristicInputs) -> int:
+    """Return the minimum split count required by a fixed KV extent."""
+    seqlen_k_per_split = inputs.seqlen_k_per_split
+    if seqlen_k_per_split is None:
+        return 1
+    if seqlen_k_per_split <= 0:
+        raise ValueError("seqlen_k_per_split must be positive")
+    return max(
+        1,
+        (inputs.max_seqlen_k + seqlen_k_per_split - 1) // seqlen_k_per_split,
+    )
+
+
+def select_sm90_tile(
+    head_dim: int,
+    head_dim_v: int,
+    causal: bool,
+    local: bool,
+    sparse_q_block_size: int | None,
+) -> tuple[int, int, bool, bool]:
+    """Return the existing SM90 tile, RS, and overlap heuristic."""
+    match head_dim:
+        case value if value <= 64:
+            # C++: 192×192 non-causal, 192×128 causal/local.
+            # Python: 192×128 RS+OL is consistently best across seqlens.
+            if sparse_q_block_size is not None and sparse_q_block_size % 192 != 0:
+                return 128, 128, True, True
+            return 192, 128, True, True
+        case value if value <= 96:
+            # C++: 192×144 noRS+OL for all cases.
+            # Python: RS is catastrophic with 192× tiles (~300 vs ~600 TFLOPS).
+            # noRS+OL is always required. Causal: 192×128 slightly better short seqlen.
+            if sparse_q_block_size is not None and sparse_q_block_size % 192 != 0:
+                return 128, 128, False, True
+            return (192, 128, False, True) if causal or local else (192, 144, False, True)
+        case value if value <= 128:
+            return 128, 128, True, True
+        case value if value <= 192:
+            match local, head_dim_v <= 128:
+                case True, _:
+                    tile_n = 96
+                case False, True:
+                    tile_n = 128
+                case False, False:
+                    tile_n = 112
+            return 128, tile_n, True, True
+        case _:
+            return 128, 64 if local else 80, True, True
+
+
+def select_initial_fwd_tile(inputs: FwdHeuristicInputs) -> tuple[int, int, bool, bool]:
+    """Resolve tile and SM90-specific flags before shape-dependent policies."""
+    tile_m, tile_n, mma_pv_is_rs, intra_wg_overlap = 128, 128, False, False
+    match inputs.device_capacity:
+        case 8:
+            tile_n = 64
+        case 9:
+            tile_m, tile_n, mma_pv_is_rs, intra_wg_overlap = select_sm90_tile(
+                inputs.head_dim,
+                inputs.head_dim_v,
+                inputs.causal,
+                inputs.local,
+                inputs.sparse_q_block_size,
+            )
+        case 12 if inputs.head_dim > 64:
+            # SM120 has 99 KB SMEM: 128×128 is preferred for D<=64, and 128×64
+            # avoids the occupancy loss from a 96 KB tile for larger head dimensions.
+            tile_n = 64
+
+    if inputs.requested_tile_m is not None:
+        tile_m = inputs.requested_tile_m
+    if inputs.requested_tile_n is not None:
+        tile_n = inputs.requested_tile_n
+    if inputs.device_capacity == 9 and (
+        inputs.requested_tile_m is not None or inputs.requested_tile_n is not None
+    ):
+        mma_pv_is_rs = True
+        intra_wg_overlap = True
+    if inputs.requested_mma_pv_is_rs is not None:
+        mma_pv_is_rs = inputs.requested_mma_pv_is_rs
+    if inputs.requested_intra_wg_overlap is not None:
+        intra_wg_overlap = inputs.requested_intra_wg_overlap
+    return tile_m, tile_n, mma_pv_is_rs, intra_wg_overlap
+
+
+def sm90_num_threads(tile_m: int) -> int:
+    """Return the thread count implied by an SM90 tile."""
+    if tile_m not in (64, 128, 192):
+        raise ValueError(f"SM90 tile_m must be 64, 128, or 192, got {tile_m}")
+    return 128 * (tile_m // 64 + 1)
+
+
+def select_sm90_register_allocation(
+    inputs: FwdHeuristicInputs,
+    *,
+    tile_m: int,
+    tile_n: int,
+) -> FwdSm90RegisterAllocation:
+    """Resolve the existing SM90 warp-group register allocation."""
+    num_mma_warp_groups = tile_m // 64
+    use_tma_q = not (inputs.pack_gqa and tile_m % inputs.qhead_per_kvhead != 0)
+    use_tma_kv = inputs.page_size in (None, tile_n)
+    if num_mma_warp_groups == 2 and (not use_tma_q or not use_tma_kv):
+        return FwdSm90RegisterAllocation(mma=224, producer=40)
+    return {
+        1: FwdSm90RegisterAllocation(mma=256, producer=56),
+        2: FwdSm90RegisterAllocation(mma=240, producer=24),
+        3: FwdSm90RegisterAllocation(mma=160, producer=32),
+    }[num_mma_warp_groups]
+
+
+def has_s_o_s_q_overlap(inputs: FwdHeuristicInputs, num_splits: int) -> bool:
+    """Return whether O and Q share storage for this SM100 problem."""
+    return (inputs.head_dim_padded == 192 and inputs.head_dim_v_padded >= 64) or (
+        inputs.head_dim_v_padded >= 128 and num_splits > 1
+    )
+
+
+def can_use_tma_o(
+    inputs: FwdHeuristicInputs,
+    *,
+    tile_m: int,
+    num_splits: int,
+) -> bool:
+    """Return whether the generic SM100 output layout supports TMA."""
+    return (
+        not (inputs.pack_gqa and tile_m % inputs.qhead_per_kvhead != 0)
+        and not (inputs.pack_gqa and num_splits > 1)
+        and not inputs.is_varlen_q
+    )
+
+
+def uses_dedicated_hd256_kernel(inputs: FwdHeuristicInputs) -> bool:
+    """Return whether this problem uses the fixed SM100 head-dim-256 kernel."""
+    return (
+        inputs.device_capacity in (10, 11) and inputs.head_dim == 256 and inputs.head_dim_v == 256
+    )
+
+
+# The 12-warp dedicated kernel does not use the generic 512-thread budget.
+_HD256_REGISTER_ALLOCATION = FwdSm100RegisterAllocation(256, 160, 32)
+# The generic kernel redistributes a 4 × 128-register CTA budget.
+_DEFAULT_REGISTER_ALLOCATION = FwdSm100RegisterAllocation(192, 80, 48)
+_PAGED_REGISTER_ALLOCATION = FwdSm100RegisterAllocation(184, 64, 80)
+# Key: (use_2cta_instrs, causal, head_dim_padded, is_sm103_family).
+_SM100_REGISTER_OVERRIDES = {
+    (True, False, 128, False): FwdSm100RegisterAllocation(176, 88, 72),
+    (False, True, 128, False): FwdSm100RegisterAllocation(192, 72, 56),
+    (True, False, 192, False): FwdSm100RegisterAllocation(184, 80, 64),
+    (False, True, 192, False): FwdSm100RegisterAllocation(192, 72, 56),
+    (True, False, 128, True): FwdSm100RegisterAllocation(176, 80, 80),
+    (False, True, 128, True): FwdSm100RegisterAllocation(176, 64, 96),
+    (True, False, 192, True): FwdSm100RegisterAllocation(176, 64, 96),
+    (False, True, 192, True): FwdSm100RegisterAllocation(176, 72, 88),
+}
+_FP8_SM100_REGISTER_OVERRIDES = {
+    (True, False, 128, False): FwdSm100RegisterAllocation(160, 72, 120),
+}
+
+
+def select_sm100_register_allocation(
+    inputs: FwdHeuristicInputs,
+    *,
+    tile_n: int,
+    use_2cta_instrs: bool,
+) -> FwdSm100RegisterAllocation:
+    """Resolve the generic SM100 warp-group register allocation."""
+    head_dim_padded = inputs.head_dim_padded
+    paged_kv_non_tma = inputs.page_size not in (None, tile_n)
+    is_fp8 = inputs.dtype in ("torch.float8_e4m3fn", "torch.float8_e5m2")
+    if head_dim_padded < 96:
+        if is_fp8:
+            return (
+                FwdSm100RegisterAllocation(152, 96, 112)
+                if paged_kv_non_tma
+                else FwdSm100RegisterAllocation(168, 96, 80)
+            )
+        return (
+            _PAGED_REGISTER_ALLOCATION
+            if paged_kv_non_tma
+            else FwdSm100RegisterAllocation(200, 64, 48)
+        )
+    if paged_kv_non_tma:
+        return _PAGED_REGISTER_ALLOCATION
+
+    is_sm103_family = inputs.device_capacity == 10 and inputs.device_arch >= 103
+    key = (use_2cta_instrs, inputs.causal, head_dim_padded, is_sm103_family)
+    registers = _SM100_REGISTER_OVERRIDES.get(key, _DEFAULT_REGISTER_ALLOCATION)
+    return _FP8_SM100_REGISTER_OVERRIDES.get(key, registers) if is_fp8 else registers
+
+
+def fixed_mla_fwd_config(inputs: FwdHeuristicInputs) -> FwdConfig:
+    """Represent the dedicated MLA implementation with one non-tunable config."""
+    return FwdConfig(
+        device_capacity=inputs.device_capacity,
+        tile_m=64,
+        tile_n=128,
+        num_stages=0,
+        num_threads=(512 if inputs.has_gather_kv or inputs.page_size not in (None, 128) else 384),
+        mma_pv_is_rs=False,
+        intra_wg_overlap=False,
+        q_stage=1,
+        use_clc_scheduler=True,
+        is_static_persistent=False,
+        use_tma_o=True,
+        num_splits=1,
+        use_2cta_instrs=True,
+        registers=None,
+    )
+
+
+@lru_cache(maxsize=1024)
+def select_fwd_config(inputs: FwdHeuristicInputs) -> FwdConfig:
+    """Select one fully resolved config from host-visible metadata."""
+    device_capacity = inputs.device_capacity
+    if device_capacity == 12 and inputs.requested_num_splits != 1:
+        raise AssertionError("SM120 forward only supports num_splits=1")
+    if inputs.has_qv:
+        if inputs.requested_num_splits not in (None, 1):
+            raise ValueError("The dedicated MLA kernel does not support SplitKV")
+        config = fixed_mla_fwd_config(inputs)
+        validate_fwd_config(config, inputs)
+        return config
+    if uses_dedicated_hd256_kernel(inputs):
+        if inputs.requested_num_splits not in (None, 1):
+            raise ValueError("The SM100 head-dim-256 kernel does not support SplitKV")
+        config = fixed_hd256_fwd_config(inputs)
+        requested_overrides = (
+            (inputs.requested_tile_m, config.tile_m),
+            (inputs.requested_tile_n, config.tile_n),
+            (inputs.requested_mma_pv_is_rs, config.mma_pv_is_rs),
+            (inputs.requested_intra_wg_overlap, config.intra_wg_overlap),
+        )
+        if any(requested not in (None, resolved) for requested, resolved in requested_overrides):
+            raise ValueError("The SM100 head-dim-256 kernel has one fixed configuration")
+        validate_fwd_config(config, inputs)
+        return config
+
+    tile_m, tile_n, mma_pv_is_rs, intra_wg_overlap = select_initial_fwd_tile(inputs)
+    is_sm100_family = device_capacity in (10, 11)
+    q_stage = 2 if is_sm100_family and inputs.max_seqlen_q * inputs.qhead_per_kvhead > tile_m else 1
+    seqlen_k_loaded = inputs.max_seqlen_k
+    if inputs.local:
+        window_left = inputs.window_size_left or inputs.max_seqlen_k
+        window_right = inputs.window_size_right or inputs.max_seqlen_k
+        seqlen_k_loaded = max(
+            0,
+            min(inputs.max_seqlen_k, window_left + window_right + 1 + tile_m),
+        )
+
+    effective_tile_m = q_stage * tile_m
+    packed_seqlen_q = inputs.max_seqlen_q * inputs.qhead_per_kvhead
+    num_m_blocks = (packed_seqlen_q + effective_tile_m - 1) // effective_tile_m
+    total_mblocks = inputs.batch_size * inputs.num_heads_kv * num_m_blocks
+    num_n_blocks = (seqlen_k_loaded + tile_n - 1) // tile_n
+    fixed_num_splits = fixed_seqlen_k_num_splits(inputs)
+    if inputs.requested_num_splits is not None:
+        num_splits = max(1, inputs.requested_num_splits)
+    elif inputs.seqlen_k_per_split is not None:
+        num_splits = fixed_num_splits
+    else:
+        num_splits = num_splits_heuristic(total_mblocks, inputs.num_sms, num_n_blocks, 128)
+
+    # SplitKV's float32 partial O doubles its shared-memory footprint for diff-head.
+    if is_sm100_family and inputs.head_dim != inputs.head_dim_v and num_splits > 1:
+        match inputs.requested_num_splits:
+            case None if (num_n_blocks >= 64 or fixed_num_splits > 1) and inputs.head_dim_v != 512:
+                tile_n = 64
+                if inputs.seqlen_k_per_split is None:
+                    num_n_blocks = (seqlen_k_loaded + tile_n - 1) // tile_n
+                    num_splits = num_splits_heuristic(
+                        total_mblocks, inputs.num_sms, num_n_blocks, 128
+                    )
+            case None:
+                num_splits = 1
+            case _ if inputs.head_dim_v != 512:
+                tile_n = 64
+
+    is_split_kv = num_splits > 1
+    use_2cta_instrs = not inputs.disable_2cta and is_2cta_eligible(
+        inputs, tile_m=tile_m, num_splits=num_splits
+    )
+
+    overlap_s_o_s_q = is_sm100_family and has_s_o_s_q_overlap(inputs, num_splits)
+    # CLC regresses varlen MHA and dense noncausal: the former increases K/V
+    # traffic under imbalance, while the latter mostly pays work-stealing overhead.
+    is_varlen = (
+        inputs.is_varlen_q
+        or inputs.has_cu_seqlens_q
+        or inputs.has_cu_seqlens_k
+        or inputs.has_seqused
+    )
+    is_varlen_mha = is_varlen and inputs.qhead_per_kvhead == 1
+    is_dense_noncausal = not is_varlen and not inputs.causal and not inputs.local
+    use_clc_scheduler = (
+        is_sm100_family
+        and inputs.requested_use_clc_scheduler
+        and not is_varlen_mha
+        and not is_dense_noncausal
+        and inputs.page_size in (None, tile_n)
+        and not overlap_s_o_s_q
+    )
+    is_static_persistent = (
+        is_sm100_family
+        and not inputs.causal
+        and not inputs.local
+        and not inputs.is_varlen_q
+        and not is_split_kv
+        and not overlap_s_o_s_q
+        and not use_clc_scheduler
+    )
+    use_tma_o = is_sm100_family and can_use_tma_o(inputs, tile_m=tile_m, num_splits=num_splits)
+
+    match device_capacity:
+        case 9:
+            num_stages = 2
+            num_threads = sm90_num_threads(tile_m)
+            registers = select_sm90_register_allocation(
+                inputs,
+                tile_m=tile_m,
+                tile_n=tile_n,
+            )
+        case 8 | 12:
+            num_stages = 1
+            num_threads = 128
+            registers = None
+        case 10 | 11:
+            num_stages = 0
+            num_threads = 512
+            registers = select_sm100_register_allocation(
+                inputs,
+                tile_n=tile_n,
+                use_2cta_instrs=use_2cta_instrs,
+            )
+        case _:
+            num_stages = 0
+            num_threads = 512
+            registers = None
+    config = FwdConfig(
+        device_capacity=device_capacity,
+        tile_m=tile_m,
+        tile_n=tile_n,
+        num_stages=num_stages,
+        num_threads=num_threads,
+        mma_pv_is_rs=mma_pv_is_rs,
+        intra_wg_overlap=intra_wg_overlap,
+        q_stage=q_stage,
+        use_clc_scheduler=use_clc_scheduler,
+        is_static_persistent=is_static_persistent,
+        use_tma_o=use_tma_o,
+        num_splits=num_splits,
+        use_2cta_instrs=use_2cta_instrs,
+        registers=registers,
+    )
+    validate_fwd_config(config, inputs)
+    return config
+
+
+@lru_cache(maxsize=1024)
+def validate_fwd_config(config: FwdConfig, inputs: FwdHeuristicInputs) -> None:
+    """Reject known unsupported or silently normalized config combinations."""
+    if inputs.device_capacity not in (8, 9, 10, 11, 12):
+        raise ValueError(f"Unsupported forward architecture family SM{inputs.device_capacity}")
+    if config.device_capacity != inputs.device_capacity:
+        raise ValueError(
+            f"Config targets SM{config.device_capacity}, but the problem targets SM{inputs.device_capacity}"
+        )
+    if config.tile_m <= 0 or config.tile_n <= 0:
+        raise ValueError(f"Tile dimensions must be positive, got {(config.tile_m, config.tile_n)}")
+    if config.tile_m % 16 != 0 or config.tile_n % 16 != 0:
+        raise ValueError(
+            f"Tile dimensions must be multiples of 16, got {(config.tile_m, config.tile_n)}"
+        )
+    if config.num_threads <= 0 or config.num_threads % 32 != 0:
+        raise ValueError(f"num_threads must be a positive multiple of 32, got {config.num_threads}")
+    if config.num_stages < 0:
+        raise ValueError(f"num_stages must be nonnegative, got {config.num_stages}")
+    if config.num_splits < 1 or config.num_splits > 256:
+        raise ValueError(f"num_splits must be in [1, 256], got {config.num_splits}")
+    fixed_num_splits = fixed_seqlen_k_num_splits(inputs)
+    if config.num_splits < fixed_num_splits:
+        raise ValueError(
+            f"seqlen_k_per_split={inputs.seqlen_k_per_split} requires "
+            f"num_splits >= {fixed_num_splits}, got {config.num_splits}"
+        )
+    if inputs.seqlen_k_per_split is not None and inputs.seqlen_k_per_split % config.tile_n != 0:
+        raise ValueError(f"seqlen_k_per_split must be divisible by tile_n={config.tile_n}")
+
+    is_sm90 = inputs.device_capacity == 9
+    is_sm100_family = inputs.device_capacity in (10, 11)
+    if is_sm90:
+        if not isinstance(config.registers, FwdSm90RegisterAllocation):
+            raise TypeError("SM90 forward requires an SM90 register allocation")
+        registers = config.registers
+        if any(value < 24 or value > 256 or value % 8 != 0 for value in registers):
+            raise ValueError(
+                f"SM90 register allocations must be multiples of 8 in [24, 256], got {registers}"
+            )
+        if registers.mma < 128:
+            raise ValueError("SM90 MMA register allocation must be at least 128 for setmaxnreg.inc")
+        if registers.producer > 128:
+            raise ValueError(
+                "SM90 producer register allocation must be at most 128 for setmaxnreg.dec"
+            )
+        num_mma_warp_groups = config.tile_m // 64
+        if num_mma_warp_groups * registers.mma + registers.producer > 512:
+            raise ValueError(
+                f"SM90 register allocation exceeds the 512-register budget: {registers}"
+            )
+    elif not is_sm100_family and config.registers is not None:
+        raise ValueError(f"SM{inputs.device_capacity} does not expose register allocation")
+
+    if not is_sm100_family:
+        match inputs.device_capacity:
+            case 8 if inputs.page_size is not None:
+                raise ValueError("SM80 forward does not support paged KV")
+            case 12 if inputs.page_size is not None or inputs.use_block_sparsity:
+                raise ValueError("SM120 forward does not support paged KV or block sparsity")
+        if config.num_stages == 0:
+            raise ValueError(f"SM{inputs.device_capacity} requires at least one pipeline stage")
+        if is_sm90:
+            expected_threads = sm90_num_threads(config.tile_m)
+            if config.num_threads != expected_threads:
+                raise ValueError(
+                    f"SM90 tile_m={config.tile_m} requires num_threads={expected_threads}"
+                )
+        elif config.mma_pv_is_rs or config.intra_wg_overlap:
+            raise ValueError(f"SM{inputs.device_capacity} does not expose SM90 MMA flags")
+        if config.q_stage != 1:
+            raise ValueError(f"SM{inputs.device_capacity} requires q_stage=1")
+        if config.num_splits != 1:
+            raise ValueError(f"SM{inputs.device_capacity} does not support SplitKV")
+        if (
+            config.use_2cta_instrs
+            or config.use_clc_scheduler
+            or config.is_static_persistent
+            or config.use_tma_o
+        ):
+            raise ValueError(f"SM{inputs.device_capacity} does not support SM100 scheduler options")
+        return
+
+    is_dedicated_hd256 = uses_dedicated_hd256_kernel(inputs)
+    if is_dedicated_hd256:
+        if config != fixed_hd256_fwd_config(inputs):
+            raise ValueError("The SM100 head-dim-256 kernel has one fixed configuration")
+        return
+    if inputs.has_qv:
+        if config != fixed_mla_fwd_config(inputs):
+            raise ValueError("The dedicated MLA kernel has one fixed configuration")
+        return
+    if not isinstance(config.registers, FwdSm100RegisterAllocation):
+        raise TypeError("Generic SM100 forward requires an SM100 register allocation")
+    registers = config.registers
+    if any(value < 24 or value > 256 or value % 8 != 0 for value in registers):
+        raise ValueError(
+            f"SM100 register allocations must be multiples of 8 in [24, 256], got {registers}"
+        )
+    if registers.softmax < 128:
+        raise ValueError(
+            "SM100 softmax register allocation must be at least 128 for setmaxnreg.inc"
+        )
+    if registers.correction > 128 or registers.other > 128:
+        raise ValueError(
+            "SM100 correction and other register allocations must be at most 128 for setmaxnreg.dec"
+        )
+    if 2 * registers.softmax + registers.correction + registers.other > 512:
+        raise ValueError(f"SM100 register allocation exceeds the 512-register budget: {registers}")
+    if config.num_stages != 0:
+        raise ValueError("SM100 forward derives internal pipeline stages and requires num_stages=0")
+    if config.num_threads != 512:
+        raise ValueError("SM100 forward uses a fixed 512-thread CTA")
+    if config.mma_pv_is_rs or config.intra_wg_overlap:
+        raise ValueError("Generic SM100 forward does not expose SM90 MMA flags")
+    if config.q_stage not in (1, 2):
+        raise ValueError(f"SM100 q_stage must be 1 or 2, got {config.q_stage}")
+    if config.num_splits > 1:
+        if config.use_2cta_instrs:
+            raise ValueError("SplitKV and 2CTA cannot be enabled together")
+        if inputs.head_dim_v_padded >= 192:
+            raise ValueError("SplitKV does not support padded value head dimensions >= 192")
+        if inputs.head_dim != inputs.head_dim_v and config.tile_n != 64:
+            raise ValueError("Diff-head SplitKV requires tile_n=64")
+
+    overlap_s_o_s_q = has_s_o_s_q_overlap(inputs, config.num_splits)
+    paged_kv_non_tma = inputs.page_size not in (None, config.tile_n)
+    if paged_kv_non_tma and (inputs.head_dim % 16 != 0 or inputs.head_dim_v % 16 != 0):
+        raise ValueError("Non-TMA paged KV requires head dimensions divisible by 16")
+    if config.use_clc_scheduler and (paged_kv_non_tma or overlap_s_o_s_q):
+        raise ValueError("CLC requires TMA KV and a non-overlapping O/Q shared-memory layout")
+    if config.is_static_persistent and (
+        inputs.causal
+        or inputs.local
+        or inputs.is_varlen_q
+        or config.num_splits > 1
+        or overlap_s_o_s_q
+        or config.use_clc_scheduler
+    ):
+        raise ValueError("Static persistent scheduling is not effective for this forward problem")
+
+    if config.use_tma_o and not can_use_tma_o(
+        inputs, tile_m=config.tile_m, num_splits=config.num_splits
+    ):
+        raise ValueError("TMA O is not supported for this GQA, SplitKV, or varlen layout")
+
+    if config.use_2cta_instrs and not is_2cta_eligible(
+        inputs, tile_m=config.tile_m, num_splits=config.num_splits
+    ):
+        raise ValueError("2CTA instructions are not supported for this forward problem")
+
+
+def fixed_hd256_fwd_config(inputs: FwdHeuristicInputs) -> FwdConfig:
+    """Return the canonical fixed head-dim-256 config."""
+    if inputs.head_dim == 256 and inputs.head_dim_v == 256:
+        return FwdConfig(
+            device_capacity=inputs.device_capacity,
+            tile_m=128,
+            tile_n=128,
+            num_stages=0,
+            num_threads=384,
+            mma_pv_is_rs=False,
+            intra_wg_overlap=False,
+            q_stage=2,
+            use_clc_scheduler=False,
+            is_static_persistent=False,
+            use_tma_o=False,
+            num_splits=1,
+            use_2cta_instrs=True,
+            registers=_HD256_REGISTER_ALLOCATION,
+        )
+    raise ValueError("No fixed config is defined for this problem")
+
+
+def is_2cta_eligible(
+    inputs: FwdHeuristicInputs,
+    *,
+    tile_m: int,
+    num_splits: int,
+) -> bool:
+    """Return whether a generic SM100 config can use 2CTA instructions."""
+    return (
+        inputs.device_capacity in (10, 11)
+        and not inputs.causal
+        and not inputs.local
+        and num_splits == 1
+        and not inputs.is_varlen_q
+        and not inputs.use_block_sparsity
+        and inputs.page_size in (None, 128)
+        and inputs.head_dim_padded in (128, 192)
+        and inputs.head_dim_v_padded == 128
+        and inputs.max_seqlen_q * inputs.qhead_per_kvhead > 2 * tile_m
+        and (tile_m % inputs.qhead_per_kvhead == 0 or not inputs.pack_gqa)
+    )

--- a/tests/cute/test_fwd_config.py
+++ b/tests/cute/test_fwd_config.py
@@ -1,0 +1,514 @@
+import json
+from dataclasses import asdict, replace
+
+import pytest
+
+from flash_attn.cute.config import (
+    FwdConfig,
+    FwdHeuristicInputs,
+    FwdSm90RegisterAllocation,
+    FwdSm100RegisterAllocation,
+    combine_log_max_splits,
+    fwd_combine_tile,
+    fwd_config_compile_bucket,
+    num_splits_heuristic,
+    select_fwd_config,
+    select_sm100_register_allocation,
+    validate_fwd_config,
+)
+
+_BASE_INPUTS = FwdHeuristicInputs(
+    device_arch=100,
+    num_sms=132,
+    dtype="torch.bfloat16",
+    head_dim=64,
+    head_dim_v=64,
+    num_heads=16,
+    num_heads_kv=16,
+    batch_size=2,
+    total_q=8192,
+    total_k=8192,
+    max_seqlen_q=4096,
+    max_seqlen_k=4096,
+    seqlen_k_per_split=None,
+    causal=False,
+    local=False,
+    window_size_left=None,
+    window_size_right=None,
+    is_varlen_q=False,
+    has_cu_seqlens_q=False,
+    has_cu_seqlens_k=False,
+    has_seqused=False,
+    pack_gqa=False,
+    page_size=None,
+    use_block_sparsity=False,
+    sparse_q_block_size=None,
+    has_qv=False,
+    has_gather_kv=False,
+    has_score_mod=False,
+    has_mask_mod=False,
+    has_learnable_sink=False,
+    has_lse=False,
+    requested_tile_m=None,
+    requested_tile_n=None,
+    requested_mma_pv_is_rs=None,
+    requested_intra_wg_overlap=None,
+    requested_num_splits=1,
+    requested_use_clc_scheduler=True,
+    disable_2cta=False,
+)
+
+
+def make_inputs(**changes) -> FwdHeuristicInputs:
+    return _BASE_INPUTS._replace(**changes)
+
+
+@pytest.mark.parametrize(
+    "changes",
+    [
+        {},
+        {"device_arch": 90, "requested_use_clc_scheduler": False},
+    ],
+)
+def test_register_allocation_round_trips_through_json_and_yaml_shapes(changes):
+    config = select_fwd_config(make_inputs(**changes))
+    serialized = json.loads(json.dumps(asdict(config)))
+    reconstructed = FwdConfig(**serialized)
+
+    assert reconstructed == config
+    assert hash(reconstructed) == hash(config)
+
+    serialized["registers"] = config.registers._asdict()
+    assert FwdConfig(**serialized) == config
+
+
+@pytest.mark.parametrize(
+    ("changes", "use_2cta_instrs", "expected"),
+    [
+        ({"head_dim": 64, "head_dim_v": 64}, False, (200, 64, 48)),
+        ({"head_dim": 80, "head_dim_v": 80, "page_size": 16}, False, (184, 64, 80)),
+        ({"head_dim": 96, "head_dim_v": 96}, False, (192, 80, 48)),
+        ({"head_dim": 128, "head_dim_v": 128}, True, (176, 88, 72)),
+        ({"head_dim": 128, "head_dim_v": 128, "causal": True}, False, (192, 72, 56)),
+        ({"head_dim": 128, "head_dim_v": 128, "device_arch": 103}, True, (176, 80, 80)),
+        (
+            {"head_dim": 128, "head_dim_v": 128, "device_arch": 103, "causal": True},
+            False,
+            (176, 64, 96),
+        ),
+        ({"head_dim": 192, "head_dim_v": 128}, True, (184, 80, 64)),
+        ({"head_dim": 192, "head_dim_v": 128, "device_arch": 103}, True, (176, 64, 96)),
+        (
+            {"dtype": "torch.float8_e4m3fn", "head_dim": 64, "head_dim_v": 64},
+            False,
+            (168, 96, 80),
+        ),
+        (
+            {
+                "dtype": "torch.float8_e5m2",
+                "head_dim": 64,
+                "head_dim_v": 64,
+                "page_size": 16,
+            },
+            False,
+            (152, 96, 112),
+        ),
+        (
+            {"dtype": "torch.float8_e4m3fn", "head_dim": 128, "head_dim_v": 128},
+            True,
+            (160, 72, 120),
+        ),
+        (
+            {
+                "dtype": "torch.float8_e5m2",
+                "head_dim": 128,
+                "head_dim_v": 128,
+                "causal": True,
+            },
+            False,
+            (192, 72, 56),
+        ),
+    ],
+)
+def test_sm100_register_allocation_matches_existing_kernel_policy(
+    changes, use_2cta_instrs, expected
+):
+    inputs = make_inputs(**changes)
+
+    assert select_sm100_register_allocation(
+        inputs, tile_n=128, use_2cta_instrs=use_2cta_instrs
+    ) == FwdSm100RegisterAllocation(*expected)
+
+
+def test_selector_preserves_a_codegen_changing_2cta_boundary():
+    one_cta = make_inputs(
+        head_dim=128,
+        head_dim_v=128,
+        max_seqlen_q=129,
+    )
+    two_cta = one_cta._replace(max_seqlen_q=257)
+
+    assert not select_fwd_config(one_cta).use_2cta_instrs
+    assert select_fwd_config(two_cta).use_2cta_instrs
+
+
+def test_varlen_mha_default_is_nonpersistent_without_tma_output():
+    inputs = make_inputs(
+        is_varlen_q=True,
+        has_cu_seqlens_q=True,
+        batch_size=4,
+        max_seqlen_q=512,
+        max_seqlen_k=768,
+    )
+    config = select_fwd_config(inputs)
+
+    assert not config.use_clc_scheduler
+    assert not config.is_static_persistent
+    assert not config.use_tma_o
+    with pytest.raises(ValueError, match="TMA O"):
+        validate_fwd_config(replace(config, use_tma_o=True), inputs)
+
+
+def test_padded_d192_overlap_disables_static_persistent_scheduling():
+    inputs = make_inputs(head_dim=192, head_dim_v=128)
+
+    assert not select_fwd_config(inputs).is_static_persistent
+
+
+def test_varlen_k_dense_q_clc_rejects_static_persistent_codegen_flag():
+    inputs = make_inputs(
+        head_dim=128,
+        head_dim_v=128,
+        num_heads=16,
+        num_heads_kv=4,
+        pack_gqa=True,
+        is_varlen_q=False,
+        has_cu_seqlens_k=True,
+    )
+    config = select_fwd_config(inputs)
+
+    assert config.use_clc_scheduler
+    assert not config.is_static_persistent
+    with pytest.raises(
+        ValueError, match="Static persistent scheduling is not effective"
+    ):
+        validate_fwd_config(replace(config, is_static_persistent=True), inputs)
+
+
+def test_long_dense_d128_selects_2cta():
+    inputs = make_inputs(head_dim=128, head_dim_v=128)
+
+    assert select_fwd_config(inputs).use_2cta_instrs
+
+
+def test_fixed_split_does_not_require_sm_count():
+    inputs = make_inputs(num_sms=0, requested_num_splits=1)
+
+    assert select_fwd_config(inputs).num_splits == 1
+
+
+def test_split_count_is_resolved_but_not_silently_changed_for_explicit_config():
+    inputs = make_inputs(
+        head_dim=128,
+        head_dim_v=128,
+        requested_num_splits=4,
+    )
+    config = select_fwd_config(inputs)
+
+    assert config.num_splits == 4
+    assert not config.use_2cta_instrs
+
+
+def test_diff_head_split_uses_required_tile():
+    inputs = make_inputs(
+        head_dim=192,
+        head_dim_v=128,
+        max_seqlen_k=16384,
+        requested_num_splits=4,
+    )
+    config = select_fwd_config(inputs)
+
+    assert config.tile_n == 64
+    assert config.num_splits == 4
+
+
+def test_hd256_has_one_canonical_config():
+    inputs = make_inputs(head_dim=256, head_dim_v=256)
+    config = select_fwd_config(inputs)
+    auto_inputs = inputs._replace(
+        batch_size=1,
+        num_heads=8,
+        num_heads_kv=8,
+        total_q=128,
+        max_seqlen_q=128,
+        max_seqlen_k=8192,
+        requested_num_splits=None,
+    )
+
+    assert config.use_2cta_instrs
+    assert config.registers == FwdSm100RegisterAllocation(256, 160, 32)
+    assert select_fwd_config(auto_inputs) == config
+    with pytest.raises(ValueError, match="does not support SplitKV"):
+        select_fwd_config(inputs._replace(requested_num_splits=2))
+    with pytest.raises(ValueError, match="one fixed configuration"):
+        select_fwd_config(inputs._replace(requested_tile_m=64))
+    with pytest.raises(ValueError, match="head-dim-256 kernel"):
+        validate_fwd_config(replace(config, use_tma_o=True), inputs)
+
+
+def test_mla_has_one_canonical_config():
+    inputs = make_inputs(head_dim=64, head_dim_v=512, has_qv=True)
+    config = select_fwd_config(inputs)
+
+    assert config.num_threads == 384
+    assert config.registers is None
+    assert select_fwd_config(inputs._replace(has_gather_kv=True)).num_threads == 512
+    with pytest.raises(ValueError, match="dedicated MLA kernel"):
+        validate_fwd_config(replace(config, tile_m=128), inputs)
+    with pytest.raises(ValueError, match="does not support SplitKV"):
+        select_fwd_config(inputs._replace(requested_num_splits=2))
+
+
+def test_unsupported_diff_head_split_is_rejected_not_normalized():
+    inputs = make_inputs(
+        head_dim=64,
+        head_dim_v=512,
+        requested_num_splits=4,
+    )
+
+    with pytest.raises(ValueError, match="does not support padded value"):
+        select_fwd_config(inputs)
+
+
+def test_basic_launch_geometry_is_rejected_before_compilation():
+    inputs = make_inputs()
+    config = select_fwd_config(inputs)
+
+    with pytest.raises(ValueError, match="Tile dimensions must be multiples of 16"):
+        validate_fwd_config(replace(config, tile_n=127), inputs)
+    with pytest.raises(ValueError, match="num_threads must be a positive multiple"):
+        validate_fwd_config(replace(config, num_threads=511), inputs)
+
+
+def test_auto_split_resolves_from_exact_shape_metadata():
+    inputs = make_inputs(
+        num_heads=1,
+        num_heads_kv=1,
+        batch_size=1,
+        max_seqlen_q=1,
+        max_seqlen_k=16384,
+        requested_num_splits=None,
+    )
+    changed_shape = inputs._replace(max_seqlen_k=8192)
+
+    assert select_fwd_config(inputs).num_splits == 128
+    assert select_fwd_config(changed_shape).num_splits == 64
+
+
+def test_auto_split_normalizes_nonsplit_to_one():
+    assert (
+        num_splits_heuristic(
+            total_mblocks=1024,
+            num_sms=132,
+            num_n_blocks=128,
+            max_splits=128,
+        )
+        == 1
+    )
+
+
+def test_seqlen_k_per_split_sets_minimum_split_count():
+    inputs = make_inputs(
+        max_seqlen_k=4224,
+        seqlen_k_per_split=1024,
+        requested_num_splits=None,
+    )
+    config = select_fwd_config(inputs)
+
+    assert config.num_splits == 5
+    with pytest.raises(ValueError, match="requires num_splits >= 5"):
+        validate_fwd_config(replace(config, num_splits=4), inputs)
+
+
+@pytest.mark.parametrize("device_arch", [80, 90, 100, 110, 120])
+def test_architecture_defaults_validate(device_arch):
+    inputs = make_inputs(
+        device_arch=device_arch,
+        requested_use_clc_scheduler=device_arch // 10 in (10, 11),
+    )
+    config = select_fwd_config(inputs)
+
+    assert config.device_capacity == device_arch // 10
+
+
+def test_architecture_specific_unsupported_features_are_rejected():
+    unsupported_arch = make_inputs(device_arch=70, requested_use_clc_scheduler=False)
+    sm120_paged = make_inputs(
+        device_arch=120,
+        page_size=128,
+        requested_use_clc_scheduler=False,
+    )
+    irregular_paged = make_inputs(head_dim=72, head_dim_v=72, page_size=64)
+
+    with pytest.raises(ValueError, match="Unsupported forward architecture family SM7"):
+        select_fwd_config(unsupported_arch)
+    with pytest.raises(ValueError, match="SM120 forward does not support"):
+        select_fwd_config(sm120_paged)
+    with pytest.raises(ValueError, match="head dimensions divisible by 16"):
+        select_fwd_config(irregular_paged)
+
+
+def test_non_sm90_tile_override_does_not_claim_ignored_mma_flags():
+    inputs = make_inputs(
+        device_arch=120,
+        requested_tile_m=64,
+        requested_use_clc_scheduler=False,
+    )
+    config = select_fwd_config(inputs)
+
+    assert not config.mma_pv_is_rs
+    assert not config.intra_wg_overlap
+    with pytest.raises(ValueError, match="does not expose SM90 MMA flags"):
+        validate_fwd_config(replace(config, mma_pv_is_rs=True), inputs)
+
+
+def test_sm90_tile_override_preserves_legacy_rs_defaults():
+    inputs = make_inputs(
+        device_arch=90,
+        head_dim=96,
+        head_dim_v=96,
+        requested_tile_m=128,
+        requested_tile_n=128,
+        requested_use_clc_scheduler=False,
+    )
+    config = select_fwd_config(inputs)
+
+    assert config.tile_m == 128
+    assert config.tile_n == 128
+    assert config.num_threads == 384
+    assert config.mma_pv_is_rs
+    assert config.intra_wg_overlap
+    with pytest.raises(ValueError, match="requires num_threads=384"):
+        validate_fwd_config(replace(config, num_threads=512), inputs)
+
+
+@pytest.mark.parametrize(
+    ("changes", "expected"),
+    [
+        ({"requested_tile_m": 64}, (256, 56)),
+        ({"requested_tile_m": 128}, (240, 24)),
+        ({}, (160, 32)),
+        ({"requested_tile_m": 128, "page_size": 16}, (224, 40)),
+        (
+            {
+                "requested_tile_m": 128,
+                "num_heads": 24,
+                "num_heads_kv": 8,
+                "pack_gqa": True,
+            },
+            (224, 40),
+        ),
+    ],
+)
+def test_sm90_register_allocation_matches_existing_kernel_policy(changes, expected):
+    inputs = make_inputs(
+        device_arch=90,
+        requested_use_clc_scheduler=False,
+        **changes,
+    )
+
+    config = select_fwd_config(inputs)
+
+    assert config.num_threads == 128 * (config.tile_m // 64 + 1)
+    assert config.registers == FwdSm90RegisterAllocation(*expected)
+
+
+def test_explicit_2cta_config_is_valid_when_environment_default_disables_it():
+    inputs = make_inputs(head_dim=128, head_dim_v=128, disable_2cta=True)
+    config = select_fwd_config(inputs)
+
+    assert not config.use_2cta_instrs
+    validate_fwd_config(replace(config, use_2cta_instrs=True), inputs)
+
+
+@pytest.mark.parametrize(
+    ("device_arch", "registers"),
+    [
+        (90, FwdSm90RegisterAllocation(152, 56)),
+        (100, FwdSm100RegisterAllocation(192, 80, 48)),
+    ],
+)
+def test_explicit_register_allocation_accepts_valid_values(device_arch, registers):
+    inputs = make_inputs(device_arch=device_arch, requested_use_clc_scheduler=False)
+    config = select_fwd_config(inputs)
+
+    validate_fwd_config(replace(config, registers=registers), inputs)
+    assert config.registers != registers
+
+
+@pytest.mark.parametrize(
+    ("device_arch", "registers", "error_type", "match"),
+    [
+        (100, None, TypeError, "requires an SM100 register allocation"),
+        (100, FwdSm100RegisterAllocation(199, 64, 48), ValueError, "multiples of 8"),
+        (100, FwdSm100RegisterAllocation(120, 120, 120), ValueError, "at least 128"),
+        (100, FwdSm100RegisterAllocation(184, 136, 24), ValueError, "at most 128"),
+        (100, FwdSm100RegisterAllocation(200, 64, 56), ValueError, "512-register budget"),
+        (90, None, TypeError, "requires an SM90 register allocation"),
+        (
+            90,
+            FwdSm100RegisterAllocation(192, 80, 48),
+            TypeError,
+            "requires an SM90 register allocation",
+        ),
+        (90, FwdSm90RegisterAllocation(159, 32), ValueError, "multiples of 8"),
+        (90, FwdSm90RegisterAllocation(120, 128), ValueError, "at least 128"),
+        (90, FwdSm90RegisterAllocation(128, 136), ValueError, "at most 128"),
+        (90, FwdSm90RegisterAllocation(168, 24), ValueError, "512-register budget"),
+    ],
+)
+def test_explicit_register_allocation_rejects_invalid_values(
+    device_arch, registers, error_type, match
+):
+    inputs = make_inputs(device_arch=device_arch, requested_use_clc_scheduler=False)
+    config = select_fwd_config(inputs)
+
+    with pytest.raises(error_type, match=match):
+        validate_fwd_config(replace(config, registers=registers), inputs)
+
+
+def test_specialization_projects_exact_split_counts_per_kernel():
+    split_2 = select_fwd_config(make_inputs(requested_num_splits=2))
+    split_4 = select_fwd_config(make_inputs(requested_num_splits=4))
+
+    assert fwd_config_compile_bucket(split_2, 64) == fwd_config_compile_bucket(
+        split_4, 64
+    )
+
+    assert fwd_combine_tile(64) == (16, 64)
+    assert fwd_combine_tile(128) == (8, 128)
+    assert combine_log_max_splits(2, tile_m=16) == 4
+    assert combine_log_max_splits(16, tile_m=16) == 4
+    assert combine_log_max_splits(17, tile_m=16) == 5
+    assert combine_log_max_splits(2, tile_m=8) == 5
+
+
+def test_sm120_legacy_split_request_preserves_public_error():
+    inputs = make_inputs(
+        device_arch=120,
+        requested_num_splits=3,
+        requested_use_clc_scheduler=False,
+    )
+
+    with pytest.raises(
+        AssertionError, match="SM120 forward only supports num_splits=1"
+    ):
+        select_fwd_config(inputs)
+
+
+def test_validator_rejects_invalid_explicit_architecture():
+    inputs = make_inputs()
+    config = replace(select_fwd_config(inputs), device_capacity=9)
+
+    with pytest.raises(ValueError, match="targets SM9"):
+        validate_fwd_config(config, inputs)


### PR DESCRIPTION
Stacked PRs:
 * #2743
 * #2741
 * #2738
 * #2735
 * #2733
 * __->__#2732


--- --- ---

# Human Note

<!-- Fill this in before landing. -->

# Agent Note

## Summary

This is the small config layer I want before we tune FA4. A forward launch is now one immutable, fully resolved `FwdConfig`; the selector gets a separate `FwdHeuristicInputs`; and only the main/combine codegen projections key compilation.

That separation is the important bit: runtime shapes can choose a policy without raw shapes becoming compile-cache keys, while an explicit config can still force one exact kernel for A/B testing. Register allocation is now one hashable architecture union inside that config: `FwdSm90RegisterAllocation(mma, producer) | FwdSm100RegisterAllocation(softmax, correction, other)`, rather than unrelated values or hidden kernel tables.

The keys do not carry mirrored facts. Varlen mode is derived once from the existing Q/K cumulative-length and `seqused` presence bits; QV presence is implied by the MLA kernel family; and combine tile geometry is derived from head dimension. Shape changes therefore key policy selection without duplicating equivalent cache dimensions.

![Typed FA4 forward config boundary](https://raw.githubusercontent.com/drisspg/flash-attention/5f1eb068d7910e1cf59d91d43fefb798bb828b83/pr-assets/typed-config-boundary.png)

There is deliberately no scheduling change in this PR. It only makes the existing choices typed, visible, and testable.

## Host representation cost

`FwdConfig` remains a frozen dataclass because it is the user-facing resolved configuration. The three key-only records are tuple-backed `NamedTuple`s: they remain typed and immutable while avoiding frozen-dataclass construction and hashing on every launch.

On exact pre/post stack heads (`69285d1c`→`56161730`), host-only medians improved as follows:

| Operation | Before | After |
|---|---:|---:|
| Construct selector inputs | 4.103 us | 1.135 us |
| Construct inputs + warm selector hit | 5.734 us | 1.378 us |
| Project main kernel spec | 10.245 us | 5.939 us |
| Hash main spec | 0.816 us | 0.237 us |
| Construct combine spec | 1.161 us | 0.227 us |

This changes only Python representation; equality, persistent-cache identity fields, selector policy, and generated kernels are unchanged. A final simplifier pass removed the mirrored varlen/QV/combine-geometry fields and consolidated architecture dispatch. Against the preceding submitted stack, cached selection measured 190.2→187.1 ns and input construction 1.103→1.080 us; selector-miss body cost remained within 1% run-to-run noise.

Successful explicit-config validation is also cached by immutable `(config, inputs)` with a bounded 1024-entry cache: repeated validation measured 1.350→0.354 us. Invalid configurations still execute validation and raise because exceptions are not cached. Combine split bucketing now uses exact integer `bit_length()` rather than floating `log2/ceil`; all split counts 1–256 produce identical buckets.

## Implementation and validation

- `FwdConfig` contains the resolved tile, stage/thread, scheduler, TMA-O, 2CTA, SplitKV, and applicable SM90 or SM100 warp-group register allocation.
- The selector preserves the existing SM90 1/2/3-MMA-warp-group and cp.async register choices, plus the existing BF16, FP16, FP8, paged, SM103, and fixed-HD256 choices. MLA, SM80, and SM120 carry `registers=None`.
- Register validation enforces the legal `setmaxnreg` direction, 8-register granularity, per-role bounds, and weighted 512-register budget.
- `FwdHeuristicInputs` contains host-visible metadata only; selection does not synchronize, inspect tensor contents, or allocate outputs.
- `FwdMainKernelSpec` and `FwdCombineKernelSpec` contain only code-generation-changing fields; register-only changes produce distinct main specializations.
- Main-kernel identity includes static tensor broadcast patterns but never concrete B/Q/K lengths. Combine identity includes the optional dynamic-split and semaphore operands that gate compile-time branches.
- Invalid explicit configs fail instead of being silently normalized.
- Fixed `seqlen_k_per_split` is selector input: automatic selection resolves the exact required split capacity, while explicit configs below it fail before scheduler metadata allocation.
- Dedicated MLA and head-dim-256 paths keep their canonical fixed configs; automatic SplitKV cannot leak into HD256 decode shapes.
- Dynamic-shape behavior: a shape change that maps to the same typed spec reuses the cache; crossing a codegen boundary compiles that specialization once.

Validation lives in `tests/cute/test_fwd_config.py`, including architecture defaults, exact forced configs, SplitKV resolution, dedicated paths, cache projections, JSON/YAML round trips, register-policy parity, and invalid combinations. The standalone #2732 boundary passes 60 host tests. An exhaustive differential audit matched the old SM100 kernel-side register policy across 110,592 dtype/architecture/head-dimension/paging/causality/CTA combinations, and a table-driven audit covers every SM90 MMA-warp-group and TMA/cp.async branch.