### PR TITLE
[CuTe] Add explicit forward config autotuning

### DIFF
--- a/flash_attn/cute/autotune.py
+++ b/flash_attn/cute/autotune.py
@@ -1,0 +1,329 @@
+# Copyright (c) 2026, Dao-AILab.
+
+"""Explicit runtime-input autotuning for FA4 forward.
+
+Given exact ``FwdConfig`` values and real ``_flash_attn_fwd`` arguments, compile
+in isolated parallel subprocesses, capture CUDA graphs on the caller's tensors,
+measure candidates sequentially, and return the winner.
+
+This first version is eager, BF16/FP16, and output-only. It does not alter
+``config=None``, persist shape policy, or tune Flex, modifier, sparse, LSE, or
+autograd calls.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import statistics
+import subprocess
+import sys
+from collections.abc import Mapping, Sequence
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+import torch
+from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
+
+from .cache_utils import CUTE_DSL_CACHE_ENABLED
+from .config import FwdConfig, fwd_config_compile_bucket
+from .interface import _flash_attn_fwd
+
+_COMPILE_REQUEST = "FA4_FWD_AUTOTUNE_COMPILE_REQUEST"
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_ROUNDS = 5
+_REPLAYS = 31
+_WARMUP = 5
+_CLOCK_WARMUP = 20
+_COMPILE_TIMEOUT_SECONDS = 15 * 60
+
+
+def _normalize_kwargs(forward_kwargs: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate the initial output-only scope and pin the real device arch."""
+    kwargs = dict(forward_kwargs)
+    if "config" in kwargs:
+        raise ValueError("pass candidate configs separately, not in forward_kwargs")
+    for name in ("out", "lse", "out_partial", "lse_partial"):
+        if kwargs.get(name) is not None:
+            raise NotImplementedError(f"output-only autotuning does not accept {name}")
+    unsupported = [
+        name
+        for name in (
+            "score_mod",
+            "mask_mod",
+            "block_sparse_tensors",
+            "aux_tensors",
+            "aux_scalars",
+            "gather_kv_indices",
+            "learnable_sink",
+            # seqused_q leaves unused output rows undefined, so full-output checks are invalid.
+            "seqused_q",
+            # Absorbed MLA currently has one fixed forward config.
+            "qv",
+        )
+        if kwargs.get(name) is not None
+    ]
+    if kwargs.get("softcap") not in (None, 0.0):
+        unsupported.append("softcap")
+    if kwargs.get("return_lse", False):
+        unsupported.append("return_lse")
+    if unsupported:
+        raise NotImplementedError(
+            "output-only autotuning does not support " + ", ".join(unsupported)
+        )
+
+    tensors = [value for value in kwargs.values() if isinstance(value, torch.Tensor)]
+    if any(tensor.requires_grad for tensor in tensors):
+        raise NotImplementedError("output-only autotuning does not support autograd")
+    if any(isinstance(tensor, FakeTensor) for tensor in tensors):
+        raise RuntimeError("autotuning requires real CUDA tensors")
+    q, k, v = (kwargs.get(name) for name in ("q", "k", "v"))
+    if not all(isinstance(tensor, torch.Tensor) for tensor in (q, k, v)):
+        raise TypeError("forward_kwargs must contain Q, K, and V tensors")
+    if any(not tensor.is_cuda for tensor in tensors):
+        raise ValueError("all tensor arguments must be CUDA tensors")
+    if any(tensor.device != v.device for tensor in tensors):
+        raise ValueError("all tensor arguments must be on the same CUDA device")
+    if v.dtype not in (torch.float16, torch.bfloat16):
+        raise NotImplementedError("output-only autotuning supports BF16 and FP16 only")
+
+    major, minor = torch.cuda.get_device_capability(v.device)
+    device_arch = major * 10 + minor
+    if kwargs.get("_arch") not in (None, device_arch):
+        raise ValueError(
+            f"requested architecture {kwargs['_arch']} does not match "
+            f"{v.device} architecture {device_arch}"
+        )
+    kwargs["_arch"] = device_arch
+    return kwargs
+
+
+def _decode_kwargs(encoded: Mapping[str, Any]) -> dict[str, Any]:
+    """Recreate fake tensor metadata inside a worker's FakeTensorMode."""
+    return {
+        name: (
+            torch.empty_strided(
+                tuple(value["shape"]),
+                tuple(value["stride"]),
+                dtype=getattr(torch, value["dtype"]),
+                device="cuda:0",
+            )
+            if isinstance(value, dict) and value.get("tensor")
+            else value
+        )
+        for name, value in encoded.items()
+    }
+
+
+def _compile_one(
+    config: FwdConfig,
+    encoded_kwargs: Mapping[str, Any],
+    visible_device: str,
+    device_arch: int,
+) -> None:
+    """Compile one full forward request in an isolated fake-tensor process."""
+    env = os.environ.copy()
+    env["CUDA_VISIBLE_DEVICES"] = visible_device
+    env["CUTE_DSL_ARCH"] = {
+        90: "sm_90a",
+        100: "sm_100a",
+        103: "sm_103a",
+        110: "sm_110a",
+        120: "sm_120a",
+    }.get(device_arch, f"sm_{device_arch}")
+    env["FLASH_ATTENTION_ARCH"] = str(device_arch)
+    env["FLASH_ATTENTION_CUTE_DSL_CACHE_ENABLED"] = "1"
+    env[_COMPILE_REQUEST] = json.dumps({"config": asdict(config), "forward_kwargs": encoded_kwargs})
+    code = """
+import os
+import sys
+import types
+package = types.ModuleType("flash_attn")
+package.__path__ = [os.path.join(os.getcwd(), "flash_attn")]
+sys.modules["flash_attn"] = package
+from flash_attn.cute.autotune import _compile_worker
+_compile_worker()
+"""
+    subprocess.run(
+        [sys.executable, "-c", code],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=_REPO_ROOT,
+        timeout=_COMPILE_TIMEOUT_SECONDS,
+    )
+
+
+def _compile_worker() -> None:
+    """Subprocess entry point: create and invoke tensors in one FakeTensorMode."""
+    request = json.loads(os.environ[_COMPILE_REQUEST])
+    with FakeTensorMode():
+        _flash_attn_fwd(
+            **_decode_kwargs(request["forward_kwargs"]),
+            config=FwdConfig(**request["config"]),
+        )
+
+
+def _compile_barrier(
+    configs: Sequence[FwdConfig],
+    forward_kwargs: Mapping[str, Any],
+    workers: int,
+) -> None:
+    """Compile deduplicated requests in parallel before any measurement."""
+    encoded = {
+        name: (
+            {
+                "tensor": True,
+                "shape": list(value.shape),
+                "stride": list(value.stride()),
+                "dtype": str(value.dtype).removeprefix("torch."),
+            }
+            if isinstance(value, torch.Tensor)
+            else value
+        )
+        for name, value in forward_kwargs.items()
+    }
+    try:
+        json.dumps(encoded)
+    except TypeError as error:
+        raise TypeError("forward arguments must be tensors or JSON-serializable scalars") from error
+
+    v = forward_kwargs["v"]
+    device_index = 0 if v.device.index is None else v.device.index
+    visible = os.environ.get("CUDA_VISIBLE_DEVICES")
+    devices = (
+        [item.strip() for item in visible.split(",") if item.strip()]
+        if visible is not None
+        else None
+    )
+    if devices is not None and device_index >= len(devices):
+        raise ValueError(f"CUDA device {device_index} is outside CUDA_VISIBLE_DEVICES={visible!r}")
+    visible_device = str(device_index) if devices is None else devices[device_index]
+
+    requests = {}
+    for config in configs:
+        requests.setdefault(fwd_config_compile_bucket(config, v.shape[-1]), config)
+    failure = None
+    with ThreadPoolExecutor(max_workers=min(workers, len(requests))) as pool:
+        futures = {
+            pool.submit(
+                _compile_one,
+                config,
+                encoded,
+                visible_device,
+                forward_kwargs["_arch"],
+            ): config
+            for config in requests.values()
+        }
+        for future in as_completed(futures):
+            try:
+                future.result()
+            except (subprocess.SubprocessError, OSError) as error:
+                failure = futures[future], error
+                for pending in futures:
+                    pending.cancel()
+                break
+    if failure is not None:
+        config, error = failure
+        detail = getattr(error, "stderr", None) or getattr(error, "stdout", None)
+        detail = str(detail).strip() if detail else str(error)
+        raise RuntimeError(f"parallel compile failed for {config}:\n{detail}") from error
+
+
+def _measure_configs(configs: Sequence[FwdConfig], forward_kwargs: Mapping[str, Any]) -> FwdConfig:
+    """Capture exact graph paths, time them cyclically, and return the winner."""
+    graphs = []
+    q, v = (forward_kwargs[name] for name in ("q", "v"))
+    shared_output = torch.empty(*q.shape[:-1], v.shape[-1], dtype=q.dtype, device=q.device)
+    max_splits = max(config.num_splits for config in configs)
+    out_partial = lse_partial = None
+    if max_splits > 1:
+        num_heads = q.shape[-2]
+        lse_shape = (
+            (num_heads, q.shape[0])
+            if forward_kwargs.get("cu_seqlens_q") is not None
+            else (q.shape[0], num_heads, q.shape[1])
+        )
+        out_partial = torch.empty(
+            max_splits,
+            *shared_output.shape,
+            dtype=torch.float32,
+            device=q.device,
+        )
+        lse_partial = torch.empty(
+            max_splits,
+            *lse_shape,
+            dtype=torch.float32,
+            device=q.device,
+        )
+
+    for config in configs:
+        call_kwargs = {**forward_kwargs, "out": shared_output}
+        if config.num_splits > 1:
+            call_kwargs.update(
+                out_partial=out_partial[: config.num_splits],
+                lse_partial=lse_partial[: config.num_splits],
+            )
+        for _ in range(_WARMUP):
+            _flash_attn_fwd(**call_kwargs, config=config)
+        torch.cuda.synchronize()
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            _flash_attn_fwd(**call_kwargs, config=config)
+        for _ in range(_WARMUP):
+            graph.replay()
+        torch.cuda.synchronize()
+        graphs.append(graph)
+
+    elapsed = [[] for _ in configs]
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    device = forward_kwargs["v"].device
+    generator = torch.Generator(device=device).manual_seed(0)
+    clock_operand = torch.randn(
+        4096, 4096, dtype=forward_kwargs["v"].dtype, device=device, generator=generator
+    )
+    clock_output = torch.empty_like(clock_operand)
+    for round_index in range(_ROUNDS):
+        for position in range(len(configs)):
+            index = (round_index + position) % len(configs)
+            for _ in range(_CLOCK_WARMUP):
+                torch.mm(clock_operand, clock_operand, out=clock_output)
+            torch.cuda.synchronize(device)
+            for _ in range(_REPLAYS):
+                start.record()
+                graphs[index].replay()
+                end.record()
+                end.synchronize()
+                elapsed[index].append(start.elapsed_time(end) * 1e3)
+    return configs[min(range(len(configs)), key=lambda index: statistics.median(elapsed[index]))]
+
+
+def tune_fwd_config(
+    configs: Sequence[FwdConfig],
+    forward_kwargs: Mapping[str, Any],
+    *,
+    compile_workers: int = 8,
+) -> FwdConfig:
+    """Return the fastest exact config for one concrete eager forward call."""
+    configs = tuple(dict.fromkeys(configs))
+    if not configs:
+        raise ValueError("at least one FwdConfig is required")
+    if compile_workers < 1:
+        raise ValueError("compile_workers must be positive")
+    if torch.compiler.is_compiling():
+        raise RuntimeError("autotuning must run outside torch.compile")
+    if not CUTE_DSL_CACHE_ENABLED:
+        raise RuntimeError("set FLASH_ATTENTION_CUTE_DSL_CACHE_ENABLED=1 before importing FA4")
+
+    kwargs = _normalize_kwargs(forward_kwargs)
+    device = kwargs["v"].device
+    with torch.cuda.device(device):
+        if torch.cuda.is_current_stream_capturing():
+            raise RuntimeError("autotuning cannot start inside CUDA graph capture")
+        _compile_barrier(configs, kwargs, compile_workers)
+        return _measure_configs(configs, kwargs)

