### PR TITLE
[ROCm] Fix CK varlen_fwd binding argument mismatch

### DIFF
--- a/csrc/flash_attn_ck/flash_api.cpp
+++ b/csrc/flash_attn_ck/flash_api.cpp
@@ -40,7 +40,8 @@ mha_varlen_fwd(at::Tensor &q,                               // total_q x num_hea
                int window_size_right,
                const float softcap,
                const bool return_softmax,
-               std::optional<at::Generator> gen_);
+               std::optional<at::Generator> gen_,
+               int /*num_splits*/);
 
 std::vector<at::Tensor>
 mha_bwd(const at::Tensor &dout,                   // batch_size x seqlen_q x num_heads, x multiple_of(head_size_og, 8)

--- a/csrc/flash_attn_ck/mha_varlen_fwd.cpp
+++ b/csrc/flash_attn_ck/mha_varlen_fwd.cpp
@@ -342,7 +342,8 @@ mha_varlen_fwd(at::Tensor &q,                   // total_q x num_heads x head_si
                int window_size_right,
                const float /*softcap*/,
                const bool return_dropout_randval,
-               std::optional<at::Generator> gen_)
+               std::optional<at::Generator> gen_,
+               int /*num_splits*/)
 {
     auto q_dtype = q.dtype();
     TORCH_CHECK(q_dtype == torch::kFloat16 || q_dtype == torch::kBFloat16,


### PR DESCRIPTION
## Summary

Fix an API mismatch between the Python `varlen_fwd` wrapper and the ROCm CK binding.

## Problem

The Python wrapper passes `num_splits` as the trailing argument to `flash_attn_gpu.varlen_fwd`, but the CK binding still uses the previous function signature. This causes CK varlen attention calls to fail with an incompatible function arguments error.

## Fix

Add the trailing `num_splits` argument to the CK `mha_varlen_fwd` declaration and definition.

The argument is intentionally unused. CK continues to initialize `num_splits` internally and select the split count using the existing heuristic, so this change does not alter kernel behavior.

## Testing

Tested tests/test_flash_attn_ck.py on gfx942:
  - Built the ROCm CK extension successfully
  - Ran the full CK test suite
    - 260680 passed, 152076 skipped