### PR TITLE
[CuTe] Fix forward dynamic-shape correctness

### DIFF
--- a/flash_attn/cute/cute_dsl_utils.py
+++ b/flash_attn/cute/cute_dsl_utils.py
@@ -1,9 +1,11 @@
 # Copyright (c) 2025, Tri Dao.
 
+import os
 from typing import Tuple
 from functools import lru_cache
 
 import torch
+from torch._subclasses.fake_tensor import FakeTensor
 
 try:
     from triton.tools.disasm import extract
@@ -39,6 +41,75 @@ def get_max_active_clusters(cluster_size):
 @lru_cache
 def get_device_capacity(device: torch.device = None) -> Tuple[int, int]:
     return torch.cuda.get_device_capability(device)
+
+
+@lru_cache
+def _get_device_arch_and_num_sms(device_index: int) -> tuple[int, int]:
+    properties = torch.cuda.get_device_properties(device_index)
+    return properties.major * 10 + properties.minor, properties.multi_processor_count
+
+
+def get_num_sms_for_selection(device_index: int, arch: int) -> int:
+    """Return the SM count of the matching local GPU or cross-compilation target."""
+    override = os.getenv("FLASH_ATTENTION_NUM_SMS")
+    if override is not None:
+        num_sms = int(override)
+        if num_sms <= 0:
+            raise ValueError("FLASH_ATTENTION_NUM_SMS must be positive")
+        return num_sms
+    if torch.cuda.is_available():
+        device_arch, num_sms = _get_device_arch_and_num_sms(device_index)
+        if device_arch == arch:
+            return num_sms
+    raise RuntimeError(
+        "Cannot determine the target GPU's SM count; set FLASH_ATTENTION_NUM_SMS "
+        "when cross-compiling without a matching local GPU"
+    )
+
+
+def _has_aligned_pointer(tensor: torch.Tensor, align_bytes: int) -> bool:
+    address = (
+        tensor.storage_offset() * tensor.element_size()
+        if isinstance(tensor, FakeTensor)
+        else tensor.data_ptr()
+    )
+    return address % align_bytes == 0
+
+
+def _is_aligned_layout(tensor: torch.Tensor, align_bytes: int) -> bool:
+    """Return whether a tensor satisfies the pointer and stride ABI kernels assume."""
+    if tensor.stride(-1) != 1 or not _has_aligned_pointer(tensor, align_bytes):
+        return False
+    stride_alignment = max(1, align_bytes // tensor.element_size())
+    return all(stride == 0 or stride % stride_alignment == 0 for stride in tensor.stride()[:-1])
+
+
+def maybe_contiguous(tensor: torch.Tensor | None, align_bytes: int = 16):
+    """Canonicalize inputs to the pointer and stride alignment kernels assume."""
+    if tensor is None:
+        return None
+    if tensor.is_contiguous():
+        return (
+            tensor
+            if _has_aligned_pointer(tensor, align_bytes)
+            else tensor.clone(memory_format=torch.contiguous_format)
+        )
+    if not _has_aligned_pointer(tensor, align_bytes):
+        return tensor.clone(memory_format=torch.contiguous_format)
+    return tensor if _is_aligned_layout(tensor, align_bytes) else tensor.contiguous()
+
+
+def validate_output_layout(tensor: torch.Tensor, name: str, align_bytes: int) -> None:
+    """Validate a caller-provided output or SplitKV workspace."""
+    assert 0 not in tensor.stride(), f"{name} must not have broadcast dimensions"
+    if tensor.is_contiguous():
+        assert _has_aligned_pointer(tensor, align_bytes), (
+            f"{name} must have aligned strides and a contiguous last dimension"
+        )
+        return
+    assert _is_aligned_layout(tensor, align_bytes), (
+        f"{name} must have aligned strides and a contiguous last dimension"
+    )
 
 
 def assume_strides_aligned(t):
@@ -102,15 +173,37 @@ def to_cute_aux_tensor(t, enable_tvm_ffi=True):
     )
 
 
+def _resolve_aux_leading_dim(tensor: torch.Tensor) -> int | None:
+    """Pick the mode CuTe keeps as a static stride-1 leading dimension."""
+    leading_dim = getattr(tensor, "__leading_dim__", None)
+    if leading_dim is not None:
+        if tensor.ndim == 0:
+            raise ValueError("Scalar aux tensors cannot declare __leading_dim__")
+        leading_dim %= tensor.ndim
+        if tensor.stride(leading_dim) != 1:
+            raise ValueError("Aux tensor __leading_dim__ must identify a stride-1 dimension")
+        return leading_dim
+
+    unit_stride_dims = [dim for dim, stride in enumerate(tensor.stride()) if stride == 1]
+    if len(unit_stride_dims) <= 1:
+        return unit_stride_dims[0] if unit_stride_dims else None
+    nontrivial_dims = [dim for dim in unit_stride_dims if tensor.shape[dim] > 1]
+    if len(nontrivial_dims) != 1:
+        raise ValueError("Aux tensor layout has no unique stride-1 leading dimension")
+    return nontrivial_dims[0]
+
+
 def get_aux_tensor_metadata(aux_tensors):
