### PR TITLE
Pass `loc` and `ip` to llvm.inline_asm

### DIFF
--- a/flash_attn/cute/copy_utils.py
+++ b/flash_attn/cute/copy_utils.py
@@ -141,6 +141,8 @@ def atomic_add_fp32x4(
         has_side_effects=True,
         is_align_stack=False,
         asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
     )
 
 
@@ -159,6 +161,8 @@ def set_block_rank(
             has_side_effects=False,
             is_align_stack=False,
             asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
         )
     )
 
@@ -204,6 +208,8 @@ def store_shared_remote_fp32x4(
         has_side_effects=True,
         is_align_stack=False,
         asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
     )
 
 
@@ -236,6 +242,8 @@ def cpasync_bulk_s2cluster(
         has_side_effects=True,
         is_align_stack=False,
         asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
     )
 
 
@@ -260,6 +268,8 @@ def cpasync_bulk_g2s(
         has_side_effects=True,
         is_align_stack=False,
         asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
     )
 
 
@@ -285,6 +295,8 @@ def cpasync_reduce_bulk_add_f32(
         has_side_effects=True,
         is_align_stack=False,
         asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
     )
 
 


### PR DESCRIPTION
There're a few inline PTX calls dropping `loc` and `ip` passed from caller. This means the compiler passes lose the line info about this kernel source line from this point on, and the eventual PTX is no longer associated to this line of kernel source.

This PR passes them to `llvm.inline_asm` calls so that the line mapping is kept for PTX, and thus tools like NCU is able to show correct line mapping as well as cost attributions.

As a comparison, see the line of `copy_utils.cpasync_bulk_s2cluster`:

Before:
<img width="1800" height="625" alt="Screenshot 2026-07-27 at 15 40 40" src="https://github.com/user-attachments/assets/694ebc1d-2947-4175-acde-62fbf27554fd" />

After:
<img width="1806" height="622" alt="Screenshot 2026-07-27 at 15 41 32" src="https://github.com/user-attachments/assets/83f7c0e2-5a58-48ad-bf48-7f7f2e2b582b" />

