### PR TITLE
Fix duplicated word in layer norm comment

### DIFF
--- a/csrc/layer_norm/ln_utils.cuh
+++ b/csrc/layer_norm/ln_utils.cuh
@@ -699,7 +699,7 @@ struct Stats<T, 1, WARPS_M, WARPS_N> {
             elts, warp_norm_factor, valid_elts_in_warp_fn, num_valid_elts
         );
 
-        //Each warp warp leader stores its stats
+        // Each warp leader stores its stats
         const auto lane = warp_stats_.reducer_.lane_;
         if( lane == 0 ) {
             smem[warp_n] = warp_stats;


### PR DESCRIPTION
Fix a duplicated `warp` in the comment above the per-warp statistics store in `ln_utils.cuh`. This is a comment-only change and does not affect generated code.

Validation:
- Confirmed the old phrase is absent and the corrected phrase is present
- `git diff --check`