-    return tuple(
-        (
-            getattr(t, "__assumed_align__", 0),
-            getattr(t, "__leading_dim__", -1),
-            hasattr(t, "__leading_dim__"),
+    """Return the static aux-tensor ABI facts that must key the compile cache."""
+    metadata = []
+    for tensor in aux_tensors:
+        leading_dim = _resolve_aux_leading_dim(tensor)
+        static_strides = tuple(
+            0 if stride == 0 else 1 if dim == leading_dim else None
+            for dim, stride in enumerate(tensor.stride())
         )
-        for t in aux_tensors
-    )
+        metadata.append((tensor.dtype, getattr(tensor, "__assumed_align__", None), static_strides))
+    return tuple(metadata)
 
 
 def get_broadcast_dims(tensor: torch.Tensor) -> Tuple[bool, ...]:
@@ -120,7 +213,11 @@ def get_broadcast_dims(tensor: torch.Tensor) -> Tuple[bool, ...]:
     stride=0 as static, meaning kernels compiled with different broadcast
     patterns are not interchangeable.
     """
-    return tuple(s == 0 for s in tensor.stride())
+    strides = tensor.stride()
+    # Written this way for speed.
+    if 0 not in strides:
+        return (False,) * len(strides)
+    return tuple(stride == 0 for stride in strides)
 
 
 # credit: monellz (https://github.com/NVIDIA/cutlass/issues/2658#issuecomment-3630564264)

--- a/flash_attn/cute/flash_fwd_sm100.py
+++ b/flash_attn/cute/flash_fwd_sm100.py
@@ -746,6 +746,8 @@ class FlashAttentionForwardSm100:
             cute.cosize(sQ_layout) if const_expr(not self.overlap_sO_sQ) else
             cutlass.max(cute.cosize(sQ_layout), cute.cosize(sO_layout) * self.o_dtype.width // self.q_dtype.width)
         )
+        # K and V alias the same physical buffer and may have different extents.
+        sKV_size = cutlass.max(cute.cosize(sK_layout), cute.cosize(sV_layout))
 
         sched_response_size = self.sched_stages * 4 if self.dynamic_persistent else 0
         sched_mbar_size = self.sched_stages * 2 if self.dynamic_persistent else 0
@@ -786,8 +788,7 @@ class FlashAttentionForwardSm100:
                 cute.struct.MemRange[self.q_dtype, sQ_size], self.buffer_align_bytes
             ]
             sK: cute.struct.Align[
-                # cute.cosize(sK_layout) is correct even in the case of self.uneven_kv_smem
-                cute.struct.MemRange[self.k_dtype, cute.cosize(sK_layout)],
+                cute.struct.MemRange[self.k_dtype, sKV_size],
                 self.buffer_align_bytes,
             ]
 

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -31,8 +31,11 @@ from flash_attn.cute import fa_logging
 from flash_attn.cute.cute_dsl_utils import (
     get_aux_tensor_metadata,
     get_broadcast_dims,
+    get_num_sms_for_selection,
+    maybe_contiguous,
     to_cute_aux_tensor,
     to_cute_tensor,
+    validate_output_layout,
 )
 from flash_attn.cute.flash_fwd import FlashAttentionForwardSm80
 from flash_attn.cute.flash_fwd_sm90 import FlashAttentionForwardSm90
@@ -93,9 +96,10 @@ def _get_device_arch():
     kernel path to use (SM80/SM90/SM100/SM120) independently of the compilation
     target (CUTE_DSL_ARCH).
 
-    For CPU-only compilation (no GPU), set both:
+    For CPU-only compilation (no GPU), set:
       FLASH_ATTENTION_ARCH=sm_80  (kernel selection)
       CUTE_DSL_ARCH=sm_80         (compilation target)
+      FLASH_ATTENTION_NUM_SMS=132 (target-SKU selector metadata)
     """
     arch_override = os.environ.get("FLASH_ATTENTION_ARCH", None)
     if arch_override is not None:
@@ -104,6 +108,7 @@ def _get_device_arch():
     return major * 10 + int(minor)
 
 
+@lru_cache(maxsize=None)
 def _validate_head_dims(head_dim: int, head_dim_v: int, compute_capability: int, alignment: int) -> None:
     """Validate head dimension constraints based on compute capability."""
     is_deepseek_shape = head_dim == 192 and head_dim_v == 128
@@ -251,16 +256,11 @@ def _tile_size_bwd_sm90(head_dim, head_dim_v, causal, local, sparse_block_size_q
 
 
 
-def maybe_contiguous(x):
-    return x.contiguous() if x is not None and x.stride(-1) != 1 else x
-
-
 def _validate_tensor(t, name, expected_shape, expected_dtype, expected_device):
     assert t.shape == expected_shape, f"{name} shape {t.shape} != expected {expected_shape}"
     assert t.dtype == expected_dtype, f"{name} dtype {t.dtype} != expected {expected_dtype}"
     assert t.device == expected_device, f"{name} device {t.device} != expected {expected_device}"
-    if not is_fake_mode():
-        assert t.is_cuda, f"{name} must be on CUDA"
+    assert t.is_cuda, f"{name} must be on CUDA"
 
 torch2cute_dtype_map = {
     torch.float16: cutlass.Float16,
@@ -363,12 +363,11 @@ def _get_fwd_config(
     num_m_blocks = (seqlen_q_packgqa + m_block_size_effective - 1) // m_block_size_effective
     total_mblocks = batch_size * num_head_kv * num_m_blocks
     num_n_blocks = (seqlen_k_loaded + tile_n - 1) // tile_n
-    num_SMs = (
-        132 if is_fake_mode() else torch.cuda.get_device_properties(device).multi_processor_count
-    )
+    num_SMs = None
     if arch // 10 == 12:
         assert num_splits == 1, "SM120 forward only supports num_splits=1"
     elif num_splits < 1:
+        num_SMs = get_num_sms_for_selection(device.index, arch)
         num_splits = num_splits_heuristic(total_mblocks, num_SMs, num_n_blocks, 128)
 
     # SplitKV uses float32 partial output, which doubles the O buffer size
@@ -377,6 +376,8 @@ def _get_fwd_config(
         if num_n_blocks >= 64 and head_dim_v != 512:
             tile_n = 64
             num_n_blocks = (seqlen_k_loaded + tile_n - 1) // tile_n
+            if num_SMs is None:
+                num_SMs = get_num_sms_for_selection(device.index, arch)
             num_splits = num_splits_heuristic(total_mblocks, num_SMs, num_n_blocks, 128)
         else:
             num_splits = 1
@@ -574,10 +575,19 @@ def _flash_attn_fwd(
         aux_scalars: Runtime scalar captures used by score_mod or mask_mod.
     """
     aux_scalars = tuple(aux_scalars) if aux_scalars else None
+    requires_grad = any(
+        t is not None and t.requires_grad for t in (q, k, v, qv, learnable_sink)
+    )
+    fake_mode = is_fake_mode()
     q, k, v, qv = [maybe_contiguous(t) for t in (q, k, v, qv)]
     assert q is not None or qv is not None
     assert v is not None
-    q_descale, k_descale, v_descale = [maybe_contiguous(t) for t in (q_descale, k_descale, v_descale)]
+    q_descale, k_descale, v_descale = [
+        maybe_contiguous(t, align_bytes=4) for t in (q_descale, k_descale, v_descale)
+    ]
+    page_table = maybe_contiguous(page_table, align_bytes=4)
+    learnable_sink = maybe_contiguous(learnable_sink, align_bytes=4)
+    gather_kv_indices = maybe_contiguous(gather_kv_indices, align_bytes=16)
     q_shape = q.shape if q is not None else qv.shape
     num_head, head_dim = q_shape[-2:]
     if cu_seqlens_q is None:
@@ -628,13 +638,9 @@ def _flash_attn_fwd(
         "inputs must be float16, bfloat16, fp8 e4m3fn, or fp8 e5m2"
     )
     
-    input_tensors = {"q": q, "k": k, "v": v, "qv": qv}
-    present = {name: t for name, t in input_tensors.items() if t is not None}
-    names = list(present.keys())
-    for i in range(len(names)):
-        for j in range(i + 1, len(names)):
-            a, b = names[i], names[j]
-            assert present[a].dtype == present[b].dtype, f"{a}.dtype {present[a].dtype} != {b}.dtype {present[b].dtype}"
+    assert all(t is None or t.dtype == v.dtype for t in (q, k, qv)), (
+        "q, k, v, and qv must have the same dtype"
+    )
 
     q_dtype = q.dtype if q is not None else qv.dtype
 
@@ -652,7 +658,7 @@ def _flash_attn_fwd(
             "learnable_sink must be float16, bfloat16, or float32"
         )
 
-    if not is_fake_mode():
+    if not fake_mode:
         assert all(
             t is None or t.is_cuda
             for t in (
@@ -689,9 +695,6 @@ def _flash_attn_fwd(
         pack_gqa = qhead_per_kvhead > 1
 
     is_fp8 = v.dtype in (torch.float8_e4m3fn, torch.float8_e5m2)
-    requires_grad = any(
-        t is not None and t.requires_grad for t in [q, k, v, qv, learnable_sink]
-    )
     if is_fp8 and requires_grad:
         raise NotImplementedError("FA4 CuTe FP8 backward is not supported yet (forward-only).")
     out_torch_dtype = torch.bfloat16 if is_fp8 else q_dtype
@@ -709,7 +712,14 @@ def _flash_attn_fwd(
             *q_batch_seqlen_shape, num_head, head_dim_v, dtype=out_torch_dtype, device=device
         )
     else:
-        _validate_tensor(out, "out", (*q_batch_seqlen_shape, num_head, head_dim_v), out_torch_dtype, device)
+        _validate_tensor(
+            out,
+            "out",
+            (*q_batch_seqlen_shape, num_head, head_dim_v),
+            out_torch_dtype,
+            device,
+        )
+        validate_output_layout(out, "out", align_bytes=16)
 
     if lse is None:
         lse = (
@@ -719,6 +729,7 @@ def _flash_attn_fwd(
         )
     elif lse is not None:
         _validate_tensor(lse, "lse", lse_shape, torch.float32, device)
+        validate_output_layout(lse, "lse", align_bytes=4)
 
     if seqlen_k == 0 or total_q == 0:
         out.zero_()
@@ -737,7 +748,13 @@ def _flash_attn_fwd(
     if is_fp8:
         for t, name in ((q_descale, "q_descale"), (k_descale, "k_descale"), (v_descale, "v_descale")):
             if t is not None:
-                _validate_tensor(t, name, (batch_size, num_head_kv), torch.float32, device)
+                _validate_tensor(
+                    t,
+                    name,
+                    (batch_size, num_head_kv),
+                    torch.float32,
+                    device,
+                )
     else:
         assert q_descale is None and k_descale is None and v_descale is None, (
             "q_descale/k_descale/v_descale are only supported for FP8 inputs"
@@ -754,8 +771,6 @@ def _flash_attn_fwd(
 
     requested_use_clc_scheduler = utils._get_use_clc_scheduler_default()
     requested_disable_2cta = utils._get_disable_2cta_default(is_fwd=True)
-
-    current_stream = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
 
     # SM80/SM120: uses SM80 MMA, 128 threads (4 warps)
     if arch // 10 in [8, 12]:
@@ -1069,6 +1084,22 @@ def _flash_attn_fwd(
         and not is_split_kv
     )
 
+    # CuTe keeps stride-zero modes static when marking layouts dynamic.
+    tensor_broadcast_patterns = tuple(
+        get_broadcast_dims(tensor) if tensor is not None else None
+        for tensor in (
+            q,
+            k,
+            v,
+            qv,
+            page_table,
+            q_descale,
+            k_descale,
+            v_descale,
+            gather_kv_indices,
+        )
+    )
+
     compile_key = (
         dtype,
         head_dim,
@@ -1079,6 +1110,7 @@ def _flash_attn_fwd(
         mask_mod_hash,
         use_block_sparsity,
         block_sparse_broadcast_pattern,
+        tensor_broadcast_patterns,
         aux_tensor_metadata,
         aux_scalar_metadata,
         lse is None,
@@ -1133,6 +1165,7 @@ def _flash_attn_fwd(
     )
 
     if compile_key not in _flash_attn_fwd.compile_cache:
+        current_stream = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
         (
             cu_seqlens_q_tensor,
             cu_seqlens_k_tensor,
@@ -1418,7 +1451,7 @@ def _flash_attn_fwd(
             compile_args.append(current_stream)
             _flash_attn_fwd.compile_cache[compile_key] = cute.compile(*compile_args, options="--enable-tvm-ffi")
 
-    if not is_fake_mode():
+    if not fake_mode:
         q_call, k_call, v_call, qv_call = [
             t.detach() if t is not None else None
             for t in (q, k, v, qv)
@@ -1515,6 +1548,7 @@ def _flash_attn_fwd(
             seqused_q,
             num_splits_dynamic_ptr=num_splits_dynamic if has_scheduler_metadata else None,
             virtual_batch_idx=virtual_batch_idx if has_scheduler_metadata else None,
+            _arch=arch,
         )
     if reuse_scheduler_metadata and tile_count_semaphore is not None:
         # TODO: pass tile_count_semaphore to the combine kernel and zero it there when
@@ -1638,6 +1672,8 @@ def _bwd_preprocess(
     nheads_kv=1,         # only used with pack_gqa
     softmax_scale=1.0,   # only used with scale_p
     cu_total_m_blocks=None,
+    *,
+    fake_mode,
 ):
     """Backward preprocess: compute (o * dout).sum(dim=-1) - dLSE, lse * log2_e, and zero out dq_accum."""
     if row_max is not None:
@@ -1671,7 +1707,7 @@ def _bwd_preprocess(
     )
     if compile_key not in _bwd_preprocess.compile_cache:
         _bwd_preprocess.compile_cache[compile_key] = _compile_bwd_preprocess(*compile_key)
-    if not is_fake_mode():
+    if not fake_mode:
         _bwd_preprocess.compile_cache[compile_key](
             out, dout, dpsum, lse, lse_log2, dq_accum, cu_seqlens_q, seqused_q, dlse,
             row_max, scale_p, softmax_scale, cu_total_m_blocks,
@@ -1729,6 +1765,8 @@ def _bwd_postprocess_convert(
     use_2cta_instrs=False, cluster_size=1,
     cu_total_m_blocks=None,
     sink_tensors=None,
+    *,
+    fake_mode,
 ):
     """Backward postprocess: convert float32 accumulator to bf16/fp16 output."""
     is_varlen = cu_seqlens is not None or seqused is not None
@@ -1755,7 +1793,7 @@ def _bwd_postprocess_convert(
     )
     if compile_key not in _bwd_postprocess_convert.compile_cache:
         _bwd_postprocess_convert.compile_cache[compile_key] = _compile_bwd_postprocess(*compile_key)
-    if not is_fake_mode():
+    if not fake_mode:
         _bwd_postprocess_convert.compile_cache[compile_key](
             accum, output, scale, cu_seqlens, seqused,
             sink_tensors,
@@ -1811,6 +1849,7 @@ def _flash_attn_bwd(
     learnable_sink: Optional[torch.Tensor] = None,
 ) -> Tuple[torch.Tensor, ...]:
     aux_scalars = tuple(aux_scalars) if aux_scalars else None
+    fake_mode = is_fake_mode()
     arch = _get_device_arch()
     assert arch // 10 in [9, 10, 11, 12], "Unsupported compute capability. Supported: 9.x, 10.x, 11.x, 12.x"
     if block_sparse_tensors is not None:
@@ -2035,7 +2074,7 @@ def _flash_attn_bwd(
         assert learnable_sink.dtype in _LEARNABLE_SINK_DTYPES, (
             "learnable_sink must be float16, bfloat16, or float32"
         )
-    if not is_fake_mode():
+    if not fake_mode:
         assert all(
             t is None or t.is_cuda
             for t in (q, k, v, out, dout, lse, cu_seqlens_q, cu_seqlens_k, learnable_sink)
@@ -2156,7 +2195,6 @@ def _flash_attn_bwd(
             )
 
     dtype = torch2cute_dtype_map[q.dtype]
-    current_stream = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
 
     if deterministic:
         dQ_semaphore = torch.zeros(batch_size, num_head, seqlen_q_rounded // m_block_size, cluster_size, dtype=torch.int32, device=device)
@@ -2196,6 +2234,7 @@ def _flash_attn_bwd(
         cu_seqlens_q, seqused_q, dlse,
         dtype, head_dim, head_dim_v, m_block_size,
         cu_total_m_blocks=cu_total_m_blocks_q,
+        fake_mode=fake_mode,
     )
     # num_threads: SM90 derives from BwdConfig.num_wg, SM120 is set to 128 above,
     # SM100/SM110 uses default from function signature (384).
@@ -2209,9 +2248,6 @@ def _flash_attn_bwd(
     num_aux_tensors = len(aux_tensors) if aux_tensors else 0
     aux_tensor_metadata = get_aux_tensor_metadata(aux_tensors) if aux_tensors is not None else None
     aux_scalar_metadata = tuple(type(s) for s in aux_scalars) if aux_scalars is not None else None
-    cute_aux_tensors = None
-    if aux_tensors is not None:
-        cute_aux_tensors = [to_cute_aux_tensor(buf) for buf in aux_tensors]
 
     block_sparse_broadcast_pattern = None
     normalized_block_sparse_tensors = None
@@ -2344,6 +2380,12 @@ def _flash_attn_bwd(
         )
 
     if compile_key not in _flash_attn_bwd.compile_cache:
+        current_stream = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
+        cute_aux_tensors = (
+            [to_cute_aux_tensor(buf) for buf in aux_tensors]
+            if aux_tensors is not None
+            else None
+        )
         q_tensor, k_tensor, v_tensor, do_tensor, dq_tensor, dk_tensor, dv_tensor = [
             to_cute_tensor(t) for t in (q, k, v, dout, dq, dk, dv)
         ]
@@ -2507,8 +2549,7 @@ def _flash_attn_bwd(
         _flash_attn_bwd.compile_cache[compile_key] = cute.compile(
             *compile_args, options="--enable-tvm-ffi"
         )
-
-    if not is_fake_mode():
+    if not fake_mode:
         dq_accum = dq if use_dedicated_hd256_kernel else dq_accum
         call_args = [
             q.detach(),
@@ -2570,6 +2611,7 @@ def _flash_attn_bwd(
                 if learnable_sink is not None
                 else None
             ),
+            fake_mode=fake_mode,
         )
 
         if dKV_postprocess:
@@ -2581,6 +2623,7 @@ def _flash_attn_bwd(
                 AtomLayoutNdKV, dKV_swapAB,
                 cluster_size=cluster_size,
                 cu_total_m_blocks=cu_total_m_blocks_k if cluster_size == 1 else None,
+                fake_mode=fake_mode,
             )
             # Postprocess: convert dv_accum from float32 to dv in bf16/fp16
             _bwd_postprocess_convert(
@@ -2590,6 +2633,7 @@ def _flash_attn_bwd(
                 AtomLayoutNdKV, dKV_swapAB,
                 cluster_size=cluster_size,
                 cu_total_m_blocks=cu_total_m_blocks_k if cluster_size == 1 else None,
+                fake_mode=fake_mode,
             )
 
     return (dq, dk, dv) if learnable_sink is None else (dq, dk, dv, dsink)
@@ -2628,6 +2672,7 @@ def _flash_attn_bwd_sparse_mla(
     dv: Optional[torch.Tensor] = None,
     dqv: Optional[torch.Tensor] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    fake_mode = is_fake_mode()
     arch = _get_device_arch()
     assert arch // 10 in [10, 11], "Unsupported compute capability. Supported: 10.x, 11.x"
     assert gather_kv_indices is not None, "require gather kv indices for backward"
@@ -2721,7 +2766,6 @@ def _flash_attn_bwd_sparse_mla(
     scale_p = torch.empty_like(row_max)
 
     dtype = torch2cute_dtype_map[dout.dtype]
-    current_stream = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
 
     # Preprocess kernel: compute (o * dout).sum(dim=-1), scale_p.
     _bwd_preprocess(
@@ -2736,6 +2780,7 @@ def _flash_attn_bwd_sparse_mla(
         qhead_per_kvhead=qhead_per_kvhead,
         nheads_kv=nheads_kv,
         softmax_scale=softmax_scale,
+        fake_mode=fake_mode,
     )
 
     compile_key = (
@@ -2755,6 +2800,7 @@ def _flash_attn_bwd_sparse_mla(
     )
 
     if compile_key not in _flash_attn_bwd_sparse_mla.compile_cache:
+        current_stream = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
         (
             cu_seqlens_q_tensor,
             cu_seqlens_k_tensor,
@@ -2808,7 +2854,7 @@ def _flash_attn_bwd_sparse_mla(
         )
         _flash_attn_bwd_sparse_mla.compile_cache[compile_key] = fa_bwd_kernel
 
-    if not is_fake_mode():
+    if not fake_mode:
         _flash_attn_bwd_sparse_mla.compile_cache[compile_key](
             dout,
             v,
@@ -3479,7 +3525,7 @@ def flash_attn_varlen_func(
 
 
 def _compile_fwd_combine(
-    dtype, dtype_partial, head_dim, num_head, tile_m, k_block_size, log_max_splits,
+    _arch, dtype, dtype_partial, head_dim, num_head, tile_m, k_block_size, log_max_splits,
     has_cu_seqlens, has_seqused, has_lse, has_virtual_batch_idx,
     has_num_splits_dynamic, has_semaphore_to_reset,
 ):
@@ -3547,6 +3593,8 @@ def _flash_attn_fwd_combine(
     num_splits_dynamic_ptr: Optional[torch.Tensor] = None,
     virtual_batch_idx: Optional[torch.Tensor] = None,
     semaphore_to_reset: Optional[torch.Tensor] = None,
+    *,
+    _arch: Optional[int] = None,
 ) -> None:
     """Forward combine kernel for split attention computation.
 
@@ -3569,23 +3617,23 @@ def _flash_attn_fwd_combine(
     Returns:
         None
     """
+    fake_mode = is_fake_mode()
     assert out_partial.dtype in [torch.float16, torch.bfloat16, torch.float32], (
         "out_partial must be fp16, bf16, or fp32"
     )
-    if not is_fake_mode():
+    if not fake_mode:
         assert out_partial.is_cuda and lse_partial.is_cuda, "tensors must be on CUDA device"
-    # Determine if this is variable length based on dimensions
-    is_varlen = out_partial.dim() == 4
-    # Validate optional tensors
-    for t, name in [
+    for tensor, name in (
         (cu_seqlens, "cu_seqlens"),
         (seqused, "seqused"),
         (num_splits_dynamic_ptr, "num_splits_dynamic_ptr"),
-    ]:
-        if t is not None:
-            if not is_fake_mode():
-                assert t.is_cuda, f"{name} must be on CUDA device"
-            assert t.is_contiguous(), f"{name} must be contiguous"
+        (virtual_batch_idx, "virtual_batch_idx"),
+        (semaphore_to_reset, "semaphore_to_reset"),
+    ):
+        if tensor is not None:
+            if not fake_mode:
+                assert tensor.is_cuda, f"{name} must be on CUDA device"
+            assert tensor.is_contiguous(), f"{name} must be contiguous"
     head_dim = out_partial.shape[-1]
     num_head = out_partial.shape[-2]
     num_splits = out_partial.shape[0]
@@ -3606,6 +3654,7 @@ def _flash_attn_fwd_combine(
     dtype = torch2cute_dtype_map[out.dtype]
     dtype_partial = torch2cute_dtype_map[out_partial.dtype]
     compile_key = (
+        _get_device_arch() if _arch is None else _arch,
         dtype,
         dtype_partial,
         head_dim,
@@ -3624,7 +3673,7 @@ def _flash_attn_fwd_combine(
         _flash_attn_fwd_combine.compile_cache[compile_key] = _compile_fwd_combine(
             *compile_key
         )
-    if not is_fake_mode():
+    if not fake_mode:
         _flash_attn_fwd_combine.compile_cache[compile_key](
             out_partial, lse_partial, out, lse,
             cu_seqlens, seqused, num_splits_dynamic_ptr, virtual_batch_idx,

--- a/flash_attn/cute/paged_kv.py
+++ b/flash_attn/cute/paged_kv.py
@@ -86,7 +86,8 @@ class PagedKVManager(ParamsBase):
         val_layout = cute.make_layout((1, async_copy_elems))
         gmem_tiled_copy_KV = cute.make_tiled_copy_tv(atom_async_copy, thr_layout, val_layout)
         gmem_thr_copy_KV = gmem_tiled_copy_KV.get_slice(thread_idx)
-        page_entry_per_thread = n_block_size // num_threads
+        # Include the final partially populated wave of rows.
+        page_entry_per_thread = (n_block_size + num_threads - 1) // num_threads
 
         tPrPage = cute.make_rmem_tensor((page_entry_per_thread,), Int32)
         tPrPageOffset = cute.make_rmem_tensor((page_entry_per_thread,), Int32)

--- a/tests/cute/test_cute_dsl_utils.py
+++ b/tests/cute/test_cute_dsl_utils.py
@@ -1,0 +1,107 @@
+"""Pin our aux-tensor cache keys to CuTe's own layout identity.
+
+``get_aux_tensor_metadata`` reproduces CuTe's leading-dimension deduction from
+torch metadata, because the launch path hands torch tensors straight to TVM-FFI
+and reading ``__cache_key__`` would force a DLPack conversion on every call. A
+DSL upgrade that changes the deduction must fail here rather than silently reuse
+a kernel compiled for a different ABI.
+"""
+
+import sys
+import types
+from pathlib import Path
+
+import pytest
+import torch
+from cutlass.cute.runtime import from_dlpack
+
+if "flash_attn" not in sys.modules:
+    package = types.ModuleType("flash_attn")
+    package.__path__ = [str(Path(__file__).resolve().parents[2] / "flash_attn")]
+    sys.modules["flash_attn"] = package
+
+from flash_attn.cute.cute_dsl_utils import (
+    get_aux_tensor_metadata,
+    get_num_sms_for_selection,
+    maybe_contiguous,
+    to_cute_aux_tensor,
+    validate_output_layout,
+)
+
+
+def _tagged(tensor: torch.Tensor, leading_dim: int) -> torch.Tensor:
+    """Declare a leading dimension the way FlexAttention tags aux tensors."""
+    tensor.__leading_dim__ = leading_dim
+    return tensor
+
+
+LAYOUTS = {
+    "bf16_1d": torch.empty(4, dtype=torch.bfloat16),
+    "bf16_1d_longer": torch.empty(8, dtype=torch.bfloat16),
+    "fp32_1d": torch.empty(4, dtype=torch.float32),
+    "bf16_1d_broadcast": torch.empty(1, dtype=torch.bfloat16).expand(4),
+    "bf16_row_major": torch.empty(2, 3, dtype=torch.bfloat16),
+    "bf16_row_major_larger": torch.empty(5, 7, dtype=torch.bfloat16),
+    "bf16_col_major": torch.empty(3, 2, dtype=torch.bfloat16).t(),
+    "bf16_unit_rows": torch.empty_strided((1, 4), (1, 1), dtype=torch.bfloat16),
+    "bf16_unit_cols": torch.empty_strided((4, 1), (1, 1), dtype=torch.bfloat16),
+    "bf16_tagged_last_dim": _tagged(torch.empty(2, 3, dtype=torch.bfloat16), 1),
+    "bf16_tagged_negative_dim": _tagged(torch.empty(2, 3, dtype=torch.bfloat16), -1),
+}
+
+
+def _equivalence_classes(key_of) -> set[frozenset[str]]:
+    """Group layout names by the cache key they produce."""
+    classes: dict[object, set[str]] = {}
+    for name, tensor in LAYOUTS.items():
+        classes.setdefault(key_of(tensor), set()).add(name)
+    return {frozenset(names) for names in classes.values()}
+
+
+def test_fake_target_num_sms(monkeypatch):
+    monkeypatch.setenv("FLASH_ATTENTION_NUM_SMS", "152")
+    assert get_num_sms_for_selection(0, 103) == 152
+
+    monkeypatch.delenv("FLASH_ATTENTION_NUM_SMS")
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    with pytest.raises(RuntimeError, match="FLASH_ATTENTION_NUM_SMS"):
+        get_num_sms_for_selection(0, 103)
+
+
+def test_layout_validation_uses_pointer_and_rejects_broadcast_output():
+    storage = bytearray(256)
+    base = torch.frombuffer(storage, dtype=torch.uint8)
+    offset = 1 if (base.data_ptr() + 1) % 16 else 2
+    unaligned = torch.frombuffer(storage, dtype=torch.uint8, count=128, offset=offset)
+
+    assert unaligned.storage_offset() == 0
+    assert unaligned.data_ptr() % 16 != 0
+    aligned = maybe_contiguous(unaligned)
+    assert aligned.data_ptr() % 16 == 0
+    torch.testing.assert_close(aligned, unaligned)
+
+    broadcast_out = torch.empty_strided((1, 4), (0, 1))
+    with pytest.raises(AssertionError, match="must not have broadcast dimensions"):
+        validate_output_layout(broadcast_out, "out", 16)
+
+
+def test_metadata_groups_layouts_exactly_like_cute():
+    cute_classes = _equivalence_classes(lambda t: to_cute_aux_tensor(t).__cache_key__)
+
+    assert _equivalence_classes(lambda t: get_aux_tensor_metadata([t])[0]) == cute_classes
+    # Sizes stay dynamic, so they must not split kernels; dtype, broadcast, and
+    # leading-dimension placement are static and must.
+    assert frozenset({"bf16_1d", "bf16_1d_longer"}) in cute_classes
+    assert frozenset({"fp32_1d"}) in cute_classes
+    assert frozenset({"bf16_1d_broadcast"}) in cute_classes
+    assert frozenset({"bf16_col_major", "bf16_unit_cols"}) in cute_classes
+
+
+@pytest.mark.parametrize("shape", [(1, 1), (2, 2)])
+def test_ambiguous_leading_dimension_is_rejected(shape):
+    tensor = torch.empty_strided(shape, (1, 1), dtype=torch.bfloat16)
+
+    with pytest.raises(ValueError, match="no unique stride-1 leading dimension"):
+        get_aux_tensor_metadata([tensor])
+    with pytest.raises(RuntimeError, match="deduce the leading dimension"):
+        from_dlpack(tensor).mark_layout_dynamic()

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -18,6 +18,7 @@ try:
 except ImportError:
     apply_rotary_emb = None
 
+from flash_attn.cute.cache_utils import JITCache
 from flash_attn.cute.testing import (
     attention_ref,
     generate_qkv,
@@ -103,6 +104,130 @@ def test_flash_attn_sm120_rejects_splitkv():
     v = torch.randn(1, 16, 1, 64, device="cuda", dtype=torch.bfloat16)
     with pytest.raises(AssertionError, match="SM120 forward only supports num_splits=1"):
         flash_attn_func(q, k, v, num_splits=3)
+
+
+@pytest.mark.skipif(
+    torch.cuda.get_device_capability()[0] not in [10, 11] or USE_FAKE_TENSOR,
+    reason="SM100/SM110 runtime layout-cache test",
+)
+def test_flash_attn_cache_separates_broadcast_layouts(monkeypatch):
+    torch.manual_seed(0)
+    q = torch.randn(1, 65, 4, 64, device="cuda", dtype=torch.bfloat16)
+    k_base = torch.randn(1, 129, 1, 64, device="cuda", dtype=torch.bfloat16)
+    v_base = torch.randn_like(k_base)
+    layouts = (
+        (k_base.expand(-1, -1, 4, -1), v_base.expand(-1, -1, 4, -1)),
+        (
+            torch.randn(1, 129, 4, 64, device="cuda", dtype=torch.bfloat16),
+            torch.randn(1, 129, 4, 64, device="cuda", dtype=torch.bfloat16),
+        ),
+    )
+    cache = JITCache()
+    monkeypatch.setattr(_flash_attn_fwd, "compile_cache", cache)
+    for k, v in layouts:
+        out = _flash_attn_fwd(q, k, v)[0]
+        reference = torch.nn.functional.scaled_dot_product_attention(
+            q.float().transpose(1, 2),
+            k.float().transpose(1, 2),
+            v.float().transpose(1, 2),
+        ).transpose(1, 2)
+        torch.testing.assert_close(out.float(), reference, atol=0.04, rtol=0.04)
+    assert len(cache.cache) == 2
+
+
+@pytest.mark.skipif(
+    torch.cuda.get_device_capability()[0] not in [10, 11] or USE_FAKE_TENSOR,
+    reason="SM100/SM110 runtime input-alignment test",
+)
+@pytest.mark.parametrize("layout", ["padded_stride", "unaligned_offset"])
+def test_flash_attn_canonicalizes_unaligned_inputs(layout):
+    torch.manual_seed(0)
+    shape = (1, 65, 4, 64)
+    if layout == "padded_stride":
+        inputs = tuple(
+            torch.randn(*shape[:-1], 65, device="cuda", dtype=torch.bfloat16)[..., :64]
+            for _ in range(3)
+        )
+    else:
+        inputs = tuple(
+            torch.as_strided(
+                torch.randn(math.prod(shape) + 1, device="cuda", dtype=torch.bfloat16),
+                shape,
+                (65 * 4 * 64, 4 * 64, 64, 1),
+                1,
+            )
+            for _ in range(3)
+        )
+
+    q, k, v = (tensor.detach().requires_grad_() for tensor in inputs)
+    q_ref, k_ref, v_ref = (
+        tensor.detach().float().requires_grad_() for tensor in (q, k, v)
+    )
+    out, _ = flash_attn_func(q, k, v)
+    reference = torch.nn.functional.scaled_dot_product_attention(
+        q_ref.transpose(1, 2),
+        k_ref.transpose(1, 2),
+        v_ref.transpose(1, 2),
+    ).transpose(1, 2)
+    torch.testing.assert_close(out.float(), reference, atol=0.04, rtol=0.04)
+
+    dout = torch.randn_like(out)
+    grads = torch.autograd.grad(out, (q, k, v), dout)
+    grads_ref = torch.autograd.grad(reference, (q_ref, k_ref, v_ref), dout.float())
+    for grad, grad_ref in zip(grads, grads_ref, strict=True):
+        torch.testing.assert_close(grad.float(), grad_ref, atol=0.05, rtol=0.05)
+
+
+@pytest.mark.skipif(
+    torch.cuda.get_device_capability()[0] not in [10, 11] or USE_FAKE_TENSOR,
+    reason="SM100/SM110 runtime value-dimension shared-memory test",
+)
+def test_flash_attn_value_dim_larger_than_query_dim():
+    torch.manual_seed(0)
+    q = torch.randn(1, 129, 8, 64, device="cuda", dtype=torch.bfloat16)
+    k = torch.randn(1, 769, 8, 64, device="cuda", dtype=torch.bfloat16)
+    v = torch.randn(1, 769, 8, 128, device="cuda", dtype=torch.bfloat16)
+
+    out = _flash_attn_fwd(q, k, v)[0]
+    reference = torch.nn.functional.scaled_dot_product_attention(
+        q.float().transpose(1, 2),
+        k.float().transpose(1, 2),
+        v.float().transpose(1, 2),
+    ).transpose(1, 2)
+    torch.testing.assert_close(out.float(), reference, atol=0.04, rtol=0.04)
+
+
+@pytest.mark.skipif(
+    torch.cuda.get_device_capability()[0] not in [10, 11] or USE_FAKE_TENSOR,
+    reason="SM100/SM110 runtime paged-KV tail-loading test",
+)
+def test_flash_attn_paged_non_tma_partial_loader_tile():
+    torch.manual_seed(0)
+    seqlen_q, seqlen_k, page_size, num_heads, head_dim = 65, 257, 16, 4, 64
+    pages_per_sequence = math.ceil(seqlen_k / page_size)
+    num_pages = pages_per_sequence + 3
+    page_ids = torch.randperm(num_pages, device="cuda")[:pages_per_sequence]
+    page_table = page_ids.to(torch.int32).unsqueeze(0)
+    q = torch.randn(1, seqlen_q, num_heads, head_dim, device="cuda", dtype=torch.bfloat16)
+    k = torch.randn(num_pages, page_size, num_heads, head_dim, device="cuda", dtype=torch.bfloat16)
+    v = torch.randn_like(k)
+
+    out = _flash_attn_fwd(
+        q,
+        k,
+        v,
+        seqused_k=torch.tensor([seqlen_k], device="cuda", dtype=torch.int32),
+        page_table=page_table,
+        tile_mn=(128, 192),
+    )[0]
+    k_ref = k[page_ids].reshape(-1, num_heads, head_dim)[:seqlen_k]
+    v_ref = v[page_ids].reshape(-1, num_heads, head_dim)[:seqlen_k]
+    reference = torch.nn.functional.scaled_dot_product_attention(
+        q.float().transpose(1, 2),
+        k_ref.float().transpose(0, 1).unsqueeze(0),
+        v_ref.float().transpose(0, 1).unsqueeze(0),
+    ).transpose(1, 2)
+    torch.testing.assert_close(out.float(), reference, atol=0.04, rtol=0.04)
 
 
 # @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float8_e4m3fn])

--- a/tests/cute/test_flash_attn_combine.py
+++ b/tests/cute/test_flash_attn_combine.py
@@ -5,12 +5,17 @@ import random
 
 import pytest
 import torch
+from torch._subclasses.fake_tensor import FakeTensorMode
 
+import flash_attn.cute.interface as interface
+from flash_attn.cute.cache_utils import JITCache
 from flash_attn.cute.testing import (
     maybe_fake_tensor_mode,
     is_fake_mode,
 )
 from flash_attn.cute.interface import (
+    _flash_attn_fwd,
+    _flash_attn_fwd_combine,
     flash_attn_combine,
 )
 
@@ -42,6 +47,87 @@ def check_combine_results(out, lse, out_ref, lse_ref, dtype):
         (out - out_ref).abs().max().item()
         <= 2 * (out_pt - out_ref).abs().max().item()
     ) or torch.allclose(out, out_pt, atol=1e-5, rtol=1e-5)
+
+
+def test_splitkv_forwards_explicit_arch(monkeypatch):
+    class HitCache:
+        def __contains__(self, _key):
+            return True
+
+    def unexpected_arch_query():
+        raise AssertionError("explicit architecture was not forwarded to combine")
+
+    monkeypatch.setattr(_flash_attn_fwd, "compile_cache", HitCache())
+    monkeypatch.setattr(_flash_attn_fwd_combine, "compile_cache", HitCache())
+    monkeypatch.setattr(interface, "_get_device_arch", unexpected_arch_query)
+    with FakeTensorMode():
+        q = torch.empty(1, 1, 8, 64, device="cuda", dtype=torch.bfloat16)
+        k = torch.empty(1, 1024, 8, 64, device="cuda", dtype=torch.bfloat16)
+        v = torch.empty_like(k)
+        _flash_attn_fwd(q, k, v, num_splits=2, _arch=100)
+
+
+@pytest.mark.skipif(USE_FAKE_TENSOR, reason="Runtime combine optional-input test")
+def test_flash_attn_combine_dynamic_splits_and_semaphore(monkeypatch):
+    torch.manual_seed(0)
+    num_splits, batch, seqlen, heads, head_dim = 3, 2, 17, 4, 64
+    out_partial = torch.randn(
+        num_splits,
+        batch,
+        seqlen,
+        heads,
+        head_dim,
+        device="cuda",
+        dtype=torch.float32,
+    )
+    lse_partial = torch.randn(
+        num_splits, batch, heads, seqlen, device="cuda", dtype=torch.float32
+    ).transpose(-1, -2)
+    out = torch.empty(
+        batch, seqlen, heads, head_dim, device="cuda", dtype=torch.bfloat16
+    )
+    lse = torch.empty(
+        batch, heads, seqlen, device="cuda", dtype=torch.float32
+    ).transpose(-1, -2)
+    dynamic_splits = torch.tensor([2, 3], device="cuda", dtype=torch.int32)
+    semaphore = torch.ones(1, device="cuda", dtype=torch.int32)
+
+    full_reference = attention_combine_ref(out_partial, lse_partial)
+    dynamic_references = [
+        attention_combine_ref(
+            out_partial[:split_count, batch_idx : batch_idx + 1],
+            lse_partial[:split_count, batch_idx : batch_idx + 1],
+        )
+        for batch_idx, split_count in enumerate((2, 3))
+    ]
+    dynamic_reference = (
+        torch.cat([reference[0] for reference in dynamic_references]),
+        torch.cat([reference[1] for reference in dynamic_references]),
+    )
+    cache = JITCache()
+    monkeypatch.setattr(_flash_attn_fwd_combine, "compile_cache", cache)
+
+    cases = (
+        (None, None, full_reference),
+        (dynamic_splits, None, dynamic_reference),
+        (None, semaphore, full_reference),
+        (dynamic_splits, semaphore, dynamic_reference),
+    )
+    for expected_cache_size, (dynamic_ptr, semaphore_ptr, reference) in enumerate(cases, 1):
+        if semaphore_ptr is not None:
+            semaphore_ptr.fill_(1)
+        _flash_attn_fwd_combine(
+            out_partial,
+            lse_partial,
+            out,
+            lse,
+            num_splits_dynamic_ptr=dynamic_ptr,
+            semaphore_to_reset=semaphore_ptr,
+        )
+        check_combine_results(out, lse, *reference, torch.bfloat16)
+        assert len(cache.cache) == expected_cache_size
+        if semaphore_ptr is not None:
+            assert semaphore_ptr.item() == 0
 
 
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])

--- a/tests/cute/test_score_mod.py
+++ b/tests/cute/test_score_mod.py
@@ -1,3 +1,5 @@
+import math
+
 import pytest
 import torch
 import cutlass
@@ -5,6 +7,7 @@ import cutlass.cute as cute
 from cutlass._mlir.dialects import math as mlir_math
 import operator
 from torch.nn.attention.flex_attention import create_block_mask, flex_attention
+from flash_attn.cute.cache_utils import JITCache
 from flash_attn.cute.interface import (
     flash_attn_func,
     _flash_attn_fwd,
@@ -28,6 +31,7 @@ from score_mod_definitions import (
     score_mod_causal_v2 as score_mod_9,
     score_mod_batch_bias as score_mod_10,
     score_mod_dual_buffer as score_mod_11,
+    score_mod_global_kv_bias,
 )  # isort: split
 from score_mod_definitions import (
     score_mod_identity_vectorized as score_mod_1_vectorized,
@@ -197,6 +201,34 @@ def run_flex_reference(q, k, v, eager_score_mod, dtype=None) -> torch.Tensor:
     if dtype is not None:
         q, k, v = q.to(dtype), k.to(dtype), v.to(dtype)
     return flex_attention(q, k, v, score_mod=eager_score_mod, enable_gqa=q.shape[1] != k.shape[1])
+
+
+@pytest.mark.skipif(COMPUTE_CAPABILITY not in [10, 11], reason="SM100/SM110 aux-cache test")
+def test_score_mod_aux_cache_separates_dtype_and_layout(monkeypatch):
+    torch.manual_seed(0)
+    batch, seqlen_q, seqlen_k, heads, head_dim = 2, 65, 129, 4, 64
+    q = torch.randn(
+        batch, seqlen_q, heads, head_dim, device="cuda", dtype=torch.bfloat16
+    )
+    k = torch.randn(
+        batch, seqlen_k, heads, head_dim, device="cuda", dtype=torch.bfloat16
+    )
+    v = torch.randn_like(k)
+    bias = torch.randn(seqlen_k, device="cuda", dtype=torch.bfloat16) * 0.1
+    aux_tensors = (bias, bias.float(), bias[:1].expand(seqlen_k))
+    cache = JITCache()
+    monkeypatch.setattr(_flash_attn_fwd, "compile_cache", cache)
+    for aux in aux_tensors:
+        out = _flash_attn_fwd(
+            q, k, v, score_mod=score_mod_global_kv_bias, aux_tensors=[aux]
+        )[0]
+        scores = q.float().transpose(1, 2) @ k.float().transpose(1, 2).transpose(-1, -2)
+        reference = (
+            torch.softmax(scores / math.sqrt(head_dim) + aux.float(), dim=-1)
+            @ v.float().transpose(1, 2)
+        ).transpose(1, 2)
+        torch.testing.assert_close(out.float(), reference, atol=0.04, rtol=0.04)
+    assert len(cache.cache) == 3
 
 
 @pytest.mark.parametrize("seqlen_q,seqlen_kv", SEQLEN_CONFIGS)


### PR DESCRIPTION
Stacked PRs:
 * #2743
 * #2741
 * #2738
 * #2735
 * #2733
 * #2732
 * __->__#2745


--- --- ---

# Human Note

This is baiscally all small tweaks to our dynamic shape infra; I did a lot of fuzzing of the stack to get a good sense for when recompiles happen and passing in a bunch of configs. These are all the result of that. While I was here I did smallish tweaks to those helpers to remove host overhead where applicable 

# Agent Note

## Summary

This is the small correctness base for the rest of the stack. Dynamic-shape and layout fuzzing found seven pre-existing forward bugs; this PR fixes them without adding configs, tuning APIs, or selector policy.

- Canonicalize unsupported strides and effective pointer alignment before TVM-FFI launch; reject broadcast output/workspace layouts.
- Include static tensor broadcast patterns in the main compile key.
- Key aux tensors by dtype, assumed alignment, and static stride modes.
- Compile SplitKV dynamic-split and semaphore operands exactly as called while retaining the lightweight existing runtime checks.
- Use matching target-SKU SM metadata during fake selection, with an explicit cross-compilation override.
- Size aliased SM100 K/V shared storage for the larger staged layout.
- Ceil-divide non-TMA paged-loader entries so partial row waves receive page pointers.

The cache fixes still keep concrete batch and sequence lengths dynamic.

## Host-path cost

The initial fuzz fix was correct but too defensive on the eager hot path. This revision keeps the same cache identities and kernel behavior while removing work unrelated to the seven root bugs:

- contiguous input/output layouts return before scanning every stride;
- no-broadcast metadata uses a C-level zero-stride fast path;
- the added same-device pass was removed, leaving the pre-existing CUDA-input contract untouched;
- internal combine no longer repeats rank/shape/dtype/device/layout checks after `_flash_attn_fwd` has allocated or validated those tensors;
- target-SM discovery runs only when automatic or rewritten diff-head SplitKV actually needs it;
- fake-mode state is resolved once per runtime call, and fake stream/aux CuTe conversion work runs only on compile misses;
- inference and training retain the original unconditional tensor detach behavior.

Nightly host microbenchmarks on the same GB300 machine:

| Host path | Before | After | Saved |
|---|---:|---:|---:|
| Q/K/V canonicalization | 1.50 us | 0.75 us | 0.75 us |
| Explicit out + LSE layout checks | 0.92 us | 0.75 us | 0.17 us |
| Common forward broadcast metadata | 1.70 us | 1.00 us | 0.70 us |
| Internal combine validation | 3.971 us | 1.168 us | 2.803 us |
| Added same-device pass | +0.94 us | removed | 0.94 us |
| Fixed-split target-SM lookup | 2.28 us | skipped | 2.28 us |

These are host-only measurements; no selector policy or generated kernel changed.

For a whole-wrapper check, I used real preallocated CUDA tensors, a warm hit-only compile cache, and a no-op compiled callable. This measures all Python dispatch through the point where the generated kernel would launch, without mixing in GPU execution:

| Shape | `main` | This PR | Net cost |
|---|---:|---:|---:|
| Decode: B1, Q1, K128, H32/Hkv8, D128 | 16.951 us | 12.922 us | -4.029 us (23.8%) |
| Short: B2, Q64, K128, H16, D64 | 16.608 us | 12.669 us | -3.939 us (23.7%) |
| Prefill: B1, Q257, K2048, H32, D64 | 16.993 us | 12.873 us | -4.120 us (24.2%) |

Despite adding the correctness checks, this PR is 3.9–4.1 us (23.7–24.2%) faster than `main` on the warm host path because it removes unconditional target-SM discovery, reuses fake-mode state, defers compile-only setup, and uses fast common-layout metadata paths. Real no-graph runs with the actual kernel also showed no latency regression.

## Validation

Focused host tests cover target-SM fallback, CuTe aux-key equivalence, external-base pointer alignment, singleton broadcast-output rejection, and explicit-architecture fake SplitKV. The combine regression now exercises one cache in the order neither optional operand → dynamic splits only → semaphore only → both, checking four specializations and numerical results. The existing unaligned-input test now checks public forward and `dq/dk/dv` for both padded-stride and unaligned-offset views.

The targeted GPU regressions pass on GB300/SM103 against independent FP32 references where applicable. After rebasing onto the varlen dynamic-persistent scheduler in `c46b8144`, 11 bottom-boundary GPU cases passed, including metadata reuse, fixed K-per-split, virtual-batch combine, dynamic combine operands, unaligned backward, paged tail, and aux-layout cache separation. Compute Sanitizer previously reported `ERROR SUMMARY: 0 errors` across the wider q-stage, paged-tail, SplitKV, and `DV > D` matrix. Ruff, formatting, `py_compile`, and `git diff --check` pass.