--- a/tests/cute/test_fwd_autotune.py
+++ b/tests/cute/test_fwd_autotune.py
@@ -1,0 +1,239 @@
+import os
+import subprocess
+import sys
+import types
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+import torch
+from torch._subclasses.fake_tensor import FakeTensorMode
+
+if "flash_attn" not in sys.modules:
+    package = types.ModuleType("flash_attn")
+    package.__path__ = [str(Path(__file__).resolve().parents[2] / "flash_attn")]
+    sys.modules["flash_attn"] = package
+
+from flash_attn.cute.autotune import _compile_barrier, _decode_kwargs, _normalize_kwargs
+from flash_attn.cute.config import (
+    FwdCombineKernelSpec,
+    FwdConfig,
+    FwdMainKernelSpec,
+    FwdSm100RegisterAllocation,
+    fwd_config_compile_bucket,
+    select_fwd_config,
+)
+from flash_attn.cute.interface import _flash_attn_fwd, _flash_attn_fwd_combine
+
+_BASE_CONFIG = FwdConfig(
+    device_capacity=10,
+    tile_m=128,
+    tile_n=128,
+    num_stages=0,
+    num_threads=512,
+    mma_pv_is_rs=False,
+    intra_wg_overlap=False,
+    q_stage=1,
+    use_clc_scheduler=False,
+    is_static_persistent=False,
+    use_tma_o=False,
+    num_splits=1,
+    use_2cta_instrs=False,
+    registers=FwdSm100RegisterAllocation(192, 80, 48),
+)
+
+
+def test_fake_compile_payload_preserves_tensor_metadata():
+    encoded = {
+        "q": {
+            "tensor": True,
+            "shape": [3, 5, 7],
+            "stride": [35, 7, 1],
+            "dtype": "bfloat16",
+        },
+        "causal": False,
+    }
+
+    with FakeTensorMode():
+        decoded = _decode_kwargs(encoded)
+
+    assert decoded["q"].shape == (3, 5, 7)
+    assert decoded["q"].stride() == (35, 7, 1)
+    assert decoded["q"].dtype == torch.bfloat16
+    assert decoded["q"].device.type == "cuda"
+    assert decoded["causal"] is False
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "lse",
+        "softcap",
+        "gather_kv_indices",
+        "score_mod",
+        "learnable_sink",
+        "seqused_q",
+        "qv",
+        "return_lse",
+    ],
+)
+def test_initial_scope_rejects_lse_modifier_and_sparse_paths(name):
+    with pytest.raises(NotImplementedError, match=name):
+        _normalize_kwargs({name: True})
+
+
+def test_dynamic_shape_churn_has_bounded_compile_specializations(monkeypatch):
+    monkeypatch.setenv("FLASH_ATTENTION_NUM_SMS", "152")
+
+    class SpecRecorder:
+        """Pretend every key is compiled while recording cache cardinality."""
+
+        def __init__(self, expected_type):
+            self.expected_type = expected_type
+            self.keys = set()
+
+        def __contains__(self, key):
+            assert isinstance(key, self.expected_type)
+            self.keys.add(key)
+            return True
+
+    main = SpecRecorder(FwdMainKernelSpec)
+    combine = SpecRecorder(FwdCombineKernelSpec)
+    original_main = _flash_attn_fwd.compile_cache
+    original_combine = _flash_attn_fwd_combine.compile_cache
+    _flash_attn_fwd.compile_cache = main
+    _flash_attn_fwd_combine.compile_cache = combine
+    select_fwd_config.cache_clear()
+    try:
+        with FakeTensorMode():
+            # One more unique shape than the selector cache can retain.
+            for index in range(1025):
+                batch = 1 + index % 64
+                seqlen_q = 1 + (index * 131) % 8191
+                seqlen_k = 1 + (index * 8191) % 65521
+                q = torch.empty(
+                    batch, seqlen_q, 32, 128, device="cuda", dtype=torch.bfloat16
+                )
+                k = torch.empty(
+                    batch, seqlen_k, 8, 128, device="cuda", dtype=torch.bfloat16
+                )
+                v = torch.empty_like(k)
+                _flash_attn_fwd(q, k, v, num_splits=0, _arch=103)
+        selector_info = select_fwd_config.cache_info()
+    finally:
+        _flash_attn_fwd.compile_cache = original_main
+        _flash_attn_fwd_combine.compile_cache = original_combine
+        select_fwd_config.cache_clear()
+
+    assert len(main.keys) == 4
+    assert len(combine.keys) == 1
+    assert selector_info.currsize == 1024
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available()
+    or torch.cuda.get_device_capability()[0] not in (10, 11),
+    reason="SM100/SM110 runtime autotuning test",
+)
+def test_tune_fwd_config_runtime(tmp_path):
+    root = Path(__file__).resolve().parents[2]
+    code = """
+import os
+import sys
+import types
+package = types.ModuleType("flash_attn")
+package.__path__ = [os.path.join(os.getcwd(), "flash_attn")]
+sys.modules["flash_attn"] = package
+import torch
+from dataclasses import replace
+from flash_attn.cute.autotune import tune_fwd_config
+from flash_attn.cute.config import FwdConfig, FwdSm100RegisterAllocation
+q = torch.randn(1, 65, 8, 64, device="cuda", dtype=torch.bfloat16)
+k = torch.randn(1, 257, 8, 64, device="cuda", dtype=torch.bfloat16)
+v = torch.randn_like(k)
+capacity = torch.cuda.get_device_capability()[0]
+base = FwdConfig(
+    device_capacity=capacity,
+    tile_m=128,
+    tile_n=128,
+    num_stages=0,
+    num_threads=512,
+    mma_pv_is_rs=False,
+    intra_wg_overlap=False,
+    q_stage=1,
+    use_clc_scheduler=False,
+    is_static_persistent=False,
+    use_tma_o=True,
+    num_splits=1,
+    use_2cta_instrs=False,
+    registers=FwdSm100RegisterAllocation(200, 64, 48),
+)
+split = replace(base, use_tma_o=False, num_splits=2)
+configs = (base, replace(base, q_stage=2), split)
+winner = tune_fwd_config(configs, {"q": q, "k": k, "v": v}, compile_workers=2)
+assert winner in configs
+
+q = q.reshape(-1, 8, 64)
+k = k.reshape(-1, 8, 64)
+v = v.reshape(-1, 8, 64)
+cu_q = torch.tensor([0, 17, 65], device="cuda", dtype=torch.int32)
+cu_k = torch.tensor([0, 129, 257], device="cuda", dtype=torch.int32)
+varlen = replace(base, use_tma_o=False, is_static_persistent=False)
+configs = (varlen, replace(varlen, q_stage=2), replace(varlen, num_splits=2))
+winner = tune_fwd_config(
+    configs,
+    {
+        "q": q,
+        "k": k,
+        "v": v,
+        "cu_seqlens_q": cu_q,
+        "cu_seqlens_k": cu_k,
+        "max_seqlen_q": 48,
+        "max_seqlen_k": 129,
+    },
+    compile_workers=2,
+)
+assert winner in configs
+"""
+    env = os.environ.copy()
+    env["FLASH_ATTENTION_CUTE_DSL_CACHE_ENABLED"] = "1"
+    env["FLASH_ATTENTION_CUTE_DSL_CACHE_DIR"] = str(tmp_path / "cache")
+    subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=root,
+        env=env,
+        check=True,
+        timeout=300,
+    )
+
+
+def test_compile_barrier_identifies_the_failing_config(monkeypatch):
+    bad = replace(_BASE_CONFIG, tile_m=64)
+
+    def compile_one(config, *_):
+        if config == bad:
+            raise subprocess.TimeoutExpired("compile", 1)
+
+    monkeypatch.setattr("flash_attn.cute.autotune._compile_one", compile_one)
+    kwargs = {"v": torch.empty(1, 1, 1, 64), "_arch": 100}
+
+    with pytest.raises(RuntimeError, match=r"parallel compile failed.*tile_m=64"):
+        _compile_barrier((_BASE_CONFIG, bad), kwargs, workers=2)
+
+
+def test_compile_bucket_deduplicates_exact_split_counts():
+    split_two = replace(_BASE_CONFIG, num_splits=2)
+    split_four = replace(_BASE_CONFIG, num_splits=4)
+    alternate_registers = replace(
+        _BASE_CONFIG, registers=FwdSm100RegisterAllocation(184, 80, 64)
+    )
+
+    assert fwd_config_compile_bucket(split_two, 128) == fwd_config_compile_bucket(
+        split_four, 128
+    )
+    assert fwd_config_compile_bucket(_BASE_CONFIG, 128) != fwd_config_compile_bucket(
+        split_two, 128
+    )
+    assert fwd_config_compile_bucket(_BASE_CONFIG, 128) != fwd_config_compile_bucket(
+        alternate_registers, 128
+    )


