### PR TITLE
[CuTe] Tune GB300 forward scheduling

### DIFF
--- a/benchmarks/configs/fwd_config_sm103.yaml
+++ b/benchmarks/configs/fwd_config_sm103.yaml
@@ -1,0 +1,260 @@
+# Explicit old-vs-new config comparisons for the four SM103 BF16 policies.
+# Adding another campaign means adding an experiment/grid here; the runner emits
+# n, geomean with paired-round 95% timing interval, time-weighted gain,
+# min/max, and W/N/L.
+settings:
+  dtype: bfloat16
+  seed: 0
+  workers: 16
+  rounds: 7
+  iters_per_round: 31
+  warmup_iters: 10
+  clock_warmup_iters: 20
+
+experiments:
+  - name: long_k_d64_nonpersistent
+    baseline: {is_static_persistent: true}
+    candidate: {is_static_persistent: false}
+    correctness:
+      mode: dense
+      q_heads: 16
+      kv_heads: 4
+      head_dim: 64
+      batch: 1
+      seqlen_q: 65
+      seqlen_k: 4096
+      causal: false
+    grids:
+      - phase: boundary
+        mode: dense
+        head_pairs: [[16, 16], [16, 4]]
+        head_dims: [64]
+        batches: [1, 8]
+        seqlen_pairs:
+          - [128, 4096]
+          - [128, 5120]
+          - [128, 8192]
+          - [1024, 4096]
+          - [1024, 5120]
+          - [1024, 8192]
+          - [4096, 4096]
+          - [4096, 5120]
+          - [4096, 8192]
+          - [8192, 4096]
+          - [8192, 5120]
+          - [8192, 8192]
+        causal: false
+      - phase: holdout
+        mode: dense
+        head_pairs: [[16, 16], [16, 1]]
+        head_dims: [64]
+        batches: [2, 16]
+        seqlen_pairs:
+          - [384, 4608]
+          - [384, 6144]
+          - [384, 7168]
+          - [1536, 4608]
+          - [1536, 6144]
+          - [1536, 7168]
+          - [6144, 4608]
+          - [6144, 6144]
+          - [6144, 7168]
+          - [12288, 4608]
+          - [12288, 6144]
+          - [12288, 7168]
+        causal: false
+
+  - name: balanced_varlen_mha_clc
+    baseline: {use_clc_scheduler: false, is_static_persistent: false}
+    candidate: {use_clc_scheduler: true, is_static_persistent: false}
+    correctness:
+      mode: varlen
+      q_heads: 8
+      kv_heads: 8
+      head_dim: 128
+      seqlens_q: [65, 129, 257, 33]
+      seqlens_k: [71, 193, 263, 41]
+      causal: false
+    grids:
+      - phase: boundary
+        mode: varlen
+        head_pairs: [[8, 8], [16, 16]]
+        head_dims: [64, 128]
+        batches: [4, 16]
+        token_pairs:
+          - [10240, 5120]
+          - [10240, 15360]
+          - [12288, 6144]
+          - [12288, 18432]
+          - [16384, 8192]
+          - [16384, 24576]
+        patterns: [uniform]
+        causal: false
+      - phase: holdout
+        mode: varlen
+        head_pairs: [[16, 16]]
+        head_dims: [96]
+        batches: [8, 24]
+        token_pairs:
+          - [11264, 4224]
+          - [11264, 11264]
+          - [11264, 22528]
+          - [13312, 4992]
+          - [13312, 13312]
+          - [13312, 26624]
+          - [18432, 6912]
+          - [18432, 18432]
+          - [18432, 36864]
+        patterns: [bimodal, staircase]
+        causal: false
+
+  - name: high_head_varlen_clc
+    baseline: {use_clc_scheduler: false, is_static_persistent: false}
+    candidate: {use_clc_scheduler: true, is_static_persistent: false}
+    correctness:
+      mode: varlen
+      q_heads: 32
+      kv_heads: 8
+      head_dim: 128
+      seqlens_q: [127, 193, 61]
+      seqlens_k: [131, 211, 73]
+      causal: true
+    case_table:
+      mode: varlen
+      columns: [phase, q_heads, kv_heads, head_dim, batch, total_q, total_k, pattern, causal]
+      rows:
+        - [boundary, 32, 8, 128, 48, 6144, 12288, bimodal, true]
+        - [boundary, 24, 24, 96, 3, 12288, 6144, staircase, false]
+        - [boundary, 28, 4, 128, 48, 6144, 6144, staircase, true]
+        - [boundary, 32, 8, 128, 24, 24576, 24576, staircase, false]
+        - [boundary, 71, 1, 64, 12, 6144, 6144, bimodal, true]
+        - [boundary, 28, 4, 128, 24, 12288, 6144, staircase, true]
+        - [boundary, 32, 8, 128, 12, 4096, 4096, staircase, false]
+        - [boundary, 24, 24, 96, 24, 6144, 6144, bimodal, true]
+        - [boundary, 71, 1, 64, 3, 12288, 6144, staircase, true]
+        - [boundary, 32, 8, 128, 3, 6144, 12288, bimodal, true]
+        - [boundary, 24, 24, 96, 12, 12288, 6144, staircase, true]
+        - [boundary, 28, 4, 128, 12, 6144, 6144, bimodal, false]
+        - [boundary, 32, 8, 128, 48, 24576, 24576, bimodal, true]
+        - [boundary, 71, 1, 64, 24, 6144, 6144, bimodal, false]
+        - [boundary, 28, 4, 128, 3, 12288, 6144, staircase, true]
+        - [boundary, 32, 8, 128, 48, 4096, 4096, staircase, false]
+        - [boundary, 24, 24, 96, 3, 6144, 6144, bimodal, false]
+        - [boundary, 71, 1, 64, 12, 12288, 6144, staircase, true]
+        - [boundary, 32, 8, 128, 24, 6144, 12288, staircase, false]
+        - [boundary, 24, 24, 96, 48, 12288, 6144, bimodal, true]
+        - [boundary, 28, 4, 128, 24, 6144, 6144, bimodal, false]
+        - [boundary, 32, 8, 128, 12, 24576, 24576, bimodal, true]
+        - [boundary, 71, 1, 64, 3, 6144, 6144, bimodal, false]
+        - [boundary, 28, 4, 128, 12, 12288, 6144, staircase, false]
+        - [boundary, 32, 8, 128, 3, 4096, 4096, bimodal, true]
+        - [boundary, 24, 24, 96, 12, 6144, 6144, staircase, false]
+        - [boundary, 71, 1, 64, 48, 12288, 6144, bimodal, false]
+        - [boundary, 32, 8, 128, 48, 6144, 12288, staircase, false]
+        - [boundary, 24, 24, 96, 3, 12288, 6144, bimodal, false]
+        - [boundary, 28, 4, 128, 3, 6144, 6144, bimodal, true]
+        - [boundary, 32, 8, 128, 24, 24576, 24576, bimodal, false]
+        - [boundary, 71, 1, 64, 12, 6144, 6144, staircase, true]
+        - [boundary, 28, 4, 128, 48, 12288, 6144, bimodal, false]
+        - [boundary, 32, 8, 128, 24, 4096, 4096, bimodal, false]
+        - [boundary, 24, 24, 96, 48, 6144, 6144, staircase, true]
+        - [boundary, 71, 1, 64, 3, 12288, 6144, bimodal, false]
+        - [boundary, 32, 8, 128, 12, 6144, 12288, staircase, true]
+        - [boundary, 24, 24, 96, 24, 12288, 6144, bimodal, false]
+        - [boundary, 28, 4, 128, 12, 6144, 6144, staircase, false]
+        - [boundary, 32, 8, 128, 3, 24576, 24576, staircase, false]
+        - [boundary, 71, 1, 64, 48, 6144, 6144, staircase, false]
+        - [boundary, 28, 4, 128, 3, 12288, 6144, bimodal, true]
+        - [boundary, 32, 8, 128, 48, 4096, 4096, bimodal, false]
+        - [boundary, 24, 24, 96, 3, 6144, 6144, staircase, false]
+        - [holdout, 28, 4, 128, 6, 6144, 12288, bimodal, false]
+        - [holdout, 28, 4, 128, 6, 6144, 12288, bimodal, true]
+        - [holdout, 32, 8, 128, 12, 12288, 6144, staircase, false]
+        - [holdout, 32, 8, 128, 12, 12288, 6144, staircase, true]
+        - [holdout, 24, 24, 96, 12, 9216, 4608, bimodal, false]
+        - [holdout, 24, 24, 96, 12, 9216, 4608, bimodal, true]
+
+  - name: dense_short_k_clc
+    baseline: {use_clc_scheduler: false, is_static_persistent: false}
+    candidate: {use_clc_scheduler: true, is_static_persistent: false}
+    correctness:
+      mode: dense
+      q_heads: 32
+      kv_heads: 8
+      head_dim: 128
+      batch: 32
+      seqlen_q: 3
+      seqlen_k: 640
+      causal: true
+    case_table:
+      mode: dense
+      causal: true
+      columns: [phase, q_heads, kv_heads, head_dim, batch, seqlen_q, seqlen_k]
+      rows:
+        - [boundary, 32, 8, 128, 32, 1, 2048]
+        - [boundary, 71, 1, 64, 48, 17, 1536]
+        - [boundary, 32, 32, 96, 96, 64, 1280]
+        - [boundary, 32, 8, 128, 32, 1, 1152]
+        - [boundary, 71, 1, 64, 48, 17, 1024]
+        - [boundary, 32, 32, 96, 96, 64, 896]
+        - [boundary, 32, 8, 128, 32, 1, 640]
+        - [boundary, 32, 32, 96, 96, 17, 1536]
+        - [boundary, 32, 32, 96, 96, 17, 1024]
+        - [boundary, 32, 32, 96, 96, 1, 2048]
+        - [boundary, 32, 8, 128, 48, 129, 1280]
+        - [boundary, 32, 32, 96, 96, 1, 1152]
+        - [boundary, 32, 8, 128, 48, 129, 896]
+        - [boundary, 32, 32, 96, 96, 1, 640]
+        - [boundary, 32, 8, 128, 48, 64, 1536]
+        - [boundary, 71, 1, 64, 96, 129, 1280]
+        - [boundary, 32, 8, 128, 48, 64, 1024]
+        - [boundary, 71, 1, 64, 96, 129, 896]
+        - [boundary, 32, 8, 128, 48, 17, 2048]
+        - [boundary, 71, 1, 64, 96, 64, 1536]
+        - [boundary, 32, 8, 128, 48, 17, 1152]
+        - [boundary, 71, 1, 64, 96, 64, 1024]
+        - [boundary, 32, 8, 128, 48, 17, 640]
+        - [boundary, 71, 1, 64, 96, 17, 2048]
+        - [boundary, 64, 8, 64, 32, 129, 1536]
+        - [boundary, 32, 8, 128, 48, 1, 1280]
+        - [boundary, 71, 1, 64, 96, 17, 1152]
+        - [boundary, 64, 8, 64, 32, 129, 1024]
+        - [boundary, 32, 8, 128, 48, 1, 896]
+        - [boundary, 71, 1, 64, 96, 17, 640]
+        - [boundary, 64, 8, 64, 32, 64, 2048]
+        - [boundary, 64, 8, 64, 32, 64, 1152]
+        - [boundary, 64, 8, 64, 32, 64, 640]
+        - [boundary, 32, 8, 128, 96, 129, 1536]
+        - [boundary, 64, 8, 64, 32, 17, 1280]
+        - [boundary, 32, 8, 128, 96, 129, 1024]
+        - [boundary, 64, 8, 64, 32, 17, 896]
+        - [boundary, 32, 8, 128, 96, 64, 2048]
+        - [boundary, 64, 8, 64, 32, 1, 1536]
+        - [boundary, 32, 8, 128, 96, 64, 1152]
+        - [boundary, 64, 8, 64, 32, 1, 1024]
+        - [boundary, 32, 8, 128, 96, 64, 640]
+        - [boundary, 32, 32, 96, 32, 129, 2048]
+        - [boundary, 32, 8, 128, 96, 17, 1280]
+        - [boundary, 32, 32, 96, 32, 129, 1152]
+        - [boundary, 32, 8, 128, 96, 17, 896]
+        - [boundary, 32, 32, 96, 32, 129, 640]
+        - [boundary, 64, 8, 64, 48, 129, 2048]
+        - [boundary, 32, 8, 128, 96, 1, 1536]
+        - [boundary, 32, 32, 96, 32, 64, 1280]
+        - [boundary, 64, 8, 64, 48, 129, 1152]
+        - [boundary, 32, 8, 128, 96, 1, 1024]
+        - [boundary, 32, 32, 96, 32, 64, 896]
+        - [boundary, 64, 8, 64, 48, 129, 640]
+        - [boundary, 32, 32, 96, 32, 17, 1536]
+        - [boundary, 64, 8, 64, 48, 64, 1280]
+        - [boundary, 32, 32, 96, 32, 17, 1024]
+        - [boundary, 64, 8, 64, 48, 64, 896]
+        - [boundary, 32, 32, 96, 32, 1, 2048]
+        - [boundary, 64, 8, 64, 48, 17, 1536]
+        - [boundary, 32, 32, 96, 32, 1, 1152]
+        - [boundary, 64, 8, 64, 48, 17, 1024]
+        - [holdout, 32, 8, 128, 40, 17, 1088]
+        - [holdout, 32, 8, 128, 40, 97, 1216]
+        - [holdout, 71, 1, 64, 40, 33, 1152]
+        - [holdout, 32, 32, 96, 40, 17, 1088]
+        - [holdout, 64, 8, 64, 40, 97, 1216]

