### PR TITLE
[CuTe] Route forward through typed configs

### DIFF
--- a/benchmarks/tune_ex2_emu.py
+++ b/benchmarks/tune_ex2_emu.py
@@ -1,13 +1,15 @@
 #!/usr/bin/env python3
-"""Sweep _TUNING_CONFIG parameters for flash_fwd_sm100.
+"""Sweep _EX2_CONFIG parameters for flash_fwd_sm100.
 
-Edits the _TUNING_CONFIG dict in flash_fwd_sm100.py, runs benchmarks, and
-reports the best configuration. Restores the original file on exit.
+Edits the exp2-emulation table in flash_fwd_sm100.py, runs benchmarks, and
+reports the best configuration. Register allocations are explicit FwdConfig
+fields and should be swept through the forward config benchmark or autotuner.
+Restores the original file on exit.
 
 Usage:
-    CUDA_VISIBLE_DEVICES=7 python benchmarks/tune_ex2_emu_v2.py [--headdim 128] [--seqlen 8192]
+    CUDA_VISIBLE_DEVICES=7 python benchmarks/tune_ex2_emu.py [--headdim 128] [--seqlen 8192]
 
-Requires: the _TUNING_CONFIG dict in flash_attn/cute/flash_fwd_sm100.py.
+Requires: the _EX2_CONFIG dict in flash_attn/cute/flash_fwd_sm100.py.
 """
 import argparse
 import atexit
@@ -31,9 +33,9 @@ def write_file(content):
         f.write(content)
 
 def find_tuning_block(src):
-    """Return (start, end) indices of the _TUNING_CONFIG = { ... } block."""
-    m = re.search(r'^_TUNING_CONFIG\s*=\s*\{', src, re.MULTILINE)
-    assert m, "Could not find _TUNING_CONFIG in source"
+    """Return (start, end) indices of the _EX2_CONFIG = { ... } block."""
+    m = re.search(r'^_EX2_CONFIG\s*=\s*\{', src, re.MULTILINE)
+    assert m, "Could not find _EX2_CONFIG in source"
     start = m.start()
     # Find matching closing brace
     depth = 0
@@ -44,19 +46,19 @@ def find_tuning_block(src):
             depth -= 1
             if depth == 0:
                 return start, i + 1
-    raise RuntimeError("Unmatched brace in _TUNING_CONFIG")
+    raise RuntimeError("Unmatched brace in _EX2_CONFIG")
 
 def parse_tuning_config(src):
-    """Extract _TUNING_CONFIG as a Python dict."""
+    """Extract _EX2_CONFIG as a Python dict."""
     start, end = find_tuning_block(src)
     block = src[start:end]
     ns = {}
     exec(block, ns)
-    return ns["_TUNING_CONFIG"]
+    return ns["_EX2_CONFIG"]
 
 def serialize_tuning_config(config):
-    """Serialize _TUNING_CONFIG back to source."""
-    lines = ["_TUNING_CONFIG = {"]
+    """Serialize _EX2_CONFIG back to source."""
+    lines = ["_EX2_CONFIG = {"]
     for key, val in config.items():
         use_2cta, is_causal, hdim, is_sm103 = key
         label_parts = []
@@ -75,7 +77,7 @@ def serialize_tuning_config(config):
     return "\n".join(lines)
 
 def patch_config(original_src, new_config):
-    """Replace _TUNING_CONFIG block in source with new_config."""
+    """Replace _EX2_CONFIG block in source with new_config."""
     start, end = find_tuning_block(original_src)
     return original_src[:start] + serialize_tuning_config(new_config) + original_src[end:]
 
@@ -185,10 +187,10 @@ def run_benchmark(causal_flag, headdim_str, seqlen, rep=20, warmup=10):
     headdim_str: '128' or '192-128' (passed directly to --headdim).
     """
     result = subprocess.run(
-        ["python", "benchmarks/benchmark_attn.py", "--fwd", "--backend", "fa4",
+        [sys.executable, "benchmarks/benchmark_attn.py", "--fwd", "--backend", "fa4",
          "--headdim", headdim_str, f"--seqlen={seqlen}", "--rep", str(rep),
          "--warmup", str(warmup), "--causal", causal_flag],
-        capture_output=True, text=True, timeout=600
+        check=True, capture_output=True, text=True, timeout=600
     )
     output = result.stdout + result.stderr
     # Output lines look like: "      128  False     4   8192      1.38/1592/70.8%"
@@ -212,7 +214,7 @@ def parse_headdim(s):
     return hdim, hdim
 
 def parse_args():
-    p = argparse.ArgumentParser(description="Tune _TUNING_CONFIG for flash_fwd_sm100")
+    p = argparse.ArgumentParser(description="Tune _EX2_CONFIG for flash_fwd_sm100")
     p.add_argument("--headdim", type=str, default="128",
                     help="Head dim spec: 128 or 192-128 (hdim-hdim_v)")
     p.add_argument("--seqlen", type=str, default="8192")
@@ -230,7 +232,7 @@ def main():
     config = parse_tuning_config(original_src)
 
     hdim, hdim_v = parse_headdim(args.headdim)
-    # _TUNING_CONFIG keys use head_dim_padded (rounded up to multiple of 16)
+    # _EX2_CONFIG keys use head_dim_padded (rounded up to multiple of 16)
     import math
     hdim_padded = int(math.ceil(hdim / 16) * 16)
     is_sm103 = detect_sm103()
@@ -238,7 +240,7 @@ def main():
     # Determine which keys to tune (matching hdim and detected arch)
     keys_to_tune = [k for k in config if k[2] == hdim_padded and k[3] == is_sm103]
     if not keys_to_tune:
-        print(f"No _TUNING_CONFIG entries for hdim_padded={hdim_padded}, is_sm103={is_sm103}")
+        print(f"No _EX2_CONFIG entries for hdim_padded={hdim_padded}, is_sm103={is_sm103}")
         print("Available keys:", [k for k in config])
         sys.exit(1)
 
@@ -318,66 +320,6 @@ def main():
             print(f"\n  Best: freq={best_freq}, start_frg={best_start}, {best_tflops:.0f} TFLOPS")
             config[key] = {**config[key], "ex2_emu_freq": best_freq, "ex2_emu_start_frg": best_start}
 
-    # ── Phase 2: Register count sweep (softmax, correction; other = 512 - 2*softmax - correction) ──
-    # hd256 skipped: its num_regs_other=32 is fixed and the 512-budget formula does not apply.
-
-    reg_combos = []
-    for softmax in [176, 184, 192, 200]:
-        for correction in [56, 64, 72, 80, 88, 96]:
-            other = 512 - softmax * 2 - correction
-            if other >= 24:  # need some minimum for other warps
-                reg_combos.append((softmax, correction, other))
-
-    for key in keys_to_tune:
-        use_2cta, is_causal, key_hdim, _ = key
-        causal_flag = "true" if is_causal else "false"
-        causal_label = "causal" if is_causal else "non-causal"
-        cta_label = "2CTA" if use_2cta else "1CTA"
-
-        print("\n" + "=" * 70)
-        print(f"Phase 2: Register sweep for {causal_label} ({cta_label})")
-        print("=" * 70)
-
-        if key_hdim == 256:
-            print("  Skipping: hd256 uses fixed num_regs_other=32; 512-budget formula does not apply.")
-            continue
-
-        print(f"{'softmax':>8} {'corr':>6} {'other':>6} {'ms':>8} {'tflops':>10} {'mfu':>8}")
-        print("-" * 55)
-
-        best_softmax = config[key]["num_regs_softmax"]
-        best_correction = config[key]["num_regs_correction"]
-        best_tflops = 0
-
-        for softmax, correction, other in reg_combos:
-            test_config = dict(config)
-            test_config[key] = {**config[key],
-                "num_regs_softmax": softmax,
-                "num_regs_correction": correction,
-            }
-            write_file(patch_config(original_src, test_config))
-            try:
-                ms, tflops, mfu = run_benchmark(causal_flag, args.headdim, args.seqlen, args.rep, args.warmup)
-                if tflops is None:
-                    print(f"{softmax:>8} {correction:>6} {other:>6}  ERROR")
-                    continue
-                marker = " ***" if tflops > best_tflops else ""
-                print(f"{softmax:>8} {correction:>6} {other:>6} {ms:>8.2f} {tflops:>10.0f} {mfu:>8.1f}{marker}")
-                if tflops > best_tflops:
-                    best_tflops = tflops
-                    best_softmax = softmax
-                    best_correction = correction
-            except Exception as e:
-                print(f"{softmax:>8} {correction:>6} {other:>6}  ERROR: {e}")
-            sys.stdout.flush()
-
-        best_other = 512 - best_softmax * 2 - best_correction
-        print(f"\n  Best: softmax={best_softmax}, correction={best_correction}, other={best_other}, {best_tflops:.0f} TFLOPS")
-        config[key] = {**config[key],
-            "num_regs_softmax": best_softmax,
-            "num_regs_correction": best_correction,
-        }
-
     # ── Final summary ──
 
     print("\n" + "=" * 70)
@@ -387,7 +329,7 @@ def main():
         val_parts = ", ".join(f'"{k}": {json.dumps(v)}' for k, v in config[key].items())
         print(f"    {key!r}: {{{val_parts}}},")
 
-    print(f"\nTo apply, update _TUNING_CONFIG in {KERNEL_FILE}")
+    print(f"\nTo apply, update _EX2_CONFIG in {KERNEL_FILE}")
 
     write_file(original_src)
     print("Restored original file.")

--- a/flash_attn/cute/cache_utils.py
+++ b/flash_attn/cute/cache_utils.py
@@ -27,7 +27,7 @@ for _lib_path in cute.runtime.find_runtime_libraries(enable_tvm_ffi=False):
     if Path(_lib_path).exists():
         ctypes.CDLL(_lib_path, mode=ctypes.RTLD_GLOBAL)
 
-CompileKeyType: TypeAlias = tuple[Hashable, ...]
+CompileKeyType: TypeAlias = Hashable
 CallableFunction: TypeAlias = JitCompiledFunction | tvm_ffi.Function
 
 # Enable cache via `FLASH_ATTENTION_CUTE_DSL_CACHE_ENABLED=1`

--- a/flash_attn/cute/config.py
+++ b/flash_attn/cute/config.py
@@ -186,6 +186,14 @@ class FwdMainKernelSpec(NamedTuple):
     is_static_persistent: bool | None
     use_tma_o: bool | None
     registers: FwdRegisterAllocation | None
+    has_num_splits_dynamic: bool
+    has_virtual_batch_idx: bool
+    has_num_nheads_in_l2: bool
+    has_tile_count_semaphore: bool
+    has_scheduler_cu_total_m_blocks: bool
+    has_scheduler_cu_total_splits_m_blocks: bool
+    has_blocks_to_batch_idx: bool
+    seqlen_k_per_split: int | None
     has_q: bool
     has_p: bool
     has_row_max: bool
@@ -244,15 +252,17 @@ class FwdMainKernelSpec(NamedTuple):
 class FwdCombineKernelSpec(NamedTuple):
     """Typed cache key for one generated SplitKV combine kernel."""
 
+    arch: int
     dtype: object
     dtype_partial: object
     head_dim: int
+    num_head: int
     log_max_splits: int
     has_cu_seqlens: bool
     has_seqused: bool
     has_lse: bool
     has_num_splits_dynamic_ptr: bool
-    has_varlen_batch_idx: bool
+    has_virtual_batch_idx: bool
     has_semaphore_to_reset: bool
 
 
@@ -596,12 +606,13 @@ def select_fwd_config(inputs: FwdHeuristicInputs) -> FwdConfig:
     )
     is_static_persistent = (
         is_sm100_family
-        and not inputs.causal
-        and not inputs.local
-        and not inputs.is_varlen_q
         and not is_split_kv
         and not overlap_s_o_s_q
         and not use_clc_scheduler
+        and (
+            (not inputs.causal and not inputs.local and not inputs.is_varlen_q)
+            or packed_seqlen_q <= effective_tile_m
+        )
     )
     use_tma_o = is_sm100_family and can_use_tma_o(inputs, tile_m=tile_m, num_splits=num_splits)
 