### PR DESCRIPTION
Stacked PRs:
 * __->__#2743
 * #2741
 * #2738
 * #2735
 * #2733
 * #2732


--- --- ---

# Human Note

<!-- Fill this in before landing. -->

# Agent Note

## Summary

This adds a small explicit autotuning boundary for direct FA4 calls. The caller provides exact `FwdConfig` candidates and the real forward arguments; FA4 compiles the required specializations in isolated parallel subprocesses, waits for the full barrier, captures preallocated CUDA graphs on those tensors, measures candidates sequentially, and returns the winning exact config.

```python
winner = tune_fwd_config(
    configs,
    {"q": q, "k": k, "v": v, "causal": False},
)

out, lse, _, _ = _flash_attn_fwd(q, k, v, causal=False, config=winner)
```

`FwdConfig` keeps one meaning: an exact resolved execution choice, including its named SM100 register allocation when applicable. Register-only candidates therefore use the same compile/timing path as tile or scheduler candidates. `config=None` remains the analytical production selector. Tuning is never hidden inside a normal forward call, and this PR does not add shape buckets or winner persistence.

## Compile and timing contract

- Requires `FLASH_ATTENTION_CUTE_DSL_CACHE_ENABLED=1` before importing FA4.
- Pins compiler workers to the input GPU and exact architecture.
- Creates fake tensors and invokes FA4 within the same `FakeTensorMode` in each isolated worker.
- Deduplicates exact SplitKV counts that share typed main/combine specializations, while register-only changes remain distinct main specializations.
- Completes the entire parallel compile barrier before timing; each worker has a timeout and queued work is cancelled after a failure.
- Does not infer correctness from candidate agreement; explicit-config validation and the FA4 test suite own correctness.
- Preallocates output and exact SplitKV partial O/LSE workspaces before capture.
- Measures five cyclic rounds × 31 individually timed fixed-pointer graph replays per candidate.
- Runs 20 untimed 4096×4096 GEMMs before every arm and returns the lowest-median exact config.