--- a/flash_attn/cute/config.py
+++ b/flash_attn/cute/config.py
@@ -586,8 +586,6 @@ def select_fwd_config(inputs: FwdHeuristicInputs) -> FwdConfig:
     )
 
     overlap_s_o_s_q = is_sm100_family and has_s_o_s_q_overlap(inputs, num_splits)
-    # CLC regresses varlen MHA and dense noncausal: the former increases K/V
-    # traffic under imbalance, while the latter mostly pays work-stealing overhead.
     is_varlen = (
         inputs.is_varlen_q
         or inputs.has_cu_seqlens_q
@@ -596,19 +594,92 @@ def select_fwd_config(inputs: FwdHeuristicInputs) -> FwdConfig:
     )
     is_varlen_mha = is_varlen and inputs.qhead_per_kvhead == 1
     is_dense_noncausal = not is_varlen and not inputs.causal and not inputs.local
+    is_standard_sm103_bf16 = (
+        inputs.device_arch == 103
+        and inputs.dtype == "torch.bfloat16"
+        and inputs.page_size is None
+        and not inputs.use_block_sparsity
+        and not inputs.has_qv
+        and not inputs.has_gather_kv
+        and not inputs.has_score_mod
+        and not inputs.has_mask_mod
+        and not inputs.has_learnable_sink
+        and not inputs.has_lse
+    )
+    has_clc_head_dim = inputs.head_dim_v == inputs.head_dim and inputs.head_dim in (64, 96, 128)
+    sm103_varlen_clc_base = (
+        is_standard_sm103_bf16
+        and has_clc_head_dim
+        and inputs.is_varlen_q
+        and inputs.has_cu_seqlens_q
+        and inputs.has_cu_seqlens_k
+        and not inputs.has_seqused
+        and not inputs.local
+        and not is_split_kv
+        and tile_m == 128
+        and tile_n == 128
+    )
+    # CLC pays off for balanced medium-head MHA and broadly for packed high-head
+    # attention once Q has enough work, including causal GQA and MQA.
+    use_clc_sm103_varlen = sm103_varlen_clc_base and (
+        (
+            inputs.qhead_per_kvhead == 1
+            and not inputs.causal
+            and inputs.num_heads in (8, 16)
+            and 4 <= inputs.batch_size <= 24
+            and inputs.total_q >= 10240
+            and inputs.total_q * 5 >= 2 * inputs.batch_size * inputs.max_seqlen_q
+            and inputs.total_k * 5 >= 2 * inputs.batch_size * inputs.max_seqlen_k
+        )
+        or (
+            inputs.num_heads >= 24
+            and (inputs.qhead_per_kvhead == 1 or inputs.pack_gqa)
+            and 3 <= inputs.batch_size <= 64
+            and inputs.total_q >= 4096
+        )
+    )
+    use_clc_sm103_dense = (
+        is_standard_sm103_bf16
+        and has_clc_head_dim
+        and not is_varlen
+        and inputs.causal
+        and not inputs.local
+        and inputs.num_heads >= 24
+        and (inputs.num_heads % 8 == 0 or inputs.num_heads_kv == 1)
+        and (inputs.num_heads_kv != 1 or inputs.max_seqlen_q > 1)
+        and (inputs.qhead_per_kvhead == 1 or inputs.pack_gqa)
+        and inputs.batch_size >= 32
+        and 640 <= inputs.max_seqlen_k <= 2048
+        and not is_split_kv
+        and tile_m == 128
+        and tile_n == 128
+    )
+    use_clc_sm103 = use_clc_sm103_varlen or use_clc_sm103_dense
     use_clc_scheduler = (
         is_sm100_family
-        and inputs.requested_use_clc_scheduler
-        and not is_varlen_mha
+        and (inputs.requested_use_clc_scheduler or use_clc_sm103)
+        and (not is_varlen_mha or use_clc_sm103)
         and not is_dense_noncausal
         and inputs.page_size in (None, tile_n)
         and not overlap_s_o_s_q
+    )
+    # On GB300, nonpersistent scheduling wins once D64 spans at least 32 K tiles.
+    use_nonpersistent_sm103 = (
+        is_standard_sm103_bf16
+        and is_dense_noncausal
+        and inputs.head_dim == 64
+        and inputs.head_dim_v == 64
+        and tile_m == 128
+        and tile_n == 128
+        and (inputs.qhead_per_kvhead == 1 or inputs.pack_gqa)
+        and num_n_blocks >= 32
     )
     is_static_persistent = (
         is_sm100_family
         and not is_split_kv
         and not overlap_s_o_s_q
         and not use_clc_scheduler
+        and not use_nonpersistent_sm103
         and (
             (not inputs.causal and not inputs.local and not inputs.is_varlen_q)
             or packed_seqlen_q <= effective_tile_m

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -449,6 +449,103 @@ def test_flash_attn_clc_rejects_static_persistent_codegen_flag():
 
 @pytest.mark.skipif(
     torch.cuda.get_device_capability()[0] not in [10, 11] or USE_FAKE_TENSOR,
+    reason="SM100/SM110 promoted CLC selector tests",
+)
+def test_flash_attn_high_head_varlen_clc_default_matches_reference():
+    """Exercise the promoted packed-varlen CLC rule through config=None."""
+    torch.manual_seed(0)
+    lengths = [1365, 1365, 1366]
+    q = torch.randn(sum(lengths), 24, 64, device="cuda", dtype=torch.bfloat16)
+    k = torch.randn(sum(lengths), 6, 64, device="cuda", dtype=torch.bfloat16)
+    v = torch.randn_like(k)
+    cu_seqlens = torch.tensor(
+        [0, lengths[0], sum(lengths[:2]), sum(lengths)],
+        device="cuda",
+        dtype=torch.int32,
+    )
+    selected = {}
+
+    def capture_config(inputs):
+        selected["inputs"] = inputs
+        selected["config"] = select_fwd_config(inputs)
+        return selected["config"]
+
+    with mock.patch(
+        "flash_attn.cute.interface.select_fwd_config", side_effect=capture_config
+    ):
+        out = _flash_attn_fwd(
+            q,
+            k,
+            v,
+            cu_seqlens_q=cu_seqlens,
+            cu_seqlens_k=cu_seqlens,
+            max_seqlen_q=max(lengths),
+            max_seqlen_k=max(lengths),
+            causal=True,
+        )[0]
+
+    assert selected["inputs"].pack_gqa
+    assert selected["config"].use_clc_scheduler
+    references = []
+    start = 0
+    for length in lengths:
+        references.append(
+            torch.nn.functional.scaled_dot_product_attention(
+                q[start : start + length].float().transpose(0, 1).unsqueeze(0),
+                k[start : start + length].float().transpose(0, 1).unsqueeze(0),
+                v[start : start + length].float().transpose(0, 1).unsqueeze(0),
+                is_causal=True,
+                scale=1 / math.sqrt(64),
+                enable_gqa=True,
+            )
+            .squeeze(0)
+            .transpose(0, 1)
+        )
+        start += length
+    torch.testing.assert_close(
+        out.float(), torch.cat(references), atol=0.04, rtol=0.04
+    )
+
+@pytest.mark.skipif(
+    torch.cuda.get_device_capability()[0] not in [10, 11] or USE_FAKE_TENSOR,
+    reason="SM100/SM110 promoted CLC selector tests",
+)
+def test_flash_attn_dense_short_k_clc_default_matches_reference():
+    """Exercise the promoted dense short-K CLC rule through config=None."""
+    torch.manual_seed(0)
+    q = torch.randn(32, 17, 24, 64, device="cuda", dtype=torch.bfloat16)
+    k = torch.randn(32, 640, 6, 64, device="cuda", dtype=torch.bfloat16)
+    v = torch.randn_like(k)
+    selected = {}
+
+    def capture_config(inputs):
+        selected["inputs"] = inputs
+        selected["config"] = select_fwd_config(inputs)
+        return selected["config"]
+
+    with mock.patch(
+        "flash_attn.cute.interface.select_fwd_config", side_effect=capture_config
+    ):
+        out = _flash_attn_fwd(q, k, v, causal=True)[0]
+
+    assert selected["inputs"].pack_gqa
+    assert selected["config"].use_clc_scheduler
+    k_expanded = k.float().repeat_interleave(4, dim=2)
+    v_expanded = v.float().repeat_interleave(4, dim=2)
+    scores = torch.einsum("bqhd,bkhd->bhqk", q.float(), k_expanded) / math.sqrt(64)
+    q_positions = torch.arange(q.shape[1], device="cuda")[:, None]
+    k_positions = torch.arange(k.shape[1], device="cuda")[None, :]
+    scores.masked_fill_(
+        k_positions > q_positions + k.shape[1] - q.shape[1], -torch.inf
+    )
+    reference = torch.einsum(
+        "bhqk,bkhd->bqhd", torch.softmax(scores, dim=-1), v_expanded
+    )
+    torch.testing.assert_close(out.float(), reference, atol=0.04, rtol=0.04)
+
+
+@pytest.mark.skipif(
+    torch.cuda.get_device_capability()[0] not in [10, 11] or USE_FAKE_TENSOR,
     reason="SM100/SM110 selector metadata test",
 )
 def test_flash_attn_lse_requirement_is_selector_metadata():

--- a/tests/cute/test_fwd_config.py
+++ b/tests/cute/test_fwd_config.py
@@ -149,6 +149,162 @@ def test_sm100_register_allocation_matches_existing_kernel_policy(
     ) == FwdSm100RegisterAllocation(*expected)
 
 
+@pytest.mark.parametrize(
+    ("changes", "expected_static_persistent"),
+    [
+        ({}, False),
+        ({"max_seqlen_k": 4096}, False),
+        ({"max_seqlen_k": 3072}, True),
+        ({"head_dim": 32, "head_dim_v": 32}, True),
+        ({"head_dim": 96, "head_dim_v": 96}, True),
+        ({"dtype": "torch.float16"}, True),
+        ({"device_arch": 100}, True),
+        ({"page_size": 128}, True),
+        ({"use_block_sparsity": True}, True),
+        ({"has_gather_kv": True}, True),
+        ({"has_score_mod": True}, True),
+        ({"has_mask_mod": True}, True),
+        ({"has_learnable_sink": True}, True),
+        ({"has_lse": True}, True),
+        ({"requested_tile_n": 64}, True),
+        ({"num_heads_kv": 2, "pack_gqa": False}, True),
+    ],
+)
+def test_sm103_long_d64_nonpersistent_scheduler_scope(
+    changes, expected_static_persistent
+):
+    inputs = make_inputs(device_arch=103, max_seqlen_k=8192)._replace(**changes)
+
+    assert select_fwd_config(inputs).is_static_persistent is expected_static_persistent
+
+
+@pytest.mark.parametrize(
+    ("changes", "expected_clc"),
+    [
+        ({}, True),
+        ({"total_q": 10239}, False),
+        ({"max_seqlen_q": 6401}, False),
+        ({"total_k": 6553}, False),
+        ({"batch_size": 3}, False),
+        ({"batch_size": 25}, False),
+        ({"head_dim": 192, "head_dim_v": 192}, False),
+        ({"num_heads": 4, "num_heads_kv": 4}, False),
+        ({"dtype": "torch.float16"}, False),
+        ({"device_arch": 100}, False),
+        ({"is_varlen_q": False}, False),
+        ({"has_cu_seqlens_q": False}, False),
+        ({"has_cu_seqlens_k": False}, False),
+        ({"has_seqused": True}, False),
+        ({"num_heads_kv": 4}, False),
+        ({"requested_num_splits": 2}, False),
+        ({"page_size": 128}, False),
+        ({"use_block_sparsity": True}, False),
+        ({"has_gather_kv": True}, False),
+        ({"has_score_mod": True}, False),
+        ({"has_mask_mod": True}, False),
+        ({"has_learnable_sink": True}, False),
+        ({"has_lse": True}, False),
+        ({"requested_tile_n": 64}, False),
+    ],
+)
+def test_sm103_balanced_varlen_mha_clc_scope(changes, expected_clc):
+    inputs = make_inputs(
+        device_arch=103,
+        batch_size=4,
+        total_q=10240,
+        max_seqlen_q=6400,
+        is_varlen_q=True,
+        has_cu_seqlens_q=True,
+        has_cu_seqlens_k=True,
+        requested_use_clc_scheduler=False,
+    )._replace(**changes)
+    config = select_fwd_config(inputs)
+
+    assert config.use_clc_scheduler is expected_clc
+    if expected_clc:
+        assert not config.is_static_persistent
+
+
+@pytest.mark.parametrize(
+    ("changes", "expected_clc"),
+    [
+        ({}, True),
+        ({"causal": False}, True),
+        ({"total_q": 4095}, False),
+        ({"batch_size": 2}, False),
+        ({"batch_size": 65}, False),
+        ({"num_heads": 23, "num_heads_kv": 1}, False),
+        ({"head_dim": 80, "head_dim_v": 80}, False),
+        ({"pack_gqa": False}, False),
+        ({"has_score_mod": True}, False),
+        ({"has_mask_mod": True}, False),
+        ({"has_learnable_sink": True}, False),
+        ({"has_lse": True}, False),
+    ],
+)
+def test_sm103_high_head_varlen_clc_scope(changes, expected_clc):
+    inputs = make_inputs(
+        device_arch=103,
+        num_heads=28,
+        num_heads_kv=4,
+        pack_gqa=True,
+        batch_size=3,
+        total_q=4096,
+        total_k=4096,
+        max_seqlen_q=2048,
+        max_seqlen_k=2048,
+        causal=True,
+        is_varlen_q=True,
+        has_cu_seqlens_q=True,
+        has_cu_seqlens_k=True,
+        requested_use_clc_scheduler=False,
+    )._replace(**changes)
+
+    assert select_fwd_config(inputs).use_clc_scheduler is expected_clc
+
+
+@pytest.mark.parametrize(
+    ("changes", "expected_clc"),
+    [
+        ({}, True),
+        ({"max_seqlen_k": 640}, True),
+        ({"max_seqlen_k": 2048}, True),
+        ({"max_seqlen_k": 639}, False),
+        ({"max_seqlen_k": 2049}, False),
+        ({"batch_size": 31}, False),
+        ({"causal": False}, False),
+        ({"num_heads": 23, "num_heads_kv": 1}, False),
+        ({"num_heads": 28, "num_heads_kv": 4}, False),
+        ({"num_heads": 71, "num_heads_kv": 1}, True),
+        ({"num_heads": 71, "num_heads_kv": 1, "max_seqlen_q": 1}, False),
+        ({"num_heads": 64, "num_heads_kv": 1, "max_seqlen_q": 1}, False),
+        ({"head_dim": 80, "head_dim_v": 80}, False),
+        ({"pack_gqa": False}, False),
+        ({"requested_num_splits": 2}, False),
+        ({"has_score_mod": True}, False),
+        ({"has_mask_mod": True}, False),
+        ({"has_learnable_sink": True}, False),
+        ({"has_lse": True}, False),
+    ],
+)
+def test_sm103_dense_short_k_clc_scope(changes, expected_clc):
+    inputs = make_inputs(
+        device_arch=103,
+        num_heads=32,
+        num_heads_kv=8,
+        pack_gqa=True,
+        batch_size=32,
+        total_q=32 * 64,
+        total_k=32 * 1024,
+        max_seqlen_q=64,
+        max_seqlen_k=1024,
+        causal=True,
+        requested_use_clc_scheduler=False,
+    )._replace(**changes)
+
+    assert select_fwd_config(inputs).use_clc_scheduler is expected_clc
+
+
 def test_selector_preserves_a_codegen_changing_2cta_boundary():
     one_cta = make_inputs(
         head_dim=128,


### PR DESCRIPTION
Stacked PRs:
 * #2743
 * #2741
 * __->__#2738
 * #2735
 * #2733
 * #2732


--- --- ---

# Human Note

<!-- Fill this in before landing. -->

# Agent Note

## Summary

Okay, this is the actual GB300 policy change. I am not trying to make a broad “CLC is better on GB300” rule; these are four narrow BF16 output-only regions that survived boundary and model-family holdout testing. Everything else keeps the old default.

![GB300 SM103 measured selector cells](https://raw.githubusercontent.com/drisspg/flash-attention/5f1eb068d7910e1cf59d91d43fefb798bb828b83/pr-assets/gb300-policy-gains.png)

This is a Seaborn strip plot over the archived result rows: every circle is one actually timed workload cell, color is the campaign phase, the outlined diamond/error bar is the geomean and paired-round 95% timing interval, and `X` is the time-weighted result. There is no fitted distribution or synthetic data.

| New choice | Cells | Geomean [paired 95% CI] | Time-weighted | Min–max |
| --- | ---: | ---: | ---: | ---: |
| Dense noncausal D64: persistent → single | 96 | 1.058× [1.058, 1.059] | 1.042× | 0.999–1.106× |
| Balanced packed-varlen MHA: non-CLC → CLC | 84 | 1.144× [1.143, 1.145] | 1.103× | 1.010–1.373× |
| Packed-varlen H≥24: non-CLC → CLC | 50 | 1.192× [1.190, 1.193] | 1.124× | 1.003–1.421× |
| Dense causal B≥32, K=640…2048: non-CLC → CLC | 67 | 1.118× [1.118, 1.119] | 1.128× | 1.005–1.357× |

All four rules require exact SM103, BF16, no LSE/output-only execution, and plain attention without paged KV, sparsity, QV/MLA, gather-KV, score/mask modifiers, sinks, or SplitKV. A Q=1 dense MQA boundary failed the paired-interval gate, so that case is explicitly excluded.

## Reproduction and validation

Produced with the runner from #2735:

```bash
gpu-run 0 -- python benchmarks/fwd_config_bench.py \
  --campaign benchmarks/configs/fwd_config_sm103.yaml \
  --out-dir agent_space/gb300_fwd_config_final_exact
```

The final dense rule was rerun after narrowing away Q=1 MQA. The checked YAML contains the exact retained cells; the complete raw samples, compile/correctness records, run logs, summary, and checksums are archived [here](https://github.com/drisspg/flash-attention/tree/5f1eb068d7910e1cf59d91d43fefb798bb828b83/pr-assets/evidence/gb300).

- Hardware: NVIDIA GB300, exact SM103, 152 SMs.
- Software: PyTorch `2.14.0.dev20260708+cu132`, CUDA 13.2, CUTLASS DSL `4.6.0.dev0`.
- Timing: seven alternating rounds × 31 fixed-pointer CUDA-graph samples per arm, preallocated outputs/workspaces, and 20 untimed BF16 GEMMs before each arm.
- The [plot generator](https://github.com/drisspg/flash-attention/blob/5f1eb068d7910e1cf59d91d43fefb798bb828b83/pr-assets/generate_stack_pr_assets.py) reads those raw rows directly and recomputes the displayed aggregates.
- The intervals propagate paired-round timing variance inside the frozen cells; they are replay-repeatability intervals, not random-workload confidence intervals.
- Final `config=None` selector checks and independent GPU correctness passed for every promoted family.