@@ -781,13 +792,11 @@ def validate_fwd_config(config: FwdConfig, inputs: FwdHeuristicInputs) -> None:
         raise ValueError("Non-TMA paged KV requires head dimensions divisible by 16")
     if config.use_clc_scheduler and (paged_kv_non_tma or overlap_s_o_s_q):
         raise ValueError("CLC requires TMA KV and a non-overlapping O/Q shared-memory layout")
+    persistent_shape = (not inputs.causal and not inputs.local and not inputs.is_varlen_q) or (
+        inputs.max_seqlen_q * inputs.qhead_per_kvhead <= config.q_stage * config.tile_m
+    )
     if config.is_static_persistent and (
-        inputs.causal
-        or inputs.local
-        or inputs.is_varlen_q
-        or config.num_splits > 1
-        or overlap_s_o_s_q
-        or config.use_clc_scheduler
+        not persistent_shape or config.num_splits > 1 or overlap_s_o_s_q or config.use_clc_scheduler
     ):
         raise ValueError("Static persistent scheduling is not effective for this forward problem")
 

--- a/flash_attn/cute/flash_fwd_sm100.py
+++ b/flash_attn/cute/flash_fwd_sm100.py
@@ -33,6 +33,7 @@ from cutlass.cutlass_dsl import BaseDSL
 
 from quack import copy_utils, layout_utils
 
+from flash_attn.cute.config import FwdSm100RegisterAllocation
 from flash_attn.cute.paged_kv import PagedKVManager
 from flash_attn.cute.cute_dsl_utils import assume_tensor_aligned
 from flash_attn.cute import utils
@@ -70,18 +71,6 @@ from flash_attn.cute.fa_logging import fa_log, fa_printf
 from flash_attn.cute.utils import smid
 from flash_attn.cute.utils import AuxData
 
-# === TUNING KNOBS (agent-editable) ===
-# Keys: (use_2cta_instrs: bool, is_causal: bool, head_dim_padded: int, is_sm103: bool)
-# Values:
-#   ex2_emu_freq: int — how often to use emulated exp2 (0=all hardware exp2, higher=more emulation).
-#                        SM103 has fast native exp2, so set freq=0 there.
-#   ex2_emu_res: int — (hd256 only) number of fragment-pairs per freq period to emulate.
-#   ex2_emu_start_frg: int — fragment index to start emulation from
-#   num_regs_softmax: int — register count for softmax warps (multiple of 8)
-#   num_regs_correction: int — register count for correction warps (multiple of 8)
-#   num_regs_other is derived: 512 - num_regs_softmax * 2 - num_regs_correction
-#                  (hd256 exception: num_regs_other is fixed at 32, not derived)
-
 # Note [Low Precision Scaling]
 # P is in (0, 1] and is cast to the input dtype before P @ V, so scaling it by 2^max_offset
 # spends the dtype's unused upper code points on the probability tail. A positive
@@ -97,31 +86,40 @@ _LOG2_DTYPE_MAX = {
     cutlass.BFloat16: math.log2(3.3895313892515355e38),
 }
 