## Scope and ownership

The initial direct-call tuner supports eager BF16/FP16 output-only calls. It explicitly rejects LSE/autograd, score or mask modifiers, block sparsity, gather-KV, learnable sinks, auxiliary captures, `seqused_q`, and absorbed MLA/QV. The latter currently has one fixed forward config, so there is nothing to rank.

Flex/FLASH does not invoke this tuner. Inductor already owns Flex candidate compilation, timing, guards, and caching through `autotune_select_algorithm`; a later PyTorch integration can add exact `FwdConfig` values to those existing choices without nesting tuners.

## Validation

- 179 focused config/cache/autotune/benchmark host tests passed, including register JSON/YAML round trips and specialization identity.
- A 1,025-shape fake-tensor churn test fills the bounded selector cache while producing exactly four main and one combine specialization.
- Real dense, packed-varlen, SplitKV, FP8-register, forced-register, and HD256 execution passed on GB300.
- Final independent fuzz pass: 20 workload cells and 97 candidate executions, zero failures; the broader layout/random hardening pass remains 48 cells and 230 executions. Native Flex dynamic-shape and captured-aux traces each stabilized at two Inductor graphs and two FA4 kernels.
- Fuzz coverage includes BF16/FP16; dense, packed-varlen, and paged KV; MHA/GQA/MQA; `D == DV`, `D > DV`, and `DV > D`; causal/local masks; odd and zero subsequence lengths; exact SplitKV counts; and nontrivial strides/storage offsets.
- Candidate-order reversal checks passed on representative dense and decode/SplitKV cells.
- Ruff, formatting, `py_compile`, `prek`, and `git diff --check` passed.