-_TUNING_CONFIG = {
-    (True, False, 128, False): {"ex2_emu_freq": 10, "ex2_emu_start_frg": 1, "num_regs_softmax": 176, "num_regs_correction": 88},
-    (False, True, 128, False): {"ex2_emu_freq": 16, "ex2_emu_start_frg": 1, "num_regs_softmax": 192, "num_regs_correction": 72},
-    (True, False, 192, False): {"ex2_emu_freq": 16, "ex2_emu_start_frg": 0, "num_regs_softmax": 184, "num_regs_correction": 80},
-    (False, True, 192, False): {"ex2_emu_freq": 32, "ex2_emu_start_frg": 1, "num_regs_softmax": 192, "num_regs_correction": 72},
-    (True, False, 128, True): {"ex2_emu_freq": 0, "ex2_emu_start_frg": 0, "num_regs_softmax": 176, "num_regs_correction": 80},
-    (False, True, 128, True): {"ex2_emu_freq": 0, "ex2_emu_start_frg": 0, "num_regs_softmax": 176, "num_regs_correction": 64},
-    (True, False, 192, True): {"ex2_emu_freq": 0, "ex2_emu_start_frg": 0, "num_regs_softmax": 176, "num_regs_correction": 64},
-    (False, True, 192, True): {"ex2_emu_freq": 0, "ex2_emu_start_frg": 0, "num_regs_softmax": 176, "num_regs_correction": 72},
-    (True, False, 256, False): {"ex2_emu_freq": 14, "ex2_emu_res": 6, "ex2_emu_start_frg": 0, "num_regs_softmax": 256, "num_regs_correction": 160},
-    (True, True, 256, False): {"ex2_emu_freq": 14, "ex2_emu_res": 6, "ex2_emu_start_frg": 0, "num_regs_softmax": 256, "num_regs_correction": 160},
+# Keys: (use_2cta_instrs, is_causal, head_dim_padded, is_sm103).
+# Register allocation is resolved by FwdConfig; only exp2 emulation remains here.
+# A frequency of zero uses hardware exp2 exclusively; larger values periodically
+# use emulation starting at ex2_emu_start_frg. Hd256 also specifies how many
+# fragment pairs per period to emulate with ex2_emu_res. SM103 uses frequency zero
+# because it has fast hardware exp2.
+_EX2_CONFIG = {
+    (True, False, 128, False): {"ex2_emu_freq": 10, "ex2_emu_start_frg": 1},
+    (False, True, 128, False): {"ex2_emu_freq": 16, "ex2_emu_start_frg": 1},
+    (True, False, 192, False): {"ex2_emu_freq": 16, "ex2_emu_start_frg": 0},
+    (False, True, 192, False): {"ex2_emu_freq": 32, "ex2_emu_start_frg": 1},
+    (True, False, 128, True): {"ex2_emu_freq": 0, "ex2_emu_start_frg": 0},
+    (False, True, 128, True): {"ex2_emu_freq": 0, "ex2_emu_start_frg": 0},
+    (True, False, 192, True): {"ex2_emu_freq": 0, "ex2_emu_start_frg": 0},
+    (False, True, 192, True): {"ex2_emu_freq": 0, "ex2_emu_start_frg": 0},
+    (True, False, 256, False): {
+        "ex2_emu_freq": 14,
+        "ex2_emu_res": 6,
+        "ex2_emu_start_frg": 0,
+    },
+    (True, True, 256, False): {
+        "ex2_emu_freq": 14,
+        "ex2_emu_res": 6,
+        "ex2_emu_start_frg": 0,
+    },
 }
-_FP8_TUNING_CONFIG = {
-    (True, False, 128, False): {'ex2_emu_freq': 10, 'ex2_emu_start_frg': 1, 'num_regs_softmax': 160, 'num_regs_correction': 72},
+_FP8_EX2_CONFIG = {
+    (True, False, 128, False): {"ex2_emu_freq": 10, "ex2_emu_start_frg": 1},
     # Causal hd128 FP8 previously inherited bf16's freq=16. FP8 fwd is MUFU/ex2-bound, so a more
     # aggressive emulation freq=8 offloads more exp from MUFU: +3.4%(4k)..+5.5%(16k) on B200,
     # MHA & GQA, accuracy-neutral (3-run validated, locked clocks). freq=8 would regress non-causal
     # (0.94x), hence keyed on is_causal=True only.
-    (False, True, 128, False): {'ex2_emu_freq': 8, 'ex2_emu_start_frg': 1},
+    (False, True, 128, False): {"ex2_emu_freq": 8, "ex2_emu_start_frg": 1},
 }
-_FP8_SMALL_HDIM_REGS = {
-    False: {"num_regs_softmax": 168, "num_regs_correction": 96, "num_regs_other": 80},
-    True: {"num_regs_softmax": 152, "num_regs_correction": 96, "num_regs_other": 112},
-}
-# === END TUNING KNOBS ===
 
 
 class DescaleTensors(NamedTuple):
@@ -160,6 +158,9 @@ class FlashAttentionForwardSm100:
         use_clc_scheduler: bool = False,
         has_tile_count_semaphore: bool = False,
         seqlen_k_per_split: Optional[int] = None,
+        *,
+        use_tma_o: bool,
+        registers: FwdSm100RegisterAllocation,
     ):
         self.use_tma_KV = not paged_kv_non_tma
         # self.dtype = dtype
@@ -209,11 +210,10 @@ class FlashAttentionForwardSm100:
         self.qhead_per_kvhead = qhead_per_kvhead
         self.is_split_kv = is_split_kv
         self.pack_gqa = pack_gqa
-        self.use_tma_O = (
-            not (self.pack_gqa and self.m_block_size % self.qhead_per_kvhead != 0)
-            and not (self.pack_gqa and self.is_split_kv)
-            and not is_varlen_q
-        )
+        self.use_tma_O = use_tma_o
+        self.num_regs_softmax = registers.softmax
+        self.num_regs_correction = registers.correction
+        self.num_regs_other = registers.other
         self.use_correction_warps_for_epi = not self.use_tma_O
         self.q_subtile_factor = q_subtile_factor
         self.kv_subtile_factor = kv_subtile_factor
@@ -356,26 +356,10 @@ class FlashAttentionForwardSm100:
         # vec buffer for row_max & row_sum
         self.tmem_vec_offset = self.tmem_s_offset
 
-        # Look up tuning config for register counts and ex2_emu params
-        _tune_key = (self.use_2cta_instrs, self.is_causal, self.head_dim_padded, self.is_sm103)
-        self._tune = _TUNING_CONFIG.get(_tune_key, {})
-        if "ex2_emu_freq" in self._tune:
-            self.enable_ex2_emu = self._tune["ex2_emu_freq"] > 0
-        if self.head_dim_padded < 96:
-            self.num_regs_softmax = 200 if not paged_kv_non_tma else 184
-            self.num_regs_correction = 64
-            self.num_regs_other = 48 if not paged_kv_non_tma else 80
-        else:
-            if not paged_kv_non_tma and "num_regs_softmax" in self._tune:
-                self.num_regs_softmax = self._tune["num_regs_softmax"]
-                self.num_regs_correction = self._tune["num_regs_correction"]
-            elif not paged_kv_non_tma:
-                self.num_regs_softmax = 192
-                self.num_regs_correction = 80
-            else:
-                self.num_regs_softmax = 184
-                self.num_regs_correction = 64
-            self.num_regs_other = 512 - self.num_regs_softmax * 2 - self.num_regs_correction
+        ex2_key = (self.use_2cta_instrs, self.is_causal, self.head_dim_padded, self.is_sm103)
+        self._ex2_config = _EX2_CONFIG.get(ex2_key, {})
+        if "ex2_emu_freq" in self._ex2_config:
+            self.enable_ex2_emu = self._ex2_config["ex2_emu_freq"] > 0
 
         self.buffer_align_bytes = 1024
 
@@ -504,32 +488,21 @@ class FlashAttentionForwardSm100:
         if const_expr(self.q_dtype != self.v_dtype):
             raise TypeError(f"Type mismatch: {self.q_dtype} != {self.v_dtype}")
         if const_expr(self.q_dtype.width == 8):
-            paged_kv_non_tma = not self.use_tma_KV
-            if const_expr(self.head_dim_padded < 96):
-                fp8_regs = _FP8_SMALL_HDIM_REGS[paged_kv_non_tma]
-                self.num_regs_softmax = fp8_regs["num_regs_softmax"]
-                self.num_regs_correction = fp8_regs["num_regs_correction"]
-                self.num_regs_other = fp8_regs["num_regs_other"]
-            else:
-                fp8_tune = _FP8_TUNING_CONFIG.get(
-                    (self.use_2cta_instrs, self.is_causal, self.head_dim_padded, self.is_sm103), {}
-                )
-                if const_expr("ex2_emu_freq" in fp8_tune):
-                    self._tune = {**self._tune, **fp8_tune}
-                    self.enable_ex2_emu = self._tune["ex2_emu_freq"] > 0
-                if const_expr(not paged_kv_non_tma and "num_regs_softmax" in fp8_tune):
-                    self.num_regs_softmax = fp8_tune["num_regs_softmax"]
-                    self.num_regs_correction = fp8_tune["num_regs_correction"]
-                    self.num_regs_other = 512 - self.num_regs_softmax * 2 - self.num_regs_correction
+            fp8_ex2_config = _FP8_EX2_CONFIG.get(
+                (self.use_2cta_instrs, self.is_causal, self.head_dim_padded, self.is_sm103), {}
+            )
+            if const_expr("ex2_emu_freq" in fp8_ex2_config):
+                self._ex2_config = {**self._ex2_config, **fp8_ex2_config}
+                self.enable_ex2_emu = self._ex2_config["ex2_emu_freq"] > 0
         self._setup_attributes()
         self.ex2_emu_freq = 0
-        self.ex2_emu_start_frg = self._tune.get("ex2_emu_start_frg", 1)
+        self.ex2_emu_start_frg = self._ex2_config.get("ex2_emu_start_frg", 1)
         if const_expr(self.enable_ex2_emu):
-            self.ex2_emu_freq = self._tune.get("ex2_emu_freq", 16)
+            self.ex2_emu_freq = self._ex2_config.get("ex2_emu_freq", 16)
             if const_expr(
                 self.pack_gqa and self.head_dim_padded > 64 and not self.is_causal and not self.is_local
             ):
-                self.ex2_emu_freq = 32 if mCuSeqlensQ is not None or mSeqUsedQ is not None else self._tune.get("ex2_emu_freq", 10)
+                self.ex2_emu_freq = 32 if mCuSeqlensQ is not None or mSeqUsedQ is not None else self._ex2_config.get("ex2_emu_freq", 10)
 
         cta_group = tcgen05.CtaGroup.TWO if self.use_2cta_instrs else tcgen05.CtaGroup.ONE
         q_major_mode = tcgen05.OperandMajorMode.K

--- a/flash_attn/cute/flash_fwd_sm90.py
+++ b/flash_attn/cute/flash_fwd_sm90.py
@@ -22,6 +22,7 @@ from quack import layout_utils
 from quack import sm90_utils
 
 from flash_attn.cute.cute_dsl_utils import assume_tensor_aligned
+from flash_attn.cute.config import FwdSm90RegisterAllocation
 from flash_attn.cute import utils
 from flash_attn.cute.mask import AttentionMask
 from flash_attn.cute.softmax import Softmax, apply_score_mod_inner
@@ -53,6 +54,7 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
     def __init__(
         self,
         *args,
+        registers: FwdSm90RegisterAllocation,
         intra_wg_overlap: bool = True,
         mma_pv_is_rs: bool = True,
         paged_kv_non_tma: bool = False,
@@ -61,6 +63,8 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         super().__init__(*args, **kwargs)
         self.intra_wg_overlap = intra_wg_overlap
         self.mma_pv_is_rs = mma_pv_is_rs
+        self.num_mma_regs = registers.mma
+        self.num_producer_regs = registers.producer
         self.buffer_align_bytes = 1024
         self.use_tma_KV = not paged_kv_non_tma
         assert self.use_tma_KV or not (self.check_hdim_oob or self.check_hdim_v_oob), (
@@ -214,9 +218,6 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
         self.num_producer_threads = 32
         self.num_Q_load_threads = self.num_threads_per_warp_group  # If not TMA_Q
         self.num_epilogue_threads = self.num_mma_threads
-        self.num_mma_regs, self.num_producer_regs = {1: (256, 56), 2: (240, 24), 3: (160, 32)}[
-            self.num_wg_mma
-        ]
         self.use_block_sparsity = cutlass.const_expr(blocksparse_tensors is not None)
 
         self.use_scheduler_barrier = (
@@ -228,9 +229,6 @@ class FlashAttentionForwardSm90(FlashAttentionForwardBase):
             self.pack_gqa and self.tile_m % self.qhead_per_kvhead != 0
         )
         self.use_tma_O = self.use_tma_Q
-        # Producer needs more registers when doing cp.async Q or KV loads
-        if const_expr(self.num_wg_mma == 2 and (not self.use_tma_Q or not self.use_tma_KV)):
-            self.num_mma_regs, self.num_producer_regs = 224, 40
         self.rescale_O_before_gemm = self.tile_hdimv > 128 and self.intra_wg_overlap
         self._setup_attributes()
         # TODO: we prob don't need most of what's in _setup_attributes

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -16,6 +16,17 @@ import cutlass.cute as cute
 from cutlass import Int32, Float32
 from quack.compile_utils import make_fake_tensor as fake_tensor
 from flash_attn.cute.cache_utils import get_jit_cache
+from flash_attn.cute.config import (
+    FwdCombineKernelSpec,
+    FwdConfig,
+    FwdHeuristicInputs,
+    FwdMainKernelSpec,
+    combine_log_max_splits,
+    fwd_combine_tile,
+    select_fwd_config,
+    uses_dedicated_hd256_kernel,
+    validate_fwd_config,
+)
 from flash_attn.cute.testing import is_fake_mode
 
 
@@ -130,50 +141,6 @@ def _validate_head_dims(head_dim: int, head_dim_v: int, compute_capability: int,
 
 
 @dataclass(frozen=True)
-class FwdConfig:
-    m_block_size: int
-    n_block_size: int
-    mma_pv_is_rs: bool
-    intra_wg_overlap: bool
-    q_stage: int = 1
-    num_splits: int = 1
-
-
-def _tile_size_fwd_sm90(head_dim, head_dim_v, is_causal, is_local, sparse_block_size_q=None):
-    """Return FwdConfig for SM90 forward.
-
-    Tile sizes and flags based on tile_size_fwd_sm90 in hopper/tile_size.h, adjusted
-    for the Python kernel's different register/smem tradeoffs (benchmarked on H100 SXM).
-
-    When sparse_block_size_q is set, tile_m must divide it. For head_dim <= 96 the
-    optimal tile_m=192 is used when compatible, otherwise we fall back to 128.
-    """
-    if head_dim <= 64:
-        # C++: 192×192 non-causal, 192×128 causal/local.
-        # Python: 192×128 RS+OL is consistently best across seqlens.
-        if sparse_block_size_q is not None and sparse_block_size_q % 192 != 0:
-            return FwdConfig(128, 128, True, True)
-        return FwdConfig(192, 128, True, True)
-    elif head_dim <= 96:
-        # C++: 192×144 noRS+OL for all cases.
-        # Python: RS is catastrophic with 192× tiles (~300 vs ~600 TFLOPS).
-        # noRS+OL is always required. Causal: 192×128 slightly better short seqlen.
-        if sparse_block_size_q is not None and sparse_block_size_q % 192 != 0:
-            return FwdConfig(128, 128, False, True)
-        if is_causal or is_local:
-            return FwdConfig(192, 128, False, True)
-        else:
-            return FwdConfig(192, 144, False, True)
-    elif head_dim <= 128:
-        return FwdConfig(128, 128, True, True)
-    elif head_dim <= 192:
-        tile_n = 96 if is_local else (128 if head_dim_v <= 128 else 112)
-        return FwdConfig(128, tile_n, True, True)
-    else:  # hdim 256
-        tile_n = 64 if is_local else 80
-        return FwdConfig(128, tile_n, True, True)
-
-@dataclass(frozen=True)
 class BwdConfig:
     m_block_size: int
     n_block_size: int
@@ -271,118 +238,6 @@ torch2cute_dtype_map = {
 }
 
 _LEARNABLE_SINK_DTYPES = (torch.float16, torch.bfloat16, torch.float32)
-
-
-def num_splits_heuristic(total_mblocks, num_SMs, num_n_blocks, max_splits):
-    # If num_n_blocks is too small, use 1 split. For example, we never split for hdim = 128 and seqlen_k = 512.
-    if num_n_blocks <= 4:
-        return 1
-    # Avoid ZeroDivisionError when batch_size or seqlen_q is 0. The empty-Q
-    # early-exit in _flash_attn_fwd handles correctness for those shapes; this
-    # guard just keeps the heuristic safe if called in other contexts.
-    if total_mblocks == 0:
-        return 1
-
-    # NOTE: We should revisit this heuristic after persistence is supported for split KV.
-    # Sometimes, it's ideal to over-schedule splits for better efficiency.
-    return min(num_SMs // total_mblocks, max_splits, num_n_blocks)
-
-
-def _get_fwd_config(
-    *,
-    arch: int,
-    head_dim: int,
-    head_dim_v: int,
-    max_seqlen_q: int,
-    max_seqlen_k: int,
-    num_head_kv: int,
-    qhead_per_kvhead: int,
-    pack_gqa: bool,
-    batch_size: int,
-    causal: bool,
-    local: bool,
-    window_size_left: Optional[int],
-    window_size_right: Optional[int],
-    num_splits: int,
-    device,
-    seqlen_q: Optional[int] = None,
-    tile_mn: Optional[Tuple[int, int]] = None,
-    block_sparse_tensors: Optional[BlockSparseTensorsTorch] = None,
-    mma_pv_is_rs: Optional[bool] = None,
-    intra_wg_overlap: Optional[bool] = None,
-) -> FwdConfig:
-    if seqlen_q is None:
-        seqlen_q = max_seqlen_q
-
-    # Base tile sizes and flags: explicit override, else per-arch heuristic.
-    cfg = FwdConfig(128, 128, True, True)
-    if tile_mn is None:
-        if arch // 10 == 12:
-            # SM120 tile sizes tuned for 99 KB SMEM capacity:
-            # D<=64:  128x128 → 48 KB (good occupancy)
-            # D>64:   128x64  → 64 KB (128x128 would use 96 KB, hurting occupancy)
-            if head_dim > 64:
-                cfg = FwdConfig(128, 64, True, True)
-        elif arch // 10 == 8:
-            cfg = FwdConfig(128, 64, True, True)  # SM80, should tune
-        elif arch // 10 == 9:
-            sparse_q = get_sparse_q_block_size(block_sparse_tensors, seqlen_q)
-            cfg = _tile_size_fwd_sm90(
-                head_dim, head_dim_v, causal, local, sparse_block_size_q=sparse_q
-            )
-    else:
-        cfg = FwdConfig(tile_mn[0], tile_mn[1], cfg.mma_pv_is_rs, cfg.intra_wg_overlap)
-
-    tile_m, tile_n = cfg.m_block_size, cfg.n_block_size
-    if mma_pv_is_rs is None:
-        mma_pv_is_rs = cfg.mma_pv_is_rs
-    if intra_wg_overlap is None:
-        intra_wg_overlap = cfg.intra_wg_overlap
-
-    seqlen_q_packgqa = max_seqlen_q * (qhead_per_kvhead if pack_gqa else 1)
-    if arch // 10 in [10, 11]:
-        q_stage = 2 if seqlen_q_packgqa > tile_m else 1
-    else:
-        q_stage = 1
-
-    m_block_size_effective = q_stage * tile_m
-    seqlen_k_loaded = (
-        max_seqlen_k
-        if not local
-        else max(
-            0,
-            min(
-                max_seqlen_k,
-                (window_size_right or max_seqlen_k)
-                + (window_size_left or max_seqlen_k)
-                + 1
-                + tile_m,
-            ),
-        )
-    )
-    num_m_blocks = (seqlen_q_packgqa + m_block_size_effective - 1) // m_block_size_effective
-    total_mblocks = batch_size * num_head_kv * num_m_blocks
-    num_n_blocks = (seqlen_k_loaded + tile_n - 1) // tile_n
-    num_SMs = None
-    if arch // 10 == 12:
-        assert num_splits == 1, "SM120 forward only supports num_splits=1"
-    elif num_splits < 1:
-        num_SMs = get_num_sms_for_selection(device.index, arch)
-        num_splits = num_splits_heuristic(total_mblocks, num_SMs, num_n_blocks, 128)
-
-    # SplitKV uses float32 partial output, which doubles the O buffer size
-    # in shared memory, causing OOM for diff-headdim (192, 128)
-    if arch // 10 in [10, 11] and head_dim != head_dim_v and num_splits > 1:
-        if num_n_blocks >= 64 and head_dim_v != 512:
-            tile_n = 64
-            num_n_blocks = (seqlen_k_loaded + tile_n - 1) // tile_n
-            if num_SMs is None:
-                num_SMs = get_num_sms_for_selection(device.index, arch)
-            num_splits = num_splits_heuristic(total_mblocks, num_SMs, num_n_blocks, 128)
-        else:
-            num_splits = 1
-
-    return FwdConfig(tile_m, tile_n, mma_pv_is_rs, intra_wg_overlap, q_stage, num_splits)
 
 
 def _resolve_causal_local_window(causal, window_size_left, window_size_right, mask_mod=None):
@@ -559,8 +414,12 @@ def _flash_attn_fwd(
     scheduler_metadata: Optional[SchedulerMetadataTensorsTorch] = None,
     seqlen_k_per_split: Optional[int] = None,
     disable_scheduler_metadata: bool = False,
+    *,
+    out_partial: Optional[torch.Tensor] = None,
+    lse_partial: Optional[torch.Tensor] = None,
+    config: FwdConfig | None = None,
 ) -> Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor]]:
-    """Forward pass for FlashAttention.
+    """Execute FlashAttention with an optional explicit forward config.
 
     Args:
         ...
@@ -571,8 +430,12 @@ def _flash_attn_fwd(
             The returned LSE supports taking gradient.
         out: Optional pre-allocated output tensor. If None, will be allocated internally.
         lse: Optional pre-allocated log-sum-exp tensor. If None, will be allocated when needed.
+        out_partial: Optional float32 SplitKV output workspace matching the resolved split count.
+        lse_partial: Optional float32 SplitKV LSE workspace matching the resolved split count.
+            Reuse across calls requires an explicit config with a fixed num_splits.
         aux_tensors: Some score_mods will want to read from global aux_tensors. This is how we thread them through to the inner kernel.
         aux_scalars: Runtime scalar captures used by score_mod or mask_mod.
+        config: Fully resolved forward configuration, or None to select the default.
     """
     aux_scalars = tuple(aux_scalars) if aux_scalars else None
     requires_grad = any(
@@ -600,7 +463,6 @@ def _flash_attn_fwd(
     if page_table is not None:
         assert cu_seqlens_k is None, "page_table is not supported with cu_seqlens_k"
         assert page_table.dtype == torch.int32, "page_table must be int32"
-        assert page_table.stride(-1) == 1, "page_table must be contiguous in the last dimension"
         max_num_pages_per_seq = page_table.shape[1]
         assert page_table.shape == (batch_size, max_num_pages_per_seq)
         num_pages, page_size = v.shape[:2]
@@ -643,6 +505,7 @@ def _flash_attn_fwd(
     )
 
     q_dtype = q.dtype if q is not None else qv.dtype
+    has_lse = lse is not None or return_lse or requires_grad
 
     for t in [cu_seqlens_q, cu_seqlens_k, seqused_q, seqused_k]:
         if t is not None:
@@ -693,6 +556,76 @@ def _flash_attn_fwd(
     qhead_per_kvhead = num_head // num_head_kv
     if pack_gqa is None:
         pack_gqa = qhead_per_kvhead > 1
+    use_block_sparsity = block_sparse_tensors is not None
+    if use_block_sparsity:
+        # NB: pack_gqa requires block sparse head dim == 1 (broadcasted)
+        head_dim_idx = 0 if block_sparse_tensors.mask_block_cnt.ndim == 2 else 1
+        if pack_gqa and block_sparse_tensors.mask_block_cnt.shape[head_dim_idx] != 1:
+            pack_gqa = False
+    causal, local, window_size_left, window_size_right = _resolve_causal_local_window(
+        causal, window_size_left, window_size_right, mask_mod
+    )
+    if max_seqlen_q is None:
+        max_seqlen_q = seqlen_q if cu_seqlens_q is None else total_q
+    if max_seqlen_k is None:
+        max_seqlen_k = seqlen_k
+    requested_num_splits = None if num_splits < 1 else num_splits
+    heuristic_inputs = FwdHeuristicInputs(
+        device_arch=arch,
+        num_sms=(
+            get_num_sms_for_selection(v.device.index, arch)
+            if requested_num_splits is None
+            else 0
+        ),
+        dtype=str(q_dtype),
+        head_dim=head_dim,
+        head_dim_v=head_dim_v,
+        num_heads=num_head,
+        num_heads_kv=num_head_kv,
+        batch_size=batch_size,
+        total_q=total_q,
+        total_k=(
+            seqlen_k
+            if cu_seqlens_k is not None or page_table is not None
+            else batch_size * seqlen_k
+        ),
+        max_seqlen_q=total_q if torch.is_tensor(max_seqlen_q) else max_seqlen_q,
+        max_seqlen_k=seqlen_k if torch.is_tensor(max_seqlen_k) else max_seqlen_k,
+        seqlen_k_per_split=seqlen_k_per_split,
+        causal=causal,
+        local=local,
+        window_size_left=window_size_left,
+        window_size_right=window_size_right,
+        is_varlen_q=cu_seqlens_q is not None or seqused_q is not None,
+        has_cu_seqlens_q=cu_seqlens_q is not None,
+        has_cu_seqlens_k=cu_seqlens_k is not None,
+        has_seqused=seqused_q is not None or seqused_k is not None,
+        pack_gqa=pack_gqa,
+        page_size=page_size,
+        use_block_sparsity=use_block_sparsity,
+        sparse_q_block_size=(
+            get_sparse_q_block_size(block_sparse_tensors, seqlen_q)
+            if arch // 10 == 9
+            else None
+        ),
+        has_qv=qv is not None,
+        has_gather_kv=gather_kv_indices is not None,
+        has_score_mod=score_mod is not None or softcap is not None,
+        has_mask_mod=mask_mod is not None,
+        has_learnable_sink=learnable_sink is not None,
+        has_lse=has_lse,
+        requested_tile_m=None if tile_mn is None else tile_mn[0],
+        requested_tile_n=None if tile_mn is None else tile_mn[1],
+        requested_mma_pv_is_rs=mma_pv_is_rs,
+        requested_intra_wg_overlap=intra_wg_overlap,
+        requested_num_splits=requested_num_splits,
+        requested_use_clc_scheduler=utils._get_use_clc_scheduler_default(),
+        disable_2cta=utils._get_disable_2cta_default(is_fwd=True),
+    )
+    if config is None:
+        config = select_fwd_config(heuristic_inputs)
+    else:
+        validate_fwd_config(config, heuristic_inputs)
 
     is_fp8 = v.dtype in (torch.float8_e4m3fn, torch.float8_e5m2)
     if is_fp8 and requires_grad:
@@ -724,7 +657,7 @@ def _flash_attn_fwd(
     if lse is None:
         lse = (
             torch.empty(lse_shape, dtype=torch.float32, device=device)
-            if requires_grad or return_lse
+            if has_lse
             else None
         )
     elif lse is not None:
@@ -763,81 +696,61 @@ def _flash_attn_fwd(
     dtype = torch2cute_dtype_map[q_dtype]
     if is_fp8:
         assert arch // 10 == 10, "FP8 is only supported on SM100 (compute capability 10.x) for FA4 CuTe."
-    use_block_sparsity = block_sparse_tensors is not None
 
-    causal, local, window_size_left, window_size_right = _resolve_causal_local_window(
-        causal, window_size_left, window_size_right, mask_mod
-    )
-
-    requested_use_clc_scheduler = utils._get_use_clc_scheduler_default()
-    requested_disable_2cta = utils._get_disable_2cta_default(is_fwd=True)
-
-    # SM80/SM120: uses SM80 MMA, 128 threads (4 warps)
-    if arch // 10 in [8, 12]:
-        num_threads = 128
-
-    if max_seqlen_q is None:
-        max_seqlen_q = seqlen_q if cu_seqlens_q is None else total_q
-    if max_seqlen_k is None:
-        max_seqlen_k = seqlen_k
     if cu_seqlens_k is None and seqused_k is None:
         min_seqlen_k = seqlen_k
 
-    fwd_cfg = _get_fwd_config(
-        arch=arch,
-        head_dim=head_dim,
-        head_dim_v=head_dim_v,
-        causal=causal,
-        local=local,
-        window_size_left=window_size_left,
-        window_size_right=window_size_right,
-        max_seqlen_q=max_seqlen_q,
-        max_seqlen_k=max_seqlen_k,
-        qhead_per_kvhead=qhead_per_kvhead,
-        pack_gqa=pack_gqa,
-        batch_size=batch_size,
-        num_head_kv=num_head_kv,
-        num_splits=num_splits,
-        device=device,
-        seqlen_q=seqlen_q,
-        tile_mn=tile_mn,
-        block_sparse_tensors=block_sparse_tensors,
-        mma_pv_is_rs=mma_pv_is_rs,
-        intra_wg_overlap=intra_wg_overlap,
-    )
-    tile_m, tile_n = fwd_cfg.m_block_size, fwd_cfg.n_block_size
-    q_stage = fwd_cfg.q_stage
-    num_splits = fwd_cfg.num_splits
-    mma_pv_is_rs = fwd_cfg.mma_pv_is_rs
-    intra_wg_overlap = fwd_cfg.intra_wg_overlap
-
-    seqlen_q_packgqa = max_seqlen_q * (qhead_per_kvhead if pack_gqa else 1)
-    max_m_blocks_leq_one = seqlen_q_packgqa <= q_stage * tile_m
+    tile_m, tile_n = config.tile_m, config.tile_n
+    num_stages = config.num_stages
+    num_threads = config.num_threads
+    mma_pv_is_rs = config.mma_pv_is_rs
+    intra_wg_overlap = config.intra_wg_overlap
+    q_stage = config.q_stage
+    num_splits = config.num_splits
+    use_2cta_instrs = config.use_2cta_instrs
+    use_clc_scheduler = config.use_clc_scheduler
+    is_static_persistent = config.is_static_persistent
+    use_tma_o = config.use_tma_o
 
     is_split_kv = num_splits > 1
     if is_split_kv:
-        out_partial = torch.empty(num_splits, *q_batch_seqlen_shape, num_head, head_dim_v, dtype=torch.float32, device=device)
-        lse_partial = torch.empty(num_splits, *lse_shape, dtype=torch.float32, device=device)
+        out_partial_shape = (
+            num_splits,
+            *q_batch_seqlen_shape,
+            num_head,
+            head_dim_v,
+        )
+        lse_partial_shape = (num_splits, *lse_shape)
+        if out_partial is None:
+            out_partial = torch.empty(
+                out_partial_shape, dtype=torch.float32, device=device
+            )
+        else:
+            _validate_tensor(
+                out_partial,
+                "out_partial",
+                out_partial_shape,
+                torch.float32,
+                device,
+            )
+            validate_output_layout(out_partial, "out_partial", align_bytes=16)
+        if lse_partial is None:
+            lse_partial = torch.empty(
+                lse_partial_shape, dtype=torch.float32, device=device
+            )
+        else:
+            _validate_tensor(
+                lse_partial,
+                "lse_partial",
+                lse_partial_shape,
+                torch.float32,
+                device,
+            )
+            validate_output_layout(lse_partial, "lse_partial", align_bytes=4)
+    elif out_partial is not None or lse_partial is not None:
+        raise ValueError("SplitKV workspaces require config.num_splits > 1")
 
-    use_2cta_instrs = (
-        arch // 10 in [10, 11]
-        and not requested_disable_2cta
-        and not causal
-        and not local
-        and not is_split_kv
-        and cu_seqlens_q is None
-        and seqused_q is None
-        and not use_block_sparsity
-        and page_size in [None, 128]
-        and int(math.ceil(head_dim / 16) * 16) in [128, 192]
-        and int(math.ceil(head_dim_v / 16) * 16) == 128
-        and seqlen_q_packgqa > 2 * tile_m
-        and (tile_m % qhead_per_kvhead == 0 or not pack_gqa)
-    )
-
-    # hd=256 2CTA forward uses dedicated kernel (Blackwell family)
-    use_dedicated_hd256_kernel = arch // 10 in [10, 11] and head_dim == 256 and head_dim_v == 256
-    use_2cta_instrs = use_2cta_instrs or use_dedicated_hd256_kernel
+    use_dedicated_hd256_kernel = uses_dedicated_hd256_kernel(heuristic_inputs)
 
     if softcap is not None:
         assert score_mod is None, "softcap and score_mod cannot be used together"
@@ -850,25 +763,7 @@ def _flash_attn_fwd(
     score_mod_hash = utils.hash_callable(score_mod) if score_mod is not None else False
     mask_mod_hash = utils.hash_callable(mask_mod) if mask_mod is not None else False
 
-    is_varlen = (
-        cu_seqlens_q is not None
-        or cu_seqlens_k is not None
-        or seqused_q is not None
-        or seqused_k is not None
-    )
-
-    # CLC regressed for varlen MHA and dense noncausal. Imbalanced varlen shapes
-    # keep more K/V blocks in flight and hurt L2; dense noncausal mostly just
-    # pays work-stealing overhead.
-    is_varlen_mha = is_varlen and qhead_per_kvhead == 1
-    is_dense_noncausal = not is_varlen and not causal and not local
-    use_clc_scheduler = requested_use_clc_scheduler and not is_varlen_mha and not is_dense_noncausal
-
     if use_block_sparsity:
-        # NB: pack_gqa requires block sparse head dim == 1 (broadcasted)
-        head_dim_idx = 0 if block_sparse_tensors.mask_block_cnt.ndim == 2 else 1
-        if pack_gqa and block_sparse_tensors.mask_block_cnt.shape[head_dim_idx] != 1:
-            pack_gqa = False
         if cu_seqlens_q is not None:
             assert block_sparse_tensors.cu_total_m_blocks is not None, (
                 "Varlen block sparsity requires block_sparse_tensors.cu_total_m_blocks."
@@ -908,6 +803,22 @@ def _flash_attn_fwd(
         aux_tensor_metadata = None
     aux_scalar_metadata = tuple(type(s) for s in aux_scalars) if aux_scalars is not None else None
 
+    # CuTe keeps stride-zero modes static when marking layouts dynamic.
+    tensor_broadcast_patterns = tuple(
+        get_broadcast_dims(tensor) if tensor is not None else None
+        for tensor in (
+            q,
+            k,
+            v,
+            qv,
+            page_table,
+            q_descale,
+            k_descale,
+            v_descale,
+            gather_kv_indices,
+        )
+    )
+
     if qv is not None:
         assert arch // 10 in [10, 11], "only support Blackwell arch with qv"
         assert q is None or qv.shape[:-1] == q.shape[:-1]
@@ -937,6 +848,7 @@ def _flash_attn_fwd(
         disable_sparse_kv_bitmask = False
         if sparse_kv:
             assert gather_kv_indices.shape[:-1] == qv.shape[:-2]
+            assert gather_kv_indices.dtype == torch.int32
             gather_kv_length = gather_kv_indices.shape[-1]
             assert gather_kv_length % 128 == 0
             # if min_seqlen_k is None or causal:
@@ -961,6 +873,10 @@ def _flash_attn_fwd(
         sparse_kv = None
         disable_sparse_kv_bitmask = None
         p = row_max = None
+
+    if use_dedicated_hd256_kernel:
+        # pack_gqa is an auto-selected optimization; disable it for hd256 kernel
+        pack_gqa = False
 
 
     reuse_scheduler_metadata = scheduler_metadata is not None
@@ -1070,20 +986,6 @@ def _flash_attn_fwd(
             cu_total_m_blocks.device,
         )
 
-    # Tensor max_seqlen values (e.g. HF varlen) must not leak into the compile key:
-    # tensor identity changes on every call and defeats the JIT cache.
-    is_static_persistent = (
-        not causal
-        and not local
-        and cu_seqlens_q is None
-        and seqused_q is None
-        and not is_split_kv
-    ) or (
-        not torch.is_tensor(max_m_blocks_leq_one)
-        and max_m_blocks_leq_one
-        and not is_split_kv
-    )
-
     # CuTe keeps stride-zero modes static when marking layouts dynamic.
     tensor_broadcast_patterns = tuple(
         get_broadcast_dims(tensor) if tensor is not None else None
@@ -1100,71 +1002,76 @@ def _flash_attn_fwd(
         )
     )
 
-    compile_key = (
-        dtype,
-        head_dim,
-        head_dim_v,
-        qhead_per_kvhead,
-        causal,
-        score_mod_hash,
-        mask_mod_hash,
-        use_block_sparsity,
-        block_sparse_broadcast_pattern,
-        tensor_broadcast_patterns,
-        aux_tensor_metadata,
-        aux_scalar_metadata,
-        lse is None,
-        cu_seqlens_q is None,
-        cu_seqlens_k is None,
-        seqused_q is None,
-        seqused_k is None,
-        page_table is not None,
-        window_size_left is not None,
-        window_size_right is not None,
-        (
+    kernel_family = (
+        "mla_sm100"
+        if qv is not None
+        else "sm100_hd256"
+        if use_dedicated_hd256_kernel
+        else f"sm{arch // 10}"
+    )
+    main_spec = FwdMainKernelSpec.from_config(
+        config,
+        kernel_family=kernel_family,
+        arch=arch,
+        pack_gqa=pack_gqa,
+        page_size=page_size,
+        q_subtile_factor=q_subtile_factor,
+        kv_subtile_factor=kv_subtile_factor,
+        dtype=dtype,
+        head_dim=head_dim,
+        head_dim_v=head_dim_v,
+        qhead_per_kvhead=qhead_per_kvhead,
+        num_heads_kv=num_head_kv if kernel_family == "mla_sm100" else None,
+        causal=causal,
+        score_mod_hash=score_mod_hash,
+        mask_mod_hash=mask_mod_hash,
+        use_block_sparsity=use_block_sparsity,
+        block_sparse_broadcast_pattern=block_sparse_broadcast_pattern,
+        tensor_broadcast_patterns=tensor_broadcast_patterns,
+        aux_tensor_metadata=aux_tensor_metadata,
+        aux_scalar_metadata=aux_scalar_metadata,
+        has_lse=is_split_kv or lse is not None,
+        has_cu_seqlens_q=cu_seqlens_q is not None,
+        has_cu_seqlens_k=cu_seqlens_k is not None,
+        has_seqused_q=seqused_q is not None,
+        has_seqused_k=seqused_k is not None,
+        has_page_table=page_table is not None,
+        has_window_size_left=window_size_left is not None,
+        has_window_size_right=window_size_right is not None,
+        learnable_sink_dtype=(
             torch2cute_dtype_map[learnable_sink.dtype]
             if learnable_sink is not None
             else None
         ),
-        q_descale is not None,
-        k_descale is not None,
-        v_descale is not None,
-        block_sparse_tensors is None or block_sparse_tensors.cu_total_m_blocks is None,
-        block_sparse_tensors is None or block_sparse_tensors.cu_block_idx_offsets is None,
-        tile_m,
-        tile_n,
-        q_stage,
-        num_threads,
-        is_split_kv,
-        pack_gqa,
-        arch,
-        page_size not in [None, tile_n],  # paged KV non-TMA
-        use_2cta_instrs,
-        q_subtile_factor,
-        kv_subtile_factor,
-        mma_pv_is_rs,
-        intra_wg_overlap,
-        use_clc_scheduler,
-        num_splits_dynamic is not None,
-        virtual_batch_idx is not None,
-        num_nheads_in_l2 is not None,
-        tile_count_semaphore is not None,
-        cu_total_m_blocks is not None,
-        cu_total_splits_m_blocks is not None,
-        blocks_to_batch_idx is not None,
-        seqlen_k_per_split,
-        is_static_persistent,
-        q is not None,
-        qv is not None,
-        p is not None,
-        row_max is not None,
-        gather_kv_length,
-        sparse_kv,
-        disable_sparse_kv_bitmask,
-        fa_logging.get_fa_log_level(),
+        has_q_descale=q_descale is not None,
+        has_k_descale=k_descale is not None,
+        has_v_descale=v_descale is not None,
+        has_cu_total_m_blocks=(
+            block_sparse_tensors is not None
+            and block_sparse_tensors.cu_total_m_blocks is not None
+        ),
+        has_cu_block_idx_offsets=(
+            block_sparse_tensors is not None
+            and block_sparse_tensors.cu_block_idx_offsets is not None
+        ),
+        has_q=q is not None,
+        has_p=p is not None,
+        has_row_max=row_max is not None,
+        gather_kv_length=gather_kv_length,
+        sparse_kv=sparse_kv,
+        disable_sparse_kv_bitmask=disable_sparse_kv_bitmask,
+        has_num_splits_dynamic=num_splits_dynamic is not None,
+        has_virtual_batch_idx=virtual_batch_idx is not None,
+        has_num_nheads_in_l2=num_nheads_in_l2 is not None,
+        has_tile_count_semaphore=tile_count_semaphore is not None,
+        has_scheduler_cu_total_m_blocks=cu_total_m_blocks is not None,
+        has_scheduler_cu_total_splits_m_blocks=cu_total_splits_m_blocks is not None,
+        has_blocks_to_batch_idx=blocks_to_batch_idx is not None,
+        seqlen_k_per_split=seqlen_k_per_split,
+        log_level=fa_logging.get_fa_log_level(),
     )
 
-    if compile_key not in _flash_attn_fwd.compile_cache:
+    if main_spec not in _flash_attn_fwd.compile_cache:
         current_stream = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
         (
             cu_seqlens_q_tensor,
@@ -1255,7 +1162,7 @@ def _flash_attn_fwd(
                 pack_gqa=pack_gqa,
                 tile_m=tile_m,
                 tile_n=tile_n,
-                num_stages=1,
+                num_stages=num_stages,
                 num_threads=num_threads,
                 Q_in_regs=False,
                 score_mod=score_mod,
@@ -1274,8 +1181,7 @@ def _flash_attn_fwd(
                 pack_gqa=pack_gqa,
                 tile_m=tile_m,
                 tile_n=tile_n,
-                # num_stages=1,
-                num_stages=2,
+                num_stages=num_stages,
                 num_threads=num_threads,
                 Q_in_regs=False,
                 intra_wg_overlap=intra_wg_overlap,
@@ -1285,6 +1191,7 @@ def _flash_attn_fwd(
                 has_aux_tensors=aux_tensors is not None,
                 q_subtile_factor=q_subtile_factor,
                 paged_kv_non_tma=page_size not in [None, tile_n],
+                registers=config.registers,
             )
         elif arch // 10 in [10, 11]:
             if qv is not None:
@@ -1325,9 +1232,6 @@ def _flash_attn_fwd(
                             f"pass page_table[:, :{max_seqlen_k // page_size}] to slice to "
                             f"the actual sequence length"
                         )
-                    # pack_gqa is an auto-selected optimization; disable it for hd256 kernel
-                    pack_gqa = False
-
                 flash_fwd_obj_cls = (
                     BlackwellFusedMultiHeadAttentionForward
                     if use_dedicated_hd256_kernel
@@ -1354,6 +1258,8 @@ def _flash_attn_fwd(
                     use_2cta_instrs=use_2cta_instrs,
                     use_clc_scheduler=use_clc_scheduler,
                     seqlen_k_per_split=seqlen_k_per_split,
+                    use_tma_o=use_tma_o,
+                    registers=config.registers,
                 )
                 if not use_dedicated_hd256_kernel:
                     fa_fwd_kwargs["has_tile_count_semaphore"] = tile_count_semaphore is not None
@@ -1373,7 +1279,7 @@ def _flash_attn_fwd(
                 pack_gqa=pack_gqa,
                 tile_m=tile_m,
                 tile_n=tile_n,
-                num_stages=1,
+                num_stages=num_stages,
                 num_threads=num_threads,
                 Q_in_regs=False,
                 score_mod=score_mod,
@@ -1386,7 +1292,7 @@ def _flash_attn_fwd(
             )
         # TODO: check @can_implement
         if qv is not None:
-            _flash_attn_fwd.compile_cache[compile_key] = cute.compile(
+            _flash_attn_fwd.compile_cache[main_spec] = cute.compile(
                 fa_fwd,
                 q_tensor,
                 qv_tensor,
@@ -1449,7 +1355,9 @@ def _flash_attn_fwd(
                     cu_total_splits_m_blocks_tensor,
                 ])
             compile_args.append(current_stream)
-            _flash_attn_fwd.compile_cache[compile_key] = cute.compile(*compile_args, options="--enable-tvm-ffi")
+            _flash_attn_fwd.compile_cache[main_spec] = cute.compile(
+                *compile_args, options="--enable-tvm-ffi"
+            )
 
     if not fake_mode:
         q_call, k_call, v_call, qv_call = [
@@ -1468,7 +1376,7 @@ def _flash_attn_fwd(
             else None
         )
         if qv is not None:
-            _flash_attn_fwd.compile_cache[compile_key](
+            _flash_attn_fwd.compile_cache[main_spec](
                 q_call,
                 qv_call,
                 k_call,
@@ -1537,7 +1445,7 @@ def _flash_attn_fwd(
                     cu_total_m_blocks,
                     cu_total_splits_m_blocks,
                 ])
-            _flash_attn_fwd.compile_cache[compile_key](*call_args)
+            _flash_attn_fwd.compile_cache[main_spec](*call_args)
     if is_split_kv:
         _flash_attn_fwd_combine(
             out_partial,
@@ -3524,12 +3432,20 @@ def flash_attn_varlen_func(
     )
 
 
-def _compile_fwd_combine(
-    _arch, dtype, dtype_partial, head_dim, num_head, tile_m, k_block_size, log_max_splits,
-    has_cu_seqlens, has_seqused, has_lse, has_virtual_batch_idx,
-    has_num_splits_dynamic, has_semaphore_to_reset,
-):
-    """Compile fwd combine kernel using cute fake tensors (no real GPU tensors needed)."""
+def _compile_fwd_combine(spec: FwdCombineKernelSpec):
+    """Compile one combine specialization using symbolic fake tensors."""
+    dtype = spec.dtype
+    dtype_partial = spec.dtype_partial
+    head_dim = spec.head_dim
+    num_head = spec.num_head
+    tile_m, k_block_size = fwd_combine_tile(head_dim)
+    log_max_splits = spec.log_max_splits
+    has_cu_seqlens = spec.has_cu_seqlens
+    has_seqused = spec.has_seqused
+    has_lse = spec.has_lse
+    has_num_splits_dynamic = spec.has_num_splits_dynamic_ptr
+    has_virtual_batch_idx = spec.has_virtual_batch_idx
+    has_semaphore_to_reset = spec.has_semaphore_to_reset
     sym = cute.sym_int
     div = 128 // dtype_partial.width  # 16-byte alignment in elements
 
@@ -3608,7 +3524,7 @@ def _flash_attn_fwd_combine(
                                        (num_splits, total_q, nheads) if there's cu_seqlens
         out: Output tensor (batch, seqlen, nheads, headdim) or (total_q, nheads, headdim) if there's cu_seqlens
         lse: Output LSE tensor (batch, seqlen, nheads) or (total_q, nheads) if there's cu_seqlens.
-        cu_seqlens: Cumulative sequence lengths for variable length sequences
+        cu_seqlens: Cumulative sequence lengths, required for rank-4 packed inputs
         seqused: Used sequence lengths for each batch
         num_splits_dynamic_ptr: Dynamic number of splits per batch
         semaphore_to_reset: Semaphore for synchronization
@@ -3638,43 +3554,29 @@ def _flash_attn_fwd_combine(
     num_head = out_partial.shape[-2]
     num_splits = out_partial.shape[0]
     assert num_splits <= 256
-    # If hdim is 96 or 192, it's faster to round them to 128 or 256 respectively
-    # so that kBlockM is smaller and we have more parallelism.
-    k_block_size = 64 if head_dim <= 64 else 128
-    # We want kBlockM to be as small as possible to maximize parallelism.
-    # E.g., if hdim is 64, we want kBlockM to be 16 so that we can use 256 threads, each reading 4 elements (floats).
-    tile_m = 8 if k_block_size % 128 == 0 else (16 if k_block_size % 64 == 0 else 32)
-    log_max_splits = max(math.ceil(math.log2(num_splits)), 4)
-    if tile_m == 8:
-        # If kBlockM == 8 then the minimum number of splits is 32.
-        # TODO: we can deal w this by using 128 threads instead
-        log_max_splits = max(log_max_splits, 5)
+    tile_m, k_block_size = fwd_combine_tile(head_dim)
+    log_max_splits = combine_log_max_splits(num_splits, tile_m)
 
-    # Create combine kernel configuration
-    dtype = torch2cute_dtype_map[out.dtype]
-    dtype_partial = torch2cute_dtype_map[out_partial.dtype]
-    compile_key = (
-        _get_device_arch() if _arch is None else _arch,
-        dtype,
-        dtype_partial,
-        head_dim,
-        num_head,
-        tile_m,
-        k_block_size,
-        log_max_splits,
-        cu_seqlens is not None,
-        seqused is not None,
-        lse is not None,
-        virtual_batch_idx is not None,
-        num_splits_dynamic_ptr is not None,
-        semaphore_to_reset is not None,
+    combine_spec = FwdCombineKernelSpec(
+        arch=_get_device_arch() if _arch is None else _arch,
+        dtype=torch2cute_dtype_map[out.dtype],
+        dtype_partial=torch2cute_dtype_map[out_partial.dtype],
+        head_dim=head_dim,
+        num_head=num_head,
+        log_max_splits=log_max_splits,
+        has_cu_seqlens=cu_seqlens is not None,
+        has_seqused=seqused is not None,
+        has_lse=lse is not None,
+        has_num_splits_dynamic_ptr=num_splits_dynamic_ptr is not None,
+        has_virtual_batch_idx=virtual_batch_idx is not None,
+        has_semaphore_to_reset=semaphore_to_reset is not None,
     )
-    if compile_key not in _flash_attn_fwd_combine.compile_cache:
-        _flash_attn_fwd_combine.compile_cache[compile_key] = _compile_fwd_combine(
-            *compile_key
+    if combine_spec not in _flash_attn_fwd_combine.compile_cache:
+        _flash_attn_fwd_combine.compile_cache[combine_spec] = _compile_fwd_combine(
+            combine_spec
         )
     if not fake_mode:
-        _flash_attn_fwd_combine.compile_cache[compile_key](
+        _flash_attn_fwd_combine.compile_cache[combine_spec](
             out_partial, lse_partial, out, lse,
             cu_seqlens, seqused, num_splits_dynamic_ptr, virtual_batch_idx,
             semaphore_to_reset,
@@ -3709,7 +3611,7 @@ def flash_attn_combine(
             - (num_splits, total_q, num_heads) for variable length input
         out: Optional output tensor. If None, will be created automatically.
         out_dtype: Optional output dtype. If None, will use fp16/bf16 based on input.
-        cu_seqlens: Cumulative sequence lengths for variable length sequences
+        cu_seqlens: Cumulative sequence lengths, required for rank-4 packed inputs
         seqused: Used sequence lengths for each batch
         virtual_batch_idx: Optional mapping from virtual batch index to real batch index
             (int32 tensor of shape (batch_size,)). Used by persistent tile schedulers
@@ -4093,26 +3995,56 @@ def get_scheduler_metadata(
     if pack_gqa is None:
         pack_gqa = qhead_per_kvhead > 1
 
-    fwd_cfg = _get_fwd_config(
-        arch=arch,
-        head_dim=headdim,
-        head_dim_v=headdim_v,
-        causal=causal,
-        local=local,
-        window_size_left=window_size_left,
-        window_size_right=window_size_right,
-        max_seqlen_q=max_seqlen_q,
-        max_seqlen_k=max_seqlen_k,
-        qhead_per_kvhead=qhead_per_kvhead,
-        pack_gqa=pack_gqa,
-        batch_size=num_batch,
-        num_head_kv=nheads_kv,
-        num_splits=num_splits,
-        device=device,
+    requested_num_splits = None if num_splits < 1 else num_splits
+    config = select_fwd_config(
+        FwdHeuristicInputs(
+            device_arch=arch,
+            num_sms=(
+                get_num_sms_for_selection(device.index, arch)
+                if requested_num_splits is None
+                else 0
+            ),
+            dtype="torch.bfloat16",
+            head_dim=headdim,
+            head_dim_v=headdim_v,
+            num_heads=nheads,
+            num_heads_kv=nheads_kv,
+            batch_size=num_batch,
+            total_q=num_batch * max_seqlen_q,
+            total_k=num_batch * max_seqlen_k,
+            max_seqlen_q=max_seqlen_q,
+            max_seqlen_k=max_seqlen_k + seqlen_k_new,
+            seqlen_k_per_split=seqlen_k_per_split,
+            causal=causal,
+            local=local,
+            window_size_left=window_size_left,
+            window_size_right=window_size_right,
+            is_varlen_q=cu_seqlens_q is not None or seqused_q is not None,
+            has_cu_seqlens_q=cu_seqlens_q is not None,
+            has_cu_seqlens_k=cu_seqlens_k is not None,
+            has_seqused=seqused_q is not None or seqused_k is not None,
+            pack_gqa=pack_gqa,
+            page_size=None,
+            use_block_sparsity=False,
+            sparse_q_block_size=None,
+            has_qv=False,
+            has_gather_kv=False,
+            has_score_mod=False,
+            has_mask_mod=False,
+            has_learnable_sink=False,
+            has_lse=False,
+            requested_tile_m=None,
+            requested_tile_n=None,
+            requested_mma_pv_is_rs=None,
+            requested_intra_wg_overlap=None,
+            requested_num_splits=requested_num_splits,
+            requested_use_clc_scheduler=utils._get_use_clc_scheduler_default(),
+            disable_2cta=utils._get_disable_2cta_default(is_fwd=True),
+        )
     )
-    tile_m, tile_n = fwd_cfg.m_block_size, fwd_cfg.n_block_size
-    q_stage = fwd_cfg.q_stage
-    num_splits = fwd_cfg.num_splits
+    tile_m, tile_n = config.tile_m, config.tile_n
+    q_stage = config.q_stage
+    num_splits = config.num_splits
 
     return _get_scheduler_metadata(
         num_batch,

--- a/flash_attn/cute/sm100_hd256_2cta_fmha_forward.py
+++ b/flash_attn/cute/sm100_hd256_2cta_fmha_forward.py
@@ -14,6 +14,7 @@ import cutlass.utils.blackwell_helpers as sm100_utils
 from cutlass.cute.typing import Int32, Int64, Float32
 
 from cutlass.utils import ClcDynamicPersistentTileScheduler
+from flash_attn.cute.config import FwdSm100RegisterAllocation
 from flash_attn.cute.tile_scheduler import (
     SchedulerState,
     compute_sm100_fmha_grid as compute_grid,
@@ -28,7 +29,7 @@ from flash_attn.cute.mask import (
     Sm100FusedMask as FusedMask,
 )
 from flash_attn.cute.tile_scheduler import SM100_TMEM_CAPACITY_COLUMNS
-from flash_attn.cute.flash_fwd_sm100 import DescaleTensors, _TUNING_CONFIG
+from flash_attn.cute.flash_fwd_sm100 import DescaleTensors, _EX2_CONFIG
 from flash_attn.cute.utils import ex2_emulation_2, as_bshkrd_tensor, AuxData
 
 
@@ -57,6 +58,9 @@ class BlackwellFusedMultiHeadAttentionForward:
         use_clc_scheduler: bool = False,
         has_tile_count_semaphore: bool = False,
         seqlen_k_per_split: Optional[int] = None,
+        *,
+        use_tma_o: bool,
+        registers: FwdSm100RegisterAllocation,
     ):
         head_dim_v = head_dim if head_dim_v is None else head_dim_v
         assert head_dim == 256 and head_dim_v == 256, (
@@ -68,6 +72,7 @@ class BlackwellFusedMultiHeadAttentionForward:
         assert not paged_kv_non_tma, (
             "SM100 hd256 2CTA supports TMA paged KV only (page_size must equal tile_n=128)"
         )
+        assert not use_tma_o, "SM100 head_dim=256 uses its fixed output path"
         assert not pack_gqa, "SM100 forward with head_dim=256 does not support pack_gqa"
         assert not is_split_kv, "SM100 forward with head_dim=256 does not support SplitKV"
         assert q_subtile_factor == 1, (
@@ -146,14 +151,14 @@ class BlackwellFusedMultiHeadAttentionForward:
         self.tmem_o_offset = 256
         self.tmem_p_offset = self.tmem_s_offset
 
-        _tune_key = (True, is_causal, 256, False)  # hd256: always 2cta, no sm103 variant
-        _tune = _TUNING_CONFIG.get(_tune_key, {})
-        self.num_regs_softmax = _tune.get("num_regs_softmax", 256)
-        self.num_regs_correction = _tune.get("num_regs_correction", 160)
-        self.num_regs_other = 32  # fixed for hd256; not derived from 512 budget like other kernels
-        self.ex2_emu_freq = _tune.get("ex2_emu_freq", 4)
-        self.ex2_emu_res = _tune.get("ex2_emu_res", 3)
-        self.ex2_emu_start_frg = _tune.get("ex2_emu_start_frg", 0)
+        ex2_key = (True, is_causal, 256, False)  # hd256: always 2cta, no sm103 variant
+        ex2_config = _EX2_CONFIG.get(ex2_key, {})
+        self.num_regs_softmax = registers.softmax
+        self.num_regs_correction = registers.correction
+        self.num_regs_other = registers.other
+        self.ex2_emu_freq = ex2_config.get("ex2_emu_freq", 4)
+        self.ex2_emu_res = ex2_config.get("ex2_emu_res", 3)
+        self.ex2_emu_start_frg = ex2_config.get("ex2_emu_start_frg", 0)
 
         self.buffer_align_bytes = 1024
 

--- a/tests/cute/benchmark_mask_mod.py
+++ b/tests/cute/benchmark_mask_mod.py
@@ -14,6 +14,7 @@ from cutlass.cute.runtime import from_dlpack
 import numpy as np
 import torch
 
+from flash_attn.cute.config import FwdSm90RegisterAllocation
 from flash_attn.cute.flash_fwd_sm90 import FlashAttentionForwardSm90
 from mask_mod_definitions import (
     get_mask_pair,
@@ -24,6 +25,9 @@ from flash_attn.cute.block_sparsity import (
     to_cute_block_sparse_tensors,
 )
 from flash_attn.cute.compute_block_sparsity import compute_block_sparsity
+
+
+_DEFAULT_REGISTERS = FwdSm90RegisterAllocation(240, 24)
 
 
 @dataclass
@@ -72,6 +76,7 @@ class BenchmarkConfig:
     num_threads: int = 384
     intra_wg_overlap: bool = True
     mma_pv_is_rs: bool = True
+    registers: FwdSm90RegisterAllocation = _DEFAULT_REGISTERS
 
     # Benchmark parameters
     warmup_iters: int = 10
@@ -332,6 +337,7 @@ class FlashAttentionBenchmark:
             mask_mod=self.mask_mod_cute,
             Q_in_regs=False,
             has_aux_tensors=config.has_aux_tensors,
+            registers=config.registers,
         )
 
         softmax_scale = 1.0 / math.sqrt(config.headdim)

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -6,7 +6,9 @@ import os
 import random
 import re
 import gc
+from dataclasses import replace
 from functools import wraps
+from unittest import mock
 
 import pytest
 import torch
@@ -19,6 +21,11 @@ except ImportError:
     apply_rotary_emb = None
 
 from flash_attn.cute.cache_utils import JITCache
+from flash_attn.cute.config import (
+    FwdSm100RegisterAllocation,
+    select_fwd_config,
+    validate_fwd_config,
+)
 from flash_attn.cute.testing import (
     attention_ref,
     generate_qkv,
@@ -33,6 +40,7 @@ from flash_attn.cute.interface import (
     flash_attn_varlen_func,
     get_scheduler_metadata,
     _flash_attn_fwd,
+    _flash_attn_fwd_combine,
     _flash_attn_bwd,
     _flash_attn_bwd_sparse_mla,
 )
@@ -228,6 +236,301 @@ def test_flash_attn_paged_non_tma_partial_loader_tile():
         v_ref.float().transpose(0, 1).unsqueeze(0),
     ).transpose(1, 2)
     torch.testing.assert_close(out.float(), reference, atol=0.04, rtol=0.04)
+
+
+@pytest.mark.skipif(
+    torch.cuda.get_device_capability()[0] != 10 or USE_FAKE_TENSOR,
+    reason="SM100 runtime FP8 register-allocation test",
+)
+@pytest.mark.parametrize("head_dim,seqlen_q", [(64, 65), (128, 257)])
+def test_flash_attn_fp8_register_allocation_matches_reference(head_dim, seqlen_q):
+    torch.manual_seed(head_dim)
+    q, k, v = [
+        tensor.to(torch.float8_e4m3fn)
+        for tensor in (
+            torch.randn(1, seqlen_q, 8, head_dim, device="cuda", dtype=torch.bfloat16),
+            torch.randn(1, 257, 8, head_dim, device="cuda", dtype=torch.bfloat16),
+            torch.randn(1, 257, 8, head_dim, device="cuda", dtype=torch.bfloat16),
+        )
+    ]
+    selected = {}
+
+    def capture_config(inputs):
+        selected["config"] = select_fwd_config(inputs)
+        return selected["config"]
+
+    with mock.patch(
+        "flash_attn.cute.interface.select_fwd_config", side_effect=capture_config
+    ):
+        out = _flash_attn_fwd(q, k, v)[0]
+    is_sm103_family = torch.cuda.get_device_capability()[1] >= 3
+    expected_registers = (
+        (168, 96, 80)
+        if head_dim == 64
+        else (176, 80, 80)
+        if is_sm103_family
+        else (160, 72, 120)
+    )
+    reference = torch.nn.functional.scaled_dot_product_attention(
+        q.float().transpose(1, 2),
+        k.float().transpose(1, 2),
+        v.float().transpose(1, 2),
+    ).transpose(1, 2)
+
+    assert selected["config"].registers == FwdSm100RegisterAllocation(*expected_registers)
+    torch.testing.assert_close(out.float(), reference, atol=0.08, rtol=0.08)
+
+@pytest.mark.skipif(
+    torch.cuda.get_device_capability()[0] not in [10, 11] or USE_FAKE_TENSOR,
+    reason="SM100/SM110 runtime register-allocation test",
+)
+def test_flash_attn_forced_register_allocation_matches_reference():
+    torch.manual_seed(0)
+    q = torch.randn(1, 65, 8, 64, device="cuda", dtype=torch.bfloat16)
+    k = torch.randn(1, 257, 8, 64, device="cuda", dtype=torch.bfloat16)
+    v = torch.randn_like(k)
+    selected = {}
+
+    def capture_config(inputs):
+        selected["config"] = select_fwd_config(inputs)
+        return selected["config"]
+
+    with mock.patch(
+        "flash_attn.cute.interface.select_fwd_config", side_effect=capture_config
+    ):
+        baseline = _flash_attn_fwd(q, k, v)[0]
+    alternate_config = replace(
+        selected["config"], registers=FwdSm100RegisterAllocation(192, 80, 48)
+    )
+    alternate = _flash_attn_fwd(q, k, v, config=alternate_config)[0]
+    reference = torch.nn.functional.scaled_dot_product_attention(
+        q.float().transpose(1, 2),
+        k.float().transpose(1, 2),
+        v.float().transpose(1, 2),
+    ).transpose(1, 2)
+
+    torch.testing.assert_close(baseline.float(), reference, atol=0.04, rtol=0.04)
+    torch.testing.assert_close(alternate.float(), reference, atol=0.04, rtol=0.04)
+
+@pytest.mark.skipif(
+    torch.cuda.get_device_capability()[0] not in [10, 11] or USE_FAKE_TENSOR,
+    reason="SM100/SM110 runtime SplitKV specialization test",
+)
+def test_flash_attn_forced_split_config_reuses_specializations():
+    torch.manual_seed(0)
+    q = torch.randn(1, 128, 8, 64, device="cuda", dtype=torch.bfloat16)
+    k = torch.randn(1, 2048, 8, 64, device="cuda", dtype=torch.bfloat16)
+    v = torch.randn(1, 2048, 8, 64, device="cuda", dtype=torch.bfloat16)
+    selected = {}
+
+    def capture_config(inputs):
+        selected["inputs"] = inputs
+        selected["config"] = select_fwd_config(inputs)
+        return selected["config"]
+
+    out_partial_2 = torch.empty(2, 1, 128, 8, 64, device="cuda", dtype=torch.float32)
+    lse_partial_2 = torch.empty(2, 1, 8, 128, device="cuda", dtype=torch.float32)
+    with mock.patch(
+        "flash_attn.cute.interface.select_fwd_config", side_effect=capture_config
+    ):
+        result_2 = _flash_attn_fwd(
+            q,
+            k,
+            v,
+            num_splits=2,
+            out_partial=out_partial_2,
+            lse_partial=lse_partial_2,
+        )
+    out_2 = result_2[0]
+    config_4 = replace(selected["config"], num_splits=4)
+    validate_fwd_config(config_4, selected["inputs"])
+
+    main_specs = set(_flash_attn_fwd.compile_cache.cache)
+    combine_specs = set(_flash_attn_fwd_combine.compile_cache.cache)
+    major, minor = torch.cuda.get_device_capability()
+    assert all(spec.arch == major * 10 + minor for spec in combine_specs)
+    split_main_specs = {spec for spec in main_specs if spec.is_split_kv}
+    assert split_main_specs
+    assert all(spec.has_lse for spec in split_main_specs)
+    out_partial_4 = torch.empty(4, 1, 128, 8, 64, device="cuda", dtype=torch.float32)
+    lse_partial_4 = torch.empty(4, 1, 8, 128, device="cuda", dtype=torch.float32)
+    out_4 = _flash_attn_fwd(
+        q,
+        k,
+        v,
+        config=config_4,
+        out_partial=out_partial_4,
+        lse_partial=lse_partial_4,
+    )[0]
+    torch.cuda.synchronize()
+    reference = torch.nn.functional.scaled_dot_product_attention(
+        q.float().transpose(1, 2),
+        k.float().transpose(1, 2),
+        v.float().transpose(1, 2),
+        scale=1 / math.sqrt(q.shape[-1]),
+    ).transpose(1, 2)
+
+    torch.testing.assert_close(out_2.float(), reference, atol=0.04, rtol=0.04)
+    torch.testing.assert_close(out_4.float(), reference, atol=0.04, rtol=0.04)
+    assert set(_flash_attn_fwd.compile_cache.cache) == main_specs
+    assert set(_flash_attn_fwd_combine.compile_cache.cache) == combine_specs
+
+@pytest.mark.skipif(
+    torch.cuda.get_device_capability()[0] not in [10, 11] or USE_FAKE_TENSOR,
+    reason="SM100/SM110 runtime CLC configuration test",
+)
+def test_flash_attn_clc_rejects_static_persistent_codegen_flag():
+    """Keep CLC off the static-persistent divisor/cluster codegen path."""
+    torch.manual_seed(0)
+    batch, seqlen_q, q_heads, kv_heads, head_dim = 2, 128, 8, 2, 128
+    lengths_k = [191, 127]
+    q = torch.randn(
+        batch,
+        seqlen_q,
+        q_heads,
+        head_dim,
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    k = torch.randn(
+        sum(lengths_k),
+        kv_heads,
+        head_dim,
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    v = torch.randn_like(k)
+    cu_seqlens_k = torch.tensor(
+        [0, lengths_k[0], sum(lengths_k)], device="cuda", dtype=torch.int32
+    )
+    selected = {}
+
+    def force_clc_config(inputs):
+        selected["inputs"] = inputs
+        selected["config"] = replace(
+            select_fwd_config(inputs), use_clc_scheduler=True, is_static_persistent=False
+        )
+        return selected["config"]
+
+    with mock.patch(
+        "flash_attn.cute.interface.select_fwd_config", side_effect=force_clc_config
+    ):
+        out = _flash_attn_fwd(
+            q,
+            k,
+            v,
+            cu_seqlens_k=cu_seqlens_k,
+            max_seqlen_k=max(lengths_k),
+        )[0]
+    validate_fwd_config(selected["config"], selected["inputs"])
+    with pytest.raises(ValueError, match="Static persistent scheduling is not effective"):
+        validate_fwd_config(
+            replace(selected["config"], is_static_persistent=True), selected["inputs"]
+        )
+    references = []
+    start = 0
+    for batch_idx, length in enumerate(lengths_k):
+        references.append(
+            torch.nn.functional.scaled_dot_product_attention(
+                q[batch_idx].float().transpose(0, 1).unsqueeze(0),
+                k[start : start + length].float().transpose(0, 1).unsqueeze(0),
+                v[start : start + length].float().transpose(0, 1).unsqueeze(0),
+                scale=1 / math.sqrt(head_dim),
+                enable_gqa=True,
+            )
+            .squeeze(0)
+            .transpose(0, 1)
+        )
+        start += length
+
+    torch.testing.assert_close(
+        out.float(), torch.stack(references), atol=0.04, rtol=0.04
+    )
+
+@pytest.mark.skipif(
+    torch.cuda.get_device_capability()[0] not in [10, 11] or USE_FAKE_TENSOR,
+    reason="SM100/SM110 selector metadata test",
+)
+def test_flash_attn_lse_requirement_is_selector_metadata():
+    q = torch.randn(1, 1, 4, 64, device="cuda", dtype=torch.bfloat16)
+    k = torch.randn_like(q)
+    v = torch.randn_like(q)
+
+    class SelectionCaptured(Exception):
+        pass
+
+    def capture(q_arg, **kwargs):
+        selected = {}
+
+        def capture_config(inputs):
+            selected["inputs"] = inputs
+            raise SelectionCaptured
+
+        with mock.patch(
+            "flash_attn.cute.interface.select_fwd_config", side_effect=capture_config
+        ), pytest.raises(SelectionCaptured):
+            _flash_attn_fwd(q_arg, k, v, **kwargs)
+        return selected["inputs"]
+
+    assert not capture(q).has_lse
+    assert capture(q, return_lse=True).has_lse
+    assert capture(
+        q, lse=torch.empty(1, 4, 1, device="cuda", dtype=torch.float32)
+    ).has_lse
+    assert capture(q.requires_grad_()).has_lse
+
+@pytest.mark.skipif(
+    torch.cuda.get_device_capability()[0] not in [10, 11] or USE_FAKE_TENSOR,
+    reason="SM100/SM110 selector metadata test",
+)
+def test_flash_attn_softcap_is_score_modifier_for_selection():
+    """Keep softcap workloads out of unmeasured plain-score selector regions."""
+    q = torch.randn(32, 1, 24, 64, device="cuda", dtype=torch.bfloat16)
+    k = torch.randn(32, 640, 6, 64, device="cuda", dtype=torch.bfloat16)
+    v = torch.randn_like(k)
+    selected = {}
+
+    class SelectionCaptured(Exception):
+        pass
+
+    def capture_config(inputs):
+        selected["inputs"] = inputs
+        raise SelectionCaptured
+
+    with mock.patch(
+        "flash_attn.cute.interface.select_fwd_config", side_effect=capture_config
+    ), pytest.raises(SelectionCaptured):
+        _flash_attn_fwd(q, k, v, causal=True, softcap=15.0)
+
+    assert selected["inputs"].has_score_mod
+    assert not select_fwd_config(selected["inputs"]).use_clc_scheduler
+
+@pytest.mark.skipif(
+    torch.cuda.get_device_capability()[0] not in [10, 11] or USE_FAKE_TENSOR,
+    reason="SM100/SM110 MLA cache projection test",
+)
+def test_flash_attn_mla_cache_separates_kv_head_counts():
+    """Prevent MLA kernels with equal GQA ratios from sharing packed layouts."""
+    torch.manual_seed(0)
+    initial_specs = set(_flash_attn_fwd.compile_cache.cache)
+    for q_heads, kv_heads in ((128, 2), (64, 1)):
+        q = torch.randn(1, 2, q_heads, 64, device="cuda", dtype=torch.bfloat16)
+        qv = torch.randn(1, 2, q_heads, 512, device="cuda", dtype=torch.bfloat16)
+        k = torch.randn(1, 17, kv_heads, 64, device="cuda", dtype=torch.bfloat16)
+        v = torch.randn(1, 17, kv_heads, 512, device="cuda", dtype=torch.bfloat16)
+        out = _flash_attn_fwd(q, k, v, qv=qv)[0]
+        k_expanded = k.float().repeat_interleave(q_heads // kv_heads, dim=2)
+        v_expanded = v.float().repeat_interleave(q_heads // kv_heads, dim=2)
+        scores = torch.einsum("bqhd,bkhd->bhqk", q.float(), k_expanded)
+        scores += torch.einsum("bqhd,bkhd->bhqk", qv.float(), v_expanded)
+        probabilities = torch.softmax(scores / math.sqrt(64 + 512), dim=-1)
+        reference = torch.einsum("bhqk,bkhd->bqhd", probabilities, v_expanded)
+        torch.testing.assert_close(out.float(), reference, atol=0.04, rtol=0.04)
+
+    new_specs = set(_flash_attn_fwd.compile_cache.cache) - initial_specs
+    assert {
+        spec.num_heads_kv for spec in new_specs if spec.kernel_family == "mla_sm100"
+    } == {1, 2}
 
 
 # @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float8_e4m3fn])
@@ -3927,7 +4230,6 @@ def test_flash_attn_varlen_seqlen_k_per_split(causal):
     dtype = torch.bfloat16
     d = 128
     nheads = nheads_kv = 4
-    num_splits = 8
     # Longest first so max_seqlen_k (and hence the tile config) matches across calls.
     seqlens = [4224, 1024, 2048]
 
@@ -3944,7 +4246,7 @@ def test_flash_attn_varlen_seqlen_k_per_split(causal):
             cu_seqlens_q=cu, cu_seqlens_k=cu,
             max_seqlen_q=seqlens[0], max_seqlen_k=seqlens[0],
             causal=causal,
-            num_splits=num_splits,
+            num_splits=0,
             seqlen_k_per_split=seqlen_k_per_split,
         )
         return out

--- a/tests/cute/test_fwd_config.py
+++ b/tests/cute/test_fwd_config.py
@@ -1,3 +1,4 @@
+import inspect
 import json
 from dataclasses import asdict, replace
 
@@ -16,6 +17,7 @@ from flash_attn.cute.config import (
     select_sm100_register_allocation,
     validate_fwd_config,
 )
+from flash_attn.cute.interface import _flash_attn_fwd
 
 _BASE_INPUTS = FwdHeuristicInputs(
     device_arch=100,
@@ -61,6 +63,13 @@ _BASE_INPUTS = FwdHeuristicInputs(
 
 def make_inputs(**changes) -> FwdHeuristicInputs:
     return _BASE_INPUTS._replace(**changes)
+
+
+def test_forward_config_is_optional_and_keyword_only():
+    parameter = inspect.signature(_flash_attn_fwd).parameters["config"]
+
+    assert parameter.kind is inspect.Parameter.KEYWORD_ONLY
+    assert parameter.default is None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Stacked PRs:
 * #2743
 * #2741
 * #2738
 * #2735
 * __->__#2733
 * #2732


--- --- ---

# Human Note

<!-- Fill this in before landing. -->

# Agent Note

## Summary

This wires the typed config model into the real forward path without changing the public wrappers. `_flash_attn_fwd` becomes the one place that extracts host metadata, selects or validates one config, and launches it.

`config=None` preserves normal policy selection. Passing an explicit `FwdConfig` means use exactly that config or raise. SM90, generic SM100, and dedicated HD256 consume the resolved named register allocation directly, so kernel code cannot silently replace an explicit choice. SplitKV callers may also provide reusable partial O/LSE workspaces for allocation-free replay.

The latest-main integration preserves the varlen dynamic-persistent scheduler and its public metadata API. `FwdConfig.is_static_persistent` controls the static-persistent choice; dynamic persistence remains derived from scheduler metadata. The typed main key separately projects dynamic split counts, virtual-batch mapping, L2-head metadata, tile-count semaphore, cumsum/block lookup operands, and fixed K-per-split geometry. `get_scheduler_metadata` uses the same typed selector for tile, q-stage, and split geometry; a fixed K extent now determines the required automatic split capacity there and in direct calls.

![FA4 forward runtime flow](https://raw.githubusercontent.com/drisspg/flash-attention/5f1eb068d7910e1cf59d91d43fefb798bb828b83/pr-assets/forward-runtime-flow.png)

## Host-path cost

The SM-count query is now lazy. Only automatic SplitKV needs the target SM count; fixed and explicit split requests store `num_sms=0` and skip the environment/device query. The fixed path measured 1.341→0.030 us, while automatic SplitKV still resolves the matching local GPU or explicit cross-compilation target exactly as before.

Together with the tuple-backed keys in #2732, constructing selector inputs plus a warm cache hit measured 5.734→1.378 us. This matters to eager and generated Flex runtime wrappers but is intentionally absent from the CUDA-graph kernel measurements in the policy PRs.

A complete warm host-dispatch check used real preallocated CUDA tensors, a hit-only compile cache, and a no-op compiled callable:

| Shape | Before cleanup | After cleanup | Saved |
|---|---:|---:|---:|
| Decode | 36.856 us | 21.482 us | 15.374 us (41.7%) |
| Short attention | 36.267 us | 21.149 us | 15.118 us (41.7%) |
| Prefill | 36.271 us | 21.289 us | 14.982 us (41.3%) |

“Before” is exact stack head `69285d1c`; “after” is `60fe2c4c`. The benchmark excludes GPU execution and compilation, so it isolates the wrapper work changed by #2732/#2733.

## Implementation and validation

- Replaces the inline forward scheduling policy with `FwdHeuristicInputs` construction followed by selection or exact validation.
- Main and SplitKV-combine kernels use independent typed identities; the rebased identities include dynamic scheduler operands, combine head count, and virtual-batch mapping.
- SM90, generic SM100/SM110, and dedicated HD256 constructors consume their typed `FwdRegisterAllocation` variant; the hidden kernel-side register tables are removed.
- Exact SplitKV counts can share one main specialization while compiling only the combine capacity buckets they require.
- Direct and standalone scheduler-metadata calls both thread `seqlen_k_per_split` into selection; the existing end-to-end fixed-extent test now exercises automatic splitting.
- Optional `out_partial` and `lse_partial` buffers are shape/device/dtype validated and accepted only for a resolved SplitKV config.
- `has_lse` is derived from preallocated LSE, `return_lse`, or autograd requirements, keeping output-only and LSE-producing policy separate.
- The standalone exp2 sweep remains exp2-only; register experiments use explicit configs.
- Public functions and autograd wrappers are unchanged.

The fuzz-found alignment, static-layout, aux-ABI, fake-SM, and combine-operand corrections live in the base PR rather than obscuring this routing change. At this boundary, `interface.py` is 50 net lines smaller than its parent. The standalone boundary passes the host config suite plus focused GB300 runtime coverage for dynamic scheduler metadata, cumsum paths, fixed K-per-split geometry, virtual-batch combine, register forcing, and SplitKV specialization reuse. The full rebased stack passes all 12 cumsum-mode cells, both automatic fixed-K-per-split cells, and representative combine mappings. SM90 default and alternate allocations also fake-compile under an explicit `CUTE_DSL_ARCH=sm_90a` target. Emitted PTX confirms the resolved register immediates are consumed.