### PR TITLE
feat(HD256 cuteDSL): expand SM100 HD256 2CTA training support and refactor kernels to generic style

### DIFF
--- a/flash_attn/cute/block_sparse_utils.py
+++ b/flash_attn/cute/block_sparse_utils.py
@@ -672,6 +672,63 @@ def load_block_list_sm100(
     return kv_producer_state
 
 
+@cute.jit
+def load_block_list_sm100_qk_ahead(
+    block_indices: cute.Tensor,
+    block_count,
+    first_block_preloaded: cutlass.Constexpr,
+    load_q_with_first: cutlass.Constexpr,
+    q_stage: cutlass.Constexpr,
+    kv_producer_state,
+    load_Q,
+    load_K,
+    load_V,
+    pipeline_kv,
+):
+    """SM100 block-list loader with QK-ahead issue order."""
+    if block_count > 0:
+        # First iteration: load Q alongside K if requested
+        n_block_first = block_indices[block_count - 1]
+
+        if const_expr(load_q_with_first):
+            load_Q(block=0, stage=0)
+            if const_expr(q_stage == 2):
+                load_Q(block=1, stage=1)
+
+        # SM100 doesn't use producer_acquire for pipeline_kv in load path.
+        # The pipeline barriers are handled inside load_KV.
+        if const_expr(not first_block_preloaded):
+            load_K(block=n_block_first, producer_state=kv_producer_state, page_idx=None)
+            kv_producer_state.advance()
+
+        # Remaining blocks: load the next K before the previous V.
+        for offset in cutlass.range(1, block_count):
+            n_block_prev = block_indices[block_count - offset]
+            n_block = block_indices[block_count - 1 - offset]
+            load_K(block=n_block, producer_state=kv_producer_state, page_idx=None)
+            kv_producer_state.advance()
+            load_V(block=n_block_prev, producer_state=kv_producer_state, page_idx=None)
+            kv_producer_state.advance()
+
+    return kv_producer_state
+
+
+@cute.jit
+def finish_qk_ahead_v_load_sm100(
+    block_indices: cute.Tensor,
+    block_count,
+    load_V,
+    kv_producer_state,
+):
+    """Load the final V block after QK-ahead K loads."""
+    if block_count > 0:
+        n_block_last = block_indices[0]
+        load_V(block=n_block_last, producer_state=kv_producer_state, page_idx=None)
+        kv_producer_state.advance()
+
+    return kv_producer_state
+
+
 # SM100-specific tile processor using SM100 helpers
 @cute.jit
 def produce_block_sparse_loads_sm100(
@@ -780,6 +837,124 @@ def produce_block_sparse_loads_sm100(
                 load_V=load_V,
                 pipeline_kv=pipeline_kv,
                 kv_subtile_factor=kv_subtile_factor,
+            )
+
+    if q_phase_flipped:
+        q_producer_phase ^= 1
+
+    return kv_producer_state, q_producer_phase
+
+
+@cute.jit
+def produce_block_sparse_loads_sm100_qk_ahead(
+    blocksparse_tensors: BlockSparseTensors,
+    batch_idx,
+    head_idx,
+    m_block,
+    seqlen_info,
+    kv_producer_state,
+    load_Q,
+    load_K,
+    load_V,
+    pipeline_kv,
+    q_stage: cutlass.Constexpr,
+    q_producer_phase: Int32,
+    qhead_per_kvhead: cutlass.Constexpr,
+    q_subtile_factor: cutlass.Constexpr,
+):
+    """SM100 sparse block iteration with QK-ahead K/V issue order."""
+    m_block_sparse = sparse_tensor_m_block(m_block, qhead_per_kvhead, q_subtile_factor)
+
+    (
+        curr_mask_block_cnt,
+        curr_mask_block_idx,
+        curr_full_block_cnt,
+        curr_full_block_idx,
+    ) = get_curr_blocksparse_tensors(
+        batch_idx,
+        head_idx,
+        m_block_sparse,
+        blocksparse_tensors,
+        seqlen_info,
+    )
+
+    mask_empty = curr_mask_block_cnt == 0
+    full_empty = curr_full_block_cnt == 0
+
+    q_phase_flipped = False
+
+    if mask_empty:
+        # No masked blocks: process full list with Q loading
+        kv_producer_state = load_block_list_sm100_qk_ahead(
+            curr_full_block_idx,
+            curr_full_block_cnt,
+            first_block_preloaded=False,
+            load_q_with_first=True,
+            q_stage=q_stage,
+            kv_producer_state=kv_producer_state,
+            load_Q=load_Q,
+            load_K=load_K,
+            load_V=load_V,
+            pipeline_kv=pipeline_kv,
+        )
+        kv_producer_state = finish_qk_ahead_v_load_sm100(
+            curr_full_block_idx,
+            curr_full_block_cnt,
+            load_V,
+            kv_producer_state,
+        )
+        q_phase_flipped = not full_empty
+    else:
+        # Process masked blocks with Q loading
+        kv_producer_state = load_block_list_sm100_qk_ahead(
+            curr_mask_block_idx,
+            curr_mask_block_cnt,
+            first_block_preloaded=False,
+            load_q_with_first=True,
+            q_stage=q_stage,
+            kv_producer_state=kv_producer_state,
+            load_Q=load_Q,
+            load_K=load_K,
+            load_V=load_V,
+            pipeline_kv=pipeline_kv,
+        )
+        q_phase_flipped = True
+
+        if full_empty:
+            kv_producer_state = finish_qk_ahead_v_load_sm100(
+                curr_mask_block_idx,
+                curr_mask_block_cnt,
+                load_V,
+                kv_producer_state,
+            )
+        else:
+            # Bridge the masked list to the full list by loading the first full K
+            # before the pending masked V.
+            n_block_mask_last = curr_mask_block_idx[0]
+            n_block_full_first = curr_full_block_idx[curr_full_block_cnt - 1]
+            load_K(block=n_block_full_first, producer_state=kv_producer_state, page_idx=None)
+            kv_producer_state.advance()
+            load_V(block=n_block_mask_last, producer_state=kv_producer_state, page_idx=None)
+            kv_producer_state.advance()
+
+            # Process full blocks without Q loading
+            kv_producer_state = load_block_list_sm100_qk_ahead(
+                curr_full_block_idx,
+                curr_full_block_cnt,
+                first_block_preloaded=True,
+                load_q_with_first=False,
+                q_stage=q_stage,
+                kv_producer_state=kv_producer_state,
+                load_Q=load_Q,
+                load_K=load_K,
+                load_V=load_V,
+                pipeline_kv=pipeline_kv,
+            )
+            kv_producer_state = finish_qk_ahead_v_load_sm100(
+                curr_full_block_idx,
+                curr_full_block_cnt,
+                load_V,
+                kv_producer_state,
             )
 
     if q_phase_flipped:

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -899,13 +899,6 @@ def _flash_attn_fwd(
             else:
                 if use_dedicated_hd256_kernel:
                     # hd=256 2CTA forward: check for currently unsupported features
-                    assert softcap is None, "SM100 forward with head_dim=256 does not support softcap"
-                    assert not use_block_sparsity, \
-                        "SM100 forward with head_dim=256 does not support block sparsity"
-                    assert learnable_sink is None, \
-                        "SM100 forward with head_dim=256 does not support learnable_sink"
-                    assert seqused_q is None and seqused_k is None, \
-                        "SM100 forward with head_dim=256 does not support seqused_q/seqused_k"
                     if page_table is not None:
                         assert max_seqlen_k % page_size == 0, (
                             f"SM100 hd256 2CTA paged KV requires max_seqlen_k divisible by "
@@ -1457,7 +1450,13 @@ def _flash_attn_bwd(
         cluster_size = 2 if use_2cta_instrs else 1
 
     use_dedicated_hd256_kernel = arch // 10 in [10, 11] and head_dim == 256 and head_dim_v == 256
+    if use_dedicated_hd256_kernel:
+        cluster_size = 2
     use_2cta_instrs = use_2cta_instrs or use_dedicated_hd256_kernel
+    dkv_n_block_size = 64 if use_dedicated_hd256_kernel else n_block_size
+    dkv_postprocess_n_block_size = (
+        cluster_size * dkv_n_block_size if use_dedicated_hd256_kernel else dkv_n_block_size
+    )
 
     q, k, v, out, dout, lse, cu_seqlens_q, cu_seqlens_k, seqused_q, seqused_k = [
         maybe_contiguous(t)
@@ -1493,6 +1492,10 @@ def _flash_attn_bwd(
     num_n_blocks = seqlen_k_rounded // n_block_size
     if cluster_size == 2 and num_n_blocks % cluster_size != 0:
         seqlen_k_rounded = seqlen_k_rounded + n_block_size
+    seqlen_k_rounded_dkv = (seqlen_k + dkv_n_block_size - 1) // dkv_n_block_size * dkv_n_block_size
+    num_n_blocks_dkv = seqlen_k_rounded_dkv // dkv_n_block_size
+    if cluster_size == 2 and num_n_blocks_dkv % cluster_size != 0:
+        seqlen_k_rounded_dkv = seqlen_k_rounded_dkv + dkv_n_block_size
 
     # The single-block specialization below only guards against TVM stride poisoning,
     # which is a host-side branch predicate that selects a kernel variant. When
@@ -1621,27 +1624,26 @@ def _flash_attn_bwd(
     # GQA (qhead_per_kvhead > 1) needs dK/dV accum+postprocess since multiple Q heads
     # accumulate into the same dK/dV. SM90 varlen_k with qhead_per_kvhead==1 now uses
     # ragged TMA tensors for direct store, so no longer needs accum+postprocess.
-    # hd=256 2CTA backward has its own internal postprocess for dK/dV.
-    dKV_postprocess = qhead_per_kvhead > 1 and not use_dedicated_hd256_kernel
+    dKV_postprocess = qhead_per_kvhead > 1
     if dKV_postprocess:
         head_dim_v_rounded = (head_dim_v + 32 - 1) // 32 * 32
         if cu_seqlens_k is None:
             dk_accum = torch.zeros(
                 batch_size,
                 num_head_kv,
-                seqlen_k_rounded * head_dim_rounded,
+                seqlen_k_rounded_dkv * head_dim_rounded,
                 dtype=torch.float32,
                 device=device,
             )
             dv_accum = torch.zeros(
                 batch_size,
                 num_head_kv,
-                seqlen_k_rounded * head_dim_v_rounded,
+                seqlen_k_rounded_dkv * head_dim_v_rounded,
                 dtype=torch.float32,
                 device=device,
             )
         else:
-            cluster_tile_n = cluster_size * n_block_size
+            cluster_tile_n = cluster_size * dkv_n_block_size
             total_k_rounded_padded = (
                 (total_k + cu_seqlens_k.shape[0] * cluster_tile_n - 1) // cluster_tile_n * cluster_tile_n
             )
@@ -1667,8 +1669,8 @@ def _flash_attn_bwd(
         dQ_semaphore = None
 
     if deterministic and qhead_per_kvhead > 1:
-        dK_semaphore = torch.zeros(batch_size, num_head_kv, seqlen_k_rounded // n_block_size, 2, dtype=torch.int32, device=device)
-        dV_semaphore = torch.zeros(batch_size, num_head_kv, seqlen_k_rounded // n_block_size, 2, dtype=torch.int32, device=device)
+        dK_semaphore = torch.zeros(batch_size, num_head_kv, seqlen_k_rounded_dkv // dkv_n_block_size, 2, dtype=torch.int32, device=device)
+        dV_semaphore = torch.zeros(batch_size, num_head_kv, seqlen_k_rounded_dkv // dkv_n_block_size, 2, dtype=torch.int32, device=device)
     else:
         dK_semaphore = None
         dV_semaphore = None
@@ -1899,14 +1901,6 @@ def _flash_attn_bwd(
             )
         else:
             if use_dedicated_hd256_kernel:
-                assert softcap == 0.0, "SM100 backward with head_dim=256 does not support softcap"
-                assert block_sparse_tensors is None, \
-                    "SM100 backward with head_dim=256 does not support block sparsity"
-                assert dlse is None, \
-                    "SM100 backward with head_dim=256 does not support dlse"
-                assert seqused_q is None and seqused_k is None, \
-                    "SM100 backward with head_dim=256 does not support seqused_q/seqused_k"
-
                 dq_tile_mn = (128, 128)
                 dkdv_tile_mn = (128, 64)
                 fa_bwd_obj = BlackwellFusedMultiHeadAttentionBackward(
@@ -2020,7 +2014,6 @@ def _flash_attn_bwd(
             else None,
         )
     # Postprocess: convert dq_accum from float32 to dq in bf16/fp16
-    # hd=256 2CTA backward has its own internal postprocess, skip here.
     if not use_dedicated_hd256_kernel:
         if arch // 10 == 9:
             # dQ postprocess: match main kernel's MMA WG count, unless dQ_single_wg
@@ -2054,6 +2047,25 @@ def _flash_attn_bwd(
                 arch, dtype, head_dim_v, n_block_size, num_threads_post_dKV,
                 AtomLayoutNdKV, dKV_swapAB,
                 cluster_size=cluster_size,
+            )
+    else:
+        num_threads_post_dKV = 128
+
+        if dKV_postprocess:
+            # Dedicated hd256 dK/dV kernels use a 128-token accumulator layout.
+            _bwd_postprocess_convert(
+                dk_accum, dk, softmax_scale,
+                cu_seqlens_k, seqused_k,
+                arch, dtype, head_dim, dkv_postprocess_n_block_size, num_threads_post_dKV,
+                AtomLayoutNdKV, dKV_swapAB,
+                cluster_size=1,
+            )
+            _bwd_postprocess_convert(
+                dv_accum, dv, 1.0,
+                cu_seqlens_k, seqused_k,
+                arch, dtype, head_dim_v, dkv_postprocess_n_block_size, num_threads_post_dKV,
+                AtomLayoutNdKV, dKV_swapAB,
+                cluster_size=1,
             )
 
     return dq, dk, dv

--- a/flash_attn/cute/sm100_hd256_2cta_fmha_backward.py
+++ b/flash_attn/cute/sm100_hd256_2cta_fmha_backward.py
@@ -15,6 +15,7 @@ import cutlass
 import cutlass.cute as cute
 from cutlass.cute.typing import Int32
 
+from flash_attn.cute.block_sparsity import BlockSparseTensors
 from flash_attn.cute.sm100_hd256_2cta_fmha_backward_dqkernel import (
     BlackwellFusedMultiHeadAttentionBackwardDQKernel,
 )
@@ -57,20 +58,12 @@ class BlackwellFusedMultiHeadAttentionBackward:
         assert head_dim == 256 and head_dim_v == 256, (
             "SM100 dedicated backward kernel only supports (head_dim, head_dim_v) = (256, 256)"
         )
-        assert not is_local, "SM100 backward with head_dim=256 does not support local attention"
         assert tile_m_dq == 128 and tile_n_dq == 128, (
             "SM100 dedicated backward kernel only supports tile_m_dq=128 and tile_n_dq=128"
         )
         assert tile_m_dkdv == 128 and tile_n_dkdv == 64, (
             "SM100 dedicated backward kernel only supports tile_m_dkdv=128 and tile_n_dkdv=64"
         )
-        assert score_mod is None and score_mod_bwd is None and mask_mod is None, (
-            "SM100 backward with head_dim=256 does not support score_mod/mask_mod"
-        )
-        assert not deterministic, (
-            "SM100 backward with head_dim=256 does not support deterministic mode"
-        )
-        assert not has_aux_tensors, "SM100 backward with head_dim=256 does not support aux_tensors"
         assert cluster_size in (1, 2), (
             "SM100 backward with head_dim=256 only supports cluster_size in {1, 2}"
         )
@@ -80,6 +73,7 @@ class BlackwellFusedMultiHeadAttentionBackward:
 
         self.acc_dtype = cutlass.Float32
         self.is_causal = is_causal
+        self.is_local = is_local
         self.window_size_left = (
             None if (window_size_left is None or window_size_left < 0) else window_size_left
         )
@@ -90,25 +84,46 @@ class BlackwellFusedMultiHeadAttentionBackward:
         self.tile_n_dq = tile_n_dq
         self.tile_m_dkdv = tile_m_dkdv
         self.tile_n_dkdv = tile_n_dkdv
+        self.qhead_per_kvhead = qhead_per_kvhead
         self.use_clc_scheduler = use_clc_scheduler
 
         self.dq_kernel = BlackwellFusedMultiHeadAttentionBackwardDQKernel(
-            self.acc_dtype,
-            (self.tile_m_dq, self.tile_n_dq, 256),
-            self.is_causal,
-            self.window_size_left,
-            self.window_size_right,
-            False,  # is_persistent
-            False,  # split_head
-            use_clc_scheduler=self.use_clc_scheduler,
+            head_dim,
+            head_dim_v,
+            is_causal=self.is_causal,
+            is_local=self.is_local,
+            qhead_per_kvhead=qhead_per_kvhead,
+            tile_m=self.tile_m_dq,
+            tile_n=self.tile_n_dq,
+            is_persistent=False,
+            deterministic=deterministic,
+            spt=None,
+            cluster_size=2,
+            use_2cta_instrs=use_2cta_instrs,
+            score_mod=score_mod,
+            score_mod_bwd=score_mod_bwd,
+            mask_mod=mask_mod,
+            has_aux_tensors=has_aux_tensors,
+            subtile_factor=q_subtile_factor,
         )
         self.dkdv_kernel = BlackwellFusedMultiHeadAttentionBackwardDKDVKernel(
-            self.acc_dtype,
-            (self.tile_m_dkdv, self.tile_n_dkdv, 256),
-            self.is_causal,
-            self.window_size_left,
-            self.window_size_right,
-            use_clc_scheduler=self.use_clc_scheduler,
+            head_dim,
+            head_dim_v,
+            is_causal=self.is_causal,
+            is_local=self.is_local,
+            qhead_per_kvhead=qhead_per_kvhead,
+            tile_m=self.tile_m_dkdv,
+            tile_n=self.tile_n_dkdv,
+            is_persistent=False,
+            deterministic=deterministic,
+            spt=None,
+            cluster_size=cluster_size,
+            use_2cta_instrs=use_2cta_instrs,
+            score_mod=score_mod,
+            score_mod_bwd=score_mod_bwd,
+            mask_mod=mask_mod,
+            has_aux_tensors=has_aux_tensors,
+            subtile_factor=q_subtile_factor,
         )
 
     @cute.jit
@@ -128,38 +143,23 @@ class BlackwellFusedMultiHeadAttentionBackward:
         cumulative_s_k: cute.Tensor | None,
         seqused_q: cute.Tensor | None = None,
         seqused_k: cute.Tensor | None = None,
-        window_size_left: Int32 | None = None,
-        window_size_right: Int32 | None = None,
+        window_size_left: Int32 | int | None = None,
+        window_size_right: Int32 | int | None = None,
         dQ_semaphore: cute.Tensor | None = None,
         dK_semaphore: cute.Tensor | None = None,
         dV_semaphore: cute.Tensor | None = None,
         aux_data: AuxData = AuxData(),
-        block_sparse_tensors: cute.Tensor | None = None,
+        block_sparse_tensors: BlockSparseTensors | None = None,
         stream: cuda.CUstream = None,
     ):
         """Host function to launch CuTeDSL kernel."""
-        assert seqused_q is None and seqused_k is None, (
-            "SM100 backward with head_dim=256 does not support seqused_q/seqused_k"
-        )
-        assert window_size_left is None and window_size_right is None, (
-            "SM100 backward with head_dim=256 uses constructor-provided window sizes"
-        )
-        assert dQ_semaphore is None and dK_semaphore is None and dV_semaphore is None, (
-            "SM100 backward with head_dim=256 does not use semaphores"
-        )
-        assert block_sparse_tensors is None, (
-            "SM100 backward with head_dim=256 does not support block sparse tensors"
-        )
-        assert aux_data.tensors is None or len(aux_data.tensors) == 0, (
-            "SM100 backward with head_dim=256 does not support aux_tensors"
-        )
-        assert aux_data.scalars is None or len(aux_data.scalars) == 0, (
-            "SM100 backward with head_dim=256 does not support aux_scalars"
-        )
         assert dQ_accum is not None, (
             "SM100 backward with head_dim=256 expects dQ tensor at dQ_accum slot"
         )
         dQ = dQ_accum
+        mQ, mK, mV = Q, K, V
+        mdO, mLSE, mdPsum = dO, lse_log2, dpsum
+        mdK, mdV = dK, dV
         varlen = cumulative_s_q is not None or cumulative_s_k is not None
         q_rank = cute.rank(Q.layout)
         k_rank = cute.rank(K.layout)
@@ -189,37 +189,53 @@ class BlackwellFusedMultiHeadAttentionBackward:
         K = as_bshkrd_tensor(K, h_k, 1, varlen)
         V = as_bshkrd_tensor(V, h_k, 1, varlen)
         dQ = as_bshkrd_tensor(dQ, h_k, h_r, varlen)
-        dK = as_bshkrd_tensor(dK, h_k, 1, varlen)
-        dV = as_bshkrd_tensor(dV, h_k, 1, varlen)
+        if cutlass.const_expr(self.qhead_per_kvhead == 1):
+            dK = as_bshkrd_tensor(dK, h_k, 1, varlen)
+            dV = as_bshkrd_tensor(dV, h_k, 1, varlen)
         dO = as_bshkrd_tensor(dO, h_k, h_r, varlen)
         scaled_LSE = as_shhb_tensor(lse_log2, h_k, h_r, b, varlen)
         sum_OdO = as_shhb_tensor(dpsum, h_k, h_r, b, varlen)
 
         # Keep original order: dQ first, then dKdV.
         self.dq_kernel(
-            Q,
-            K,
-            V,
-            dQ,
-            dO,
-            scaled_LSE,
-            sum_OdO,
-            cumulative_s_q,
-            cumulative_s_k,
+            mQ,
+            mK,
+            mV,
+            mdO,
+            mLSE,
+            mdPsum,
+            dQ_accum,
             scale_softmax,
-            stream,
+            mCuSeqlensQ=cumulative_s_q,
+            mCuSeqlensK=cumulative_s_k,
+            mSeqUsedQ=seqused_q,
+            mSeqUsedK=seqused_k,
+            window_size_left=window_size_left,
+            window_size_right=window_size_right,
+            mdQ_semaphore=None,
+            mdK_semaphore=None,
+            mdV_semaphore=None,
+            aux_data=aux_data,
+            stream=stream,
         )
         self.dkdv_kernel(
-            Q,
-            K,
-            V,
-            dK,
-            dV,
-            dO,
-            scaled_LSE,
-            sum_OdO,
-            cumulative_s_q,
-            cumulative_s_k,
+            mQ,
+            mK,
+            mV,
+            mdO,
+            mLSE,
+            mdPsum,
+            mdK,
+            mdV,
             scale_softmax,
-            stream,
+            mCuSeqlensQ=cumulative_s_q,
+            mCuSeqlensK=cumulative_s_k,
+            mSeqUsedQ=seqused_q,
+            mSeqUsedK=seqused_k,
+            window_size_left=window_size_left,
+            window_size_right=window_size_right,
+            mdK_semaphore=dK_semaphore,
+            mdV_semaphore=dV_semaphore,
+            aux_data=aux_data,
+            stream=stream,
         )

--- a/flash_attn/cute/sm100_hd256_2cta_fmha_backward_dkdvkernel.py
+++ b/flash_attn/cute/sm100_hd256_2cta_fmha_backward_dkdvkernel.py
@@ -8,86 +8,69 @@ Constraints:
 * Batch size must be the same for Q, K, and V tensors
 """
 
-import enum
 import math
+from functools import partial
+from typing import Optional
 
 import cuda.bindings.driver as cuda
 
 import cutlass
 import cutlass.cute as cute
+from cutlass.cute import FastDivmodDivisor
+from cutlass import Float32, const_expr
 from cutlass.cute.nvgpu import cpasync, tcgen05
-import cutlass.utils as utils
-import cutlass.pipeline as pipeline
+from cutlass.cutlass_dsl import dsl_user_op
+from cutlass._mlir.dialects import llvm
+from cutlass.utils import LayoutEnum
 import cutlass.utils.blackwell_helpers as sm100_utils
+import cutlass.utils.blackwell_helpers as sm100_utils_basic
 from cutlass.cute.typing import Int32
-from cutlass.pipeline import pipeline_init_arrive, pipeline_init_wait
+from cutlass.pipeline import PipelineAsync, pipeline_init_arrive, pipeline_init_wait
 
-from cutlass.utils import ClcDynamicPersistentTileScheduler
+from flash_attn.cute import barrier
+from flash_attn.cute import copy_utils
+from flash_attn.cute import pipeline
+from flash_attn.cute import utils
+from quack import layout_utils
+from flash_attn.cute.cute_dsl_utils import assume_tensor_aligned
 from flash_attn.cute.tile_scheduler import (
-    ClcState,
-    SM100_TMEM_CAPACITY_COLUMNS,
-    make_sm100_thread_cooperative_group as make_thread_cooperative_group,
-    Sm100FmhaClcDynamicTileSchedulerParams as FmhaClcDynamicTileSchedulerParams,
-    Sm100FmhaClcDynamicTileScheduler as FmhaClcDynamicTileScheduler,
-    Sm100FmhaStaticTileSchedulerParams as FmhaStaticTileSchedulerParams,
+    TileSchedulerArguments,
+    SingleTileScheduler,
+    SingleTileVarlenScheduler,
+    WorkTileInfo,
 )
-
-import flash_attn.cute.copy_utils as fa_copy_utils
-
-LAYOUT_RANK_CONSTANT = 3
-
-
-@cute.jit
-def split_wg(
-    t: cute.Tensor,
-    num_warp_groups: Int32,
-    wg_idx: Int32,
-) -> cute.Tensor:
-    """Split warp group."""
-    # dishengbin, TODO：need to double check if more efficient to split in other dimensions
-    ret = None
-    if cutlass.const_expr(cute.rank(t.layout) == LAYOUT_RANK_CONSTANT):
-        p = cute.composition(
-            t,
-            cute.make_layout(
-                (
-                    t.shape[0],
-                    t.shape[1],
-                    (num_warp_groups, cute.size(t, mode=[2]) // num_warp_groups),
-                )
-            ),
-        )
-        ret = p[None, None, (wg_idx, None)]
-    else:
-        p = cute.composition(
-            t,
-            cute.make_layout(
-                (
-                    t.shape[0],
-                    t.shape[1],
-                    t.shape[2],
-                    (num_warp_groups, cute.size(t, mode=[3]) // num_warp_groups),
-                )
-            ),
-        )
-        ret = p[None, None, None, (wg_idx, None)]
-    return ret
+from flash_attn.cute.mask import AttentionMask
+from flash_attn.cute.block_info import BlockInfo
+from flash_attn.cute.blackwell_helpers import gemm_w_idx
+from flash_attn.cute.seqlen_info import SeqlenInfoQK
+from flash_attn.cute.named_barrier import NamedBarrierBwdSm100
+from flash_attn.cute.softmax import call_score_mod, call_score_mod_bwd
 
 
-class MaskType(enum.Enum):
-    """Mask type used in FMHA backward."""
-
-    NO_MASK = enum.auto()
-    RESIDUAL_MASK_FOR_BACKWARD = enum.auto()
-    CAUSAL_MASK_FOR_BACKWARD = enum.auto()
-
-
-def Tmemory_offset(lane, col):
-    """Tensor memory offset."""
-    return (lane << 16) + col
-
-
-permute_order = (0, 1, 2, 3, 4)
+@dsl_user_op
+def atomic_add_fp32x4_l2_evict_last(
+    a: Float32, b: Float32, c: Float32, d: Float32, gmem_ptr: cute.Pointer, *, loc=None, ip=None
+) -> None:
+    gmem_ptr_i64 = gmem_ptr.toint(loc=loc, ip=ip).ir_value()
+    llvm.inline_asm(
+        None,
+        [
+            gmem_ptr_i64,
+            Float32(a).ir_value(loc=loc, ip=ip),
+            Float32(b).ir_value(loc=loc, ip=ip),
+            Float32(c).ir_value(loc=loc, ip=ip),
+            Float32(d).ir_value(loc=loc, ip=ip),
+        ],
+        "{\n\t"
+        ".reg .b64 cache_policy;\n\t"
+        "createpolicy.fractional.L2::evict_last.b64 cache_policy, 1.0;\n\t"
+        "red.global.add.L2::cache_hint.v4.f32 [$0], {$1, $2, $3, $4}, cache_policy;\n\t"
+        "}\n",
+        "l,f,f,f,f",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
 
 
 class BlackwellFusedMultiHeadAttentionBackwardDKDVKernel:
@@ -95,2279 +78,1900 @@ class BlackwellFusedMultiHeadAttentionBackwardDKDVKernel:
 
     def __init__(
         self,
-        acc_dtype: type[cutlass.Numeric],
-        cta_tiler: tuple[int, int, int],
-        is_causal: bool,
-        window_size_left: int | None,
-        window_size_right: int | None,
-        use_clc_scheduler: bool = False,
+        head_dim: int,
+        head_dim_v: Optional[int] = None,
+        is_causal: bool = False,
+        is_local: bool = False,
+        qhead_per_kvhead: cutlass.Constexpr[int] = 1,
+        tile_m: int = 128,
+        tile_n: int = 64,
+        is_persistent: bool = False,
+        deterministic: bool = False,
+        spt: Optional[bool] = None,
+        cluster_size: int = 2,
+        use_2cta_instrs: bool = True,
+        score_mod: cutlass.Constexpr | None = None,
+        score_mod_bwd: cutlass.Constexpr | None = None,
+        mask_mod: cutlass.Constexpr | None = None,
+        has_aux_tensors: cutlass.Constexpr = False,
+        subtile_factor: cutlass.Constexpr[int] = 1,
     ):
         """Initialization."""
-        self.acc_dtype = acc_dtype
-        self.cta_tiler = cta_tiler
-        self.use_clc_scheduler = use_clc_scheduler
-        self.sched_warp_id = 10 if use_clc_scheduler else None
-        # TODO: need check, not sure whether need to *2 if 2cta
-        self.tile_shape_Q = cta_tiler[0]
-        self.tile_shape_K = cta_tiler[1]
-        self.tile_shape_dQ_K = cta_tiler[2]
-        self.tile_shape_dV_dO = cta_tiler[2]
-        # For S
-        self.KQ_mma_tiler = (
-            cta_tiler[1] * 2,
-            cta_tiler[0],
-            cta_tiler[2],
-        )
-        # For dP
-        self.VdO_mma_tiler = (
-            cta_tiler[1] * 2,
-            cta_tiler[0],
-            cta_tiler[2],
-        )
-        # For dV
-        self.PdO_mma_tiler = (
-            cta_tiler[1] * 2,
-            cta_tiler[2],
-            cta_tiler[0],
-        )
-        # For dK
-        self.dSQ_mma_tiler = (
-            cta_tiler[1] * 2,
-            cta_tiler[2],
-            cta_tiler[0],
-        )
-        # For dQ, dishengbin, need to remove
-        self.dSK_mma_tiler = (
-            cta_tiler[0] * 2,
-            cta_tiler[2],
-            cta_tiler[1],
-        )
-        self.cluster_shape_mn = (2, 1)
-        self.is_causal = is_causal
-        self.window_size_left: int = -1 if window_size_left is None else window_size_left
-        self.window_size_right: int = -1 if window_size_right is None else window_size_right
-        self.has_sliding_window = False
-        if self.window_size_left > 0 or self.window_size_right > 0:
-            self.has_sliding_window = True
-        if self.is_causal:
-            self.window_size_right = 0
+        # padding head_dim to a multiple of 16 as k_block_size
+        hdim_multiple_of = 16
+        self.tile_hdim = int(math.ceil(head_dim / hdim_multiple_of) * hdim_multiple_of)
+        head_dim_v = head_dim_v if head_dim_v is not None else head_dim
+        self.same_hdim_kv = head_dim == head_dim_v
+        self.tile_hdimv = int(math.ceil(head_dim_v / hdim_multiple_of) * hdim_multiple_of)
+        self.check_hdim_oob = head_dim != self.tile_hdim
+        self.check_hdim_v_oob = head_dim_v != self.tile_hdimv
 
-        self.compute_warp_id = (0, 1, 2, 3, 4, 5, 6, 7)
+        self.tile_m = tile_m
+        self.tile_n = tile_n
+
+        assert head_dim == 256 and head_dim_v == 256, (
+            "SM100 HD256 dK/dV kernel only supports (head_dim, head_dim_v) = (256, 256)"
+        )
+        assert self.tile_hdim == 256 and self.tile_hdimv == 256
+        assert self.tile_m == 128 and self.tile_n == 64, (
+            "SM100 HD256 dK/dV kernel only supports tile_m=128 and tile_n=64"
+        )
+
+        self.use_2cta_instrs = bool(use_2cta_instrs and cluster_size == 2)
+        self.cta_group_size = 2 if self.use_2cta_instrs else 1
+
+        assert self.use_2cta_instrs, "SM100 HD256 dK/dV kernel requires use_2cta_instrs=True"
+
+        # CTA tiler
+        self.cta_tiler = (tile_n, tile_m, self.tile_hdim)
+        # S = K @ Q.T
+        self.mma_tiler_kq = (self.cta_group_size * tile_n, tile_m, self.tile_hdim)
+        # dP = V @ dO.T
+        self.mma_tiler_vdo = (self.cta_group_size * tile_n, tile_m, self.tile_hdimv)
+        # dV = P.T @ dO
+        self.mma_tiler_pdo = (self.cta_group_size * tile_n, self.tile_hdimv, tile_m)
+        # dK = dS.T @ Q
+        self.mma_tiler_dsq = (self.cta_group_size * tile_n, self.tile_hdim, tile_m)
+        # dQ = dS @ K
+        self.mma_tiler_dsk = (tile_m, self.tile_hdim, tile_n * self.cta_group_size)
+
+        self.acc_dtype = Float32
+
+        assert cluster_size == 2, "SM100 HD256 dK/dV kernel only supports cluster_size=2"
+        self.cluster_shape_mn = (cluster_size, 1)
+        self.is_persistent = is_persistent
+        self.is_causal = is_causal
+        self.is_local = is_local
+        self.qhead_per_kvhead = qhead_per_kvhead
+        self.pack_gqa = False
+        self.deterministic = deterministic
+        self.spt_override = spt
+
+        # Score mod and mask mod support
+        self.score_mod = score_mod
+        self.score_mod_bwd = score_mod_bwd
+        self.mask_mod = mask_mod
+        self.has_aux_tensors = has_aux_tensors
+        self.subtile_factor = subtile_factor
+        # For score_mod, use vec_size=1 (like forward) to handle per-element indices
+        if cutlass.const_expr(has_aux_tensors):
+            self.vec_size: cutlass.Constexpr = 1
+        else:
+            self.vec_size: cutlass.Constexpr = 4
+        self.qk_acc_dtype = Float32
+
+        # Speed optimizations, does not affect correctness
+        self.shuffle_LSE = False
+        self.shuffle_dPsum = False
+        # Generally slower to use store dS in smem for dK, and doesn't work for 2cta
+        self.use_smem_dS_for_mma_dK = False
+
+        self.compute_warp_ids = (0, 1, 2, 3, 4, 5, 6, 7)
         self.mma_warp_id = 8
         self.load_warp_id = 9
-        self.empty_warp_id = 10
+        self.empty_warp_ids = (10, 11)
 
-        self.num_compute_warps = 8
+        self.num_compute_warps = len(self.compute_warp_ids)
 
-        self.tmem_alloc_cols = SM100_TMEM_CAPACITY_COLUMNS
+        # 12 warps -> 384 threads
+        self.threads_per_warp = cute.arch.WARP_SIZE
+        self.threads_per_cta = cute.arch.WARP_SIZE * len(
+            (
+                *self.empty_warp_ids,
+                *self.compute_warp_ids,
+                self.mma_warp_id,
+                self.load_warp_id,
+            )
+        )
 
-        self.threads_per_warp = 32
-        self.threads_per_cta = self.threads_per_warp * (self.num_compute_warps + 4)
+        self.tmem_alloc_sync_bar_id = int(NamedBarrierBwdSm100.TmemPtr)
+        self.epilogue_sync_bar_id = int(NamedBarrierBwdSm100.EpilogueWG1)
+        # NamedBarrier
+        self.compute_sync_barrier = cutlass.pipeline.NamedBarrier(
+            barrier_id=int(NamedBarrierBwdSm100.Compute),
+            num_threads=len(self.compute_warp_ids) * cute.arch.WARP_SIZE,
+        )
 
-        self.cta_sync_bar_id = 0
-        self.tmem_alloc_sync_bar_id = 1
-        self.compute_sync_bar_id = 2
-        self.epilogue_sync_bar_id = 3
-        self.reduce_sync_bar_id = 4
-
+        # TMEM setup
+        self.tmem_alloc_cols = cute.arch.get_max_tmem_alloc_cols("sm_100")
         self.tmem_dK_offset = 0
-        self.tmem_dV_offset = Tmemory_offset(0, cta_tiler[2] // 2)
-        self.tmem_dP_offset = Tmemory_offset(0, cta_tiler[2] + cta_tiler[0] // 2)
-        self.tmem_S_offset = Tmemory_offset(0, cta_tiler[2])
+        self.tmem_dV_offset = self.tmem_dK_offset + self.tile_hdim // 2
+        self.tmem_S_offset = self.tmem_dK_offset + self.tile_hdim
+        self.tmem_dP_offset = self.tmem_S_offset + self.tile_m // 2
 
-        self.num_regs_reduce = 152
-        self.num_regs_compute = 128
-        self.num_regs_mma = 128
-        self.num_regs_empty = 96
-        self.num_regs_load = 96
+        if (not is_causal and not is_local) or deterministic:
+            self.num_regs_compute = 128 if self.use_2cta_instrs else 136
+            self.num_regs_load = 104 if self.use_2cta_instrs else 96 - 8
+            self.num_regs_mma = 104 if self.use_2cta_instrs else self.num_regs_load
+        else:
+            self.num_regs_compute = 128 if self.use_2cta_instrs else 144
+            self.num_regs_load = 104 if self.use_2cta_instrs else 96 - 8
+            self.num_regs_mma = 104 if self.use_2cta_instrs else self.num_regs_load
+        self.num_regs_empty = 24
 
-        self.buffer_align_bytes = 128
+        assert (
+            self.num_regs_compute * 2
+            + max(self.num_regs_load, self.num_regs_mma, self.num_regs_empty)
+            <= 512
+        )
+        self.buffer_align_bytes = 1024
 
     def _setup_attributes(self):
-        """Settings for pipeline stage."""
-        self.load_mma_Q_stage = 1
-        self.load_mma_K_stage = 1
-        self.load_mma_V_stage = 1
-        self.load_mma_QT_stage = 1
-        self.load_mma_dO_stage = 1
-        self.load_compute_LSE_stage = 1
-        self.load_compute_sum_OdO_stage = 1
-        self.mma_compute_S_stage = 1
-        self.mma_compute_dP_stage = 1
-        self.compute_mma_P_stage = 1
-        self.compute_mma_dS_stage = 1
-        self.mma_compute_dKdV_stage = 2
+        self.Q_stage = 1 if self.use_2cta_instrs else 2
+        self.dO_stage = 1
+        self.single_stage = 1
+        # LSE_stage = Q_stage and dPsum_stage = dO_stage
+        self.sdKVaccum_stage = 2
+        self.dK_reduce_ncol = math.gcd(32, self.tile_hdim // 2)
+        # CTA group for MMA operations
+        self.cta_group = tcgen05.CtaGroup.TWO if self.use_2cta_instrs else tcgen05.CtaGroup.ONE
 
-        if cutlass.const_expr(self.use_clc_scheduler):
-            self.num_clc_stage = 1
-            self.num_clc_response_bytes = 16
+    def _get_tiled_mma(self):
+        # S.T = K @ Q.T
+        tiled_mma_S = sm100_utils.make_trivial_tiled_mma(
+            self.k_dtype,
+            tcgen05.OperandMajorMode.K,
+            tcgen05.OperandMajorMode.K,
+            self.acc_dtype,
+            self.cta_group,
+            self.mma_tiler_kq[:2],
+        )
+        # dP.T = V @ dO.T
+        tiled_mma_dP = sm100_utils.make_trivial_tiled_mma(
+            self.v_dtype,
+            tcgen05.OperandMajorMode.K,
+            tcgen05.OperandMajorMode.K,
+            self.acc_dtype,
+            self.cta_group,
+            self.mma_tiler_vdo[:2],
+        )
+        # dV += P.T @ dO
+        tiled_mma_dV = sm100_utils.make_trivial_tiled_mma(
+            self.do_dtype,
+            tcgen05.OperandMajorMode.K,
+            tcgen05.OperandMajorMode.MN,
+            self.acc_dtype,
+            self.cta_group,
+            self.mma_tiler_pdo[:2],
+            tcgen05.OperandSource.SMEM,
+        )
+        # dK += dS.T @ Q
+        tiled_mma_dK = sm100_utils.make_trivial_tiled_mma(
+            self.ds_dtype,
+            tcgen05.OperandMajorMode.K,
+            tcgen05.OperandMajorMode.MN,
+            self.acc_dtype,
+            self.cta_group,
+            self.mma_tiler_dsq[:2],
+        )
+        # dQ = dS @ K. HD256 dK/dV keeps this only for the staged dS layout.
+        tiled_mma_dQ = sm100_utils.make_trivial_tiled_mma(
+            self.k_dtype,
+            tcgen05.OperandMajorMode.MN,
+            tcgen05.OperandMajorMode.MN,
+            self.acc_dtype,
+            self.cta_group,
+            self.mma_tiler_dsk[:2],
+        )
+        return tiled_mma_S, tiled_mma_dP, tiled_mma_dK, tiled_mma_dV, tiled_mma_dQ
+
+    def _setup_smem_layout(self):
+        # S.T = K @ Q.T
+        self.sK_layout = sm100_utils.make_smem_layout_a(
+            self.tiled_mma_S,
+            self.mma_tiler_kq,
+            self.k_dtype,
+            1,
+        )
+        self.sQ_layout = sm100_utils.make_smem_layout_b(
+            self.tiled_mma_S,
+            self.mma_tiler_kq,
+            self.q_dtype,
+            self.Q_stage,
+        )
+        # dP.T = V @ dO.T
+        self.sV_layout = sm100_utils.make_smem_layout_a(
+            self.tiled_mma_dP,
+            self.mma_tiler_vdo,
+            self.v_dtype,
+            1,
+        )
+        self.sdOt_layout = sm100_utils.make_smem_layout_b(
+            self.tiled_mma_dP,
+            self.mma_tiler_vdo,
+            self.do_dtype,
+            self.dO_stage,
+        )
+        # dK += dS.T @ Q
+        self.sdSt_layout = sm100_utils.make_smem_layout_a(
+            self.tiled_mma_dK,
+            self.mma_tiler_dsq,
+            self.ds_dtype,
+            self.single_stage,
+        )
+        self.sQt_layout = sm100_utils.make_smem_layout_b(
+            self.tiled_mma_dK,
+            self.mma_tiler_dsq,
+            self.q_dtype,
+            self.Q_stage,
+        )
+        # dV += P.T @ dO
+        self.sP_layout = sm100_utils.make_smem_layout_a(
+            self.tiled_mma_dV,
+            self.mma_tiler_pdo,
+            self.ds_dtype,
+            self.single_stage,
+        )
+        self.sdO_layout = sm100_utils.make_smem_layout_b(
+            self.tiled_mma_dV,
+            self.mma_tiler_pdo,
+            self.do_dtype,
+            self.dO_stage,
+        )
+        self.sLSE_layout = cute.make_layout(
+            shape=(self.tile_m, self.Q_stage),
+            stride=(1, cute.round_up(self.tile_m, 64)),
+        )
+        self.sdPsum_layout = cute.make_layout(
+            shape=(self.tile_m, self.dO_stage),
+            stride=(1, cute.round_up(self.tile_m, 64)),
+        )
+
+        num_compute_wgs = self.num_compute_warps // 4
+        self.sdK_epi_tile = (
+            self.tile_n,
+            math.gcd(128 // (self.dk_dtype.width // 8), self.tile_hdim // num_compute_wgs),
+        )
+        self.sdV_epi_tile = (
+            self.tile_n,
+            math.gcd(128 // (self.dk_dtype.width // 8), self.tile_hdimv // num_compute_wgs),
+        )
+        self.num_epi_stages = (self.tile_hdim // num_compute_wgs) // self.sdK_epi_tile[1]
+        self.num_epi_stages_v = (self.tile_hdimv // num_compute_wgs) // self.sdV_epi_tile[1]
+        self.dKV_postprocess_tile_n = self.tile_n * self.cta_group_size
+        self.sdK_flat_epi_tile = (
+            self.dKV_postprocess_tile_n * (self.tile_hdim // num_compute_wgs) // self.num_epi_stages
+        )
+        self.sdV_flat_epi_tile = (
+            self.dKV_postprocess_tile_n
+            * (self.tile_hdimv // num_compute_wgs)
+            // self.num_epi_stages_v
+        )
+        total_epi_stages = num_compute_wgs * self.num_epi_stages
+        total_epi_stages_v = num_compute_wgs * self.num_epi_stages_v
+        if const_expr(not self.dKV_postprocess):
+            self.sdK_layout = sm100_utils_basic.make_smem_layout_epi(
+                self.dk_dtype,
+                LayoutEnum.ROW_MAJOR,
+                self.sdK_epi_tile,
+                total_epi_stages,
+            )
+            self.sdV_layout = sm100_utils_basic.make_smem_layout_epi(
+                self.dv_dtype,
+                LayoutEnum.ROW_MAJOR,
+                self.sdV_epi_tile,
+                total_epi_stages_v,
+            )
+        else:
+            self.sdK_layout = cute.make_layout(
+                (self.dKV_postprocess_tile_n * self.dK_reduce_ncol, num_compute_wgs)
+            )
+            # self.dK_reduce_ncol same for dV
+            self.sdV_layout = cute.make_layout(
+                (self.dKV_postprocess_tile_n * self.dK_reduce_ncol, num_compute_wgs)
+            )
 
     @cute.jit
     def __call__(
         self,
-        Q: cute.Tensor,
-        K: cute.Tensor,
-        V: cute.Tensor,
-        dK: cute.Tensor,
-        dV: cute.Tensor,
-        dO: cute.Tensor,
-        scaled_LSE: cute.Tensor,
-        sum_OdO: cute.Tensor,
-        cumulative_s_q: cute.Tensor | None,
-        cumulative_s_k: cute.Tensor | None,
-        scale_softmax: cutlass.Float32,
-        stream: cuda.CUstream,
+        mQ: cute.Tensor,
+        mK: cute.Tensor,
+        mV: cute.Tensor,
+        mdO: cute.Tensor,
+        mLSE: cute.Tensor,
+        mdPsum: cute.Tensor,
+        mdK: cute.Tensor,
+        mdV: cute.Tensor,
+        softmax_scale: Float32,
+        mCuSeqlensQ: Optional[cute.Tensor] = None,
+        mCuSeqlensK: Optional[cute.Tensor] = None,
+        mSeqUsedQ: Optional[cute.Tensor] = None,
+        mSeqUsedK: Optional[cute.Tensor] = None,
+        window_size_left: Int32 | int | None = None,
+        window_size_right: Int32 | int | None = None,
+        mdK_semaphore: Optional[cute.Tensor] = None,
+        mdV_semaphore: Optional[cute.Tensor] = None,
+        aux_data: utils.AuxData = utils.AuxData(),
+        # Always keep stream as the last parameter (EnvStream: obtained implicitly via TVM FFI).
+        stream: cuda.CUstream = None,
     ):
-        """Host function to launch CuTeDSL kernel."""
-        varlen = cumulative_s_q is not None or cumulative_s_k is not None
-        # Infer shape metadata from normalized 5D tensors (B, S, H_k, H_r, D).
-        h_r = Q.shape[3]
-        h_k = Q.shape[2]
-        if cutlass.const_expr(cumulative_s_q is not None):
-            b = cumulative_s_q.shape[0] - 1
-        elif cutlass.const_expr(cumulative_s_k is not None):
-            b = cumulative_s_k.shape[0] - 1
+        self.q_dtype = mQ.element_type
+        self.k_dtype = mK.element_type
+        self.v_dtype = mV.element_type
+        self.do_dtype = mdO.element_type
+        self.lse_dtype = mLSE.element_type
+        self.dpsum_dtype = mdPsum.element_type
+        self.dk_dtype = mdK.element_type
+        self.dv_dtype = mdV.element_type
+        self.ds_dtype = self.q_dtype
+
+        self.is_varlen_k = mCuSeqlensK is not None or mSeqUsedK is not None
+        self.is_varlen_q = mCuSeqlensQ is not None or mSeqUsedQ is not None
+        self.use_tma_store = True
+        self.dKV_postprocess = self.qhead_per_kvhead > 1
+
+        if const_expr(self.dKV_postprocess):
+            assert self.dk_dtype.width == 32, "Must accumulate dK in float precision for GQA"
+            assert self.dv_dtype.width == 32, "Must accumulate dV in float precision for GQA"
+
+        mdK, mdV = [assume_tensor_aligned(t) for t in (mdK, mdV)]
+
+        # (b, s, n, h) --> (s, h, n, b) or (t, n, h) -> (t, h, n)
+        QO_layout_transpose = [1, 3, 2, 0] if const_expr(mCuSeqlensQ is None) else [0, 2, 1]
+        mQ, mdO = [layout_utils.select(t, mode=QO_layout_transpose) for t in (mQ, mdO)]
+
+        KV_layout_transpose = [1, 3, 2, 0] if const_expr(mCuSeqlensK is None) else [0, 2, 1]
+        mK, mV = [layout_utils.select(t, mode=KV_layout_transpose) for t in (mK, mV)]
+
+        # (b, n, s) --> (s, n, b) or (n, t) --> (t, n)
+        LSE_dPsum_dQaccum_transpose = [2, 1, 0] if const_expr(mCuSeqlensQ is None) else [1, 0]
+        mLSE, mdPsum = [
+            layout_utils.select(t, mode=LSE_dPsum_dQaccum_transpose) for t in (mLSE, mdPsum)
+        ]
+
+        if const_expr(not self.dKV_postprocess):
+            layout_dKV_transpose = KV_layout_transpose
         else:
-            b = Q.shape[0]
-        problem_shape = (
-            Q.shape[1],
-            K.shape[1],
-            Q.shape[4],
-            ((h_r, h_k), b),
-        )
-        hb = ((h_r, h_k), b)
-        # (b, s, h_k, h_r, d) -> (s, d, ((h_r, h_k), b))
-        Q = cute.make_tensor(
-            Q.iterator,
-            cute.make_layout(
-                (Q.shape[1], Q.shape[4], hb),
-                stride=(
-                    cute.assume(Q.stride[1], divby=64),
-                    Q.stride[4],
-                    (
-                        (Q.stride[3], Q.stride[2]),
-                        0 if cumulative_s_q is not None else cute.assume(Q.stride[0], divby=64),
-                    ),
-                ),
-            ),
-        )
-        # (b, s, h_k, 1, d) -> (s, d, ((1, h_k), b))
-        K = cute.make_tensor(
-            K.iterator,
-            cute.make_layout(
-                (K.shape[1], K.shape[4], hb),
-                stride=(
-                    cute.assume(K.stride[1], divby=64),
-                    K.stride[4],
-                    (
-                        (0, K.stride[2]),
-                        0 if cumulative_s_k is not None else cute.assume(K.stride[0], divby=64),
-                    ),
-                ),
-            ),
-        )
-        # (b, s, h_k, 1, d) -> (s, d, ((1, h_k), b))
-        V = cute.make_tensor(
-            V.iterator,
-            cute.make_layout(
-                (V.shape[1], V.shape[4], hb),
-                stride=(
-                    cute.assume(V.stride[1], divby=64),
-                    V.stride[4],
-                    (
-                        (0, V.stride[2]),
-                        0 if cumulative_s_k is not None else cute.assume(V.stride[0], divby=64),
-                    ),
-                ),
-            ),
-        )
-        # (s, d, ((h_r, h_k), b)) -> (d, s, ((h_r, h_k), b))
-        QT = cute.make_tensor(
-            Q.iterator,
-            cute.make_layout(
-                (Q.shape[1], Q.shape[0], Q.shape[2]),
-                stride=(
-                    Q.stride[1],
-                    Q.stride[0],
-                    Q.stride[2],
-                ),
-            ),
-        )
-        dK = cute.make_tensor(
-            dK.iterator,
-            cute.make_layout(
-                (dK.shape[1], dK.shape[4], hb),
-                stride=(
-                    cute.assume(dK.stride[1], divby=64),
-                    dK.stride[4],
-                    (
-                        (0, dK.stride[2]),
-                        0 if cumulative_s_k is not None else cute.assume(dK.stride[0], divby=64),
-                    ),
-                ),
-            ),
-        )
-        dV = cute.make_tensor(
-            dV.iterator,
-            cute.make_layout(
-                (dV.shape[1], dV.shape[4], hb),
-                stride=(
-                    cute.assume(dV.stride[1], divby=64),
-                    dV.stride[4],
-                    (
-                        (0, dV.stride[2]),
-                        0 if cumulative_s_k is not None else cute.assume(dV.stride[0], divby=64),
-                    ),
-                ),
-            ),
-        )
-        # (s, d, ((h_r, h_k), b))
-        dO = cute.make_tensor(
-            dO.iterator,
-            cute.make_layout(
-                (dO.shape[1], dO.shape[4], hb),
-                stride=(
-                    cute.assume(dO.stride[1], divby=64),
-                    dO.stride[4],
-                    (
-                        (dO.stride[3], dO.stride[2]),
-                        0 if cumulative_s_q is not None else cute.assume(dO.stride[0], divby=64),
-                    ),
-                ),
-            ),
-        )
+            layout_dKV_transpose = [2, 1, 0] if const_expr(mCuSeqlensK is None) else [1, 0]
+        mdK, mdV = [layout_utils.select(t, mode=layout_dKV_transpose) for t in (mdK, mdV)]
+        # (s, h, n, b) --> (h, s, n, b) or (t, h, n) -> (h, t, b)
+        dO_transpose = [1, 0, 2, 3] if const_expr(mCuSeqlensQ is None) else [1, 0, 2]
+        mdO = layout_utils.select(mdO, mode=dO_transpose)
 
-        # (s, d, ((h_r, h_k), b)) -> (d, s, ((h_r, h_k), b))
-        dOT = cute.make_tensor(
-            dO.iterator,
-            cute.make_layout(
-                (dO.shape[1], dO.shape[0], dO.shape[2]),
-                stride=(
-                    dO.stride[1],
-                    dO.stride[0],
-                    dO.stride[2],
-                ),
-            ),
-        )
+        # Transposes for 2-CTA K/Q paths (Q follows Q seqlens, K follows K seqlens)
+        transpose_sh_q = dO_transpose
 
-        self.Q_major_mode = utils.LayoutEnum.from_tensor(Q).mma_major_mode()
-        self.K_major_mode = utils.LayoutEnum.from_tensor(K).mma_major_mode()
-        self.dK_major_mode = utils.LayoutEnum.from_tensor(dK).mma_major_mode()
-        self.V_major_mode = utils.LayoutEnum.from_tensor(V).mma_major_mode()
-        self.dV_major_mode = utils.LayoutEnum.from_tensor(dV).mma_major_mode()
-        self.dO_major_mode = utils.LayoutEnum.from_tensor(dO).mma_major_mode()
-
-        if cutlass.const_expr(self.Q_major_mode != tcgen05.OperandMajorMode.K):
-            raise RuntimeError(f"The layout of q is not supported: {self.Q_major_mode}")
-        if cutlass.const_expr(self.K_major_mode != tcgen05.OperandMajorMode.K):
-            raise RuntimeError("The layout of k is not supported")
-        if cutlass.const_expr(self.dK_major_mode != tcgen05.OperandMajorMode.K):
-            raise RuntimeError("The layout of dk is not supported")
-        if cutlass.const_expr(self.V_major_mode != tcgen05.OperandMajorMode.K):
-            raise RuntimeError("The layout of v is not supported")
-        if cutlass.const_expr(self.dV_major_mode != tcgen05.OperandMajorMode.K):
-            raise RuntimeError("The layout of dv is not supported")
+        # (b, n, block, stage) -> (block, stage, n, b)
+        semaphore_transpose = [2, 3, 1, 0]
+        if const_expr(self.deterministic and self.qhead_per_kvhead > 1):
+            assert mdK_semaphore is not None
+            assert mdV_semaphore is not None
+            mdK_semaphore, mdV_semaphore = [
+                layout_utils.select(t, mode=semaphore_transpose)
+                for t in (mdK_semaphore, mdV_semaphore)
+            ]
+        else:
+            mdK_semaphore = None
+            mdV_semaphore = None
 
         self._setup_attributes()
+        (
+            self.tiled_mma_S,
+            self.tiled_mma_dP,
+            self.tiled_mma_dK,
+            self.tiled_mma_dV,
+            self.tiled_mma_dQ,
+        ) = self._get_tiled_mma()
+        self._setup_smem_layout()
 
-        cta_group = tcgen05.CtaGroup.TWO
-        PT_source = tcgen05.OperandSource.SMEM
-
-        # compute S
-        KQ_tiled_mma = sm100_utils.make_trivial_tiled_mma(
-            K.element_type,
-            tcgen05.OperandMajorMode.K,
-            tcgen05.OperandMajorMode.K,
-            self.acc_dtype,
-            cta_group,
-            self.KQ_mma_tiler[:2],
-        )
-        # compute dP
-        VdO_tiled_mma = sm100_utils.make_trivial_tiled_mma(
-            V.element_type,
-            tcgen05.OperandMajorMode.K,
-            tcgen05.OperandMajorMode.K,
-            self.acc_dtype,
-            cta_group,
-            self.VdO_mma_tiler[:2],
-        )
-        # compute dV
-        PdO_tiled_mma = sm100_utils.make_trivial_tiled_mma(
-            dO.element_type,
-            tcgen05.OperandMajorMode.K,
-            tcgen05.OperandMajorMode.MN,
-            self.acc_dtype,
-            cta_group,
-            self.PdO_mma_tiler[:2],
-            PT_source,
-        )
-        # compute dK
-        dSQ_tiled_mma = sm100_utils.make_trivial_tiled_mma(
-            Q.element_type,
-            tcgen05.OperandMajorMode.K,
-            tcgen05.OperandMajorMode.MN,
-            self.acc_dtype,
-            cta_group,
-            self.dSQ_mma_tiler[:2],
-        )
-        # compute dQ
-        # dishengbin, need to remove, but used in dS_mem_layout_staged
-        dSK_tiled_mma = sm100_utils.make_trivial_tiled_mma(
-            K.element_type,
-            tcgen05.OperandMajorMode.MN,
-            tcgen05.OperandMajorMode.MN,
-            self.acc_dtype,
-            cta_group,
-            self.dSK_mma_tiler[:2],
-        )
-
-        atom_thr_size = cute.size(KQ_tiled_mma.thr_id.shape)
-        self.cluster_shape_mnk = (*self.cluster_shape_mn, 1)  # type: ignore[assignment]
+        self.cluster_shape_mnk = (*self.cluster_shape_mn, 1)
         self.cluster_layout_vmnk = cute.tiled_divide(
             cute.make_layout(self.cluster_shape_mnk),
-            (atom_thr_size,),
+            (self.tiled_mma_S.thr_id.shape,),
         )
+        self.num_mcast_ctas_b = cute.size(self.cluster_layout_vmnk.shape[1])
+        self.is_q_do_mcast = self.num_mcast_ctas_b > 1
 
-        K_smem_layout_staged = sm100_utils.make_smem_layout_a(
-            KQ_tiled_mma,
-            self.KQ_mma_tiler,
-            K.element_type,
-            1,
-        )
-        Q_smem_layout_staged = sm100_utils.make_smem_layout_b(
-            KQ_tiled_mma,
-            self.KQ_mma_tiler,
-            Q.element_type,
-            self.load_mma_Q_stage,
-        )
-        V_smem_layout_staged = sm100_utils.make_smem_layout_a(
-            VdO_tiled_mma,
-            self.VdO_mma_tiler,
-            V.element_type,
-            1,
-        )
-        dO_smem_layout_staged = sm100_utils.make_smem_layout_b(
-            VdO_tiled_mma,
-            self.VdO_mma_tiler,
-            dO.element_type,
-            self.load_mma_dO_stage,
-        )
-        # dishengbin, need to remove, but used for sPT, need to double check
-        dS_smem_layout_staged = sm100_utils.make_smem_layout_a(
-            dSK_tiled_mma,
-            self.dSK_mma_tiler,
-            Q.element_type,
-            self.compute_mma_dS_stage,
-        )
-        dST_smem_layout_staged = sm100_utils.make_smem_layout_a(
-            dSQ_tiled_mma,
-            self.dSQ_mma_tiler,
-            Q.element_type,
-            self.compute_mma_dS_stage,
-        )
-        tiled_mma = dSQ_tiled_mma
-        is_k_major = tiled_mma.op.a_major_mode == tcgen05.OperandMajorMode.K
-        a_major_mode = tcgen05.OperandMajorMode.K if is_k_major else tcgen05.OperandMajorMode.MN
-        tmp = cute.dice(self.dSQ_mma_tiler, (1, None, 1))
-        a_smem_shape = tiled_mma.partition_shape_A(
-            cute.dice(self.dSQ_mma_tiler, (1, None, 1)),
-        )
-        a_smem_shape_mn_k = (
-            cute.size(a_smem_shape[0][0]) * a_smem_shape[1],
-            cute.size(a_smem_shape[0][1]) * a_smem_shape[2],
-        )
-        smem_layout_atom_kind = sm100_utils.get_smem_layout_atom_ab(
-            a_major_mode,
-            K.element_type,
-            a_smem_shape_mn_k,
-        )
-        a_smem_layout_atom = sm100_utils.make_smem_layout_atom(
-            smem_layout_atom_kind,
-            K.element_type,
-        )
+        if const_expr(not self.dKV_postprocess):
+            self.mdK_layout_enum = LayoutEnum.from_tensor(mdK)
+            self.mdV_layout_enum = LayoutEnum.from_tensor(mdV)
+            dK_major_mode = self.mdK_layout_enum.mma_major_mode()
+            dV_major_mode = self.mdV_layout_enum.mma_major_mode()
+            if const_expr(dK_major_mode != tcgen05.OperandMajorMode.K):
+                raise RuntimeError("The layout of mdK is wrong")
+            if const_expr(dV_major_mode != tcgen05.OperandMajorMode.K):
+                raise RuntimeError("The layout of mdV is wrong")
 
-        a_smem_shape = cute.append(
-            a_smem_shape,
-            self.compute_mma_dS_stage,
-        )
-        order = (2, 1, 3) if not is_k_major else (1, 2, 3)
-        dST_smem_layout_staged_tmp = sm100_utils.tile_to_mma_shape(
-            a_smem_layout_atom,
-            a_smem_shape,
-            order=order,
-        )
-        QT_smem_layout_staged = sm100_utils.make_smem_layout_b(
-            dSQ_tiled_mma,
-            self.dSQ_mma_tiler,
-            Q.element_type,
-            self.load_mma_QT_stage,
-        )
-        P_smem_layout_staged = sm100_utils.make_smem_layout_a(
-            PdO_tiled_mma,
-            self.PdO_mma_tiler,
-            Q.element_type,
-            self.compute_mma_P_stage,
-        )
-        dOT_smem_layout_staged = sm100_utils.make_smem_layout_b(
-            PdO_tiled_mma,
-            self.PdO_mma_tiler,
-            dO.element_type,
-            self.load_mma_dO_stage,
-        )
-        LSE_smem_layout = cute.make_layout((self.cta_tiler[0], self.load_compute_LSE_stage))
-        sum_OdO_smem_layout = cute.make_layout((self.cta_tiler[0], self.load_compute_sum_OdO_stage))
-
-        tma_load_op = cpasync.CopyBulkTensorTileG2SOp(cta_group)
-        tma_reduce_op = cpasync.CopyReduceBulkTensorTileS2GOp()
-
-        K_smem_layout = cute.select(K_smem_layout_staged, mode=[0, 1, 2])
+        tma_load_op = cpasync.CopyBulkTensorTileG2SOp(self.cta_group)
+        # S.T = K @ Q.T
         tma_atom_K, tma_tensor_K = cute.nvgpu.make_tiled_tma_atom_A(
             tma_load_op,
-            K,
-            K_smem_layout,
-            self.KQ_mma_tiler,
-            KQ_tiled_mma,
+            mK,
+            cute.select(self.sK_layout, mode=[0, 1, 2]),
+            self.mma_tiler_kq,
+            self.tiled_mma_S,
             self.cluster_layout_vmnk.shape,
         )
-
-        V_smem_layout = cute.select(V_smem_layout_staged, mode=[0, 1, 2])
+        Q_tma_op = sm100_utils_basic.cluster_shape_to_tma_atom_B(
+            self.cluster_shape_mnk, self.tiled_mma_S.thr_id
+        )
+        tma_atom_Q, tma_tensor_Q = cute.nvgpu.make_tiled_tma_atom_B(
+            Q_tma_op,
+            mQ,
+            cute.select(self.sQ_layout, mode=[0, 1, 2]),
+            self.mma_tiler_kq,
+            self.tiled_mma_S,
+            self.cluster_layout_vmnk.shape,
+        )
+        # dP.T = V @ dO.T
         tma_atom_V, tma_tensor_V = cute.nvgpu.make_tiled_tma_atom_A(
             tma_load_op,
-            V,
-            V_smem_layout,
-            self.VdO_mma_tiler,
-            VdO_tiled_mma,
+            mV,
+            cute.select(self.sV_layout, mode=[0, 1, 2]),
+            self.mma_tiler_vdo,
+            self.tiled_mma_dP,
             self.cluster_layout_vmnk.shape,
         )
-
-        Q_smem_layout = cute.select(Q_smem_layout_staged, mode=[0, 1, 2])
-        tma_atom_Q, tma_tensor_Q = cute.nvgpu.make_tiled_tma_atom_B(
-            tma_load_op,
-            Q,
-            Q_smem_layout,
-            self.KQ_mma_tiler,
-            KQ_tiled_mma,
-            self.cluster_layout_vmnk.shape,
+        dO_tma_op = sm100_utils_basic.cluster_shape_to_tma_atom_B(
+            self.cluster_shape_mnk, self.tiled_mma_dV.thr_id
         )
-        QT_smem_layout = cute.select(QT_smem_layout_staged, mode=[0, 1, 2])
-        tma_atom_QT, tma_tensor_QT = cute.nvgpu.make_tiled_tma_atom_B(
-            tma_load_op,
-            QT,
-            QT_smem_layout,
-            self.dSQ_mma_tiler,
-            dSQ_tiled_mma,
-            self.cluster_layout_vmnk.shape,
-        )
-
-        dO_smem_layout = cute.select(dO_smem_layout_staged, mode=[0, 1, 2])
         tma_atom_dO, tma_tensor_dO = cute.nvgpu.make_tiled_tma_atom_B(
-            tma_load_op,
-            dO,
-            dO_smem_layout,
-            self.VdO_mma_tiler,
-            VdO_tiled_mma,
+            dO_tma_op,
+            mdO,
+            cute.select(self.sdO_layout, mode=[0, 1, 2]),
+            self.mma_tiler_pdo,
+            self.tiled_mma_dV,
             self.cluster_layout_vmnk.shape,
         )
-        dOT_smem_layout = cute.select(dOT_smem_layout_staged, mode=[0, 1, 2])
-        tma_atom_dOT, tma_tensor_dOT = cute.nvgpu.make_tiled_tma_atom_B(
-            tma_load_op,
-            dOT,
-            dOT_smem_layout,
-            self.PdO_mma_tiler,
-            PdO_tiled_mma,
-            self.cluster_layout_vmnk.shape,
+        # ------------------------------------------------------------
+        # 2-CTA
+        # ------------------------------------------------------------
+        tma_atom_dOt = tma_tensor_dOt = None
+        if const_expr(self.use_2cta_instrs):
+            tma_atom_dOt, tma_tensor_dOt = cute.nvgpu.make_tiled_tma_atom_B(
+                dO_tma_op,
+                layout_utils.select(mdO, mode=transpose_sh_q),
+                cute.select(self.sdOt_layout, mode=[0, 1, 2]),
+                self.mma_tiler_vdo,
+                self.tiled_mma_dP,
+                self.cluster_layout_vmnk.shape,
+            )
+        tma_atom_Qt = tma_tensor_Qt = None
+        if const_expr(self.use_2cta_instrs):
+            tma_atom_Qt, tma_tensor_Qt = cute.nvgpu.make_tiled_tma_atom_B(
+                Q_tma_op,
+                layout_utils.select(mQ, mode=transpose_sh_q),
+                cute.select(self.sQt_layout, mode=[0, 1, 2]),
+                self.mma_tiler_dsq,
+                self.tiled_mma_dK,
+                self.cluster_layout_vmnk.shape,
+            )
+
+        self.tma_copy_bytes = {
+            name: self.cta_group_size
+            * cute.size_in_bytes(mX.element_type, cute.select(layout, mode=[0, 1, 2]))
+            for name, mX, layout in [
+                ("Q", mQ, self.sQ_layout),
+                ("K", mK, self.sK_layout),
+                ("V", mV, self.sV_layout),
+                ("dO", mdO, self.sdO_layout),
+            ]
+        }
+        self.tma_copy_bytes["LSE"] = self.tile_m * Float32.width // 8
+        self.tma_copy_bytes["dPsum"] = self.tile_m * Float32.width // 8
+        self.tma_copy_bytes["dKacc"] = (
+            self.dKV_postprocess_tile_n * self.dK_reduce_ncol * Float32.width // 8
+        )
+        self.tma_copy_bytes["dVacc"] = (
+            self.dKV_postprocess_tile_n * self.dK_reduce_ncol * Float32.width // 8
         )
 
-        # for 2cta, tma_copy_QT_bytes is same as the tma_copy_Q_bytes
-        self.tma_copy_Q_bytes = cute.size_in_bytes(Q.element_type, Q_smem_layout) * atom_thr_size
-        self.tma_copy_K_bytes = cute.size_in_bytes(K.element_type, K_smem_layout) * atom_thr_size
-        self.tma_copy_V_bytes = cute.size_in_bytes(V.element_type, V_smem_layout) * atom_thr_size
-        self.tma_copy_dO_bytes = cute.size_in_bytes(dO.element_type, dO_smem_layout) * atom_thr_size
+        if const_expr(not self.dKV_postprocess):
+            tma_store_op = cpasync.CopyBulkTensorTileS2GOp()
+            tma_atom_dK, mdK_tma_tensor = cpasync.make_tiled_tma_atom(
+                tma_store_op,
+                mdK,
+                cute.select(self.sdK_layout, mode=[0, 1]),
+                self.sdK_epi_tile,
+            )
+            tma_atom_dV, mdV_tma_tensor = cpasync.make_tiled_tma_atom(
+                tma_store_op,
+                mdV,
+                cute.select(self.sdV_layout, mode=[0, 1]),
+                self.sdV_epi_tile,
+            )
+        else:
+            mdK_tma_tensor = mdK
+            mdV_tma_tensor = mdV
+            tma_atom_dK = None
+            tma_atom_dV = None
+        tma_tensor_dK = mdK_tma_tensor
+        tma_tensor_dV = mdV_tma_tensor
 
-        # Variant 3a epilogue: TMA store atoms (S2G) for dK / dV.
-        # Each compute warp group owns half the hd_v output via split_wg, so
-        # the per-WG epi tile is (cta_tiler[1], cta_tiler[2] / num_compute_wgs).
-        # SMEM staging will alias onto sP+sdST in subsequent commits; for now
-        # the atoms and layouts are built and threaded through but unused.
-        tma_store_op = cpasync.CopyBulkTensorTileS2GOp()
-        num_compute_wgs = self.num_compute_warps // 4
-        # Variant 3a Path 2: CTA-shared epilogue SMEM. epi_tile is (M, gcd(128B, ...))
-        # = (M, 64) for bf16 hd=256. Total stages = num_compute_wgs * num_epi_stages
-        # = 4 stages of (64, 64), virtually a per-CTA (64, 256) buffer aliased onto
-        # sP+sdST. Both warp-groups cooperatively populate this buffer; TMA fires
-        # one (64, 64) box per stage to the corresponding (64, 64) GMEM slice.
-        epi_cols_dKV = math.gcd(
-            128 // (dK.element_type.width // 8), self.cta_tiler[2] // num_compute_wgs
+        # TileScheduler = SingleTileScheduler
+        if const_expr(self.is_varlen_k):
+            TileScheduler = SingleTileVarlenScheduler
+        else:
+            TileScheduler = SingleTileScheduler
+        if const_expr(self.spt_override is None):
+            self.spt = (self.is_causal or self.is_local) and self.deterministic
+        else:
+            assert self.spt_override is not None
+            self.spt = self.spt_override and self.deterministic
+        tile_sched_args = TileSchedulerArguments(
+            cute.ceil_div(cute.size(mK.shape[0]), self.cta_tiler[0]),  # num K-blocks
+            cute.size(mQ.shape[2]),  # num_heads = num_query_heads
+            cute.size(mK.shape[3])
+            if const_expr(mCuSeqlensK is None)
+            else cute.size(mCuSeqlensK.shape[0] - 1),  # num_batches
+            1,  # num_splits
+            cute.size(mK.shape[0]),  # pass seqlen_k/static_k
+            mK.shape[1],  # headdim
+            mV.shape[1],  # headdim_v
+            total_q=cute.size(mK.shape[0])  # pass total_k for total_q
+            if const_expr(mCuSeqlensK is not None)
+            else cute.size(mK.shape[0]) * cute.size(mK.shape[3]),
+            tile_shape_mn=self.cta_tiler[:2],  # (tile_n, tile_m)
+            cluster_shape_mn=self.cluster_shape_mnk[:2],
+            mCuSeqlensQ=mCuSeqlensK,
+            mSeqUsedQ=mSeqUsedK,
+            qhead_per_kvhead_packgqa=1,
+            element_size=self.k_dtype.width // 8,
+            is_persistent=self.is_persistent,
+            lpt=self.spt,
+            head_swizzle=self.deterministic,
         )
-        num_epi_stages_dKV = (self.cta_tiler[2] // num_compute_wgs) // epi_cols_dKV
-        epi_tile_dKV = (self.cta_tiler[1], epi_cols_dKV)
-        total_epi_stages = num_compute_wgs * num_epi_stages_dKV
-        dK_layout_enum = utils.LayoutEnum.from_tensor(dK)
-        dV_layout_enum = utils.LayoutEnum.from_tensor(dV)
-        sdK_epi_layout = sm100_utils.make_smem_layout_epi(
-            dK.element_type,
-            dK_layout_enum,
-            epi_tile_dKV,
-            total_epi_stages,
-        )
-        sdV_epi_layout = sm100_utils.make_smem_layout_epi(
-            dV.element_type,
-            dV_layout_enum,
-            epi_tile_dKV,
-            total_epi_stages,
-        )
-        tma_atom_dK, tma_tensor_dK = cpasync.make_tiled_tma_atom(
-            tma_store_op,
-            dK,
-            cute.select(sdK_epi_layout, mode=[0, 1]),
-            epi_tile_dKV,
-        )
-        tma_atom_dV, tma_tensor_dV = cpasync.make_tiled_tma_atom(
-            tma_store_op,
-            dV,
-            cute.select(sdV_epi_layout, mode=[0, 1]),
-            epi_tile_dKV,
-        )
+
+        tile_sched_params = TileScheduler.to_underlying_arguments(tile_sched_args)
+        self.tile_scheduler_cls = TileScheduler
+        grid_dim = TileScheduler.get_grid_shape(tile_sched_params)
 
         @cute.struct
         class SharedStorage:
             # Pipeline barriers
-            load_mma_Q_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.load_mma_Q_stage * 2]
-            load_mma_K_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.load_mma_K_stage * 2]
-            load_mma_V_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.load_mma_V_stage * 2]
-            load_mma_QT_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.load_mma_QT_stage * 2]
-            load_mma_dO_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.load_mma_dO_stage * 2]
-            load_mma_dOT_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.load_mma_dO_stage * 2]
-            load_compute_lse_mbar_ptr: cute.struct.MemRange[
-                cutlass.Int64, self.load_compute_LSE_stage * 2
-            ]
-            load_compute_sum_OdO_mbar_ptr: cute.struct.MemRange[
-                cutlass.Int64, self.load_compute_sum_OdO_stage * 2
-            ]
-            mma_compute_S_mbar_ptr: cute.struct.MemRange[
-                cutlass.Int64, self.mma_compute_S_stage * 2
-            ]
-            mma_compute_dP_mbar_ptr: cute.struct.MemRange[
-                cutlass.Int64, self.mma_compute_dP_stage * 2
-            ]
-            compute_mma_P_mbar_ptr: cute.struct.MemRange[
-                cutlass.Int64, self.compute_mma_P_stage * 2
-            ]
-            compute_mma_dS_mbar_ptr: cute.struct.MemRange[
-                cutlass.Int64, self.compute_mma_dS_stage * 2
-            ]
-            mma_compute_dKdV_mbar_ptr: cute.struct.MemRange[
-                cutlass.Int64, self.mma_compute_dKdV_stage * 2
-            ]
+            Q_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.Q_stage * 2]
+            K_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.single_stage * 2]
+            V_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.single_stage * 2]
+            Qt_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.Q_stage * 2]
+            dO_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.dO_stage * 2]
+            LSE_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.Q_stage * 2]
+            dPsum_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.dO_stage * 2]
+            S_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.single_stage * 2]
+            dP_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.single_stage * 2]
+            P_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.single_stage * 2]
+            dS_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.single_stage * 2]
+            dKV_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.sdKVaccum_stage * 2]
             tmem_holding_buf: cutlass.Int32
             tmem_dealloc_mbar: cutlass.Int64
             clc_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2]
             clc_response: cute.struct.MemRange[Int32, 4]
+            work_tile_info: cute.struct.Align[cute.struct.MemRange[Int32, 5], 128]
             # Smem tensors
             sK: cute.struct.Align[
-                cute.struct.MemRange[K.element_type, cute.cosize(K_smem_layout_staged)],
+                cute.struct.MemRange[self.k_dtype, cute.cosize(self.sK_layout)],
                 self.buffer_align_bytes,
             ]
             # only used in 2cta
             sV: cute.struct.Align[
-                cute.struct.MemRange[V.element_type, cute.cosize(V_smem_layout_staged)],
+                cute.struct.MemRange[self.v_dtype, cute.cosize(self.sV_layout)],
                 self.buffer_align_bytes,
             ]
             sQ: cute.struct.Align[
-                cute.struct.MemRange[Q.element_type, cute.cosize(Q_smem_layout_staged)],
+                cute.struct.MemRange[self.q_dtype, cute.cosize(self.sQ_layout)],
                 self.buffer_align_bytes,
             ]
-            sQT: cute.struct.Align[
-                cute.struct.MemRange[Q.element_type, cute.cosize(QT_smem_layout_staged)],
+            sQt: cute.struct.Align[
+                cute.struct.MemRange[self.q_dtype, cute.cosize(self.sQt_layout)],
                 self.buffer_align_bytes,
             ]
             sdO: cute.struct.Align[
-                cute.struct.MemRange[dO.element_type, cute.cosize(dO_smem_layout_staged)],
+                cute.struct.MemRange[self.do_dtype, cute.cosize(self.sdO_layout)],
                 self.buffer_align_bytes,
             ]
-            sdOT: cute.struct.Align[
-                cute.struct.MemRange[dO.element_type, cute.cosize(dOT_smem_layout_staged)],
+            sdOt: cute.struct.Align[
+                cute.struct.MemRange[self.do_dtype, cute.cosize(self.sdOt_layout)],
                 self.buffer_align_bytes,
             ]
             # only used in 2cta
             # dishengbin checked whether we need sP
             sP: cute.struct.Align[
-                cute.struct.MemRange[Q.element_type, cute.cosize(P_smem_layout_staged)],
+                cute.struct.MemRange[self.ds_dtype, cute.cosize(self.sP_layout)],
                 self.buffer_align_bytes,
             ]
-            sdST: cute.struct.Align[
-                cute.struct.MemRange[Q.element_type, cute.cosize(dST_smem_layout_staged)],
+            sdSt: cute.struct.Align[
+                cute.struct.MemRange[self.ds_dtype, cute.cosize(self.sdSt_layout)],
                 self.buffer_align_bytes,
             ]
 
             sLSE: cute.struct.Align[
-                cute.struct.MemRange[self.acc_dtype, cute.cosize(LSE_smem_layout)],
+                cute.struct.MemRange[self.lse_dtype, cute.cosize(self.sLSE_layout)],
                 self.buffer_align_bytes,
             ]
-            sSum_OdO: cute.struct.Align[
-                cute.struct.MemRange[self.acc_dtype, cute.cosize(sum_OdO_smem_layout)],
+            sdPsum: cute.struct.Align[
+                cute.struct.MemRange[self.dpsum_dtype, cute.cosize(self.sdPsum_layout)],
                 self.buffer_align_bytes,
             ]
 
         self.shared_storage = SharedStorage
 
-        # =============================== bwd ===============================
-        K_val = problem_shape[1]
-        _, H_K = problem_shape[3][0]
-        B = problem_shape[3][1]
-        problem_shape_mbh = (
-            cute.ceil_div(K_val, self.cta_tiler[1]),
-            cute.size(B),
-            cute.size(H_K),
-        )
-        if cutlass.const_expr(self.use_clc_scheduler):
-            self.tile_sched_params = FmhaClcDynamicTileSchedulerParams(
-                problem_shape_mbh,
-                (*self.cluster_shape_mn, 1),
-            )
-            bwd_grid = FmhaClcDynamicTileScheduler.get_grid_shape(self.tile_sched_params)
+        LOG2_E = math.log2(math.e)
+        if const_expr(self.score_mod is None):
+            # Without score_mod: bake scale into log2
+            softmax_scale_log2 = softmax_scale * LOG2_E
         else:
-            self.tile_sched_params = FmhaStaticTileSchedulerParams(
-                is_persistent=False,
-                problem_shape_mbh=problem_shape_mbh,
-            )
-            bwd_grid = self._compute_bwd_grid(problem_shape, self.cta_tiler[1])
-            bwd_grid = cute.round_up(bwd_grid, self.cluster_shape_mnk)
+            # With score_mod: score_mod applied to S * softmax_scale, then use LOG2_E only
+            softmax_scale_log2 = LOG2_E
 
-        self.dkdv_bwd(
-            KQ_tiled_mma,
-            VdO_tiled_mma,
-            PdO_tiled_mma,
-            dSQ_tiled_mma,
-            tma_atom_K,
-            tma_tensor_K,
-            K,
-            tma_atom_V,
-            tma_tensor_V,
-            tma_atom_Q,
+        if const_expr(window_size_left is not None):
+            window_size_left = Int32(window_size_left)
+        if const_expr(window_size_right is not None):
+            window_size_right = Int32(window_size_right)
+
+        fastdiv_mods = None
+        if const_expr(aux_data.tensors is not None):
+            seqlen_q = cute.size(mQ.shape[0])
+            seqlen_k = cute.size(mK.shape[0])
+            seqlen_q_divmod = FastDivmodDivisor(seqlen_q)
+            seqlen_k_divmod = FastDivmodDivisor(seqlen_k)
+            fastdiv_mods = (seqlen_q_divmod, seqlen_k_divmod)
+
+        self.kernel(
             tma_tensor_Q,
-            Q,
-            tma_atom_QT,
-            tma_tensor_QT,
-            tma_atom_dO,
+            tma_tensor_Qt,
+            tma_tensor_K,
+            tma_tensor_V,
+            mLSE,
+            mdPsum,
             tma_tensor_dO,
-            tma_atom_dOT,
-            tma_tensor_dOT,
-            dK,
-            dV,
-            tma_atom_dK,
-            tma_tensor_dK,
-            tma_atom_dV,
+            tma_tensor_dOt,
+            mdV,
+            mdK,
             tma_tensor_dV,
-            scaled_LSE,
-            scale_softmax,
-            sum_OdO,
-            problem_shape,
-            cumulative_s_q,
-            cumulative_s_k,
-            self.cluster_layout_vmnk,
-            K_smem_layout_staged,
-            Q_smem_layout_staged,
-            V_smem_layout_staged,
-            dO_smem_layout_staged,
-            dS_smem_layout_staged,
-            dST_smem_layout_staged,
-            QT_smem_layout_staged,
-            dOT_smem_layout_staged,
-            P_smem_layout_staged,
-            LSE_smem_layout,
-            sum_OdO_smem_layout,
-            sdK_epi_layout,
-            sdV_epi_layout,
-            self.tile_sched_params,
+            tma_tensor_dK,
+            mCuSeqlensQ,
+            mCuSeqlensK,
+            mSeqUsedQ,
+            mSeqUsedK,
+            tma_atom_Q,
+            tma_atom_Qt,
+            tma_atom_K,
+            tma_atom_V,
+            tma_atom_dO,
+            tma_atom_dOt,
+            tma_atom_dV,
+            tma_atom_dK,
+            self.sQ_layout,
+            self.sQt_layout,
+            self.sK_layout,
+            self.sV_layout,
+            self.sLSE_layout,
+            self.sdPsum_layout,
+            self.sdO_layout,
+            self.sdOt_layout,
+            self.sdSt_layout,
+            self.sP_layout,
+            self.sdK_layout,
+            self.sdV_layout,
+            self.tiled_mma_S,
+            self.tiled_mma_dP,
+            self.tiled_mma_dV,
+            self.tiled_mma_dK,
+            softmax_scale,
+            softmax_scale_log2,
+            window_size_left,
+            window_size_right,
+            mdK_semaphore,
+            mdV_semaphore,
+            tile_sched_params,
+            aux_data,
+            fastdiv_mods,
         ).launch(
-            grid=bwd_grid,
+            grid=grid_dim,
             block=[self.threads_per_cta, 1, 1],
-            cluster=self.cluster_shape_mnk,
-            smem=self.shared_storage.size_in_bytes(),  # type: ignore [attr-defined]
+            cluster=self.cluster_shape_mnk if cute.size(self.cluster_shape_mnk) > 1 else None,
+            smem=self.shared_storage.size_in_bytes(),
             stream=stream,
             min_blocks_per_mp=1,
         )
 
     @cute.kernel
-    def dkdv_bwd(
+    def kernel(
         self,
-        KQ_tiled_mma: cute.TiledMma,
-        VdO_tiled_mma: cute.TiledMma,
-        PdO_tiled_mma: cute.TiledMma,
-        dSQ_tiled_mma: cute.TiledMma,
-        tma_atom_K: cute.CopyAtom,
-        K_in: cute.Tensor,
-        K_ref: cute.Tensor,
-        tma_atom_V: cute.CopyAtom,
-        V_in: cute.Tensor,
+        mQ: cute.Tensor,
+        mQt: Optional[cute.Tensor],
+        mK: cute.Tensor,
+        mV: cute.Tensor,
+        mLSE: cute.Tensor,
+        mdPsum: cute.Tensor,
+        mdO: cute.Tensor,
+        mdOt: Optional[cute.Tensor],
+        mdV: cute.Tensor,
+        mdK: cute.Tensor,
+        mdV_tma_tensor: cute.Tensor,
+        mdK_tma_tensor: cute.Tensor,
+        mCuSeqlensQ: Optional[cute.Tensor],
+        mCuSeqlensK: Optional[cute.Tensor],
+        mSeqUsedQ: Optional[cute.Tensor],
+        mSeqUsedK: Optional[cute.Tensor],
         tma_atom_Q: cute.CopyAtom,
-        Q_in: cute.Tensor,
-        Q_ref: cute.Tensor,
-        tma_atom_QT: cute.CopyAtom,
-        QT_in: cute.Tensor,
+        tma_atom_Qt: Optional[cute.CopyAtom],
+        tma_atom_K: cute.CopyAtom,
+        tma_atom_V: cute.CopyAtom,
         tma_atom_dO: cute.CopyAtom,
-        dO_in: cute.Tensor,
-        tma_atom_dOT: cute.CopyAtom,
-        dOT_in: cute.Tensor,
-        dK: cute.Tensor,
-        dV: cute.Tensor,
-        tma_atom_dK: cute.CopyAtom,
-        dK_tma: cute.Tensor,
-        tma_atom_dV: cute.CopyAtom,
-        dV_tma: cute.Tensor,
-        LSE: cute.Tensor,
-        scale_softmax: cutlass.Float32,
-        sum_OdO: cute.Tensor,
-        problem_shape: tuple[Int32, Int32, Int32, tuple[tuple[Int32, Int32], Int32]],
-        cumulative_s_q: cute.Tensor | None,
-        cumulative_s_k: cute.Tensor | None,
-        cluster_layout_vmnk: cute.Layout,
-        K_smem_layout_staged: cute.ComposedLayout,
-        Q_smem_layout_staged: cute.ComposedLayout,
-        V_smem_layout_staged: cute.ComposedLayout,
-        dO_smem_layout_staged: cute.ComposedLayout,
-        dS_smem_layout_staged: cute.ComposedLayout,
-        dST_smem_layout_staged: cute.ComposedLayout,
-        QT_smem_layout_staged: cute.ComposedLayout,
-        dOT_smem_layout_staged: cute.ComposedLayout,
-        P_smem_layout_staged: cute.ComposedLayout,
-        LSE_smem_layout: cute.Layout,
-        sum_OdO_smem_layout: cute.Layout,
-        sdK_epi_layout: cute.ComposedLayout,
-        sdV_epi_layout: cute.ComposedLayout,
-        tile_sched_params: FmhaStaticTileSchedulerParams | FmhaClcDynamicTileSchedulerParams,
+        tma_atom_dOt: Optional[cute.CopyAtom],
+        tma_atom_dV: Optional[cute.CopyAtom],
+        tma_atom_dK: Optional[cute.CopyAtom],
+        sQ_layout: cute.ComposedLayout,
+        sQt_layout: cute.ComposedLayout,
+        sK_layout: cute.ComposedLayout,
+        sV_layout: cute.ComposedLayout,
+        sLSE_layout: cute.Layout,
+        sdPsum_layout: cute.Layout,
+        sdO_layout: cute.ComposedLayout,
+        sdOt_layout: cute.ComposedLayout,
+        sdSt_layout: cute.ComposedLayout,
+        sP_layout: cute.ComposedLayout,
+        sdK_layout: cute.ComposedLayout | cute.Layout,
+        sdV_layout: cute.ComposedLayout | cute.Layout,
+        tiled_mma_S: cute.TiledMma,
+        tiled_mma_dP: cute.TiledMma,
+        tiled_mma_dV: cute.TiledMma,
+        tiled_mma_dK: cute.TiledMma,
+        softmax_scale: cutlass.Float32,
+        softmax_scale_log2: cutlass.Float32,
+        window_size_left: Optional[Int32],
+        window_size_right: Optional[Int32],
+        mdK_semaphore: Optional[cute.Tensor],
+        mdV_semaphore: Optional[cute.Tensor],
+        tile_sched_params,
+        aux_data: utils.AuxData = utils.AuxData(),
+        fastdiv_mods=(None, None),
     ):
         """Core CuTeDSL backward kernel."""
-        bidx, bidy, bidz = cute.arch.block_idx()
         warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
-        varlen = cumulative_s_q is not None or cumulative_s_k is not None
-
-        mma_tile_coord_v = bidx % cute.size(KQ_tiled_mma.thr_id.shape)
-
+        bidx, _, _ = cute.arch.block_idx()
+        mma_tile_coord_v = bidx % self.cta_group_size
+        is_leader_cta = mma_tile_coord_v == 0
+        cta_rank_in_cluster = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster())
+        # Prefetch tma descriptor
         if warp_idx == self.load_warp_id:
-            cpasync.prefetch_descriptor(tma_atom_K)
-            cpasync.prefetch_descriptor(tma_atom_Q)
-            cpasync.prefetch_descriptor(tma_atom_QT)
-            cpasync.prefetch_descriptor(tma_atom_V)
-            cpasync.prefetch_descriptor(tma_atom_dO)
-            cpasync.prefetch_descriptor(tma_atom_dOT)
+            with cute.arch.elect_one():
+                cpasync.prefetch_descriptor(tma_atom_Q)
+                if const_expr(tma_atom_Qt is not None):
+                    cpasync.prefetch_descriptor(tma_atom_Qt)
+                cpasync.prefetch_descriptor(tma_atom_K)
+                cpasync.prefetch_descriptor(tma_atom_V)
+                cpasync.prefetch_descriptor(tma_atom_dO)
+                if const_expr(tma_atom_dOt is not None):
+                    cpasync.prefetch_descriptor(tma_atom_dOt)
 
-        smem = utils.SmemAllocator()
+        cluster_layout_vmnk = cute.tiled_divide(
+            cute.make_layout(self.cluster_shape_mnk),
+            (tiled_mma_S.thr_id.shape,),
+        )
+
+        # Alloc
+        smem = cutlass.utils.SmemAllocator()
         storage = smem.allocate(self.shared_storage)
 
-        load_mma_Q_producer, load_mma_Q_consumer = pipeline.PipelineTmaUmma.create(
-            num_stages=self.load_mma_Q_stage,
-            producer_group=make_thread_cooperative_group(len([self.load_warp_id])),
-            consumer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
-            tx_count=self.tma_copy_Q_bytes,
-            barrier_storage=storage.load_mma_Q_mbar_ptr.data_ptr(),
-            cta_layout_vmnk=cluster_layout_vmnk,
-            defer_sync=True,
-        ).make_participants()
-        load_mma_K_producer, load_mma_K_consumer = pipeline.PipelineTmaUmma.create(
-            num_stages=self.load_mma_K_stage,
-            producer_group=make_thread_cooperative_group(len([self.load_warp_id])),
-            consumer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
-            tx_count=self.tma_copy_K_bytes,
-            barrier_storage=storage.load_mma_K_mbar_ptr.data_ptr(),
-            cta_layout_vmnk=cluster_layout_vmnk,
-            defer_sync=True,
-        ).make_participants()
-        load_mma_V_producer, load_mma_V_consumer = pipeline.PipelineTmaUmma.create(
-            num_stages=self.load_mma_V_stage,
-            producer_group=make_thread_cooperative_group(len([self.load_warp_id])),
-            consumer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
-            tx_count=self.tma_copy_V_bytes,
-            barrier_storage=storage.load_mma_V_mbar_ptr.data_ptr(),
-            cta_layout_vmnk=cluster_layout_vmnk,
-            defer_sync=True,
-        ).make_participants()
-        load_mma_QT_producer, load_mma_QT_consumer = pipeline.PipelineTmaUmma.create(
-            num_stages=self.load_mma_QT_stage,
-            producer_group=make_thread_cooperative_group(len([self.load_warp_id])),
-            consumer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
-            tx_count=self.tma_copy_Q_bytes,
-            barrier_storage=storage.load_mma_QT_mbar_ptr.data_ptr(),
-            cta_layout_vmnk=cluster_layout_vmnk,
-            defer_sync=True,
-        ).make_participants()
-        load_mma_dO_producer, load_mma_dO_consumer = pipeline.PipelineTmaUmma.create(
-            num_stages=self.load_mma_dO_stage,
-            producer_group=make_thread_cooperative_group(len([self.load_warp_id])),
-            consumer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
-            tx_count=self.tma_copy_dO_bytes,
-            barrier_storage=storage.load_mma_dO_mbar_ptr.data_ptr(),
-            cta_layout_vmnk=cluster_layout_vmnk,
-            defer_sync=True,
-        ).make_participants()
-        load_mma_dOT_producer, load_mma_dOT_consumer = pipeline.PipelineTmaUmma.create(
-            num_stages=self.load_mma_dO_stage,
-            producer_group=make_thread_cooperative_group(len([self.load_warp_id])),
-            consumer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
-            tx_count=self.tma_copy_dO_bytes,
-            barrier_storage=storage.load_mma_dOT_mbar_ptr.data_ptr(),
-            cta_layout_vmnk=cluster_layout_vmnk,
-            defer_sync=True,
-        ).make_participants()
-        load_compute_LSE_producer, load_compute_LSE_consumer = pipeline.PipelineCpAsync.create(
-            num_stages=self.load_compute_LSE_stage,
-            producer_group=make_thread_cooperative_group(self.threads_per_warp),
-            consumer_group=make_thread_cooperative_group(
-                self.threads_per_warp * self.num_compute_warps
-            ),
-            barrier_storage=storage.load_compute_lse_mbar_ptr.data_ptr(),
-        ).make_participants()
-        load_compute_sum_OdO_producer, load_compute_sum_OdO_consumer = (
-            pipeline.PipelineCpAsync.create(
-                num_stages=self.load_compute_sum_OdO_stage,
-                producer_group=make_thread_cooperative_group(self.threads_per_warp),
-                consumer_group=make_thread_cooperative_group(
-                    self.threads_per_warp * self.num_compute_warps
-                ),
-                barrier_storage=storage.load_compute_sum_OdO_mbar_ptr.data_ptr(),
-            ).make_participants()
+        tmem_alloc_barrier = cutlass.pipeline.NamedBarrier(
+            barrier_id=int(NamedBarrierBwdSm100.TmemPtr),
+            num_threads=cute.arch.WARP_SIZE * len((self.mma_warp_id, *self.compute_warp_ids)),
         )
-        mma_compute_S_producer, mma_compute_S_consumer = pipeline.PipelineUmmaAsync.create(
-            num_stages=self.mma_compute_S_stage,
-            producer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
-            consumer_group=make_thread_cooperative_group(
-                self.num_compute_warps * self.threads_per_warp * cluster_layout_vmnk.shape[0][0]
-            ),
-            barrier_storage=storage.mma_compute_S_mbar_ptr.data_ptr(),
-            cta_layout_vmnk=cluster_layout_vmnk,
-            defer_sync=True,
-        ).make_participants()
-        mma_compute_dP_producer, mma_compute_dP_consumer = pipeline.PipelineUmmaAsync.create(
-            num_stages=self.mma_compute_dP_stage,
-            producer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
-            consumer_group=make_thread_cooperative_group(
-                self.num_compute_warps * self.threads_per_warp * cluster_layout_vmnk.shape[0][0]
-            ),
-            barrier_storage=storage.mma_compute_dP_mbar_ptr.data_ptr(),
-            cta_layout_vmnk=cluster_layout_vmnk,
-            defer_sync=True,
-        ).make_participants()
-        compute_mma_P_producer, compute_mma_P_consumer = pipeline.PipelineAsyncUmma.create(
-            num_stages=self.compute_mma_P_stage,
-            producer_group=make_thread_cooperative_group(
-                self.num_compute_warps * self.threads_per_warp * cluster_layout_vmnk.shape[0][0]
-            ),
-            consumer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
-            barrier_storage=storage.compute_mma_P_mbar_ptr.data_ptr(),
-            cta_layout_vmnk=cluster_layout_vmnk,
-            defer_sync=True,
-        ).make_participants()
-        compute_mma_dS_producer, compute_mma_dS_consumer = pipeline.PipelineAsyncUmma.create(
-            num_stages=self.compute_mma_dS_stage,
-            producer_group=make_thread_cooperative_group(
-                self.num_compute_warps * self.threads_per_warp * cluster_layout_vmnk.shape[0][0]
-            ),
-            consumer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
-            barrier_storage=storage.compute_mma_dS_mbar_ptr.data_ptr(),
-            cta_layout_vmnk=cluster_layout_vmnk,
-            defer_sync=True,
-        ).make_participants()
-        mma_compute_dKdV_producer, mma_compute_dKdV_consumer = pipeline.PipelineUmmaAsync.create(
-            num_stages=self.mma_compute_dKdV_stage,
-            producer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
-            consumer_group=make_thread_cooperative_group(
-                self.num_compute_warps * self.threads_per_warp * cluster_layout_vmnk.shape[0][0]
-            ),
-            barrier_storage=storage.mma_compute_dKdV_mbar_ptr.data_ptr(),
-            cta_layout_vmnk=cluster_layout_vmnk,
-            defer_sync=True,
-        ).make_participants()
-
-        cute.arch.barrier(barrier_id=self.cta_sync_bar_id, number_of_threads=self.threads_per_cta)
-
-        # setup mma
-        sQ = storage.sQ.get_tensor(Q_smem_layout_staged.outer, swizzle=Q_smem_layout_staged.inner)
-        sK = storage.sK.get_tensor(K_smem_layout_staged.outer, swizzle=K_smem_layout_staged.inner)
-        sV = storage.sV.get_tensor(V_smem_layout_staged.outer, swizzle=V_smem_layout_staged.inner)
-        sdO = storage.sdO.get_tensor(
-            dO_smem_layout_staged.outer, swizzle=dO_smem_layout_staged.inner
-        )
-        sLSE = storage.sLSE.get_tensor(LSE_smem_layout)
-        sSum_OdO = storage.sSum_OdO.get_tensor(sum_OdO_smem_layout)
-        tmem_holding_buf = storage.tmem_holding_buf
-        # for 2cta, QT use different mem from Q
-
-        sQT = storage.sQT.get_tensor(
-            QT_smem_layout_staged.outer, swizzle=QT_smem_layout_staged.inner
-        )
-        sdST = storage.sdST.get_tensor(
-            dST_smem_layout_staged.outer, swizzle=dST_smem_layout_staged.inner
-        )
-        tP_fake_ptr = cute.make_ptr(sQ.element_type, 0, cute.AddressSpace.tmem)
-        tP = cute.make_tensor(tP_fake_ptr, P_smem_layout_staged.outer)
-
-        sP = storage.sP.get_tensor(P_smem_layout_staged.outer, swizzle=P_smem_layout_staged.inner)
-
-        sdOT = storage.sdOT.get_tensor(
-            dOT_smem_layout_staged.outer, swizzle=dOT_smem_layout_staged.inner
-        )
-
-        # tSTrK shape : (MMA, MMA_M, MMA_K, STAGE)
-        tSTrK = KQ_tiled_mma.make_fragment_A(sK)
-        # tSTrQ shape : (MMA, MMA_N, MMA_K, STAGE)
-        tSTrQ = KQ_tiled_mma.make_fragment_B(sQ)
-
-        # tdPTrV shape : (MMA, MMA_M, MMA_K, STAGE)
-        tdPTrV = VdO_tiled_mma.make_fragment_A(sV)
-        # tdPTrdO shape : (MMA, MMA_N, MMA_K, STAGE)
-        tdPTrdO = VdO_tiled_mma.make_fragment_B(sdO)
-
-        # tdKrdST shape: (MMA, MMA_M, MMA_K, STAGE)
-        tdKrdST = dSQ_tiled_mma.make_fragment_A(sdST)
-        # tdKrQT shape : (MMA, MMA_N, MMA_K, STAGE)
-        tdKrQT = dSQ_tiled_mma.make_fragment_B(sQT)
-
-        tmem_alloc_barrier = pipeline.NamedBarrier(
-            barrier_id=self.tmem_alloc_sync_bar_id,
-            num_threads=self.threads_per_cta,
-        )
-
-        tmem = utils.TmemAllocator(
+        tmem = cutlass.utils.TmemAllocator(
             storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=tmem_alloc_barrier,
-            allocator_warp_id=self.load_warp_id,
+            allocator_warp_id=self.mma_warp_id,
             is_two_cta=True,
             two_cta_tmem_dealloc_mbar_ptr=storage.tmem_dealloc_mbar.ptr,
         )
 
-        tmem.allocate(self.tmem_alloc_cols)
-
-        # wait for tmem allocation and retrieve the pointer
-        tmem.wait_for_alloc()
-        tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
-
-        # Cluster arrive after barrier init
-        # is_relaxed=False has memory consistency guarantee
-        pipeline_init_arrive(cluster_shape_mn=cluster_layout_vmnk, is_relaxed=False)
-
-        if cutlass.const_expr(self.use_clc_scheduler):
-            clc_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
-            cluster_size = cute.size(self.cluster_shape_mnk)
-            num_clc_consumer_threads = self.threads_per_warp * (
-                1  # sched_warp (CTA 0 only)
-                + cluster_size
-                * (
-                    len(self.compute_warp_id)
-                    + 1  # mma_warp
-                    + 1  # load_warp
-                )
-            )
-            clc_pipeline_consumer_group = pipeline.CooperativeGroup(
-                pipeline.Agent.Thread, num_clc_consumer_threads
-            )
-            clc_response_ptr = storage.clc_response.data_ptr()
-            clc = ClcState.create(
-                hw_scheduler=ClcDynamicPersistentTileScheduler.create(
-                    self.tile_sched_params.clc_hw_params(),
-                    cute.arch.block_idx(),
-                    cute.arch.grid_dim(),
-                    clc_response_ptr,
-                ),
-                pipeline=pipeline.PipelineClcFetchAsync.create(
-                    barrier_storage=storage.clc_mbar_ptr.data_ptr(),
-                    num_stages=self.num_clc_stage,
-                    producer_group=clc_pipeline_producer_group,
-                    consumer_group=clc_pipeline_consumer_group,
-                    tx_count=self.num_clc_response_bytes,
-                    cta_layout_vmnk=cluster_layout_vmnk,
-                    defer_sync=True,
-                ),
-                consumer_state=pipeline.make_pipeline_state(
-                    pipeline.PipelineUserType.Consumer, self.num_clc_stage
-                ),
-                producer_state=pipeline.make_pipeline_state(
-                    pipeline.PipelineUserType.Producer, self.num_clc_stage
-                ),
-            )
-            tile_sched = FmhaClcDynamicTileScheduler.create(
-                tile_sched_params,
-                cute.arch.block_idx(),
-                cute.arch.grid_dim(),
-                clc_response_ptr,
-                clc,
-            )
-            work_tile = tile_sched.initial_work_tile_info()
-        else:
-            clc = None
-            clc_response_ptr = None
-
-        tSTtST_shape = KQ_tiled_mma.partition_shape_C(cute.select(self.KQ_mma_tiler, mode=[0, 1]))
-        tSTtST = KQ_tiled_mma.make_fragment_C(tSTtST_shape)
-        # tSTtST shape : (MMA, MMA_M, MMA_N)
-        tSTtST = cute.make_tensor(tmem_ptr + self.tmem_S_offset, tSTtST.layout)
-
-        # tdVrP shape : (MMA, MMA_M, MMA_K, STAGE)
-        tdVrP = PdO_tiled_mma.make_fragment_A(sP)
-        # tdVrdOT shape : (MMA, MMA_N, MMA_K, STAGE)
-        tdVrdOT = PdO_tiled_mma.make_fragment_B(sdOT)
-
-        tdPTtdPT_shape = VdO_tiled_mma.partition_shape_C(
-            cute.select(self.VdO_mma_tiler, mode=[0, 1])
+        # UMMA producers and AsyncThread consumers
+        pipeline_producer_group_MMA_AsyncThread = cutlass.pipeline.CooperativeGroup(
+            cutlass.pipeline.Agent.Thread, len([self.mma_warp_id])
         )
-        tdPTtdPT = VdO_tiled_mma.make_fragment_C(tdPTtdPT_shape)
-        # tdPTtdPT shape : (MMA, MMA_M, MMA_N)
-        tdPTtdPT = cute.make_tensor(tmem_ptr + self.tmem_dP_offset, tdPTtdPT.layout)
+        pipeline_consumer_group_MMA_AsyncThread = cutlass.pipeline.CooperativeGroup(
+            cutlass.pipeline.Agent.Thread, len(self.compute_warp_ids) * self.cta_group_size
+        )
+        pipeline_S = cutlass.pipeline.PipelineUmmaAsync.create(
+            num_stages=1,
+            producer_group=pipeline_producer_group_MMA_AsyncThread,
+            consumer_group=pipeline_consumer_group_MMA_AsyncThread,
+            barrier_storage=storage.S_mbar_ptr.data_ptr(),
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        )
+        pipeline_dP = cutlass.pipeline.PipelineUmmaAsync.create(
+            num_stages=1,
+            producer_group=pipeline_producer_group_MMA_AsyncThread,
+            consumer_group=pipeline_consumer_group_MMA_AsyncThread,
+            barrier_storage=storage.dP_mbar_ptr.data_ptr(),
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        )
+        pipeline_dKV = cutlass.pipeline.PipelineUmmaAsync.create(
+            num_stages=2,
+            producer_group=pipeline_producer_group_MMA_AsyncThread,
+            consumer_group=pipeline_consumer_group_MMA_AsyncThread,
+            barrier_storage=storage.dKV_mbar_ptr.data_ptr(),
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        )
 
-        tdKtdK_shape = dSQ_tiled_mma.partition_shape_C(cute.select(self.dSQ_mma_tiler, mode=[0, 1]))
-        tdKtdK = dSQ_tiled_mma.make_fragment_C(tdKtdK_shape)
-        # tdKtdK shape : (MMA, MMA_M, MMA_N)
+        # AsyncThread producers and UMMA consumers
+        # Only 1 thread per warp will signal
+        pipeline_PdS_producer_group = cutlass.pipeline.CooperativeGroup(
+            cutlass.pipeline.Agent.Thread,
+            len(self.compute_warp_ids) * self.cta_group_size,
+        )
+        pipeline_PdS_consumer_group = cutlass.pipeline.CooperativeGroup(
+            cutlass.pipeline.Agent.Thread, len([self.mma_warp_id])
+        )
+        pipeline_P = cutlass.pipeline.PipelineAsyncUmma.create(
+            num_stages=1,
+            producer_group=pipeline_PdS_producer_group,
+            consumer_group=pipeline_PdS_consumer_group,
+            barrier_storage=storage.P_mbar_ptr.data_ptr(),
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        )
+        pipeline_dS = cutlass.pipeline.PipelineAsyncUmma.create(
+            num_stages=1,
+            producer_group=pipeline_PdS_producer_group,
+            consumer_group=pipeline_PdS_consumer_group,
+            barrier_storage=storage.dS_mbar_ptr.data_ptr(),
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        )
+
+        # TMA producer and UMMA consumers
+        pipeline_producer_group = cutlass.pipeline.CooperativeGroup(
+            cutlass.pipeline.Agent.Thread, len([self.load_warp_id])
+        )
+        # The arrive count is the number of mcast size
+        pipeline_consumer_group = cutlass.pipeline.CooperativeGroup(
+            cutlass.pipeline.Agent.Thread, len([self.mma_warp_id]) * self.num_mcast_ctas_b
+        )
+        pipeline_consumer_group_compute = cutlass.pipeline.CooperativeGroup(
+            cutlass.pipeline.Agent.Thread,
+            len(self.compute_warp_ids) * 1,
+        )
+        pipeline_LSE = cutlass.pipeline.PipelineTmaAsync.create(
+            barrier_storage=storage.LSE_mbar_ptr.data_ptr(),
+            num_stages=self.Q_stage,
+            producer_group=pipeline_producer_group,
+            consumer_group=pipeline_consumer_group_compute,
+            tx_count=self.tma_copy_bytes["LSE"],
+            defer_sync=True,
+        )
+        pipeline_dPsum = cutlass.pipeline.PipelineTmaAsync.create(
+            barrier_storage=storage.dPsum_mbar_ptr.data_ptr(),
+            num_stages=self.dO_stage,
+            producer_group=pipeline_producer_group,
+            consumer_group=pipeline_consumer_group_compute,
+            tx_count=self.tma_copy_bytes["dPsum"],
+            defer_sync=True,
+        )
+        pipeline_Q = pipeline.PipelineTmaUmma.create(
+            num_stages=self.Q_stage,
+            producer_group=pipeline_producer_group,
+            consumer_group=pipeline_consumer_group,
+            tx_count=self.tma_copy_bytes["Q"],
+            barrier_storage=storage.Q_mbar_ptr.data_ptr(),
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        )
+        pipeline_K = pipeline.PipelineTmaUmma.create(
+            num_stages=self.single_stage,
+            producer_group=pipeline_producer_group,
+            consumer_group=pipeline_consumer_group,
+            tx_count=self.tma_copy_bytes["K"],
+            barrier_storage=storage.K_mbar_ptr.data_ptr(),
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        )
+        pipeline_V = pipeline.PipelineTmaUmma.create(
+            num_stages=self.single_stage,
+            producer_group=pipeline_producer_group,
+            consumer_group=pipeline_consumer_group,
+            tx_count=self.tma_copy_bytes["V"],
+            barrier_storage=storage.V_mbar_ptr.data_ptr(),
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        )
+        pipeline_Qt = pipeline.PipelineTmaUmma.create(
+            num_stages=self.Q_stage,
+            producer_group=pipeline_producer_group,
+            consumer_group=pipeline_consumer_group,
+            tx_count=self.tma_copy_bytes["Q"],
+            barrier_storage=storage.Qt_mbar_ptr.data_ptr(),
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        )
+        pipeline_dO = pipeline.PipelineTmaUmma.create(
+            num_stages=self.dO_stage,
+            producer_group=pipeline_producer_group,
+            consumer_group=pipeline_consumer_group,
+            tx_count=self.tma_copy_bytes["dO"],
+            barrier_storage=storage.dO_mbar_ptr.data_ptr(),
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=False,
+        )
+
+        # Logical m_block range helper (same role as flash_bwd_sm100).
+        block_info = BlockInfo(
+            self.tile_m,
+            self.tile_n * self.cluster_shape_mn[0],
+            self.is_causal,
+            self.is_local,
+            False,
+            window_size_left,
+            window_size_right,
+            qhead_per_kvhead_packgqa=1,
+        )
+        SeqlenInfoCls = partial(
+            SeqlenInfoQK.create,
+            seqlen_q_static=mQ.shape[0],
+            seqlen_k_static=mK.shape[0],
+            mCuSeqlensQ=mCuSeqlensQ,
+            mCuSeqlensK=mCuSeqlensK,
+            mSeqUsedQ=mSeqUsedQ,
+            mSeqUsedK=mSeqUsedK,
+            tile_m=self.tile_m,
+            tile_n=self.tile_n * self.cluster_shape_mn[0],
+        )
+
+        TileSchedulerCls = partial(self.tile_scheduler_cls.create, tile_sched_params)
+        shared_work_tile_info = storage.work_tile_info.get_tensor((5,))
+        if warp_idx == self.load_warp_id:
+            cute.arch.setmaxregister_decrease(self.num_regs_load)
+            tile_scheduler = TileSchedulerCls()
+            work_tile = tile_scheduler.initial_work_tile_info()
+            with cute.arch.elect_one():
+                n_block, head_idx, batch_idx, split_idx = work_tile.tile_idx
+                shared_work_tile_info[0] = n_block
+                shared_work_tile_info[1] = head_idx
+                shared_work_tile_info[2] = batch_idx
+                shared_work_tile_info[3] = split_idx
+                work_tile_state = Int32(0)
+                if work_tile.is_valid_tile:
+                    work_tile_state = Int32(1)
+                    if const_expr(self.is_local or self.is_varlen_q):
+                        seqlen = SeqlenInfoCls(batch_idx)
+                        m_block_min, m_block_max = block_info.get_m_block_min_max(
+                            seqlen, n_block // self.cluster_shape_mn[0]
+                        )
+                        if m_block_min >= m_block_max:
+                            work_tile_state = Int32(2)
+                shared_work_tile_info[4] = work_tile_state
+        cute.arch.sync_threads()
+        shared_work_tile = WorkTileInfo(
+            (
+                shared_work_tile_info[0],
+                shared_work_tile_info[1],
+                shared_work_tile_info[2],
+                shared_work_tile_info[3],
+            ),
+            shared_work_tile_info[4] == 1,
+        )
+        # Cluster arrive after barrier init
+        if shared_work_tile.is_valid_tile:
+            pipeline_init_arrive(cluster_shape_mn=cluster_layout_vmnk, is_relaxed=True)
+
+        # setup mma
+        sQ = storage.sQ.get_tensor(sQ_layout.outer, swizzle=sQ_layout.inner)
+        sK = storage.sK.get_tensor(sK_layout.outer, swizzle=sK_layout.inner)
+        sV = storage.sV.get_tensor(sV_layout.outer, swizzle=sV_layout.inner)
+        if const_expr(self.dKV_postprocess):
+            sdK = storage.sK.get_tensor(sdK_layout, dtype=self.dk_dtype)
+            sdV = storage.sV.get_tensor(sdV_layout, dtype=self.dv_dtype)
+        else:
+            sdK = None
+            sdV = None
+        sdO = storage.sdO.get_tensor(sdO_layout.outer, swizzle=sdO_layout.inner)
+        sLSE = storage.sLSE.get_tensor(sLSE_layout)
+        sdPsum = storage.sdPsum.get_tensor(sdPsum_layout)
+        tmem_holding_buf = storage.tmem_holding_buf
+        # for 2cta, Qt use different mem from Q
+
+        sQt = storage.sQt.get_tensor(sQt_layout.outer, swizzle=sQt_layout.inner)
+        sdSt = storage.sdSt.get_tensor(sdSt_layout.outer, swizzle=sdSt_layout.inner)
+        sP = storage.sP.get_tensor(sP_layout.outer, swizzle=sP_layout.inner)
+
+        sdOt = storage.sdOt.get_tensor(sdOt_layout.outer, swizzle=sdOt_layout.inner)
+
+        # TMEM
+        # This is a fake tensor, by right need to retrieve tmem_ptr. But we know that we always
+        # request 512 columns of tmem, so we know that it starts at 0.
+        tmem_ptr = cute.make_ptr(Float32, 0, mem_space=cute.AddressSpace.tmem, assumed_align=16)
+
+        blk_coord_k, _, _ = cute.arch.block_idx()
+        mma_tile_coord_v = blk_coord_k % self.cta_group_size
+        is_leader_cta = mma_tile_coord_v == 0
+
+        # S
+        thr_mma_S = tiled_mma_S.get_slice(mma_tile_coord_v)
+        Sacc_shape = thr_mma_S.partition_shape_C(self.mma_tiler_kq[:2])
+        tStS = thr_mma_S.make_fragment_C(Sacc_shape)
+        tStS = cute.make_tensor(tmem_ptr + self.tmem_S_offset, tStS.layout)
+
+        # dP
+        thr_mma_dP = tiled_mma_dP.get_slice(mma_tile_coord_v)
+        dPacc_shape = thr_mma_dP.partition_shape_C(self.mma_tiler_vdo[:2])
+        tdPtdP = thr_mma_dP.make_fragment_C(dPacc_shape)
+        tdPtdP = cute.make_tensor(tmem_ptr + self.tmem_dP_offset, tdPtdP.layout)
+
+        # dV
+        thr_mma_dV = tiled_mma_dV.get_slice(mma_tile_coord_v)
+        dvacc_shape = thr_mma_dV.partition_shape_C(self.mma_tiler_pdo[:2])
+        tdVtdV = thr_mma_dV.make_fragment_C(dvacc_shape)
+        tdVtdV = cute.make_tensor(tmem_ptr + self.tmem_dV_offset, tdVtdV.layout)
+        tdVrP = tiled_mma_dV.make_fragment_A(sP)
+
+        # dK
+        thr_mma_dK = tiled_mma_dK.get_slice(mma_tile_coord_v)
+        dkacc_shape = thr_mma_dK.partition_shape_C(self.mma_tiler_dsq[:2])
+        tdKtdK = thr_mma_dK.make_fragment_C(dkacc_shape)
         tdKtdK = cute.make_tensor(tmem_ptr + self.tmem_dK_offset, tdKtdK.layout)
 
-        tdVtdV_shape = PdO_tiled_mma.partition_shape_C(cute.select(self.PdO_mma_tiler, mode=[0, 1]))
-        tdVtdV = PdO_tiled_mma.make_fragment_C(tdVtdV_shape)
-        # tdVtdV shape : (MMA, MMA_M, MMA_N)
-        tdVtdV = cute.make_tensor(tmem_ptr + self.tmem_dV_offset, tdVtdV.layout)
+        AttentionMaskCls = partial(
+            AttentionMask,
+            self.tile_m,
+            self.tile_n * self.cta_group_size,
+            swap_AB=True,
+            window_size_left=window_size_left,
+            window_size_right=window_size_right,
+        )
 
-        # get the current batch problem shape
-
-        if cutlass.const_expr(self.use_clc_scheduler):
-            # ===== CLC PERSISTENT PATH: per-warp while loops =====
-            cta_rank_in_cluster = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster())
-            is_first_cta_in_cluster = cta_rank_in_cluster == 0
-            is_sched_warp = warp_idx == self.sched_warp_id and is_first_cta_in_cluster
-
-            # Register allocation ONCE (before any loop)
-            if warp_idx == self.load_warp_id:
-                cute.arch.warpgroup_reg_dealloc(self.num_regs_load)
-            elif warp_idx == self.mma_warp_id:
-                cute.arch.warpgroup_reg_alloc(self.num_regs_mma)
-            elif warp_idx >= self.compute_warp_id[0] and warp_idx <= self.compute_warp_id[-1]:
-                cute.arch.warpgroup_reg_alloc(self.num_regs_compute)
-            else:
-                cute.arch.warpgroup_reg_dealloc(self.num_regs_empty)
-
-            # Cluster wait
+        # Cluster wait before tensor memory alloc.  Varlen launches an upper-bound
+        # grid; invalid padding CTAs do not allocate TMEM or touch pipelines.
+        if shared_work_tile.is_valid_tile:
             pipeline_init_wait(cluster_shape_mn=cluster_layout_vmnk)
 
-            # ===== SCHEDULER WARP =====
-            if is_sched_warp:
-                while work_tile.is_valid_tile:
-                    tile_sched.prefetch_next_work()
-                    work_tile = tile_sched.advance_to_next_work()
-                tile_sched.producer_tail()
+        #  EMPTY
+        # (10, 11)
+        for i in cutlass.range_constexpr(len(self.empty_warp_ids)):
+            if warp_idx == self.empty_warp_ids[i]:
+                cute.arch.setmaxregister_decrease(self.num_regs_empty)
 
-            # ===== LOAD WARP =====
-            elif warp_idx == self.load_warp_id:
-                while work_tile.is_valid_tile:
-                    # Decode coordinates from CLC work tile
-                    blk_coord_k = work_tile.tile_idx[0]
-                    blk_coord_b = work_tile.tile_idx[2][0]
-                    blk_coord_h_k = work_tile.tile_idx[2][1]
-                    blk_coord = (
-                        Int32(0),
-                        blk_coord_k,
-                        Int32(0),
-                        ((Int32(0), blk_coord_h_k), blk_coord_b),
-                    )
-                    seqlen_q_cur_batch = Q_ref.shape[0]
-                    seqlen_k_cur_batch = K_ref.shape[0]
-                    blk_offset = (Int32(0), Int32(0), Int32(0), ((Int32(0), Int32(0)), Int32(0)))
-                    if cutlass.const_expr(varlen):
-                        assert isinstance(cumulative_s_q, cute.Tensor)
-                        assert isinstance(cumulative_s_k, cute.Tensor)
-                        seqlen_q_cur_batch = (
-                            cumulative_s_q[blk_coord_b + 1] - cumulative_s_q[blk_coord_b]
-                        )
-                        seqlen_k_cur_batch = (
-                            cumulative_s_k[blk_coord_b + 1] - cumulative_s_k[blk_coord_b]
-                        )
-                        blk_offset = (
-                            cumulative_s_q[blk_coord_b],
-                            cumulative_s_k[blk_coord_b],
-                            Int32(0),
-                            ((Int32(0), Int32(0)), Int32(0)),
-                        )
-                    iter_start, iter_end = self.get_Q_block_min_max(
-                        seqlen_q_cur_batch,
-                        seqlen_k_cur_batch,
-                        blk_coord_k,
-                        is_2cta=True,
-                    )
-                    iter_count = (iter_end - iter_start) * problem_shape[3][0][0]
-                    if iter_count <= 0:
-                        if blk_coord_k * self.tile_shape_K < seqlen_k_cur_batch:
-                            problem_shape_cur_batch = (
-                                seqlen_q_cur_batch,
-                                seqlen_k_cur_batch,
-                                problem_shape[2],
-                                problem_shape[3],
-                            )
-                            self.epilogue_clear(
-                                blk_coord, blk_offset, problem_shape_cur_batch, dK, dV
-                            )
-                    else:
-                        problem_shape_cur_batch = (
-                            seqlen_q_cur_batch,
-                            seqlen_k_cur_batch,
-                            problem_shape[2],
-                            problem_shape[3],
-                        )
-                        (
-                            load_mma_Q_producer,
-                            load_mma_K_producer,
-                            load_mma_V_producer,
-                            load_compute_LSE_producer,
-                            load_mma_dO_producer,
-                            load_mma_dOT_producer,
-                            load_compute_sum_OdO_producer,
-                            load_mma_QT_producer,
-                        ) = self.load(
-                            K_in,
-                            V_in,
-                            Q_in,
-                            QT_in,
-                            dO_in,
-                            dOT_in,
-                            LSE,
-                            sum_OdO,
-                            sK,
-                            sQ,
-                            sQT,
-                            sV,
-                            sdO,
-                            sdOT,
-                            sLSE,
-                            sSum_OdO,
-                            KQ_tiled_mma,
-                            VdO_tiled_mma,
-                            PdO_tiled_mma,
-                            dSQ_tiled_mma,
-                            tma_atom_K,
-                            tma_atom_Q,
-                            tma_atom_QT,
-                            tma_atom_V,
-                            tma_atom_dO,
-                            tma_atom_dOT,
-                            blk_offset,
-                            problem_shape_cur_batch,
-                            varlen,
-                            iter_count,
-                            iter_start,
-                            iter_end,
-                            load_mma_Q_producer,
-                            load_mma_Q_consumer,
-                            load_mma_K_producer,
-                            load_mma_K_consumer,
-                            load_mma_V_producer,
-                            load_mma_V_consumer,
-                            load_compute_LSE_producer,
-                            load_compute_LSE_consumer,
-                            load_mma_dO_producer,
-                            load_mma_dO_consumer,
-                            load_mma_dOT_producer,
-                            load_mma_dOT_consumer,
-                            load_compute_sum_OdO_producer,
-                            load_compute_sum_OdO_consumer,
-                            load_mma_QT_producer,
-                            load_mma_QT_consumer,
-                            blk_coord_k,
-                            blk_coord_h_k,
-                            blk_coord_b,
-                        )
-                    # CLC advance
-                    work_tile = tile_sched.advance_to_next_work()
-                # producer_tail after loop
-                load_mma_K_producer.tail()
-                load_mma_V_producer.tail()
-                load_mma_Q_producer.tail()
-                load_compute_LSE_producer.tail()
-                load_mma_dO_producer.tail()
-                load_mma_dOT_producer.tail()
-                load_compute_sum_OdO_producer.tail()
-                load_mma_QT_producer.tail()
-
-            # ===== MMA WARP =====
-            elif warp_idx == self.mma_warp_id:
-                while work_tile.is_valid_tile:
-                    blk_coord_k = work_tile.tile_idx[0]
-                    blk_coord_b = work_tile.tile_idx[2][0]
-                    blk_coord_h_k = work_tile.tile_idx[2][1]
-                    blk_coord = (
-                        Int32(0),
-                        blk_coord_k,
-                        Int32(0),
-                        ((Int32(0), blk_coord_h_k), blk_coord_b),
-                    )
-                    seqlen_q_cur_batch = Q_ref.shape[0]
-                    seqlen_k_cur_batch = K_ref.shape[0]
-                    blk_offset = (Int32(0), Int32(0), Int32(0), ((Int32(0), Int32(0)), Int32(0)))
-                    if cutlass.const_expr(varlen):
-                        assert isinstance(cumulative_s_q, cute.Tensor)
-                        assert isinstance(cumulative_s_k, cute.Tensor)
-                        seqlen_q_cur_batch = (
-                            cumulative_s_q[blk_coord_b + 1] - cumulative_s_q[blk_coord_b]
-                        )
-                        seqlen_k_cur_batch = (
-                            cumulative_s_k[blk_coord_b + 1] - cumulative_s_k[blk_coord_b]
-                        )
-                        blk_offset = (
-                            cumulative_s_q[blk_coord_b],
-                            cumulative_s_k[blk_coord_b],
-                            Int32(0),
-                            ((Int32(0), Int32(0)), Int32(0)),
-                        )
-                    iter_start, iter_end = self.get_Q_block_min_max(
-                        seqlen_q_cur_batch,
-                        seqlen_k_cur_batch,
-                        blk_coord_k,
-                        is_2cta=True,
-                    )
-                    iter_count = (iter_end - iter_start) * problem_shape[3][0][0]
-                    if iter_count <= 0:
-                        if blk_coord_k * self.tile_shape_K < seqlen_k_cur_batch:
-                            problem_shape_cur_batch = (
-                                seqlen_q_cur_batch,
-                                seqlen_k_cur_batch,
-                                problem_shape[2],
-                                problem_shape[3],
-                            )
-                            self.epilogue_clear(
-                                blk_coord, blk_offset, problem_shape_cur_batch, dK, dV
-                            )
-                    else:
-                        (
-                            mma_compute_S_producer,
-                            mma_compute_dP_producer,
-                            mma_compute_dKdV_producer,
-                            load_mma_Q_consumer,
-                            load_mma_K_consumer,
-                            load_mma_V_consumer,
-                            load_mma_dO_consumer,
-                            load_mma_dOT_consumer,
-                            compute_mma_P_consumer,
-                            compute_mma_dS_consumer,
-                            load_mma_QT_consumer,
-                        ) = self.mma_2cta(
-                            KQ_tiled_mma,
-                            VdO_tiled_mma,
-                            PdO_tiled_mma,
-                            dSQ_tiled_mma,
-                            tSTtST,
-                            tSTrQ,
-                            tSTrK,
-                            tdPTtdPT,
-                            tdPTrV,
-                            tdPTrdO,
-                            tdVtdV,
-                            tdVrP,
-                            tdVrdOT,
-                            tdKrdST,
-                            tdKtdK,
-                            tdKrQT,
-                            iter_count,
-                            load_mma_Q_consumer,
-                            load_mma_K_consumer,
-                            load_mma_V_consumer,
-                            mma_compute_S_producer,
-                            load_mma_dO_consumer,
-                            mma_compute_dP_producer,
-                            load_mma_dOT_consumer,
-                            compute_mma_P_consumer,
-                            compute_mma_dS_consumer,
-                            load_mma_QT_consumer,
-                            mma_compute_dKdV_producer,
-                        )
-                    # CLC advance
-                    work_tile = tile_sched.advance_to_next_work()
-                # producer_tail after loop
-                mma_compute_S_producer.tail()
-                mma_compute_dP_producer.tail()
-                mma_compute_dKdV_producer.tail()
-
-            # ===== COMPUTE WARPS =====
-            elif warp_idx >= self.compute_warp_id[0] and warp_idx <= self.compute_warp_id[-1]:
-                while work_tile.is_valid_tile:
-                    blk_coord_k = work_tile.tile_idx[0]
-                    blk_coord_b = work_tile.tile_idx[2][0]
-                    blk_coord_h_k = work_tile.tile_idx[2][1]
-                    blk_coord = (
-                        Int32(0),
-                        blk_coord_k,
-                        Int32(0),
-                        ((Int32(0), blk_coord_h_k), blk_coord_b),
-                    )
-                    seqlen_q_cur_batch = Q_ref.shape[0]
-                    seqlen_k_cur_batch = K_ref.shape[0]
-                    blk_offset = (Int32(0), Int32(0), Int32(0), ((Int32(0), Int32(0)), Int32(0)))
-                    if cutlass.const_expr(varlen):
-                        assert isinstance(cumulative_s_q, cute.Tensor)
-                        assert isinstance(cumulative_s_k, cute.Tensor)
-                        seqlen_q_cur_batch = (
-                            cumulative_s_q[blk_coord_b + 1] - cumulative_s_q[blk_coord_b]
-                        )
-                        seqlen_k_cur_batch = (
-                            cumulative_s_k[blk_coord_b + 1] - cumulative_s_k[blk_coord_b]
-                        )
-                        blk_offset = (
-                            cumulative_s_q[blk_coord_b],
-                            cumulative_s_k[blk_coord_b],
-                            Int32(0),
-                            ((Int32(0), Int32(0)), Int32(0)),
-                        )
-                    iter_start, iter_end = self.get_Q_block_min_max(
-                        seqlen_q_cur_batch,
-                        seqlen_k_cur_batch,
-                        blk_coord_k,
-                        is_2cta=True,
-                    )
-                    iter_count = (iter_end - iter_start) * problem_shape[3][0][0]
-                    if iter_count <= 0:
-                        if blk_coord_k * self.tile_shape_K < seqlen_k_cur_batch:
-                            problem_shape_cur_batch = (
-                                seqlen_q_cur_batch,
-                                seqlen_k_cur_batch,
-                                problem_shape[2],
-                                problem_shape[3],
-                            )
-                            self.epilogue_clear(
-                                blk_coord, blk_offset, problem_shape_cur_batch, dK, dV
-                            )
-                    else:
-                        problem_shape_cur_batch = (
-                            seqlen_q_cur_batch,
-                            seqlen_k_cur_batch,
-                            problem_shape[2],
-                            problem_shape[3],
-                        )
-                        (
-                            compute_mma_P_producer,
-                            compute_mma_dS_producer,
-                            mma_compute_S_consumer,
-                            compute_mma_P_consumer,
-                            load_compute_LSE_consumer,
-                            load_compute_sum_OdO_consumer,
-                            mma_compute_dP_consumer,
-                            compute_mma_dS_consumer,
-                            mma_compute_dKdV_consumer,
-                        ) = self.compute(
-                            tSTtST,
-                            tdPTtdPT,
-                            tdVrP,
-                            sP,
-                            sLSE,
-                            sdST,
-                            sdOT,
-                            sSum_OdO,
-                            dK,
-                            dV,
-                            tdKtdK,
-                            tdVtdV,
-                            PdO_tiled_mma,
-                            dSQ_tiled_mma,
-                            blk_coord,
-                            blk_offset,
-                            problem_shape_cur_batch,
-                            iter_count,
-                            iter_start,
-                            iter_end,
-                            scale_softmax,
-                            mma_compute_S_producer,
-                            mma_compute_S_consumer,
-                            compute_mma_P_producer,
-                            compute_mma_P_consumer,
-                            load_compute_LSE_producer,
-                            load_compute_LSE_consumer,
-                            load_compute_sum_OdO_producer,
-                            load_compute_sum_OdO_consumer,
-                            mma_compute_dP_producer,
-                            mma_compute_dP_consumer,
-                            compute_mma_dS_producer,
-                            compute_mma_dS_consumer,
-                            mma_compute_dKdV_producer,
-                            mma_compute_dKdV_consumer,
-                            varlen,
-                            sK,
-                            seqlen_k_cur_batch,
-                            tma_atom_dK,
-                            dK_tma,
-                            tma_atom_dV,
-                            dV_tma,
-                            sdK_epi_layout,
-                            sdV_epi_layout,
-                        )
-                        cute.arch.barrier(
-                            barrier_id=self.epilogue_sync_bar_id,
-                            number_of_threads=self.num_compute_warps * self.threads_per_warp,
-                        )
-                    # CLC advance
-                    work_tile = tile_sched.advance_to_next_work()
-                # producer_tail after loop
-                compute_mma_P_producer.tail()
-                compute_mma_dS_producer.tail()
-
-        else:
-            # ===== STATIC PATH: original non-persistent code =====
-            blk_coord = (Int32(0), bidx, Int32(0), ((Int32(0), bidy), bidz))
-            seqlen_q_cur_batch = Q_ref.shape[0]
-            seqlen_k_cur_batch = K_ref.shape[0]
-            blk_offset = (Int32(0), Int32(0), Int32(0), ((Int32(0), Int32(0)), Int32(0)))
-            if cutlass.const_expr(varlen):
-                assert isinstance(cumulative_s_q, cute.Tensor)
-                assert isinstance(cumulative_s_k, cute.Tensor)
-                seqlen_q_cur_batch = cumulative_s_q[bidz + 1] - cumulative_s_q[bidz]
-                seqlen_k_cur_batch = cumulative_s_k[bidz + 1] - cumulative_s_k[bidz]
-                blk_offset = (
-                    cumulative_s_q[bidz],
-                    cumulative_s_k[bidz],
-                    Int32(0),
-                    ((Int32(0), Int32(0)), Int32(0)),
-                )
-
-            iter_start, iter_end = self.get_Q_block_min_max(
-                seqlen_q_cur_batch,
-                seqlen_k_cur_batch,
-                blk_coord[1],
-                is_2cta=True,
-            )
-
-            # Cluster wait
-            pipeline_init_wait(cluster_shape_mn=cluster_layout_vmnk)
-
-            iter_count = (iter_end - iter_start) * problem_shape[3][0][0]
-            problem_shape_cur_batch = (
-                seqlen_q_cur_batch,
-                seqlen_k_cur_batch,
-                problem_shape[2],
-                problem_shape[3],
-            )
-            if iter_count <= 0:
-                if bidx * self.tile_shape_K < seqlen_k_cur_batch:
-                    self.epilogue_clear(
-                        blk_coord,
-                        blk_offset,
-                        problem_shape_cur_batch,
-                        dK,
-                        dV,
-                    )
-            # ///////////////////////////////////////////////////////////////////////////////
-            #  LOAD
-            # ///////////////////////////////////////////////////////////////////////////////
-            elif warp_idx == self.load_warp_id:
-                cute.arch.warpgroup_reg_dealloc(self.num_regs_load)
-
+        #  LOAD
+        # (9)
+        if warp_idx == self.load_warp_id:
+            if shared_work_tile.is_valid_tile:
                 self.load(
-                    K_in,
-                    V_in,
-                    Q_in,
-                    QT_in,
-                    dO_in,
-                    dOT_in,
-                    LSE,
-                    sum_OdO,
-                    sK,
+                    thr_mma_S,
+                    thr_mma_dP,
+                    thr_mma_dV,
+                    thr_mma_dK,
+                    mQ,
+                    mK,
+                    mV,
+                    mdO,
+                    mQt,
+                    mdOt,
+                    mLSE,
+                    mdPsum,
                     sQ,
-                    sQT,
+                    sK,
                     sV,
                     sdO,
-                    sdOT,
+                    sQt,
+                    sdOt,
                     sLSE,
-                    sSum_OdO,
-                    KQ_tiled_mma,
-                    VdO_tiled_mma,
-                    PdO_tiled_mma,
-                    dSQ_tiled_mma,
-                    tma_atom_K,
+                    sdPsum,
                     tma_atom_Q,
-                    tma_atom_QT,
+                    tma_atom_K,
                     tma_atom_V,
                     tma_atom_dO,
-                    tma_atom_dOT,
-                    blk_offset,
-                    problem_shape_cur_batch,
-                    varlen,
-                    iter_count,
-                    iter_start,
-                    iter_end,
-                    load_mma_Q_producer,
-                    load_mma_Q_consumer,
-                    load_mma_K_producer,
-                    load_mma_K_consumer,
-                    load_mma_V_producer,
-                    load_mma_V_consumer,
-                    load_compute_LSE_producer,
-                    load_compute_LSE_consumer,
-                    load_mma_dO_producer,
-                    load_mma_dO_consumer,
-                    load_mma_dOT_producer,
-                    load_mma_dOT_consumer,
-                    load_compute_sum_OdO_producer,
-                    load_compute_sum_OdO_consumer,
-                    load_mma_QT_producer,
-                    load_mma_QT_consumer,
+                    tma_atom_Qt,
+                    tma_atom_dOt,
+                    pipeline_Q,
+                    pipeline_Qt,
+                    pipeline_K,
+                    pipeline_V,
+                    pipeline_dO,
+                    pipeline_LSE,
+                    pipeline_dPsum,
+                    cluster_layout_vmnk,
+                    block_info,
+                    SeqlenInfoCls,
+                    TileSchedulerCls,
+                    shared_work_tile,
+                    should_load_Q=True,
+                    should_load_dO=True,
                 )
 
-            # ///////////////////////////////////////////////////////////////////////////////
-            #  MMA
-            # ///////////////////////////////////////////////////////////////////////////////
-            elif warp_idx == self.mma_warp_id:
-                cute.arch.warpgroup_reg_alloc(self.num_regs_mma)
+        #  MMA
+        # (8)
+        if warp_idx == self.mma_warp_id:
+            cute.arch.setmaxregister_decrease(self.num_regs_mma)
 
-                self.mma_2cta(
-                    KQ_tiled_mma,
-                    VdO_tiled_mma,
-                    PdO_tiled_mma,
-                    dSQ_tiled_mma,
-                    tSTtST,
-                    tSTrQ,
-                    tSTrK,
-                    tdPTtdPT,
-                    tdPTrV,
-                    tdPTrdO,
-                    tdVtdV,
-                    tdVrP,
-                    tdVrdOT,
-                    tdKrdST,
-                    tdKtdK,
-                    tdKrQT,
-                    iter_count,
-                    load_mma_Q_consumer,
-                    load_mma_K_consumer,
-                    load_mma_V_consumer,
-                    mma_compute_S_producer,
-                    load_mma_dO_consumer,
-                    mma_compute_dP_producer,
-                    load_mma_dOT_consumer,
-                    compute_mma_P_consumer,
-                    compute_mma_dS_consumer,
-                    load_mma_QT_consumer,
-                    mma_compute_dKdV_producer,
-                )
+            if shared_work_tile.is_valid_tile:
+                # Alloc tmem buffer
+                tmem.allocate(self.tmem_alloc_cols)
+                tmem.wait_for_alloc()
+                tmem_ptr = tmem.retrieve_ptr(Float32)
 
-            # ///////////////////////////////////////////////////////////////////////////////
-            #  Compute
-            # ///////////////////////////////////////////////////////////////////////////////
-            elif warp_idx >= self.compute_warp_id[0] and warp_idx <= self.compute_warp_id[-1]:
-                cute.arch.warpgroup_reg_alloc(self.num_regs_compute)
-
-                self.compute(
-                    tSTtST,
-                    tdPTtdPT,
-                    tdVrP,
-                    sP,
-                    sLSE,
-                    sdST,
-                    sdOT,
-                    sSum_OdO,
-                    dK,
-                    dV,
-                    tdKtdK,
-                    tdVtdV,
-                    PdO_tiled_mma,
-                    dSQ_tiled_mma,
-                    blk_coord,
-                    blk_offset,
-                    problem_shape_cur_batch,
-                    iter_count,
-                    iter_start,
-                    iter_end,
-                    scale_softmax,
-                    mma_compute_S_producer,
-                    mma_compute_S_consumer,
-                    compute_mma_P_producer,
-                    compute_mma_P_consumer,
-                    load_compute_LSE_producer,
-                    load_compute_LSE_consumer,
-                    load_compute_sum_OdO_producer,
-                    load_compute_sum_OdO_consumer,
-                    mma_compute_dP_producer,
-                    mma_compute_dP_consumer,
-                    compute_mma_dS_producer,
-                    compute_mma_dS_consumer,
-                    mma_compute_dKdV_producer,
-                    mma_compute_dKdV_consumer,
-                    varlen,
+                self.mma(
+                    tiled_mma_S,
+                    tiled_mma_dP,
+                    tiled_mma_dV,
+                    tiled_mma_dK,
+                    sQ,
+                    sQt,
                     sK,
-                    seqlen_k_cur_batch,
-                    tma_atom_dK,
-                    dK_tma,
+                    sV,
+                    sdO,
+                    sdOt,
+                    tdVrP,
+                    sdSt,
+                    tStS,
+                    tdPtdP,
+                    tdVtdV,
+                    tdKtdK,
+                    pipeline_Q,
+                    pipeline_Qt,
+                    pipeline_K,
+                    pipeline_V,
+                    pipeline_dO,
+                    pipeline_S,
+                    pipeline_dS,
+                    pipeline_dKV,
+                    pipeline_dP,
+                    pipeline_P,
+                    block_info,
+                    SeqlenInfoCls,
+                    TileSchedulerCls,
+                    shared_work_tile,
+                    is_leader_cta,
+                )
+
+                # Dealloc the tensor memory buffer
+                tmem.relinquish_alloc_permit()
+                tmem_alloc_barrier.arrive_and_wait()
+                tmem.free(tmem_ptr)
+
+        # Compute
+        # (0, 1, 2, 3, 4, 5, 6, 7) --> 8 warps
+        if warp_idx >= self.compute_warp_ids[0] and warp_idx <= self.compute_warp_ids[-1]:
+            cute.arch.setmaxregister_increase(self.num_regs_compute)
+            if const_expr((self.is_local or self.is_varlen_q) and not self.dKV_postprocess):
+                if shared_work_tile_info[4] == 2 and is_leader_cta:
+                    n_block, head_idx, batch_idx, _ = shared_work_tile.tile_idx
+                    self.zero_empty_dKV(
+                        cute.arch.thread_idx()[0],
+                        batch_idx,
+                        head_idx,
+                        n_block,
+                        SeqlenInfoCls(batch_idx),
+                        mdV,
+                        mdK,
+                    )
+            if shared_work_tile.is_valid_tile:
+                tmem.wait_for_alloc()
+                tmem_ptr = tmem.retrieve_ptr(Float32)
+                self.compute_loop(
+                    thr_mma_S,
+                    thr_mma_dP,
+                    thr_mma_dV,
+                    thr_mma_dK,
+                    tStS,
+                    tdPtdP,
+                    tdVtdV,
+                    tdKtdK,
+                    sLSE,
+                    sdPsum,
+                    mdV,
+                    mdK,
+                    mdV_tma_tensor,
+                    mdK_tma_tensor,
+                    sdV,
+                    sdK,
                     tma_atom_dV,
-                    dV_tma,
-                    sdK_epi_layout,
-                    sdV_epi_layout,
+                    tma_atom_dK,
+                    sdSt,
+                    sdOt,
+                    pipeline_LSE,
+                    pipeline_dPsum,
+                    pipeline_S,
+                    pipeline_P,
+                    pipeline_dS,
+                    pipeline_dKV,
+                    pipeline_dP,
+                    softmax_scale,
+                    softmax_scale_log2,
+                    block_info,
+                    SeqlenInfoCls,
+                    AttentionMaskCls,
+                    TileSchedulerCls,
+                    shared_work_tile,
+                    sP,
+                    mdV_semaphore,
+                    mdK_semaphore,
+                    aux_data,
+                    fastdiv_mods,
                 )
-
-                cute.arch.barrier(
-                    barrier_id=self.epilogue_sync_bar_id,
-                    number_of_threads=self.num_compute_warps * self.threads_per_warp,
-                )
-
-            else:
-                cute.arch.warpgroup_reg_dealloc(self.num_regs_empty)
-
-        cute.arch.cluster_arrive()
-        cute.arch.cluster_wait()
-        # dishengbin Deallocate tmem for early exit
-        # Dealloc the tensor memory
-        tmem.relinquish_alloc_permit()
-        tmem.free(tmem_ptr)
-
-    @cute.jit
-    def get_Q_block_min_max(
-        self,
-        seq_Q: Int32,
-        seq_K: Int32,
-        blk_coord_k: Int32,
-        is_2cta: bool,
-    ):
-        """Get Q tiles range."""
-        Q_block_max = cute.ceil_div(seq_Q, self.tile_shape_Q)
-        Q_block_min = cutlass.Int32(0)
-        if cutlass.const_expr(self.has_sliding_window):
-            # For 2cta, use the last K block in the cluster so both CTAs get the same Q_block_max
-            blk_coord_k_for_max = (blk_coord_k // 2) * 2 + 1
-            Q_block_max_tmp = cute.ceil_div(
-                (blk_coord_k_for_max + 1) * self.tile_shape_K
-                + seq_Q
-                - seq_K
-                + self.window_size_left,
-                self.tile_shape_Q,
-            )
-            Q_block_max = min(Q_block_max, Q_block_max_tmp)
-        if cutlass.const_expr(self.is_causal or self.has_sliding_window):
-            # For 2cta, use the first K block in the cluster so both CTAs get the same Q_block_min.
-            # This ensures both CTAs in a cluster run the same number of pipeline iterations,
-            # avoiding hang from mismatched producer_commit / consumer_wait counts.
-            blk_coord_k_for_min = (blk_coord_k // 2) * 2
-            Q_block_min_tmp = (
-                blk_coord_k_for_min * self.tile_shape_K + seq_Q - seq_K - self.window_size_right
-            ) // self.tile_shape_Q
-            # Consider the case of 2cta, we need to ensure the K block is aligned to 2
-            Q_block_min_tmp = Q_block_min_tmp - Q_block_min_tmp % 2
-            Q_block_min = max(Q_block_min_tmp, Q_block_min)
-        return Q_block_min, Q_block_max
+                tmem_alloc_barrier.arrive()
 
     @cute.jit
     def load(
         self,
-        K_in: cute.Tensor,
-        V_in: cute.Tensor,
-        Q_in: cute.Tensor,
-        QT_in: cute.Tensor,
-        dO_in: cute.Tensor,
-        dOT_in: cute.Tensor,
-        LSE_in: cute.Tensor,
-        sum_OdO_in: cute.Tensor,
-        sK: cute.Tensor,
+        thr_mma_S,
+        thr_mma_dP,
+        thr_mma_dV,
+        thr_mma_dK,
+        mQ: cute.Tensor,
+        mK: cute.Tensor,
+        mV: cute.Tensor,
+        mdO: cute.Tensor,
+        mQt: cute.Tensor,
+        mdOt: cute.Tensor,
+        mLSE: cute.Tensor,
+        mdPsum: cute.Tensor,
         sQ: cute.Tensor,
-        sQT: cute.Tensor,
+        sK: cute.Tensor,
         sV: cute.Tensor,
         sdO: cute.Tensor,
-        sdOT: cute.Tensor,
+        sQt: cute.Tensor,
+        sdOt: cute.Tensor,
         sLSE: cute.Tensor,
-        sSum_OdO: cute.Tensor,
-        KQ_tiled_mma: cute.TiledMma,
-        VdO_tiled_mma: cute.TiledMma,
-        PdO_tiled_mma: cute.TiledMma,
-        dSQ_tiled_mma: cute.TiledMma,
-        tma_atom_K: cute.CopyAtom,
+        sdPsum: cute.Tensor,
         tma_atom_Q: cute.CopyAtom,
-        tma_atom_QT: cute.CopyAtom,
+        tma_atom_K: cute.CopyAtom,
         tma_atom_V: cute.CopyAtom,
         tma_atom_dO: cute.CopyAtom,
-        tma_atom_dOT: cute.CopyAtom,
-        blk_offset: cute.Shape,
-        problem_shape: tuple[Int32, Int32, Int32, tuple[tuple[Int32, Int32], Int32]],
-        varlen: bool,
-        iter_count: Int32,
-        iter_start: Int32,
-        iter_end: Int32,
-        load_mma_Q_producer,
-        load_mma_Q_consumer,
-        load_mma_K_producer,
-        load_mma_K_consumer,
-        load_mma_V_producer,
-        load_mma_V_consumer,
-        load_compute_LSE_producer,
-        load_compute_LSE_consumer,
-        load_mma_dO_producer,
-        load_mma_dO_consumer,
-        load_mma_dOT_producer,
-        load_mma_dOT_consumer,
-        load_compute_sum_OdO_producer,
-        load_compute_sum_OdO_consumer,
-        load_mma_QT_producer,
-        load_mma_QT_consumer,
-        blk_coord_k_override: Int32 = Int32(-1),
-        blk_coord_h_k_override: Int32 = Int32(-1),
-        blk_coord_b_override: Int32 = Int32(-1),
+        tma_atom_Qt: cute.CopyAtom,
+        tma_atom_dOt: cute.CopyAtom,
+        pipeline_Q,
+        pipeline_Qt,
+        pipeline_K,
+        pipeline_V,
+        pipeline_dO,
+        pipeline_LSE,
+        pipeline_dPsum,
+        cluster_layout_vmnk: cute.Layout,
+        block_info: BlockInfo,
+        SeqlenInfoCls,
+        TileSchedulerCls,
+        work_tile,
+        should_load_Q: bool = True,
+        should_load_dO: bool = True,
     ):
         """TMA load."""
-        tidx, _, _ = cute.arch.thread_idx()
-        if cutlass.const_expr(self.use_clc_scheduler):
-            blk_coord_k = blk_coord_k_override
-            blk_coord_h_k = blk_coord_h_k_override
-            blk_coord_b = blk_coord_b_override
-        else:
-            blk_coord_k, blk_coord_h_k, blk_coord_b = cute.arch.block_idx()
-        blk_coord_h_r = Int32(0)
-        blk_coord_h = (blk_coord_h_r, blk_coord_h_k)
-        iter_index = iter_start
-        mma_tile_coord_v = blk_coord_k % cute.size(KQ_tiled_mma.thr_id.shape)
-        mma_tile_coord_m = blk_coord_k // cute.size(KQ_tiled_mma.thr_id.shape)
+        producer_state_Q_LSE = cutlass.pipeline.make_pipeline_state(
+            cutlass.pipeline.PipelineUserType.Producer, self.Q_stage
+        )
+        producer_state_K = cutlass.pipeline.make_pipeline_state(
+            cutlass.pipeline.PipelineUserType.Producer, self.single_stage
+        )
+        producer_state_V = cutlass.pipeline.make_pipeline_state(
+            cutlass.pipeline.PipelineUserType.Producer, self.single_stage
+        )
+        producer_state_Qt = cutlass.pipeline.make_pipeline_state(
+            cutlass.pipeline.PipelineUserType.Producer, self.Q_stage
+        )
+        producer_state_dO_dPsum = cutlass.pipeline.make_pipeline_state(
+            cutlass.pipeline.PipelineUserType.Producer, self.dO_stage
+        )
 
-        K = cute.domain_offset(cute.select(blk_offset, mode=[1, 2, 3]), K_in)
-        V = cute.domain_offset(cute.select(blk_offset, mode=[1, 2, 3]), V_in)
-        Q = cute.domain_offset(cute.select(blk_offset, mode=[0, 2, 3]), Q_in)
-        QT = cute.domain_offset(cute.select(blk_offset, mode=[2, 0, 3]), QT_in)
-        dO = cute.domain_offset(cute.select(blk_offset, mode=[0, 2, 3]), dO_in)
-        dOT = cute.domain_offset(cute.select(blk_offset, mode=[2, 0, 3]), dOT_in)
-        blk_offset_stats = blk_offset
-        if cutlass.const_expr(varlen):
-            cuseqlen_q_stats = cute.assume(
-                (blk_offset[0] + blk_coord_b * self.tile_shape_Q)
-                // self.tile_shape_Q
-                * self.tile_shape_Q,
-                divby=self.tile_shape_Q,
+        # Compute multicast mask for Q & dO buffer full
+        cta_rank_in_cluster = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster())
+        block_in_cluster_coord_vmnk = cluster_layout_vmnk.get_flat_coord(cta_rank_in_cluster)
+        q_do_mcast_mask = None
+        if const_expr(self.is_q_do_mcast):
+            q_do_mcast_mask = cpasync.create_tma_multicast_mask(
+                cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=1
             )
-            blk_offset_stats = (
-                cuseqlen_q_stats,
-                blk_offset[1],
-                blk_offset[2],
-                blk_offset[3],
+
+        while work_tile.is_valid_tile:
+            n_block, head_idx, batch_idx, _ = work_tile.tile_idx
+            head_idx_kv = head_idx // self.qhead_per_kvhead
+            seqlen = SeqlenInfoCls(batch_idx)
+            m_block_min, m_block_max = block_info.get_m_block_min_max(
+                seqlen, n_block // self.cluster_shape_mn[0]
             )
-        LSE = cute.domain_offset(cute.select(blk_offset_stats, mode=[0, 3]), LSE_in)
-        sum_OdO = cute.domain_offset(cute.select(blk_offset_stats, mode=[0, 3]), sum_OdO_in)
+            n_block_cta_group = n_block // self.cta_group_size
 
-        gK = cute.local_tile(K, cute.select(self.KQ_mma_tiler, mode=[0, 2]), (None, None, None))
-        gQ = cute.local_tile(Q, cute.select(self.KQ_mma_tiler, mode=[1, 2]), (None, None, None))
-        gQT = cute.local_tile(QT, cute.select(self.dSQ_mma_tiler, mode=[1, 2]), (None, None, None))
-        gV = cute.local_tile(V, cute.select(self.VdO_mma_tiler, mode=[0, 2]), (None, None, None))
-        gdO = cute.local_tile(dO, cute.select(self.VdO_mma_tiler, mode=[1, 2]), (None, None, None))
-        gdOT = cute.local_tile(
-            dOT, cute.select(self.PdO_mma_tiler, mode=[1, 2]), (None, None, None)
-        )
+            # GMEM tensors (varlen-aware)
+            mK_cur = seqlen.offset_batch_K(mK, batch_idx, dim=3)[None, None, head_idx_kv]
+            mV_cur = seqlen.offset_batch_K(mV, batch_idx, dim=3)[None, None, head_idx_kv]
 
-        KQ_thr_mma = KQ_tiled_mma.get_slice(mma_tile_coord_v)
-        VdO_thr_mma = VdO_tiled_mma.get_slice(mma_tile_coord_v)
-        PdO_thr_mma = PdO_tiled_mma.get_slice(mma_tile_coord_v)
-        dSQ_thr_mma = dSQ_tiled_mma.get_slice(mma_tile_coord_v)
+            # (1) S.T = K @ Q.T
+            gK = cute.local_tile(
+                mK_cur, cute.select(self.mma_tiler_kq, mode=[0, 2]), (n_block_cta_group, 0)
+            )
+            tSgK = thr_mma_S.partition_A(gK)
 
-        tSTgK = KQ_thr_mma.partition_A(gK)
-        tSTgQ = KQ_thr_mma.partition_B(gQ)
-        tdKgQT = dSQ_thr_mma.partition_B(gQT)
-        tdPTgV = VdO_thr_mma.partition_A(gV)
-        tdPTgdO = VdO_thr_mma.partition_B(gdO)
-        tdVgdOT = PdO_thr_mma.partition_B(gdOT)
+            a_cta_layout = cute.make_layout(cute.slice_(cluster_layout_vmnk, (0, 0, None, 0)).shape)
+            load_K, _, _ = copy_utils.tma_get_copy_fn(
+                tma_atom_K,
+                block_in_cluster_coord_vmnk[2],
+                a_cta_layout,
+                tSgK,
+                sK,
+                single_stage=True,
+            )
 
-        cta_layout_mnk = cute.make_layout(self.cluster_shape_mnk)
-        cta_layout_vmnk = cute.tiled_divide(cta_layout_mnk, (KQ_tiled_mma.thr_id,))
-        cta_in_cluster_coord_vmnk = cta_layout_vmnk.get_flat_coord(cute.arch.block_idx_in_cluster())
+            # (2) dP = V @ dO.T
+            gV = cute.local_tile(
+                mV_cur, cute.select(self.mma_tiler_vdo, mode=[0, 2]), (n_block_cta_group, 0)
+            )
+            tdPgV = thr_mma_dP.partition_A(gV)
 
-        tKsK, tKgK_mkl = cute.nvgpu.cpasync.tma_partition(
-            tma_atom_K,
-            cta_in_cluster_coord_vmnk[2],
-            cute.make_layout(cute.size(cta_layout_vmnk, mode=[2])),
-            cute.group_modes(sK, 0, 3),
-            cute.group_modes(tSTgK, 0, 3),
-        )
-        tQsQ, tQgQ_mkl = cute.nvgpu.cpasync.tma_partition(
-            tma_atom_Q,
-            cta_in_cluster_coord_vmnk[1],
-            cute.make_layout(cute.size(cta_layout_vmnk, mode=[1])),
-            cute.group_modes(sQ, 0, 3),
-            cute.group_modes(tSTgQ, 0, 3),
-        )
-        tQTsQT, tQTgQT_mkl = cute.nvgpu.cpasync.tma_partition(
-            tma_atom_QT,
-            cta_in_cluster_coord_vmnk[1],
-            cute.make_layout(cute.size(cta_layout_vmnk, mode=[1])),
-            cute.group_modes(sQT, 0, 3),
-            cute.group_modes(tdKgQT, 0, 3),
-        )
-        tVsV, tVgV_mkl = cute.nvgpu.cpasync.tma_partition(
-            tma_atom_V,
-            cta_in_cluster_coord_vmnk[2],
-            cute.make_layout(cute.size(cta_layout_vmnk, mode=[2])),
-            cute.group_modes(sV, 0, 3),
-            cute.group_modes(tdPTgV, 0, 3),
-        )
-        tdOsdO, tdOgdO_mkl = cute.nvgpu.cpasync.tma_partition(
-            tma_atom_dO,
-            cta_in_cluster_coord_vmnk[1],
-            cute.make_layout(cute.size(cta_layout_vmnk, mode=[1])),
-            cute.group_modes(sdO, 0, 3),
-            cute.group_modes(tdPTgdO, 0, 3),
-        )
-        tdOTsdOT, tdOTgdOT_mkl = cute.nvgpu.cpasync.tma_partition(
-            tma_atom_dOT,
-            cta_in_cluster_coord_vmnk[1],
-            cute.make_layout(cute.size(cta_layout_vmnk, mode=[1])),
-            cute.group_modes(sdOT, 0, 3),
-            cute.group_modes(tdVgdOT, 0, 3),
-        )
+            load_V, _, _ = copy_utils.tma_get_copy_fn(
+                tma_atom_V,
+                block_in_cluster_coord_vmnk[2],
+                a_cta_layout,
+                tdPgV,
+                sV,
+                single_stage=True,
+            )
 
-        k_handle = load_mma_K_producer.acquire_and_advance()
-        cute.copy(
-            tma_atom_K,
-            tKgK_mkl[(None, mma_tile_coord_m, 0, (blk_coord_h, blk_coord_b))],
-            tKsK[None, 0],
-            tma_bar_ptr=k_handle.barrier,
-        )
+            # some tiles might be empty due to local/window masking
+            process_tile = (
+                const_expr(not self.is_local and not self.is_varlen_q) or m_block_min < m_block_max
+            )
 
-        q_handle = load_mma_Q_producer.acquire_and_advance()
-        cute.copy(
-            tma_atom_Q,
-            tQgQ_mkl[(None, iter_index, 0, (blk_coord_h, blk_coord_b))],
-            tQsQ[None, q_handle.index],
-            tma_bar_ptr=q_handle.barrier,
-        )
+            if process_tile:
+                if const_expr(should_load_Q):
+                    # K, for S.T = K @ Q.T
+                    pipeline_K.producer_acquire(producer_state_K)
+                    load_K(tma_bar_ptr=pipeline_K.producer_get_barrier(producer_state_K))
+                    producer_state_K.advance()
 
-        lse_handle = load_compute_LSE_producer.acquire_and_advance()
-        thread_idx = tidx % self.threads_per_warp
-        async_copy_num_elts = sLSE.shape[0] // self.threads_per_warp
-        atom_async_copy = cute.make_copy_atom(
-            cpasync.CopyG2SOp(cache_mode=cpasync.LoadCacheMode.ALWAYS),
-            self.acc_dtype,
-            num_bits_per_copy=self.acc_dtype.width,
-        )
-        sLSE_for_copy = cute.flat_divide(sLSE, (1,))
-        LSE_for_copy = cute.flat_divide(LSE, (1,))
-        # Warp-coalesced: at each i, lane T accesses index `T + i*W` (stride-1
-        # across the warp) instead of `T*N + i` (stride-N across the warp).
-        for i in cutlass.range_constexpr(async_copy_num_elts):
-            LSE_idx = self.tile_shape_Q * iter_index + thread_idx + i * self.threads_per_warp
-            sLSE_idx = thread_idx + i * self.threads_per_warp
-            if cute.elem_less(LSE_idx, problem_shape[0]):
-                cute.copy(
-                    atom_async_copy,
-                    LSE_for_copy[None, LSE_idx, (blk_coord_h, blk_coord_b)],
-                    sLSE_for_copy[None, sLSE_idx, lse_handle.index],
+                if const_expr(should_load_dO):
+                    # V, for dP = V @ dO.T
+                    pipeline_V.producer_acquire(producer_state_V)
+                    load_V(tma_bar_ptr=pipeline_V.producer_get_barrier(producer_state_V))
+                    producer_state_V.advance()
+
+                b_cta_layout = cute.make_layout(
+                    cute.slice_(cluster_layout_vmnk, (0, None, 0, 0)).shape
                 )
-            else:
-                sLSE_for_copy[None, sLSE_idx, lse_handle.index].fill(0.0)
-        lse_handle.commit()
-
-        v_handle = load_mma_V_producer.acquire_and_advance()
-        cute.copy(
-            tma_atom_V,
-            tVgV_mkl[(None, mma_tile_coord_m, 0, (blk_coord_h, blk_coord_b))],
-            tVsV[(None, 0)],
-            tma_bar_ptr=v_handle.barrier,
-        )
-
-        do_handle = load_mma_dO_producer.acquire_and_advance()
-        cute.copy(
-            tma_atom_dO,
-            tdOgdO_mkl[(None, iter_index, 0, (blk_coord_h, blk_coord_b))],
-            tdOsdO[(None, do_handle.index)],
-            tma_bar_ptr=do_handle.barrier,
-        )
-
-        sum_odo_handle = load_compute_sum_OdO_producer.acquire_and_advance()
-        sSum_OdO_for_copy = cute.flat_divide(sSum_OdO, (1,))
-        sum_OdO_for_copy = cute.flat_divide(sum_OdO, (1,))
-        for i in cutlass.range_constexpr(async_copy_num_elts):
-            sum_OdO_idx = self.tile_shape_Q * iter_index + thread_idx + i * self.threads_per_warp
-            sSum_OdO_idx = thread_idx + i * self.threads_per_warp
-            if cute.elem_less(sum_OdO_idx, problem_shape[0]):
-                cute.copy(
-                    atom_async_copy,
-                    sum_OdO_for_copy[None, sum_OdO_idx, (blk_coord_h, blk_coord_b)],
-                    sSum_OdO_for_copy[None, sSum_OdO_idx, sum_odo_handle.index],
-                )
-            else:
-                sSum_OdO_for_copy[None, sSum_OdO_idx, sum_odo_handle.index].fill(0.0)
-        sum_odo_handle.commit()
-
-        dot_handle = load_mma_dOT_producer.acquire_and_advance()
-        cute.copy(
-            tma_atom_dOT,
-            tdOTgdOT_mkl[(None, 0, iter_index, (blk_coord_h, blk_coord_b))],
-            tdOTsdOT[None, dot_handle.index],
-            tma_bar_ptr=dot_handle.barrier,
-        )
-
-        qt_handle = load_mma_QT_producer.acquire_and_advance()
-        cute.copy(
-            tma_atom_QT,
-            tQTgQT_mkl[(None, 0, iter_index, (blk_coord_h, blk_coord_b))],
-            tQTsQT[None, qt_handle.index],
-            tma_bar_ptr=qt_handle.barrier,
-        )
-
-        iter_count -= 1
-        iter_index += 1
-
-        while iter_count > 0:
-            if iter_index == iter_end:
-                iter_index = iter_start
-                blk_coord_h_r += 1
-                blk_coord_h = (blk_coord_h_r, blk_coord_h_k)
-
-            q_handle = load_mma_Q_producer.acquire_and_advance()
-            cute.copy(
-                tma_atom_Q,
-                tQgQ_mkl[(None, iter_index, 0, (blk_coord_h, blk_coord_b))],
-                tQsQ[None, q_handle.index],
-                tma_bar_ptr=q_handle.barrier,
-            )
-
-            lse_handle = load_compute_LSE_producer.acquire_and_advance()
-            sLSE_for_copy = cute.flat_divide(sLSE, (1,))
-            LSE_for_copy = cute.flat_divide(LSE, (1,))
-            for i in cutlass.range_constexpr(async_copy_num_elts):
-                LSE_idx = self.tile_shape_Q * iter_index + thread_idx + i * self.threads_per_warp
-                sLSE_idx = thread_idx + i * self.threads_per_warp
-                if cute.elem_less(LSE_idx, problem_shape[0]):
-                    cute.copy(
-                        atom_async_copy,
-                        LSE_for_copy[None, LSE_idx, (blk_coord_h, blk_coord_b)],
-                        sLSE_for_copy[None, sLSE_idx, lse_handle.index],
-                    )
+                mQ_cur = seqlen.offset_batch_Q(mQ, batch_idx, dim=3)[None, None, head_idx]
+                if const_expr(not seqlen.has_cu_seqlens_q):
+                    mdO_cur = mdO[None, None, head_idx, batch_idx]
+                    mdOt_cur = mdOt[None, None, head_idx, batch_idx]
+                    mQt_cur = mQt[None, None, head_idx, batch_idx]
                 else:
-                    sLSE_for_copy[None, sLSE_idx, lse_handle.index].fill(0.0)
-            lse_handle.commit()
+                    mdO_cur = cute.domain_offset((0, seqlen.offset_q), mdO[None, None, head_idx])
+                    mdOt_cur = cute.domain_offset((seqlen.offset_q, 0, 0), mdOt)[
+                        None, None, head_idx
+                    ]
+                    mQt_cur = cute.domain_offset((0, seqlen.offset_q, 0), mQt)[None, None, head_idx]
+                mLSE_cur = seqlen.offset_batch_Q(mLSE, batch_idx, dim=2, padded=True)[
+                    None, head_idx
+                ]
+                mdPsum_cur = seqlen.offset_batch_Q(mdPsum, batch_idx, dim=2, padded=True)[
+                    None, head_idx
+                ]
+                gLSE = cute.local_tile(mLSE_cur, (self.tile_m,), (None,))
+                gdPsum = cute.local_tile(mdPsum_cur, (self.tile_m,), (None,))
 
-            do_handle = load_mma_dO_producer.acquire_and_advance()
-            cute.copy(
-                tma_atom_dO,
-                tdOgdO_mkl[(None, iter_index, 0, (blk_coord_h, blk_coord_b))],
-                tdOsdO[None, do_handle.index],
-                tma_bar_ptr=do_handle.barrier,
-            )
+                gQ = cute.local_tile(mQ_cur, cute.select(self.mma_tiler_kq, mode=[1, 2]), (None, 0))
+                tSgQ = thr_mma_S.partition_B(gQ)
 
-            sum_odo_handle = load_compute_sum_OdO_producer.acquire_and_advance()
-            sSum_OdO_for_copy = cute.flat_divide(sSum_OdO, (1,))
-            sum_OdO_for_copy = cute.flat_divide(sum_OdO, (1,))
-            for i in cutlass.range_constexpr(async_copy_num_elts):
-                sum_OdO_idx = (
-                    self.tile_shape_Q * iter_index + thread_idx + i * self.threads_per_warp
+                load_Q, _, _ = copy_utils.tma_get_copy_fn(
+                    tma_atom_Q,
+                    cta_coord=block_in_cluster_coord_vmnk[1],
+                    cta_layout=b_cta_layout,
+                    src_tensor=tSgQ,
+                    dst_tensor=sQ,
+                    mcast_mask=q_do_mcast_mask,
                 )
-                sSum_OdO_idx = thread_idx + i * self.threads_per_warp
-                if cute.elem_less(sum_OdO_idx, problem_shape[0]):
-                    cute.copy(
-                        atom_async_copy,
-                        sum_OdO_for_copy[None, sum_OdO_idx, (blk_coord_h, blk_coord_b)],
-                        sSum_OdO_for_copy[None, sSum_OdO_idx, sum_odo_handle.index],
+                load_Q = copy_utils.tma_producer_copy_fn(load_Q, pipeline_Q)
+
+                # (2) dP = V @ dO.T
+                gdOt = cute.local_tile(
+                    mdOt_cur, cute.select(self.mma_tiler_vdo, mode=[1, 2]), (None, 0)
+                )
+                tdPgdO = thr_mma_dP.partition_B(gdOt)
+                load_dOt, _, _ = copy_utils.tma_get_copy_fn(
+                    tma_atom_dOt,
+                    cta_coord=block_in_cluster_coord_vmnk[1],
+                    cta_layout=b_cta_layout,
+                    src_tensor=tdPgdO,
+                    dst_tensor=sdOt,
+                    mcast_mask=q_do_mcast_mask,
+                )
+                load_dOt = copy_utils.tma_producer_copy_fn(load_dOt, pipeline_dO)
+
+                # (3) dV += P.T @ dO
+                gdO = cute.local_tile(
+                    mdO_cur, cute.select(self.mma_tiler_pdo, mode=[1, 2]), (0, None)
+                )
+                tdVgdO = thr_mma_dV.partition_B(gdO)
+                load_dO, _, _ = copy_utils.tma_get_copy_fn(
+                    tma_atom_dO,
+                    cta_coord=block_in_cluster_coord_vmnk[1],
+                    cta_layout=b_cta_layout,
+                    src_tensor=tdVgdO,
+                    dst_tensor=sdO,
+                    mcast_mask=q_do_mcast_mask,
+                )
+                load_dO = copy_utils.tma_producer_copy_fn(load_dO, pipeline_dO)
+
+                # (4) dK += dS.T @ Q
+                gQt = cute.local_tile(
+                    mQt_cur, cute.select(self.mma_tiler_dsq, mode=[1, 2]), (0, None)
+                )
+                tdKgQt = thr_mma_dK.partition_B(gQt)
+                load_Qt, _, _ = copy_utils.tma_get_copy_fn(
+                    tma_atom_Qt,
+                    cta_coord=block_in_cluster_coord_vmnk[1],
+                    cta_layout=b_cta_layout,
+                    src_tensor=tdKgQt,
+                    dst_tensor=sQt,
+                    mcast_mask=q_do_mcast_mask,
+                )
+                load_Qt = copy_utils.tma_producer_copy_fn(load_Qt, pipeline_Qt)
+
+                copy_atom_stats = cute.make_copy_atom(cpasync.CopyBulkG2SOp(), Float32)
+                copy_stats = partial(cute.copy, copy_atom_stats)
+
+                first_m_block = m_block_min
+                #### Prologue ####
+                if const_expr(should_load_Q):
+                    # Q (for S)
+                    pipeline_Q.producer_acquire(producer_state_Q_LSE)
+                    load_Q(first_m_block, producer_state=producer_state_Q_LSE)
+                    pipeline_Q.producer_commit(producer_state_Q_LSE)
+
+                    # LSE
+                    pipeline_LSE.producer_acquire(producer_state_Q_LSE)
+                    with cute.arch.elect_one():
+                        copy_stats(
+                            gLSE[None, first_m_block],
+                            sLSE[None, producer_state_Q_LSE.index],
+                            mbar_ptr=pipeline_LSE.producer_get_barrier(producer_state_Q_LSE),
+                        )
+                    producer_state_Q_LSE.advance()
+
+                if const_expr(should_load_dO):
+                    # dO + dOt
+                    pipeline_dO.producer_acquire(
+                        producer_state_dO_dPsum,
+                        extra_tx_count=self.tma_copy_bytes["dO"],
                     )
-                else:
-                    sSum_OdO_for_copy[None, sSum_OdO_idx, sum_odo_handle.index].fill(0.0)
-            sum_odo_handle.commit()
+                    load_dO(first_m_block, producer_state=producer_state_dO_dPsum)
+                    load_dOt(first_m_block, producer_state=producer_state_dO_dPsum)
+                    pipeline_dO.producer_commit(producer_state_dO_dPsum)
 
-            dot_handle = load_mma_dOT_producer.acquire_and_advance()
-            cute.copy(
-                tma_atom_dOT,
-                tdOTgdOT_mkl[(None, 0, iter_index, (blk_coord_h, blk_coord_b))],
-                tdOTsdOT[None, dot_handle.index],
-                tma_bar_ptr=dot_handle.barrier,
-            )
+                    # dPsum
+                    pipeline_dPsum.producer_acquire(producer_state_dO_dPsum)
+                    with cute.arch.elect_one():
+                        copy_stats(
+                            gdPsum[None, first_m_block],
+                            sdPsum[None, producer_state_dO_dPsum.index],
+                            mbar_ptr=pipeline_dPsum.producer_get_barrier(producer_state_dO_dPsum),
+                        )
+                    producer_state_dO_dPsum.advance()
 
-            qt_handle = load_mma_QT_producer.acquire_and_advance()
-            cute.copy(
-                tma_atom_QT,
-                tQTgQT_mkl[(None, 0, iter_index, (blk_coord_h, blk_coord_b))],
-                tQTsQT[None, qt_handle.index],
-                tma_bar_ptr=qt_handle.barrier,
-            )
+                #### Main Loop ####
+                for m_block in cutlass.range(m_block_min + 1, m_block_max, unroll=1):
+                    if const_expr(should_load_Q):
+                        # Qt, for dK = dS.T @ Q
+                        pipeline_Qt.producer_acquire(producer_state_Qt)
+                        load_Qt(m_block - 1, producer_state=producer_state_Qt)
+                        pipeline_Qt.producer_commit(producer_state_Qt)
+                        producer_state_Qt.advance()
 
-            iter_count -= 1
-            iter_index += 1
+                        # Q (for S)
+                        pipeline_Q.producer_acquire(producer_state_Q_LSE)
+                        load_Q(m_block, producer_state=producer_state_Q_LSE)
+                        pipeline_Q.producer_commit(producer_state_Q_LSE)
 
-        if not cutlass.const_expr(self.use_clc_scheduler):
-            load_mma_K_producer.tail()
-            load_mma_V_producer.tail()
-            load_mma_Q_producer.tail()
-            load_compute_LSE_producer.tail()
-            load_mma_dO_producer.tail()
-            load_mma_dOT_producer.tail()
-            load_compute_sum_OdO_producer.tail()
-            load_mma_QT_producer.tail()
+                        # LSE
+                        pipeline_LSE.producer_acquire(producer_state_Q_LSE)
+                        with cute.arch.elect_one():
+                            copy_stats(
+                                gLSE[None, m_block],
+                                sLSE[None, producer_state_Q_LSE.index],
+                                mbar_ptr=pipeline_LSE.producer_get_barrier(producer_state_Q_LSE),
+                            )
+                        producer_state_Q_LSE.advance()
 
-        return (
-            load_mma_Q_producer,
-            load_mma_K_producer,
-            load_mma_V_producer,
-            load_compute_LSE_producer,
-            load_mma_dO_producer,
-            load_mma_dOT_producer,
-            load_compute_sum_OdO_producer,
-            load_mma_QT_producer,
-        )
+                    if const_expr(should_load_dO):
+                        # dO + dOt
+                        pipeline_dO.producer_acquire(
+                            producer_state_dO_dPsum,
+                            extra_tx_count=self.tma_copy_bytes["dO"],
+                        )
+                        load_dO(m_block, producer_state=producer_state_dO_dPsum)
+                        load_dOt(m_block, producer_state=producer_state_dO_dPsum)
+                        pipeline_dO.producer_commit(producer_state_dO_dPsum)
+
+                        # dPsum
+                        pipeline_dPsum.producer_acquire(producer_state_dO_dPsum)
+                        with cute.arch.elect_one():
+                            copy_stats(
+                                gdPsum[None, m_block],
+                                sdPsum[None, producer_state_dO_dPsum.index],
+                                mbar_ptr=pipeline_dPsum.producer_get_barrier(
+                                    producer_state_dO_dPsum
+                                ),
+                            )
+                        producer_state_dO_dPsum.advance()
+
+                #### Tail ####
+                if const_expr(should_load_Q):
+                    pipeline_Qt.producer_acquire(producer_state_Qt)
+                    load_Qt(m_block_max - 1, producer_state=producer_state_Qt)
+                    pipeline_Qt.producer_commit(producer_state_Qt)
+                    producer_state_Qt.advance()
+
+                if cutlass.const_expr(True):
+                    if const_expr(should_load_Q):
+                        pipeline_K.producer_tail(producer_state_K)
+                        pipeline_Q.producer_tail(producer_state_Q_LSE.clone())
+                        pipeline_LSE.producer_tail(producer_state_Q_LSE)
+                        pipeline_Qt.producer_tail(producer_state_Qt)
+                    if const_expr(should_load_dO):
+                        pipeline_V.producer_tail(producer_state_V)
+                        pipeline_dO.producer_tail(producer_state_dO_dPsum.clone())
+                        pipeline_dPsum.producer_tail(producer_state_dO_dPsum)
+
+            work_tile = WorkTileInfo(work_tile.tile_idx, False)
 
     @cute.jit
-    def mma_2cta(
+    def mma(
         self,
-        KQ_tiled_mma: cute.TiledMma,
-        VdO_tiled_mma: cute.TiledMma,
-        PdO_tiled_mma: cute.TiledMma,
-        dSQ_tiled_mma: cute.TiledMma,
-        tSTtST: cute.Tensor,
-        tSTrQ: cute.Tensor,
-        tSTrK: cute.Tensor,
-        tdPTtdPT: cute.Tensor,
-        tdPTrV: cute.Tensor,
-        tdPTrdO: cute.Tensor,
-        tdVtdV: cute.Tensor,
+        tiled_mma_S: cute.TiledMma,
+        tiled_mma_dP: cute.TiledMma,
+        tiled_mma_dV: cute.TiledMma,
+        tiled_mma_dK: cute.TiledMma,
+        sQ: cute.Tensor,
+        sQt: cute.Tensor,
+        sK: cute.Tensor,
+        sV: cute.Tensor,
+        sdO: cute.Tensor,
+        sdOt: cute.Tensor,
         tdVrP: cute.Tensor,
-        tdVrdOT: cute.Tensor,
-        tdKrdST: cute.Tensor,
+        sdSt: cute.Tensor,
+        tSTtST: cute.Tensor,
+        tdPTtdPT: cute.Tensor,
+        tdVtdV: cute.Tensor,
         tdKtdK: cute.Tensor,
-        tdKrQT: cute.Tensor,
-        iter_count: Int32,
-        load_mma_Q_consumer,
-        load_mma_K_consumer,
-        load_mma_V_consumer,
-        mma_compute_S_producer,
-        load_mma_dO_consumer,
-        mma_compute_dP_producer,
-        load_mma_dOT_consumer,
-        compute_mma_P_consumer,
-        compute_mma_dS_consumer,
-        load_mma_QT_consumer,
-        mma_compute_dKdV_producer,
+        pipeline_Q,
+        pipeline_Qt,
+        pipeline_K,
+        pipeline_V,
+        pipeline_dO,
+        pipeline_S,
+        pipeline_dS,
+        pipeline_dKV,
+        pipeline_dP,
+        pipeline_P,
+        block_info: BlockInfo,
+        SeqlenInfoCls,
+        TileSchedulerCls,
+        work_tile,
+        is_leader_cta: cutlass.Boolean,
     ):
         """CuTeDSL kernel for mma pipeline."""
-        load_mma_Q_releaser = load_mma_Q_consumer.clone()
-        load_mma_K_releaser = load_mma_K_consumer.clone()
-        load_mma_V_releaser = load_mma_V_consumer.clone()
+        # [2025-10-21] For reasons I don't understand, putting these partitioning in the main
+        # kernel (before warp specialization) is a lot slower tha putting them here.
+        # Partition smem / tmem tensors
+        # S = K @ Q.T
+        tSrK = tiled_mma_S.make_fragment_A(sK)
+        tSrQ = tiled_mma_S.make_fragment_B(sQ)
+        # dP = V @ dOt.T
+        tdPrV = tiled_mma_dP.make_fragment_A(sV)
+        tdPrdOt = tiled_mma_dP.make_fragment_B(sdOt)
+        # dV = P @ dO.T
+        tdVrdO = tiled_mma_dV.make_fragment_B(sdO)
+        # dK = dS.T @ Q
+        tdKrdS = tiled_mma_dK.make_fragment_A(sdSt)
+        tdKrQ = tiled_mma_dK.make_fragment_B(sQt)
 
-        cta_rank_in_cluster = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster())
-        is_leader_cta = cta_rank_in_cluster % 2 == 0
-
-        if is_leader_cta:
-            s_handle = mma_compute_S_producer.acquire_and_advance()
-            k_handle = load_mma_K_consumer.wait_and_advance()
-            q_handle = load_mma_Q_consumer.wait_and_advance()
-
-            # Compute S = K * Q
-            for k_block in cutlass.range(0, cute.size(tSTrQ, mode=[2]), unroll_full=True):
-                KQ_tiled_mma.set(tcgen05.Field.ACCUMULATE, k_block != 0)
-                cute.gemm(
-                    KQ_tiled_mma,
-                    tSTtST,
-                    tSTrK[None, None, k_block, 0],
-                    tSTrQ[None, None, k_block, q_handle.index],
-                    tSTtST,
-                )
-            q_handle.release()
-
-            cute.arch.fence_view_async_tmem_store()
-            s_handle.commit()
-
-            do_handle = load_mma_dO_consumer.wait_and_advance()
-            v_handle = load_mma_V_consumer.wait_and_advance()
-
-            dp_handle = mma_compute_dP_producer.acquire_and_advance()
-
-            # Compute dP = V * dO
-            VdO_tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
-            for k_block in cutlass.range(0, cute.size(tdPTrV, mode=[2]), unroll_full=True):
-                cute.gemm(
-                    VdO_tiled_mma,
-                    tdPTtdPT,
-                    tdPTrV[None, None, k_block, 0],
-                    tdPTrdO[None, None, k_block, do_handle.index],
-                    tdPTtdPT,
-                )
-                VdO_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
-
-            dp_handle.commit()
-            do_handle.release()
-            # V only produced once by load(); hold v_handle until end, release there via releaser
-
-            p_handle = compute_mma_P_consumer.wait_and_advance()
-            dot_handle = load_mma_dOT_consumer.wait_and_advance()
-
-            # Compute dV = P * dO (First iteration)
-            PdO_tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
-            for k_block in cutlass.range(0, cute.size(tdVrP, mode=[2]), unroll_full=True):
-                cute.gemm(
-                    PdO_tiled_mma,
-                    tdVtdV,
-                    tdVrP[None, None, k_block, 0],
-                    tdVrdOT[None, None, k_block, dot_handle.index],
-                    tdVtdV,
-                )
-                PdO_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
-
-            dot_handle.release()
-            p_handle.release()
-
-        iter_count -= 1
-
-        dSQ_tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
-        while iter_count > 0:
-            if is_leader_cta:
-                q_handle = load_mma_Q_consumer.wait_and_advance()
-                s_handle = mma_compute_S_producer.acquire_and_advance()
-
-                # Compute S = K * Q
-                for k_block in cutlass.range(0, cute.size(tSTrQ, mode=[2]), unroll_full=True):
-                    KQ_tiled_mma.set(tcgen05.Field.ACCUMULATE, k_block != 0)
-                    cute.gemm(
-                        KQ_tiled_mma,
-                        tSTtST,
-                        tSTrK[None, None, k_block, 0],
-                        tSTrQ[None, None, k_block, q_handle.index],
-                        tSTtST,
-                    )
-                q_handle.release()
-                s_handle.commit()
-
-            if is_leader_cta:
-                qt_handle = load_mma_QT_consumer.wait_and_advance()
-                ds_handle = compute_mma_dS_consumer.wait_and_advance()
-
-                # Compute dK = dS * QT
-                for k_block in cutlass.range(0, cute.size(tdKrdST, mode=[2]), unroll_full=True):
-                    cute.gemm(
-                        dSQ_tiled_mma,
-                        tdKtdK,
-                        tdKrdST[
-                            None,
-                            None,
-                            k_block,
-                            ds_handle.index,
-                        ],
-                        tdKrQT[None, None, k_block, qt_handle.index],
-                        tdKtdK,
-                    )
-                    dSQ_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
-                qt_handle.release()
-                ds_handle.release()
-
-            if is_leader_cta:
-                dp_handle = mma_compute_dP_producer.acquire_and_advance()
-                do_handle = load_mma_dO_consumer.wait_and_advance()
-                # V only produced once by load(); reuse same V (index 0) for all loop iterations
-                VdO_tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
-                for k_block in cutlass.range(0, cute.size(tdPTrV, mode=[2]), unroll_full=True):
-                    cute.gemm(
-                        VdO_tiled_mma,
-                        tdPTtdPT,
-                        tdPTrV[None, None, k_block, 0],
-                        tdPTrdO[None, None, k_block, do_handle.index],
-                        tdPTtdPT,
-                    )
-                    VdO_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
-
-                dp_handle.commit()
-                do_handle.release()
-
-            if is_leader_cta:
-                p_handle = compute_mma_P_consumer.wait_and_advance()
-                dot_handle = load_mma_dOT_consumer.wait_and_advance()
-
-                # Compute dV = P * dO (Loop iterations)
-                for k_block in cutlass.range(0, cute.size(tdVrP, mode=[2]), unroll_full=True):
-                    cute.gemm(
-                        PdO_tiled_mma,
-                        tdVtdV,
-                        tdVrP[None, None, k_block, 0],
-                        tdVrdOT[None, None, k_block, dot_handle.index],
-                        tdVtdV,
-                    )
-                    PdO_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
-
-                p_handle.release()
-                dot_handle.release()
-
-            iter_count -= 1
-
-        if is_leader_cta:
-            dkdv_handle = mma_compute_dKdV_producer.acquire_and_advance()
-            dkdv_handle.commit()
-
-            load_mma_K_releaser.release()
-            load_mma_K_releaser.advance()
-            load_mma_V_releaser.release()
-            load_mma_V_releaser.advance()
-
-        if is_leader_cta:
-            dkdv_handle = mma_compute_dKdV_producer.acquire_and_advance()
-
-            ds_handle = compute_mma_dS_consumer.wait_and_advance()
-            qt_handle = load_mma_QT_consumer.wait_and_advance()
-
-            # Compute dK = dS * Q
-            for k_block in cutlass.range(0, cute.size(tdKrdST, mode=[2]), unroll_full=True):
-                cute.gemm(
-                    dSQ_tiled_mma,
-                    tdKtdK,
-                    tdKrdST[None, None, k_block, ds_handle.index],
-                    tdKrQT[None, None, k_block, qt_handle.index],
-                    tdKtdK,
-                )
-                dSQ_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
-
-            dkdv_handle.commit()
-            qt_handle.release()
-            ds_handle.release()
-
-        if not cutlass.const_expr(self.use_clc_scheduler):
-            mma_compute_S_producer.tail()
-            mma_compute_dP_producer.tail()
-            mma_compute_dKdV_producer.tail()
-
-        return (
-            mma_compute_S_producer,
-            mma_compute_dP_producer,
-            mma_compute_dKdV_producer,
-            load_mma_Q_consumer,
-            load_mma_K_consumer,
-            load_mma_V_consumer,
-            load_mma_dO_consumer,
-            load_mma_dOT_consumer,
-            compute_mma_P_consumer,
-            compute_mma_dS_consumer,
-            load_mma_QT_consumer,
+        mma_qk_fn = partial(
+            gemm_w_idx,
+            tiled_mma_S,
+            tSTtST,
+            tSrK,
+            tSrQ,
+            zero_init=True,
         )
+        mma_dov_fn = partial(
+            gemm_w_idx,
+            tiled_mma_dP,
+            tdPTtdPT,
+            tdPrV,
+            tdPrdOt,
+            zero_init=True,
+        )
+        mma_pdo_fn = partial(
+            gemm_w_idx,
+            tiled_mma_dV,
+            tdVtdV,
+            tdVrP,
+            tdVrdO,
+        )
+        mma_dsq_fn = partial(
+            gemm_w_idx,
+            tiled_mma_dK,
+            tdKtdK,
+            tdKrdS,
+            tdKrQ,
+        )
+
+        consumer_state_Qt = cutlass.pipeline.make_pipeline_state(
+            cutlass.pipeline.PipelineUserType.Consumer, self.Q_stage
+        )
+        consumer_state_Q = cutlass.pipeline.make_pipeline_state(
+            cutlass.pipeline.PipelineUserType.Consumer, self.Q_stage
+        )
+        consumer_state_dO = cutlass.pipeline.make_pipeline_state(
+            cutlass.pipeline.PipelineUserType.Consumer, self.dO_stage
+        )
+        consumer_state_dS = cutlass.pipeline.make_pipeline_state(
+            cutlass.pipeline.PipelineUserType.Consumer, self.single_stage
+        )
+        producer_phase_acc = Int32(1)  # For S and dP
+        producer_phase_dKV = Int32(1)
+        consumer_phase_KV = Int32(0)
+        consumer_phase_P = Int32(0)
+        cta_group = pipeline_S.cta_group
+
+        while work_tile.is_valid_tile:
+            n_block, head_idx, batch_idx, _ = work_tile.tile_idx
+            seqlen = SeqlenInfoCls(batch_idx)
+            m_block_min, m_block_max = block_info.get_m_block_min_max(
+                seqlen, n_block // self.cluster_shape_mn[0]
+            )
+            process_tile = (
+                cutlass.const_expr(not self.is_local and not self.is_varlen_q)
+                or m_block_min < m_block_max
+            )
+
+            if process_tile:
+                loop_count = m_block_max - m_block_min
+                accumulate_dK = False
+
+                if is_leader_cta and process_tile:
+                    # -----------------------------------------------------------
+                    ###### Prologue
+                    # -----------------------------------------------------------
+                    # 1. S  = K @ Q
+                    # 2. dP = V @ dOt.T
+                    # 3. dV = P @ dO
+
+                    # 1) S = K @ Q
+                    pipeline_S.sync_object_empty.wait(0, producer_phase_acc)
+                    pipeline_K.sync_object_full.wait(0, consumer_phase_KV)
+                    pipeline_Q.consumer_wait(consumer_state_Q)
+
+                    mma_qk_fn(A_idx=0, B_idx=consumer_state_Q.index)
+                    pipeline_Q.consumer_release(consumer_state_Q)
+                    consumer_state_Q.advance()
+
+                    cute.arch.fence_view_async_tmem_store()
+                    pipeline_S.sync_object_full.arrive(0, pipeline_S.producer_mask, cta_group)
+
+                    pipeline_dO.consumer_wait(consumer_state_dO)
+                    pipeline_V.sync_object_full.wait(0, consumer_phase_KV)
+
+                    pipeline_dP.sync_object_empty.wait(0, producer_phase_acc)
+
+                    # 2) dP = V @ dOt.T
+                    mma_dov_fn(A_idx=0, B_idx=consumer_state_dO.index)
+
+                    pipeline_dP.sync_object_full.arrive(0, pipeline_dP.producer_mask, cta_group)
+                    # V only produced once by load(); hold it until end, release there via release state.
+
+                    pipeline_P.sync_object_full.wait(0, consumer_phase_P)
+
+                    # 3) dV = P.T @ dO
+                    producer_phase_acc ^= 1
+                    mma_pdo_fn(A_idx=0, B_idx=consumer_state_dO.index, zero_init=True)
+
+                    pipeline_dO.consumer_release(consumer_state_dO)
+                    consumer_state_dO.advance()
+                    pipeline_P.sync_object_empty.arrive(
+                        0, pipeline_P.consumer_mask, pipeline_P.cta_group
+                    )
+                    consumer_phase_P ^= 1
+
+                # -----------------------------------------------------------
+                ###### MAIN LOOP
+                # -----------------------------------------------------------
+                # 1. S.T  = K    @ Q.T
+                # 2. dK   = dS.T @ Q
+                # 3. dP.T = V    @ dO.T
+                # 4. dV   = P.T  @ dO
+
+                main_loop_iters = loop_count - 1
+                for _ in cutlass.range(main_loop_iters, unroll=1):
+                    if is_leader_cta and process_tile:
+                        pipeline_Q.consumer_wait(consumer_state_Q)
+                        pipeline_S.sync_object_empty.wait(0, producer_phase_acc)
+
+                        # (1) S.T = K @ Q.T (next)
+                        mma_qk_fn(A_idx=0, B_idx=consumer_state_Q.index)
+                        pipeline_Q.consumer_release(consumer_state_Q)
+                        consumer_state_Q.advance()
+                        pipeline_S.sync_object_full.arrive(0, pipeline_S.producer_mask, cta_group)
+
+                        pipeline_Qt.consumer_wait(consumer_state_Qt)
+                        pipeline_dS.consumer_wait(consumer_state_dS)
+
+                        # (2) dK += dS.T @ Q (cur)
+                        mma_dsq_fn(
+                            A_idx=consumer_state_dS.index,
+                            B_idx=consumer_state_Qt.index,
+                            zero_init=not accumulate_dK,
+                        )
+                        accumulate_dK = True
+                        pipeline_Qt.consumer_release(consumer_state_Qt)
+                        consumer_state_Qt.advance()
+                        pipeline_dS.consumer_release(consumer_state_dS)
+                        consumer_state_dS.advance()
+
+                        pipeline_dP.sync_object_empty.wait(0, producer_phase_acc)
+                        pipeline_dO.consumer_wait(consumer_state_dO)
+                        # (3) dP.T = V @ dO.T (next)
+                        # V only produced once by load(); reuse same V (index 0) for all loop iterations
+                        mma_dov_fn(A_idx=0, B_idx=consumer_state_dO.index)
+
+                        pipeline_dP.sync_object_full.arrive(0, pipeline_dP.producer_mask, cta_group)
+
+                        pipeline_P.sync_object_full.wait(0, consumer_phase_P)
+
+                        # (4) dV += P.T @ dO (next)
+                        producer_phase_acc ^= 1
+                        mma_pdo_fn(A_idx=0, B_idx=consumer_state_dO.index, zero_init=False)
+
+                        pipeline_P.sync_object_empty.arrive(
+                            0, pipeline_P.consumer_mask, pipeline_P.cta_group
+                        )
+                        consumer_phase_P ^= 1
+                        pipeline_dO.consumer_release(consumer_state_dO)
+                        consumer_state_dO.advance()
+
+                if is_leader_cta and process_tile:
+                    # signal to the epilogue that dV is ready
+                    pipeline_dKV.sync_object_empty.wait(0, producer_phase_dKV)
+                    pipeline_dKV.sync_object_full.arrive(0, pipeline_dKV.producer_mask, cta_group)
+
+                    pipeline_K.sync_object_empty.arrive(
+                        0, pipeline_K.consumer_mask, pipeline_K.cta_group
+                    )
+                    pipeline_V.sync_object_empty.arrive(
+                        0, pipeline_V.consumer_mask, pipeline_V.cta_group
+                    )
+                    consumer_phase_KV ^= 1
+
+                    # -----------------------------------------------------------
+                    # Tail: Remaining dK
+                    # -----------------------------------------------------------
+                    pipeline_dKV.sync_object_empty.wait(1, producer_phase_dKV)
+
+                    pipeline_dS.consumer_wait(consumer_state_dS)
+                    pipeline_Qt.consumer_wait(consumer_state_Qt)
+
+                    # dK += dS.T @ Q
+                    mma_dsq_fn(
+                        A_idx=consumer_state_dS.index,
+                        B_idx=consumer_state_Qt.index,
+                        zero_init=not accumulate_dK,
+                    )
+
+                    # signal to the epilogue that dK is ready
+                    pipeline_dKV.sync_object_full.arrive(1, pipeline_dKV.producer_mask, cta_group)
+                    producer_phase_dKV ^= 1
+                    pipeline_Qt.consumer_release(consumer_state_Qt)
+                    consumer_state_Qt.advance()
+                    pipeline_dS.consumer_release(consumer_state_dS)
+                    consumer_state_dS.advance()
+
+            work_tile = WorkTileInfo(work_tile.tile_idx, False)
 
     @cute.jit
-    def reg_to_smem_mma64x64(
+    def split_wg(
         self,
-        regs: cute.Tensor,
-        smem: cute.Tensor,
-        index: Int32,
-        tiler_mn: tuple[Int32, Int32],
-        dp_idx: Int32,
-        wg_idx: Int32,
+        t: cute.Tensor,
+        wg_idx: cutlass.Int32,
+        num_wg: cutlass.Constexpr[int],
     ):
-        smem_slice = smem[None, None, None, index]
-        # TODO: double check the layout of the data in reg.
-        # TODO: this may introduce additional smem transpose.
-        thread_layout = cute.make_ordered_layout(
-            tiler_mn,
-            (0, 1),  # TODO: (0,1) or (1,0) ???
-        )
-        smem_slice_tmp = cute.composition(smem_slice, thread_layout)
+        if cutlass.const_expr(cute.rank(t.layout) == 3):
+            t = cute.composition(
+                t,
+                cute.make_layout(
+                    (
+                        t.shape[0],
+                        t.shape[1],
+                        (num_wg, cute.size(t, mode=[2]) // num_wg),
+                    )
+                ),
+            )
+            return t[None, None, (wg_idx, None)]
+        else:
+            t = cute.composition(
+                t,
+                cute.make_layout(
+                    (
+                        t.shape[0],
+                        t.shape[1],
+                        t.shape[2],
+                        (num_wg, cute.size(t, mode=[3]) // num_wg),
+                    )
+                ),
+            )
+            return t[None, None, None, (wg_idx, None)]
 
-        # TODO: temporary code for tile 64 x 64.
-        tmp_shape = ((8, 2, 4), (2, 4, 2, 2, 2))
-        tmp_stride = ((64, 512, 1024), (1, 2, 8, 16, 32))
-        smem_copy = cute.composition(smem_slice_tmp, cute.make_layout(tmp_shape, stride=tmp_stride))
+    @cute.jit
+    def split_wg_mode1(
+        self,
+        t: cute.Tensor,
+        wg_idx: cutlass.Int32,
+        num_wg: cutlass.Constexpr[int],
+    ):
+        if cutlass.const_expr(cute.rank(t.layout) == 3):
+            t = cute.composition(
+                t,
+                cute.make_layout(
+                    (
+                        t.shape[0],
+                        (num_wg, cute.size(t, mode=[1]) // num_wg),
+                        t.shape[2],
+                    )
+                ),
+            )
+            return t[None, (wg_idx, None), None]
+        else:
+            t = cute.composition(
+                t,
+                cute.make_layout(
+                    (
+                        t.shape[0],
+                        (num_wg, cute.size(t, mode=[1]) // num_wg),
+                        t.shape[2],
+                        t.shape[3],
+                    )
+                ),
+            )
+            return t[None, (wg_idx, None), None, None]
 
-        # TODO: the following code is only for tile 64 x 64.
-        # TODO: need to modify the code for other tile sizes.
-        lane_idx = dp_idx % 32
-        reg_shape = regs.shape
-        atom_loops = reg_shape[0][0][2]
-        block_loops = reg_shape[2]
-        # | 00 ~ 07 | 08 ~ 15 | 16 ~ 23 | 24 ~ 31 | 32 ~ 39 | 40 ~ 47 | 48 ~ 55 | 56 ~ 63 |
-        # |---- atom size ----|---- atom size ----|---- atom size ----|---- atom size ----|
-        # |----     wg0   ----|----     wg1   ----|----     wg0   ----|----     wg1   ----|
-        for ia in cutlass.range(atom_loops):
-            for ib in cutlass.range(block_loops):
-                # the lower 8 lines
-                regs_copy = regs[((None, 0, ia), 0), 0, ib]  # two elements
-                smem_copy_slice = smem_copy[
-                    (lane_idx // 4, 0, dp_idx // 32),
-                    (None, lane_idx % 4, ia, wg_idx, ib),
-                ]
-                cute.autovec_copy(regs_copy, smem_copy_slice)
-                # the upper 8 lines
-                regs_copy = regs[((None, 1, ia), 0), 0, ib]
-                smem_copy_slice = smem_copy[
-                    (lane_idx // 4, 1, dp_idx // 32),
-                    (None, lane_idx % 4, ia, wg_idx, ib),
-                ]
-                cute.autovec_copy(regs_copy, smem_copy_slice)
+    @cute.jit
+    def split_wg_tmem_copy(
+        self,
+        t: cute.Tensor,
+        wg_idx: cutlass.Int32,
+        num_wg: cutlass.Constexpr[int],
+    ):
+        reduced_shape = cute.product_each(t.shape)
+        rank = len(reduced_shape)
+        if const_expr(reduced_shape[1] > 1):
+            t = cute.logical_divide(t, (reduced_shape[0], reduced_shape[1] // num_wg))
+            coord = (None, (None, wg_idx)) + (None,) * (rank - 2)
+        else:
+            if const_expr(rank == 3):
+                t = cute.logical_divide(
+                    t, (reduced_shape[0], reduced_shape[1], reduced_shape[2] // num_wg)
+                )
+                coord = (None, None, (None, wg_idx))
+            else:
+                t = cute.logical_divide(
+                    t,
+                    (
+                        reduced_shape[0],
+                        reduced_shape[1],
+                        reduced_shape[2],
+                        reduced_shape[3] // num_wg,
+                    ),
+                )
+                coord = (None, None, None, (None, wg_idx)) + (None,) * (rank - 4)
+        return t[coord]
 
     @cute.jit
     def reg_to_smem_mma128x128_2cta(
@@ -2417,365 +2021,626 @@ class BlackwellFusedMultiHeadAttentionBackwardDKDVKernel:
             cute.autovec_copy(regs_copy, smem_copy_slice)
 
     @cute.jit
-    def reg_to_smem_mma128x64_2cta(
+    def apply_score_mod(
         self,
-        regs: cute.Tensor,
-        smem: cute.Tensor,
-        index: Int32,
-        tiler_mn: tuple[Int32, Int32],
-        dp_idx: Int32,
-        wg_idx: Int32,
-        smem_RowMajor: bool = True,
+        tSrS_t2r,
+        tScS_t2r,
+        batch_idx,
+        head_idx,
+        m_block,
+        n_block,
+        softmax_scale,
+        seqlen_info,
+        aux_data: utils.AuxData = utils.AuxData(),
+        fastdiv_mods=(None, None),
     ):
-        smem_slice = smem[None, None, None, index]
-        thread_layout = cute.make_ordered_layout(
-            # (tileN, tileM)
-            tiler_mn,
-            (1, 0) if smem_RowMajor else (0, 1),
-        )
-        smem_slice_tmp = cute.composition(smem_slice, thread_layout)
-        # NOTE: hardcode for tcgen05.ld.32x32b.x8 & mma128x64+2cta
-        tmp_shape = ((32, 2), (8, 2, 2, 2))
-        tmp_stride = ((64, 32 * 64), (1, 8, 16, 32))
-        smem_copy = cute.composition(smem_slice_tmp, cute.make_layout(tmp_shape, stride=tmp_stride))
+        """Apply forward score modification for SM100 backward pass."""
+        n_vals = cutlass.const_expr(cute.size(tSrS_t2r.shape))
+        score_vec = cute.make_rmem_tensor(self.vec_size, self.qk_acc_dtype)
+        q_idx_vec = cute.make_rmem_tensor(self.vec_size, Int32)
+        kv_idx_vec = cute.make_rmem_tensor(self.vec_size, Int32)
+        batch_idx_ssa = utils.scalar_to_ssa(batch_idx, Int32).broadcast_to((self.vec_size,))
+        q_block_offset = m_block * self.tile_m
+        kv_block_offset = n_block * self.cta_group_size * self.tile_n
+        if const_expr(aux_data.tensors is not None and fastdiv_mods is not None):
+            seqlen_q_divmod, seqlen_k_divmod = fastdiv_mods
 
-        warp_idx = dp_idx // 32
-        warp_row_idx = warp_idx % 2
-        warp_col_idx = warp_idx // 2
-        lane_idx = dp_idx % 32
-        reg_shape = regs.shape  # ((8,1),1,2):((1,0),0,8)
-        block_loops = reg_shape[2]
+        for i in cutlass.range(0, n_vals, self.vec_size, unroll_full=True):
+            for j in cutlass.range(self.vec_size, unroll_full=True):
+                score_vec[j] = tSrS_t2r[i + j] * softmax_scale
+                kv_idx = tScS_t2r[i + j][0] + kv_block_offset
+                q_idx = tScS_t2r[i + j][1] + q_block_offset
+                if const_expr(aux_data.tensors is not None and fastdiv_mods is not None):
+                    _, q_idx = divmod(q_idx, seqlen_q_divmod)
+                    _, kv_idx = divmod(kv_idx, seqlen_k_divmod)
+                kv_idx_vec[j] = kv_idx
+                q_idx_vec[j] = q_idx
 
-        # TODO: maybe can use cp.async for optimization
-        for ib in cutlass.range(block_loops):
-            regs_copy = regs[(None, 0), 0, ib]
-            smem_copy_slice = smem_copy[(lane_idx, warp_row_idx), (None, wg_idx, ib, warp_col_idx)]
-            cute.autovec_copy(regs_copy, smem_copy_slice)
+            score_ssa = score_vec.load()
+            q_idx_ssa = q_idx_vec.load()
+            kv_idx_ssa = kv_idx_vec.load()
+            head_idx_ssa = utils.scalar_to_ssa(head_idx, Int32).broadcast_to((self.vec_size,))
+            score_vec.store(
+                call_score_mod(
+                    self.score_mod,
+                    score_ssa,
+                    batch_idx_ssa,
+                    head_idx_ssa,
+                    q_idx_ssa,
+                    kv_idx_ssa,
+                    seqlen_info,
+                    aux_data,
+                )
+            )
+            for j in cutlass.range(self.vec_size, unroll_full=True):
+                tSrS_t2r[i + j] = score_vec[j]
 
     @cute.jit
-    def compute(
+    def apply_score_mod_bwd(
         self,
-        tSTtST: cute.Tensor,
-        tdPTtdPT: cute.Tensor,
-        tdVrP: cute.Tensor,
-        sP: cute.Tensor,
-        sLSE: cute.Tensor,
-        # sdS: cute.Tensor,
-        sdST: cute.Tensor,
-        sdOT: cute.Tensor,
-        sSum_OdO: cute.Tensor,
-        dK: cute.Tensor,
-        dV: cute.Tensor,
-        tdKtdK: cute.Tensor,
+        grad_tensor,
+        score_tensor,
+        index_tensor,
+        batch_idx,
+        head_idx,
+        m_block,
+        n_block,
+        softmax_scale,
+        seqlen_info,
+        aux_data: utils.AuxData = utils.AuxData(),
+        fastdiv_mods=(None, None),
+    ):
+        """Apply backward score modification (joint graph) for SM100."""
+        n_vals = cutlass.const_expr(cute.size(grad_tensor.shape))
+        grad_vec = cute.make_rmem_tensor(self.vec_size, self.qk_acc_dtype)
+        score_vec = cute.make_rmem_tensor(self.vec_size, self.qk_acc_dtype)
+        q_idx_vec = cute.make_rmem_tensor(self.vec_size, Int32)
+        kv_idx_vec = cute.make_rmem_tensor(self.vec_size, Int32)
+        batch_idx_ssa = utils.scalar_to_ssa(batch_idx, Int32).broadcast_to((self.vec_size,))
+        q_block_offset = m_block * self.tile_m
+        kv_block_offset = n_block * self.cta_group_size * self.tile_n
+        if const_expr(aux_data.tensors is not None and fastdiv_mods is not None):
+            seqlen_q_divmod, seqlen_k_divmod = fastdiv_mods
+
+        for i in cutlass.range(0, n_vals, self.vec_size, unroll_full=True):
+            for j in cutlass.range(self.vec_size, unroll_full=True):
+                grad_vec[j] = grad_tensor[i + j]
+                score_vec[j] = score_tensor[i + j] * softmax_scale
+                kv_idx = index_tensor[i + j][0] + kv_block_offset
+                q_idx = index_tensor[i + j][1] + q_block_offset
+                if const_expr(aux_data.tensors is not None and fastdiv_mods is not None):
+                    _, q_idx = divmod(q_idx, seqlen_q_divmod)
+                    _, kv_idx = divmod(kv_idx, seqlen_k_divmod)
+                kv_idx_vec[j] = kv_idx
+                q_idx_vec[j] = q_idx
+
+            grad_ssa = grad_vec.load()
+            score_ssa = score_vec.load()
+            q_idx_ssa = q_idx_vec.load()
+            kv_idx_ssa = kv_idx_vec.load()
+            head_idx_ssa = utils.scalar_to_ssa(head_idx, Int32).broadcast_to((self.vec_size,))
+            grad_vec.store(
+                call_score_mod_bwd(
+                    self.score_mod_bwd,
+                    grad_ssa,
+                    score_ssa,
+                    batch_idx_ssa,
+                    head_idx_ssa,
+                    q_idx_ssa,
+                    kv_idx_ssa,
+                    seqlen_info,
+                    aux_data,
+                )
+            )
+            for j in cutlass.range(self.vec_size, unroll_full=True):
+                grad_tensor[i + j] = grad_vec[j]
+
+    @cute.jit
+    def apply_dPsum_and_scale_dS(
+        self,
+        tdPrdP_t2r: cute.Tensor,
+        tSrS_t2r: cute.Tensor,
+        tdPcdP_t2r: cute.Tensor,
+        sdPsum: cute.Tensor,
+        consumer_state_dPsum: cutlass.pipeline.PipelineState,
+        seqlen_q_cur_batch: Int32,
+        check_q_boundary: cutlass.Constexpr[bool],
+    ):
+        for v in cutlass.range(0, cute.size(tdPrdP_t2r), 2, unroll_full=True):
+            dPsum_pair = (
+                -sdPsum[
+                    cute.get(tdPcdP_t2r[v], mode=[1]),
+                    consumer_state_dPsum.index,
+                ],
+                -sdPsum[
+                    cute.get(tdPcdP_t2r[v + 1], mode=[1]),
+                    consumer_state_dPsum.index,
+                ],
+            )
+            if const_expr(check_q_boundary):
+                if not cute.elem_less(cute.get(tdPcdP_t2r[v], mode=[1]), seqlen_q_cur_batch):
+                    dPsum_pair = (0.0, dPsum_pair[1])
+                if not cute.elem_less(cute.get(tdPcdP_t2r[v + 1], mode=[1]), seqlen_q_cur_batch):
+                    dPsum_pair = (dPsum_pair[0], 0.0)
+            tdPrdP_t2r[v], tdPrdP_t2r[v + 1] = cute.arch.add_packed_f32x2(
+                (tdPrdP_t2r[v], tdPrdP_t2r[v + 1]), dPsum_pair
+            )
+            tdPrdP_t2r[v], tdPrdP_t2r[v + 1] = cute.arch.mul_packed_f32x2(
+                (tSrS_t2r[v], tSrS_t2r[v + 1]),
+                (tdPrdP_t2r[v], tdPrdP_t2r[v + 1]),
+            )
+
+    @cute.jit
+    def apply_dPsum_and_scale_dS_stage(
+        self,
+        tdPrdP_cur: cute.Tensor,
+        tSrS_cur: cute.Tensor,
+        tdPcdP_cur: cute.Tensor,
+        sdPsum: cute.Tensor,
+        consumer_state_dPsum: cutlass.pipeline.PipelineState,
+        seqlen_q_cur_batch: Int32,
+        check_q_boundary: cutlass.Constexpr[bool],
+    ):
+        for v in cutlass.range_constexpr(cute.size(tdPrdP_cur) // 2):
+            dPsum_pair = (
+                -sdPsum[
+                    cute.get(tdPcdP_cur[2 * v], mode=[1]),
+                    consumer_state_dPsum.index,
+                ],
+                -sdPsum[
+                    cute.get(tdPcdP_cur[2 * v + 1], mode=[1]),
+                    consumer_state_dPsum.index,
+                ],
+            )
+            if const_expr(check_q_boundary):
+                if not cute.elem_less(cute.get(tdPcdP_cur[2 * v], mode=[1]), seqlen_q_cur_batch):
+                    dPsum_pair = (0.0, dPsum_pair[1])
+                if not cute.elem_less(
+                    cute.get(tdPcdP_cur[2 * v + 1], mode=[1]), seqlen_q_cur_batch
+                ):
+                    dPsum_pair = (dPsum_pair[0], 0.0)
+            tdPrdP_cur[2 * v], tdPrdP_cur[2 * v + 1] = cute.arch.add_packed_f32x2(
+                (tdPrdP_cur[2 * v], tdPrdP_cur[2 * v + 1]), dPsum_pair
+            )
+            tdPrdP_cur[2 * v], tdPrdP_cur[2 * v + 1] = cute.arch.mul_packed_f32x2(
+                (tSrS_cur[2 * v], tSrS_cur[2 * v + 1]),
+                (tdPrdP_cur[2 * v], tdPrdP_cur[2 * v + 1]),
+            )
+
+    @cute.jit
+    def compute_loop(
+        self,
+        thr_mma_S,
+        thr_mma_dP,
+        thr_mma_dV,
+        thr_mma_dK,
+        tStS: cute.Tensor,
+        tdPtdP: cute.Tensor,
         tdVtdV: cute.Tensor,
-        PdO_tiled_mma: cute.TiledMma,
-        dSQ_tiled_mma: cute.TiledMma,
-        blk_coord: cute.Coord,
-        blk_offset: cute.Shape,
-        problem_shape: tuple[Int32, Int32, Int32, tuple[tuple[Int32, Int32], Int32]],
-        iter_count: Int32,
-        iter_start: Int32,
-        iter_end: Int32,
-        scale_softmax: cutlass.Float32,
-        mma_compute_S_producer,
-        mma_compute_S_consumer,
-        compute_mma_P_producer,
-        compute_mma_P_consumer,
-        load_compute_LSE_producer,
-        load_compute_LSE_consumer,
-        load_compute_sum_OdO_producer,
-        load_compute_sum_OdO_consumer,
-        mma_compute_dP_producer,
-        mma_compute_dP_consumer,
-        compute_mma_dS_producer,
-        compute_mma_dS_consumer,
-        mma_compute_dKdV_producer,
-        mma_compute_dKdV_consumer,
-        varlen: bool,
-        sK: cute.Tensor,
-        problem_shape_k_cur_batch: Int32,
-        tma_atom_dK: cute.CopyAtom,
-        dK_tma: cute.Tensor,
-        tma_atom_dV: cute.CopyAtom,
-        dV_tma: cute.Tensor,
-        sdK_epi_layout: cute.ComposedLayout,
-        sdV_epi_layout: cute.ComposedLayout,
+        tdKtdK: cute.Tensor,
+        sLSE: cute.Tensor,
+        sdPsum: cute.Tensor,
+        mdV: cute.Tensor,
+        mdK: cute.Tensor,
+        mdV_tma_tensor: cute.Tensor,
+        mdK_tma_tensor: cute.Tensor,
+        sdV: Optional[cute.Tensor],
+        sdK: Optional[cute.Tensor],
+        tma_atom_dV: Optional[cute.CopyAtom],
+        tma_atom_dK: Optional[cute.CopyAtom],
+        sdSt: cute.Tensor,
+        sdOt: cute.Tensor,
+        pipeline_LSE,
+        pipeline_dPsum,
+        pipeline_S,
+        pipeline_P,
+        pipeline_dS,
+        pipeline_dKV,
+        pipeline_dP,
+        softmax_scale: cutlass.Float32,
+        softmax_scale_log2: cutlass.Float32,
+        block_info: BlockInfo,
+        SeqlenInfoCls,
+        AttentionMaskCls,
+        TileSchedulerCls,
+        work_tile,
+        sP: cute.Tensor,
+        mdV_semaphore: Optional[cute.Tensor],
+        mdK_semaphore: Optional[cute.Tensor],
+        aux_data: utils.AuxData = utils.AuxData(),
+        fastdiv_mods=(None, None),
     ):
         """CuTeDSL kernel for recomputing softmax and producing dk and dv."""
-        tidx, _, _ = cute.arch.thread_idx()
-        Q, K, _, _ = problem_shape
-        _, blk_coord_k, _, _ = blk_coord
-
-        iter_index = iter_start
-
-        # adi: TMEM_ST, TMEM_DPT
-        tmem_load_op = tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(16))
-        tmem_load_atom = cute.make_copy_atom(
-            tmem_load_op,
-            self.acc_dtype,
-        )
-
-        tSTtST = tSTtST[(None, None), 0, 0]
-        tdPTtdPT = tdPTtdPT[(None, None), 0, 0]
-
-        cST = cute.make_identity_tensor(cute.select(self.cta_tiler, mode=[1, 0]))
-        cdPT = cute.make_identity_tensor(cute.select(self.cta_tiler, mode=[1, 0]))
-
-        num_warp_groups = self.num_compute_warps // 4
+        # tix: [0...256]  8 warps
+        warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())  # 0-7
+        tidx = cute.arch.thread_idx()[0] % (cute.arch.WARP_SIZE * len(self.compute_warp_ids))
         dp_idx = tidx % 128
+        num_wg = len(self.compute_warp_ids) // 4  # 2
         wg_idx = (tidx % (self.num_compute_warps * self.threads_per_warp)) // 128
-        tiled_t2r = tcgen05.make_tmem_copy(tmem_load_atom, tSTtST)
-        thr_t2r = tiled_t2r.get_slice(dp_idx)
 
-        tTR_cST = thr_t2r.partition_D(cST)
-        tTR_cST = split_wg(tTR_cST, num_warp_groups, wg_idx)
-        tTR_rST = cute.make_rmem_tensor(tTR_cST.shape, self.acc_dtype)
-
-        tTR_tST = thr_t2r.partition_S(tSTtST)
-        tTR_tST = split_wg(tTR_tST, num_warp_groups, wg_idx)
-
-        tTR_cdPT_p = thr_t2r.partition_D(cdPT)
-        tTR_cdPT = split_wg(tTR_cdPT_p, num_warp_groups, wg_idx)
-        tTR_rdPT = cute.make_rmem_tensor(tTR_cdPT.shape, self.acc_dtype)
-
-        tTR_tdPT = thr_t2r.partition_S(tdPTtdPT)
-        tTR_tdPT = split_wg(tTR_tdPT, num_warp_groups, wg_idx)
-
-        tdVcST = PdO_tiled_mma.get_slice(0).partition_A(cST)
-
-        is_residual_k = blk_coord_k * self.tile_shape_K + self.tile_shape_K > K
-        last_iter = iter_end - 1
-
-        while iter_count > 0:
-            s_handle = mma_compute_S_consumer.wait_and_advance()
-            p_handle = compute_mma_P_producer.acquire_and_advance()
-            lse_handle = load_compute_LSE_consumer.wait_and_advance()
-
-            leading_causal_masking = cutlass.Boolean(False)
-            if cutlass.const_expr(self.is_causal):
-                # TODO: could be optimized by specify an exact iter_index
-                #
-                # NOTE (causal + 2CTA correctness):
-                # `iter_start` can be rounded down to an even index for 2CTA. When the true
-                # causal boundary Q tile is odd, it becomes (iter_start + 1). In that case,
-                # we must treat both (iter_start, iter_start + 1) as "masked tiles" so the
-                # per-element causal mask is applied on the boundary tile too.
-                leading_causal_masking = iter_index == iter_start
-                q_block_min_unaligned = (
-                    blk_coord_k * self.tile_shape_K + Q - K - self.window_size_right
-                ) // self.tile_shape_Q
-                boundary_in_second = (q_block_min_unaligned % 2) == 1
-                leading_causal_masking = leading_causal_masking or (
-                    boundary_in_second and (iter_index == iter_start + 1)
-                )
-                offset_partial_tile = (K - Q) % self.tile_shape_K
-                need_additional_mask = offset_partial_tile and iter_index == iter_start + 1
-                leading_causal_masking = leading_causal_masking or need_additional_mask
-                leading_causal_masking = cute.arch.shuffle_sync(leading_causal_masking, 0)
-
-            trailing_residual_masking = cutlass.Boolean(False)
-            trailing_residual_masking = iter_index == last_iter or is_residual_k
-            trailing_residual_masking = cute.arch.shuffle_sync(trailing_residual_masking, 0)
-
-            # For causal, every tile may contain (q,k) with k > q; we must apply per-element mask for all Q tiles.
-            is_masked_tile = (
-                leading_causal_masking
-                or trailing_residual_masking
-                or self.has_sliding_window
-                or cutlass.const_expr(self.is_causal)
-            )
-
-            # Compute P = softmax(S, LSE)
-            cute.copy(tiled_t2r, tTR_tST, tTR_rST)
-
-            if is_masked_tile:
-                for i in cutlass.range(cute.size(tTR_rST), unroll_full=True):
-                    c_transpose = tTR_cST[i]
-                    pos = (
-                        cute.get(c_transpose, mode=[1]) + iter_index * self.tile_shape_Q,
-                        cute.get(c_transpose, mode=[0]) + blk_coord_k * self.tile_shape_K,
-                    )
-                    if cutlass.const_expr(self.has_sliding_window):
-                        if cutlass.const_expr(self.window_size_left < 0):
-                            tTR_rST[i] = (
-                                -cutlass.Float32.inf
-                                if pos[1] > pos[0] + K - Q + self.window_size_right
-                                else tTR_rST[i]
-                            )
-                        else:
-                            max_K_index = min(pos[0] + K - Q + self.window_size_right, K)
-                            min_K_index = max(0, pos[0] + K - Q - self.window_size_left)
-                            tTR_rST[i] = (
-                                -cutlass.Float32.inf
-                                if pos[1] > max_K_index or pos[1] < min_K_index
-                                else tTR_rST[i]
-                            )
-                    if cutlass.const_expr(self.is_causal) and (
-                        pos[0] + K - Q < pos[1] or not cute.elem_less(pos, (Q, K))
-                    ):
-                        tTR_rST[i] = -cutlass.Float32.inf
-                    if not cute.elem_less(pos, (Q, K)):
-                        tTR_rST[i] = -cutlass.Float32.inf
-
-            log2_e = cutlass.Float32(math.log2(math.e))
-            softmax_scale_log2_e = scale_softmax * log2_e
-
-            for i in cutlass.range(0, cute.size(tTR_rST), 2, unroll_full=True):
-                lse = (
-                    -sLSE[
-                        cute.get(tTR_cST[i], mode=[1]),
-                        lse_handle.index,
-                    ],
-                    -sLSE[
-                        cute.get(tTR_cST[i + 1], mode=[1]),
-                        lse_handle.index,
-                    ],
-                )
-                tTR_rST[i], tTR_rST[i + 1] = cute.arch.fma_packed_f32x2(
-                    (tTR_rST[i], tTR_rST[i + 1]),
-                    (softmax_scale_log2_e, softmax_scale_log2_e),
-                    lse,
-                )
-                tTR_rST[i] = cute.math.exp2(tTR_rST[i], fastmath=True)
-                tTR_rST[i + 1] = cute.math.exp2(tTR_rST[i + 1], fastmath=True)
-
-            # convert fp32 P to fp16 P which will be used in the PdO
-            tTR_rPT = self.quantize(tTR_rST, dV.element_type)  # tTR_rST is ST in fp32 in RF.
-            self.reg_to_smem_mma128x128_2cta(
-                tTR_rPT,
-                sP,
-                p_handle.index,
-                (self.tile_shape_K, self.tile_shape_Q),
-                dp_idx,
-                wg_idx,
-            )
-            cute.arch.fence_view_async_shared()
-            cute.arch.barrier(
-                barrier_id=self.compute_sync_bar_id,
-                number_of_threads=self.num_compute_warps * self.threads_per_warp,
-            )
-
-            p_handle.commit()
-
-            s_handle.release()
-            lse_handle.release()
-
-            sum_odo_handle = load_compute_sum_OdO_consumer.wait_and_advance()
-            dp_handle = mma_compute_dP_consumer.wait_and_advance()
-            ds_handle = compute_mma_dS_producer.acquire_and_advance()
-
-            # Compute dS = dsoftmax(P, dP, sum_OdO)
-            cute.copy(tiled_t2r, tTR_tdPT, tTR_rdPT)
-
-            for i in cutlass.range(0, cute.size(tTR_rdPT), 2, unroll_full=True):
-                dpsum_0 = -sSum_OdO[
-                    cute.get(tTR_cdPT[i], mode=[1]),
-                    sum_odo_handle.index,
-                ]
-                dpsum_1 = -sSum_OdO[
-                    cute.get(tTR_cdPT[i + 1], mode=[1]),
-                    sum_odo_handle.index,
-                ]
-                if cutlass.const_expr(varlen):
-                    if not cute.elem_less(cute.get(tTR_cdPT[i], mode=[1]), Q):
-                        dpsum_0 = 0.0
-                    if not cute.elem_less(cute.get(tTR_cdPT[i + 1], mode=[1]), Q):
-                        dpsum_1 = 0.0
-                tTR_rdPT[i], tTR_rdPT[i + 1] = cute.arch.add_packed_f32x2(
-                    (tTR_rdPT[i], tTR_rdPT[i + 1]),
-                    (dpsum_0, dpsum_1),
-                )
-                tTR_rdPT[i], tTR_rdPT[i + 1] = cute.arch.mul_packed_f32x2(
-                    (tTR_rdPT[i], tTR_rdPT[i + 1]), (tTR_rST[i], tTR_rST[i + 1])
-                )
-            # For causal, force dS to zero at masked (q,k) so dK/dV accumulation is correct
-            if cutlass.const_expr(self.is_causal):
-                for i in cutlass.range(cute.size(tTR_rdPT), unroll_full=True):
-                    c_transpose = tTR_cdPT[i]
-                    pos = (
-                        cute.get(c_transpose, mode=[1]) + iter_index * self.tile_shape_Q,
-                        cute.get(c_transpose, mode=[0]) + blk_coord_k * self.tile_shape_K,
-                    )
-                    if pos[0] + K - Q < pos[1] or not cute.elem_less(pos, (Q, K)):
-                        tTR_rdPT[i] = cutlass.Float32(0.0)
-            # convert fp32 dS to fp16 dS which will be used in the computation of dK and DQ
-            tTR_rdST = self.quantize(tTR_rdPT, dV.element_type)
-
-            cute.arch.fence_view_async_tmem_load()
-            dp_handle.release()
-
-            self.reg_to_smem_mma128x128_2cta(
-                tTR_rdST,
-                sdST,
-                ds_handle.index,
-                (self.tile_shape_K, self.tile_shape_Q),
-                dp_idx,
-                wg_idx,
-            )
-            cute.arch.fence_view_async_shared()
-            cute.arch.barrier(
-                barrier_id=self.compute_sync_bar_id,
-                number_of_threads=self.num_compute_warps * self.threads_per_warp,
-            )
-
-            ds_handle.commit()
-            sum_odo_handle.release()
-
-            iter_count -= 1
-            iter_index += 1
-            if iter_index == iter_end:
-                iter_index = iter_start
-
-        # Epilogue
-        mma_compute_dKdV_consumer = self.epilogue(
-            blk_coord,
-            blk_offset,
-            problem_shape,
-            dK,
-            dV,
-            tdKtdK,
-            tdVtdV,
-            scale_softmax,
-            mma_compute_dKdV_producer,
-            mma_compute_dKdV_consumer,
-            problem_shape_k_cur_batch,
-            tma_atom_dK,
-            dK_tma,
-            tma_atom_dV,
-            dV_tma,
-            sdK_epi_layout,
-            sdV_epi_layout,
-            varlen,
-            sdOT,
-            sP,
+        cta_rank_in_cluster = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster())
+        cS_smem = cute.make_identity_tensor((self.cta_group_size * self.tile_n, self.tile_m))
+        cS_smem = cute.local_tile(
+            cS_smem,
+            cute.select(self.cta_tiler, mode=[0, 1]),
+            (cta_rank_in_cluster, 0),
         )
 
-        if not cutlass.const_expr(self.use_clc_scheduler):
-            compute_mma_P_producer.tail()
-            compute_mma_dS_producer.tail()
-
-        return (
-            compute_mma_P_producer,
-            compute_mma_dS_producer,
-            mma_compute_S_consumer,
-            compute_mma_P_consumer,
-            load_compute_LSE_consumer,
-            load_compute_sum_OdO_consumer,
-            mma_compute_dP_consumer,
-            compute_mma_dS_consumer,
-            mma_compute_dKdV_consumer,
+        tmem_load_atom = cute.make_copy_atom(
+            tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(16)), self.acc_dtype
         )
+
+        thr_copy_t2r = tcgen05.make_tmem_copy(tmem_load_atom, tStS[(None, None), 0, 0]).get_slice(
+            dp_idx
+        )
+        tScS_t2r = self.split_wg(thr_copy_t2r.partition_D(cS_smem), wg_idx, num_wg)
+        t0ScS_t2r = self.split_wg(thr_copy_t2r.get_slice(0).partition_D(cS_smem), wg_idx, num_wg)
+        tStS_t2r = self.split_wg(thr_copy_t2r.partition_S(tStS[(None, None), 0, 0]), wg_idx, num_wg)
+        tdPcdP_t2r = self.split_wg(thr_copy_t2r.partition_D(cS_smem), wg_idx, num_wg)
+        tdPtdP_t2r = self.split_wg(
+            thr_copy_t2r.partition_S(tdPtdP[(None, None), 0, 0]), wg_idx, num_wg
+        )
+        consumer_state_S = cutlass.pipeline.make_pipeline_state(
+            cutlass.pipeline.PipelineUserType.Consumer, self.single_stage
+        )
+        producer_state_P = cutlass.pipeline.make_pipeline_state(
+            cutlass.pipeline.PipelineUserType.Producer, self.single_stage
+        )
+        consumer_state_LSE = cutlass.pipeline.make_pipeline_state(
+            cutlass.pipeline.PipelineUserType.Consumer, self.Q_stage
+        )
+        consumer_state_dPsum = cutlass.pipeline.make_pipeline_state(
+            cutlass.pipeline.PipelineUserType.Consumer, self.dO_stage
+        )
+        consumer_state_dP = cutlass.pipeline.make_pipeline_state(
+            cutlass.pipeline.PipelineUserType.Consumer, self.single_stage
+        )
+        producer_state_dS = cutlass.pipeline.make_pipeline_state(
+            cutlass.pipeline.PipelineUserType.Producer, self.single_stage
+        )
+        consumer_state_dKV = cutlass.pipeline.make_pipeline_state(
+            cutlass.pipeline.PipelineUserType.Consumer, self.sdKVaccum_stage
+        )
+
+        while work_tile.is_valid_tile:
+            n_block, head_idx, batch_idx, _ = work_tile.tile_idx
+            head_idx_kv = head_idx // self.qhead_per_kvhead
+            seqlen = SeqlenInfoCls(batch_idx)
+            seqlen_q_cur_batch = seqlen.seqlen_q
+            recompute_fastdiv_mods_q = const_expr(
+                aux_data.tensors is not None and (seqlen.has_cu_seqlens_q or seqlen.has_seqused_q)
+            )
+            recompute_fastdiv_mods_k = const_expr(
+                aux_data.tensors is not None and (seqlen.has_cu_seqlens_k or seqlen.has_seqused_k)
+            )
+            if const_expr(fastdiv_mods is not None and fastdiv_mods[0] is not None):
+                seqlen_q_divmod, seqlen_k_divmod = fastdiv_mods
+                fastdiv_mods = (
+                    seqlen_q_divmod
+                    if not recompute_fastdiv_mods_q
+                    else FastDivmodDivisor(seqlen.seqlen_q),
+                    seqlen_k_divmod
+                    if not recompute_fastdiv_mods_k
+                    else FastDivmodDivisor(seqlen.seqlen_k),
+                )
+            m_block_min, m_block_max = block_info.get_m_block_min_max(
+                seqlen, n_block // self.cluster_shape_mn[0]
+            )
+            mask = AttentionMaskCls(seqlen)
+            n_block_for_cluster = n_block // self.cluster_shape_mn[0]
+            mask_fn = partial(
+                mask.apply_mask_sm100_transposed,
+                tScS_t2r=tScS_t2r,
+                t0ScS_t2r=t0ScS_t2r,
+                n_block=n_block_for_cluster,
+                mask_seqlen=True,
+                mask_causal=self.is_causal,
+                mask_local=self.is_local,
+                mask_mod=self.mask_mod,
+                batch_idx=batch_idx,
+                head_idx=head_idx,
+                aux_data=aux_data,
+                fastdiv_mods=fastdiv_mods,
+            )
+            process_tile = (
+                cutlass.const_expr(not self.is_local and not self.is_varlen_q)
+                or m_block_min < m_block_max
+            )
+            loop_count = m_block_max - m_block_min
+
+            # Mainloop
+            for iter_idx in cutlass.range(loop_count, unroll=1):
+                m_block = m_block_min + iter_idx
+                pipeline_S.consumer_wait(consumer_state_S)
+                pipeline_P.producer_acquire(producer_state_P)
+                pipeline_LSE.consumer_wait(consumer_state_LSE)
+
+                #### TMEM->RMEM (Load S from TMEM)
+                tSrS_t2r = cute.make_rmem_tensor(tScS_t2r.shape, self.acc_dtype)
+                cute.copy(thr_copy_t2r, tStS_t2r, tSrS_t2r)
+                cute.arch.fence_view_async_tmem_load()
+
+                if const_expr(self.score_mod_bwd is not None):
+                    tSrS_pre = cute.make_fragment_like(tSrS_t2r)
+                    cute.autovec_copy(tSrS_t2r, tSrS_pre)
+                if const_expr(self.score_mod is not None):
+                    self.apply_score_mod(
+                        tSrS_t2r,
+                        tScS_t2r,
+                        batch_idx,
+                        head_idx,
+                        m_block,
+                        n_block_for_cluster,
+                        softmax_scale,
+                        seqlen,
+                        aux_data,
+                        fastdiv_mods,
+                    )
+
+                #### APPLY MASK (after score_mod, matching forward pass order)
+                check_m_boundary = (m_block + 1) * self.tile_m > seqlen_q_cur_batch
+                full_k_tile = (
+                    n_block_for_cluster + 1
+                ) * self.cta_group_size * self.tile_n <= seqlen.seqlen_k
+                need_mask = True
+                if const_expr(
+                    self.is_causal
+                    and not self.is_local
+                    and self.mask_mod is None
+                    and self.score_mod is None
+                    and self.score_mod_bwd is None
+                ):
+                    need_mask = (m_block == m_block_min) or check_m_boundary or (not full_k_tile)
+                    if seqlen_q_cur_batch != seqlen.seqlen_k:
+                        need_mask = True
+                if const_expr(
+                    not self.is_causal
+                    and not self.is_local
+                    and self.mask_mod is None
+                    and self.score_mod is None
+                    and self.score_mod_bwd is None
+                ):
+                    need_mask = check_m_boundary or (not full_k_tile)
+                if need_mask:
+                    mask_fn(
+                        tSrS_t2r,
+                        m_block=m_block,
+                        is_full_block=False,
+                        check_m_boundary=check_m_boundary,
+                    )
+
+                # ---------------------------------------------
+                #### P = exp(S - LSE)
+                # ---------------------------------------------
+                for v in cutlass.range(0, cute.size(tSrS_t2r), 2, unroll_full=True):
+                    lse_pair = (
+                        sLSE[
+                            cute.get(tScS_t2r[v], mode=[1]),
+                            consumer_state_LSE.index,
+                        ],
+                        sLSE[
+                            cute.get(tScS_t2r[v + 1], mode=[1]),
+                            consumer_state_LSE.index,
+                        ],
+                    )
+                    tSrS_t2r[v], tSrS_t2r[v + 1] = cute.arch.fma_packed_f32x2(
+                        (tSrS_t2r[v], tSrS_t2r[v + 1]),
+                        (softmax_scale_log2, softmax_scale_log2),
+                        (-lse_pair[0], -lse_pair[1]),
+                    )
+                    tSrS_t2r[v] = cute.math.exp2(tSrS_t2r[v], fastmath=True)
+                    tSrS_t2r[v + 1] = cute.math.exp2(tSrS_t2r[v + 1], fastmath=True)
+
+                tSrP = cute.make_rmem_tensor(tSrS_t2r.shape, self.v_dtype)
+                utils.cvt_f16(tSrS_t2r, tSrP)
+                self.reg_to_smem_mma128x128_2cta(
+                    tSrP,
+                    sP,
+                    producer_state_P.index,
+                    (self.tile_n, self.tile_m),
+                    dp_idx,
+                    wg_idx,
+                )
+                cute.arch.fence_view_async_shared()
+                self.compute_sync_barrier.arrive_and_wait()
+
+                with cute.arch.elect_one():
+                    pipeline_P.producer_commit(producer_state_P)
+                producer_state_P.advance()
+
+                with cute.arch.elect_one():
+                    pipeline_S.consumer_release(consumer_state_S)
+                consumer_state_S.advance()
+                pipeline_LSE.consumer_release(consumer_state_LSE)
+                consumer_state_LSE.advance()
+
+                # ---------------------------------------------
+                # dS.T = P.T * (dP.T - D)
+                # ---------------------------------------------
+                pipeline_dPsum.consumer_wait(consumer_state_dPsum)
+                pipeline_dP.consumer_wait(consumer_state_dP)
+                pipeline_dS.producer_acquire(producer_state_dS)
+
+                ##### dS.T = P.T * (dP.T - Psum)
+                tdPrdP_t2r = cute.make_rmem_tensor(tdPcdP_t2r.shape, self.acc_dtype)
+                cute.copy(thr_copy_t2r, tdPtdP_t2r, tdPrdP_t2r)
+                cute.arch.fence_view_async_tmem_load()
+                self.compute_sync_barrier.arrive_and_wait()
+                if const_expr(self.score_mod_bwd is None):
+                    self.apply_dPsum_and_scale_dS(
+                        tdPrdP_t2r,
+                        tSrS_t2r,
+                        tdPcdP_t2r,
+                        sdPsum,
+                        consumer_state_dPsum,
+                        seqlen_q_cur_batch,
+                        check_q_boundary=self.is_varlen_q,
+                    )
+                else:
+                    self.apply_dPsum_and_scale_dS(
+                        tdPrdP_t2r,
+                        tSrS_t2r,
+                        tdPcdP_t2r,
+                        sdPsum,
+                        consumer_state_dPsum,
+                        seqlen_q_cur_batch,
+                        check_q_boundary=True,
+                    )
+                    self.apply_score_mod_bwd(
+                        tdPrdP_t2r,
+                        tSrS_pre,
+                        tScS_t2r,
+                        batch_idx,
+                        head_idx,
+                        m_block,
+                        n_block_for_cluster,
+                        softmax_scale,
+                        seqlen,
+                        aux_data,
+                        fastdiv_mods,
+                    )
+                    for i in cutlass.range(cute.size(tdPrdP_t2r), unroll_full=True):
+                        kv_idx = (
+                            tScS_t2r[i][0] + n_block_for_cluster * self.cta_group_size * self.tile_n
+                        )
+                        tdPrdP_t2r[i] = 0.0 if kv_idx >= seqlen.seqlen_k else tdPrdP_t2r[i]
+
+                # A single valid key has a constant softmax output, so its Jacobian is zero.
+                # Avoid residual dS from independently reduced dP and dPsum.
+                if seqlen.seqlen_k <= 1:
+                    tdPrdP_t2r.fill(0.0)
+
+                tdPrdS = cute.make_rmem_tensor(tdPrdP_t2r.shape, self.ds_dtype)
+                utils.cvt_f16(tdPrdP_t2r, tdPrdS)
+                cute.arch.fence_view_async_tmem_load()
+                with cute.arch.elect_one():
+                    pipeline_dP.consumer_release(consumer_state_dP)
+                consumer_state_dP.advance()
+                self.reg_to_smem_mma128x128_2cta(
+                    tdPrdS,
+                    sdSt,
+                    producer_state_dS.index,
+                    (self.tile_n, self.tile_m),
+                    dp_idx,
+                    wg_idx,
+                )
+                cute.arch.fence_view_async_shared()
+                self.compute_sync_barrier.arrive_and_wait()
+
+                with cute.arch.elect_one():
+                    pipeline_dS.producer_commit(producer_state_dS)
+                producer_state_dS.advance()
+                pipeline_dPsum.consumer_release(consumer_state_dPsum)
+                consumer_state_dPsum.advance()
+
+            # Epilogue
+            if process_tile:
+                if const_expr(not self.dKV_postprocess):
+                    consumer_state_dKV = self.epilogue_dKV(
+                        tidx,
+                        batch_idx,
+                        head_idx,
+                        n_block,
+                        seqlen,
+                        thr_mma_dV,
+                        thr_mma_dK,
+                        tdVtdV,
+                        tdKtdK,
+                        mdV,
+                        mdK,
+                        pipeline_dKV,
+                        consumer_state_dKV,
+                        softmax_scale,
+                    )
+                else:
+                    #### STORE dV
+                    consumer_state_dKV = self.epilogue_dK_or_dV_atomic(
+                        dp_idx,
+                        batch_idx,
+                        head_idx,
+                        n_block,
+                        seqlen,
+                        tdVtdV,
+                        mdV,
+                        pipeline_dKV,
+                        consumer_state_dKV,
+                        int(NamedBarrierBwdSm100.EpilogueWG1),  # barrier_id
+                        mdV_semaphore,
+                        "V",
+                    )
+                    #### STORE dK
+                    consumer_state_dKV = self.epilogue_dK_or_dV_atomic(
+                        dp_idx,
+                        batch_idx,
+                        head_idx,
+                        n_block,
+                        seqlen,
+                        tdKtdK,
+                        mdK,
+                        pipeline_dKV,
+                        consumer_state_dKV,
+                        int(NamedBarrierBwdSm100.EpilogueWG1),  # barrier_id
+                        mdK_semaphore,
+                        "K",
+                    )
+
+            work_tile = WorkTileInfo(work_tile.tile_idx, False)
+
+        return
 
     @cute.jit
-    def quantize(
+    def zero_empty_dKV(
         self,
-        input_t: cute.Tensor,
-        element_dtype: type[cutlass.Numeric],
-    ) -> cute.Tensor:
-        """Convert Float32 to element dtype."""
-        output = cute.make_rmem_tensor(input_t.shape, element_dtype)
-        output.store(input_t.load().to(element_dtype))
-        return output
+        tidx: Int32,
+        batch_idx: Int32,
+        head_idx: Int32,
+        n_block: Int32,
+        seqlen,
+        mdV: cute.Tensor,
+        mdK: cute.Tensor,
+    ):
+        """Zero a cluster-wide dK/dV tile with one CTA."""
+        dp_idx = tidx % 128
+        head_idx_kv = head_idx // self.qhead_per_kvhead
+        cluster_tile_n = self.tile_n * self.cta_group_size
+        n_block_for_tile = n_block // self.cta_group_size
+        gmem_tiled_copy_zero_dK = copy_utils.tiled_copy_2d(
+            self.dk_dtype,
+            math.gcd(64, self.tile_hdim),
+            128,
+        )
+        gmem_tiled_copy_zero_dV = copy_utils.tiled_copy_2d(
+            self.dv_dtype,
+            math.gcd(64, self.tile_hdimv),
+            128,
+        )
+        gmem_thr_copy_zero_dK = gmem_tiled_copy_zero_dK.get_slice(dp_idx)
+        gmem_thr_copy_zero_dV = gmem_tiled_copy_zero_dV.get_slice(dp_idx)
+        mdV_cur = seqlen.offset_batch_K(mdV, batch_idx, dim=3)[None, None, head_idx_kv]
+        mdK_cur = seqlen.offset_batch_K(mdK, batch_idx, dim=3)[None, None, head_idx_kv]
+        gdK = cute.local_tile(mdK_cur, (cluster_tile_n, self.tile_hdim), (n_block_for_tile, 0))
+        gdV = cute.local_tile(mdV_cur, (cluster_tile_n, self.tile_hdimv), (n_block_for_tile, 0))
+        tdKgdK = gmem_thr_copy_zero_dK.partition_D(gdK)
+        tdVgdV = gmem_thr_copy_zero_dV.partition_D(gdV)
+        cdK = cute.make_identity_tensor((cluster_tile_n, self.tile_hdim))
+        cdV = cute.make_identity_tensor((cluster_tile_n, self.tile_hdimv))
+        tdKcdK = gmem_thr_copy_zero_dK.partition_D(cdK)
+        tdVcdV = gmem_thr_copy_zero_dV.partition_D(cdV)
+        assert cute.size(tdKgdK[None, 0, 0]) == cute.size(tdVgdV[None, 0, 0])
+        zero = cute.make_fragment_like(tdKgdK[None, 0, 0])
+        zero.fill(0.0)
+        if tidx < 128:
+            for i in cutlass.range_constexpr(tdKgdK.shape[1]):
+                row_idx = tdKcdK[0, i, 0][0]
+                if row_idx < seqlen.seqlen_k - cluster_tile_n * n_block_for_tile:
+                    for j in cutlass.range_constexpr(tdKgdK.shape[2]):
+                        cute.copy(gmem_tiled_copy_zero_dK, zero, tdKgdK[None, i, j])
+        else:
+            for i in cutlass.range_constexpr(tdVgdV.shape[1]):
+                row_idx = tdVcdV[0, i, 0][0]
+                if row_idx < seqlen.seqlen_k - cluster_tile_n * n_block_for_tile:
+                    for j in cutlass.range_constexpr(tdVgdV.shape[2]):
+                        cute.copy(gmem_tiled_copy_zero_dV, zero, tdVgdV[None, i, j])
 
     @cute.jit
     def store(
@@ -2793,387 +2658,192 @@ class BlackwellFusedMultiHeadAttentionBackwardDKDVKernel:
                 gmem_i.store(regs_i.load().to(gmem.element_type))
 
     @cute.jit
-    def epilogue_clear(
+    def epilogue_dKV(
         self,
-        blk_coord: cute.Coord,
-        blk_offset: cute.Shape,
-        problem_shape: tuple[Int32, Int32, Int32, tuple[tuple[Int32, Int32], Int32]],
-        dK: cute.Tensor,
-        dV: cute.Tensor,
-    ):
-        """Early stopping needs to clear dK and dV."""
-        tidx, _, _ = cute.arch.thread_idx()
-        block_dim_x, _, _ = cute.arch.block_dim()
-        _, K, _, HB = problem_shape
-        _, blk_coord_k, _, blk_coord_batch = blk_coord
-
-        mdK_offset = cute.assume(blk_offset[1] * dK.stride[0], divby=64)
-        mdK = cute.make_tensor(
-            dK.iterator + mdK_offset,
-            cute.make_layout((K, self.tile_shape_dQ_K, HB), stride=dK.stride),
-        )
-        gdK = cute.local_tile(mdK, (self.cta_tiler[1], self.cta_tiler[2]), (None, None, None))
-        gdK = gdK[None, None, blk_coord_k, 0, blk_coord_batch]
-        cdK = cute.domain_offset(
-            (blk_coord_k * self.tile_shape_K, 0),
-            cute.make_identity_tensor((self.cta_tiler[1], self.cta_tiler[2])),
-        )
-
-        mdV_offset = cute.assume(blk_offset[1] * dV.stride[0], divby=64)
-        mdV = cute.make_tensor(
-            dV.iterator + mdV_offset,
-            cute.make_layout((K, self.tile_shape_dV_dO, HB), stride=dV.stride),
-        )
-        gdV = cute.local_tile(mdV, (self.cta_tiler[1], self.cta_tiler[2]), (None, None, None))
-        gdV = gdV[None, None, blk_coord_k, 0, blk_coord_batch]
-        cdV = cute.domain_offset(
-            (blk_coord_k * self.tile_shape_K, 0),
-            cute.make_identity_tensor((self.cta_tiler[1], self.cta_tiler[2])),
-        )
-
-        num_zero_epi_threads = 256
-
-        tiled_copy_r2g = fa_copy_utils.tiled_copy_2d(
-            dK.element_type, self.cta_tiler[2], num_zero_epi_threads
-        )
-
-        thr_copy_r2g = tiled_copy_r2g.get_slice(tidx)
-
-        tRG_gdK = thr_copy_r2g.partition_D(gdK)
-        tRG_cdK = thr_copy_r2g.partition_D(cdK)
-        tRG_gdV = thr_copy_r2g.partition_D(gdV)
-        tRG_cdV = thr_copy_r2g.partition_D(cdV)
-
-        zero_frg = cute.make_rmem_tensor_like(tRG_gdK[None, 0, None])
-        zero_frg.fill(dK.element_type(0.0))
-
-        # check we don't need zero fragment duplication
-        V_frg_size = cute.size(tRG_gdV[None, 0, None])
-        assert cute.size(zero_frg) == V_frg_size
-
-        if tidx < num_zero_epi_threads:
-            for n in cutlass.range(cute.size(tRG_gdK.shape[1]), unroll_full=True):
-                if cute.elem_less(tRG_cdK[0, n, 0][0], problem_shape[1]):
-                    cute.copy(tiled_copy_r2g, zero_frg, tRG_gdK[None, n, None])
-
-            for n in cutlass.range(cute.size(tRG_gdV.shape[1]), unroll_full=True):
-                if cute.elem_less(tRG_cdV[0, n, 0][0], problem_shape[1]):
-                    cute.copy(tiled_copy_r2g, zero_frg, tRG_gdV[None, n, None])
-
-    @cute.jit
-    def epilogue(
-        self,
-        blk_coord: cute.Coord,
-        blk_offset: cute.Shape,
-        problem_shape: tuple[Int32, Int32, Int32, tuple[tuple[Int32, Int32], Int32]],
-        dK: cute.Tensor,
-        dV: cute.Tensor,
-        tdKtdK: cute.Tensor,
+        tidx: Int32,
+        batch_idx: Int32,
+        head_idx: Int32,
+        n_block: Int32,
+        seqlen,
+        thr_mma_dV,
+        thr_mma_dK,
         tdVtdV: cute.Tensor,
-        scale_softmax: cutlass.Float32,
-        mma_compute_dKdV_producer,
-        mma_compute_dKdV_consumer,
-        problem_shape_k_cur_batch: Int32,
-        tma_atom_dK: cute.CopyAtom,
-        dK_tma: cute.Tensor,
-        tma_atom_dV: cute.CopyAtom,
-        dV_tma: cute.Tensor,
-        sdK_epi_layout: cute.ComposedLayout,
-        sdV_epi_layout: cute.ComposedLayout,
-        varlen: bool,
-        sdOT: cute.Tensor,
-        sP: cute.Tensor,
+        tdKtdK: cute.Tensor,
+        mdV: cute.Tensor,
+        mdK: cute.Tensor,
+        pipeline_dKV,
+        consumer_state_dKV,
+        softmax_scale: cutlass.Float32,
     ):
-        """Variant 3a (5/5) Path 2: CTA-shared SMEM with cooperative WG writes + TMA bulk store.
-
-        Both warp-groups cooperatively populate a per-CTA (64, 256) virtual SMEM
-        buffer (4 stages of (64, 64) aliased onto sP+sdST). Per-thread t2r N
-        coverage is interleaved across the full hd=256, so per-WG TMA is not
-        viable — instead we treat SMEM as one shared per-CTA buffer and let
-        each thread's `self.store`-equivalent write into it via a (64, 256)
-        virtual tensor whose N axis maps (n%64, n//64) → (N_within, stage).
-        After an inter-WG barrier (256 threads), the leader warp fires 4 TMA
-        bulk stores, one per stage, to the corresponding (64, 64) GMEM slice.
-        Varlen falls back to per-thread self.store as in flash_bwd_sm100.py.
-        """
-        tidx, _, _ = cute.arch.thread_idx()
-        _, K, D, HB = problem_shape
-        _, blk_coord_k, _, blk_coord_batch = blk_coord
-
-        # adi: TMEM_DK, TMEM_DV
-        tmem_copy_op = tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(32))
-        load_op = cute.make_copy_atom(
-            tmem_copy_op,
-            self.acc_dtype,
-        )
-
-        tdKtdK = tdKtdK[(None, None), 0, 0]
-        mdK_offset = cute.assume(blk_offset[1] * dK.stride[0], divby=64)
-        mdK = cute.make_tensor(
-            dK.iterator + mdK_offset,
-            cute.make_layout((K, self.tile_shape_dQ_K, HB), stride=dK.stride),
-        )
-        gdK = cute.local_tile(mdK, (self.cta_tiler[1], self.cta_tiler[2]), (None, None, None))
-        gdK = gdK[None, None, blk_coord_k, 0, blk_coord_batch]
-        cdK = cute.domain_offset(
-            (blk_coord_k * self.tile_shape_K, 0),
-            cute.make_identity_tensor((self.cta_tiler[1], self.cta_tiler[2])),
-        )
-
-        num_warp_groups = self.num_compute_warps // 4
-        dp_idx = tidx % 128
+        num_wg = self.num_compute_warps // 4
         wg_idx = (tidx % (self.num_compute_warps * self.threads_per_warp)) // 128
-        leader_warp = (cute.arch.make_warp_uniform(cute.arch.warp_idx()) % 4) == 0
 
-        # Path 2 SMEM staging. dV stages through sdOT (already-consumed by the
-        # dV MMA before the dV epilogue begins). dK stages through sP+sdST
-        # (dead after dK MMA completes, before dK epilogue runs).
-        s_epi_dK = cute.make_tensor(
-            cute.recast_ptr(sP.iterator, sdK_epi_layout.inner, dK.element_type),
-            sdK_epi_layout.outer,
-        )
-        s_epi_dV = cute.make_tensor(
-            cute.recast_ptr(sdOT.iterator, sdV_epi_layout.inner, dV.element_type),
-            sdV_epi_layout.outer,
+        if cutlass.const_expr(self.qhead_per_kvhead == 1):
+            assert self.qhead_per_kvhead == 1, "This epilogue path is only for MHA"
+        mdV_cur = seqlen.offset_batch_K(mdV, batch_idx, dim=3)[None, None, head_idx]
+        mdK_cur = seqlen.offset_batch_K(mdK, batch_idx, dim=3)[None, None, head_idx]
+
+        tmem_load_atom = cute.make_copy_atom(
+            tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(32)), Float32
         )
 
-        # Compile-time: stage tile shape and number of stages.
-        epi_cols_dKV = math.gcd(
-            128 // (dV.element_type.width // 8), self.cta_tiler[2] // num_warp_groups
-        )
-        num_epi_stages_dKV = (self.cta_tiler[2] // num_warp_groups) // epi_cols_dKV
-        total_epi_stages = num_warp_groups * num_epi_stages_dKV
-        epi_tile_dKV = (self.cta_tiler[1], epi_cols_dKV)
-
-        # Local (M, N) coord tensor for SMEM indexing (no global domain offset
-        # — cdK/cdV are domain-offset by blk_coord_k * tile_shape_K to match
-        # the GMEM destination, but the SMEM indexing must be per-CTA-local).
-        cdV_local = cute.make_identity_tensor((self.cta_tiler[1], self.cta_tiler[2]))
-        cdK_local = cdV_local
-
-        tiled_t2r_dK = tcgen05.make_tmem_copy(load_op, tdKtdK)
-        thread_t2r_dK = tiled_t2r_dK.get_slice(dp_idx)
-
-        tTR_cdK = thread_t2r_dK.partition_D(cdK)
-        tTR_cdK = split_wg(tTR_cdK, num_warp_groups, wg_idx)
-        tTR_cdK_local = thread_t2r_dK.partition_D(cdK_local)
-        tTR_cdK_local = split_wg(tTR_cdK_local, num_warp_groups, wg_idx)
-        tTR_gdK = thread_t2r_dK.partition_D(gdK)
-        tTR_gdK = split_wg(tTR_gdK, num_warp_groups, wg_idx)
-        tTR_rdK = cute.make_rmem_tensor(tTR_cdK.shape, self.acc_dtype)
-        tTR_tdK = thread_t2r_dK.partition_S(tdKtdK)
-        tTR_tdK = split_wg(tTR_tdK, num_warp_groups, wg_idx)
-
-        mdV_in = cute.make_tensor(
-            dV.iterator, cute.make_layout((K, self.cta_tiler[2], HB), stride=dV.stride)
-        )
-        offset_mdV = cute.assume(blk_offset[1] * mdV_in.stride[0], divby=64)
-        mdV = cute.make_tensor(mdV_in.iterator + offset_mdV, mdV_in.layout)
-        gdV = cute.local_tile(mdV, (self.cta_tiler[1], self.cta_tiler[2]), (None, None, None))
-        gdV = gdV[None, None, blk_coord_k, 0, blk_coord_batch]
-
-        cdV = cute.domain_offset(
-            (blk_coord_k * self.cta_tiler[1], 0),
-            cute.make_identity_tensor((self.cta_tiler[1], self.cta_tiler[2])),
-        )
+        # dV
+        pipeline_dKV.consumer_wait(consumer_state_dKV)
 
         tdVtdV = tdVtdV[(None, None), 0, 0]
+        tiled_tmem_ld_dV = tcgen05.make_tmem_copy(tmem_load_atom, tdVtdV)
+        thr_tmem_ld_dV = tiled_tmem_ld_dV.get_slice(tidx % 128)
 
-        tiled_t2r_dV = tcgen05.make_tmem_copy(load_op, tdVtdV)
-        thread_t2r_dV = tiled_t2r_dV.get_slice(dp_idx)
+        tdVtdV_t2r_p = thr_tmem_ld_dV.partition_S(tdVtdV)
+        tdVtdV_t2r = self.split_wg(tdVtdV_t2r_p, wg_idx, num_wg)
 
-        tTR_cdV = thread_t2r_dV.partition_D(cdV)
-        tTR_cdV = split_wg(tTR_cdV, num_warp_groups, wg_idx)
-        tTR_cdV_local = thread_t2r_dV.partition_D(cdV_local)
-        tTR_cdV_local = split_wg(tTR_cdV_local, num_warp_groups, wg_idx)
-        tTR_gdV = thread_t2r_dV.partition_D(gdV)
-        tTR_gdV = split_wg(tTR_gdV, num_warp_groups, wg_idx)
-        tTR_rdV = cute.make_rmem_tensor(tTR_cdV.shape, self.acc_dtype)
-        tTR_tdV = thread_t2r_dV.partition_S(tdVtdV)
-        tTR_tdV = split_wg(tTR_tdV, num_warp_groups, wg_idx)
+        cdV = cute.domain_offset(
+            (n_block * self.tile_n, 0),
+            cute.make_identity_tensor((self.cta_tiler[0], self.cta_tiler[2])),
+        )
+        gdV = cute.local_tile(mdV_cur, (self.cta_tiler[0], self.cta_tiler[2]), (n_block, 0))
+        tdVcdV_t2r_p = thr_tmem_ld_dV.partition_D(cdV)
+        tdVcdV_t2r = self.split_wg(tdVcdV_t2r_p, wg_idx, num_wg)
+        tdVgdV_t2r_p = thr_tmem_ld_dV.partition_D(gdV)
+        tdVgdV_t2r = self.split_wg(tdVgdV_t2r_p, wg_idx, num_wg)
+        tdVrdV_t2r = cute.make_rmem_tensor(tdVcdV_t2r.shape, Float32)
 
-        # GMEM destinations for the multi-stage TMA path (gated on not-varlen).
-        if cutlass.const_expr(not varlen):
-            mdV_tma_3d = cute.make_tensor(
-                dV_tma.iterator,
-                cute.make_layout((K, self.cta_tiler[2], HB), stride=dV_tma.stride),
-            )
-            mdV_tma_cur = mdV_tma_3d[None, None, blk_coord_batch]
-            gdV_tma = cute.local_tile(
-                mdV_tma_cur, (self.cta_tiler[1], self.cta_tiler[2]), (blk_coord_k, 0)
-            )
-            gdV_tma_epi = cute.local_tile(gdV_tma, epi_tile_dKV, (0, None))
-
-            mdK_tma_3d = cute.make_tensor(
-                dK_tma.iterator,
-                cute.make_layout((K, self.cta_tiler[2], HB), stride=dK_tma.stride),
-            )
-            mdK_tma_cur = mdK_tma_3d[None, None, blk_coord_batch]
-            gdK_tma = cute.local_tile(
-                mdK_tma_cur, (self.cta_tiler[1], self.cta_tiler[2]), (blk_coord_k, 0)
-            )
-            gdK_tma_epi = cute.local_tile(gdK_tma, epi_tile_dKV, (0, None))
-
-        cta_threads = self.num_compute_warps * self.threads_per_warp
-
-        dkdv_handle = mma_compute_dKdV_consumer.wait_and_advance()
-
-        if blk_coord_k * self.tile_shape_K < problem_shape_k_cur_batch:
-            cute.copy(tiled_t2r_dV, tTR_tdV, tTR_rdV)
-            tTR_rdV_cast = cute.make_rmem_tensor(tTR_rdV.shape, dV.element_type)
-            tTR_rdV_cast.store(tTR_rdV.load().to(dV.element_type))
-
-            if cutlass.const_expr(not varlen):
-                # reg -> SMEM via per-element indexed stores using tTR_cdV's
-                # per-thread (M, N) coords. (M, N) is per-CTA cdV space (M=0..63,
-                # N=0..255). We map N=(n%epi_cols, n//epi_cols) → (N_within, stage)
-                # of the 3D s_epi_dV tensor.
-                for _i in cutlass.range_constexpr(cute.size(tTR_cdV_local, mode=[2])):
-                    for _j in cutlass.range_constexpr(cute.size(tTR_cdV_local[None, 0, _i])):
-                        c = tTR_cdV_local[None, 0, _i][_j]
-                        m_pos = c[0]
-                        n_pos = c[1]
-                        stage_pos = n_pos // epi_cols_dKV
-                        n_within_pos = n_pos % epi_cols_dKV
-                        v = tTR_rdV_cast[None, 0, _i][_j]
-                        s_epi_dV[m_pos, n_within_pos, stage_pos] = v
-                cute.arch.fence_view_async_shared()
-                # Inter-WG barrier — both warp-groups must finish their writes
-                # before the leader warp reads SMEM via TMA.
-                cute.arch.barrier(barrier_id=5, number_of_threads=cta_threads)
-                # TMA bulk store, one (64, 64) box per stage.
-                if leader_warp and wg_idx == 0:
-                    for _stage in cutlass.range_constexpr(total_epi_stages):
-                        sdV_stage = s_epi_dV[None, None, _stage]
-                        gdV_stage = gdV_tma_epi[None, None, _stage]
-                        td_sdV, td_gdV = cpasync.tma_partition(
-                            tma_atom_dV,
-                            0,
-                            cute.make_layout(1),
-                            cute.group_modes(sdV_stage, 0, 2),
-                            cute.group_modes(gdV_stage, 0, 2),
-                        )
-                        cute.copy(tma_atom_dV, td_sdV, td_gdV)
-                        cute.arch.cp_async_bulk_commit_group()
-                cute.arch.cp_async_bulk_wait_group(0, read=True)
-            else:
-                self.store(tTR_gdV, tTR_rdV, tTR_cdV, (K, D))
-
+        cute.copy(tiled_tmem_ld_dV, tdVtdV_t2r, tdVrdV_t2r)
         cute.arch.fence_view_async_tmem_load()
-        dkdv_handle.release()
+        self.store(tdVgdV_t2r, tdVrdV_t2r, tdVcdV_t2r, (seqlen.seqlen_k, mdV.shape[1]))
 
-        dkdv_handle = mma_compute_dKdV_consumer.wait_and_advance()
+        cute.arch.sync_warp()
+        with cute.arch.elect_one():
+            pipeline_dKV.consumer_release(consumer_state_dKV)
+        consumer_state_dKV.advance()
 
-        if blk_coord_k * self.tile_shape_K < problem_shape_k_cur_batch:
-            cute.copy(tiled_t2r_dK, tTR_tdK, tTR_rdK)
+        # dK
+        pipeline_dKV.consumer_wait(consumer_state_dKV)
 
-            for i in cutlass.range(cute.size(tTR_rdK), unroll_full=True):
-                tTR_rdK[i] = scale_softmax * tTR_rdK[i]
+        tdKtdK = tdKtdK[(None, None), 0, 0]
+        tiled_tmem_ld_dK = tcgen05.make_tmem_copy(tmem_load_atom, tdKtdK)
+        thr_tmem_ld_dK = tiled_tmem_ld_dK.get_slice(tidx % 128)
 
-            tTR_rdK_cast = cute.make_rmem_tensor(tTR_rdK.shape, dK.element_type)
-            tTR_rdK_cast.store(tTR_rdK.load().to(dK.element_type))
+        tdKtdK_t2r_p = thr_tmem_ld_dK.partition_S(tdKtdK)
+        tdKtdK_t2r = self.split_wg(tdKtdK_t2r_p, wg_idx, num_wg)
 
-            if cutlass.const_expr(not varlen):
-                for _i in cutlass.range_constexpr(cute.size(tTR_cdK_local, mode=[2])):
-                    for _j in cutlass.range_constexpr(cute.size(tTR_cdK_local[None, 0, _i])):
-                        c = tTR_cdK_local[None, 0, _i][_j]
-                        m_pos = c[0]
-                        n_pos = c[1]
-                        stage_pos = n_pos // epi_cols_dKV
-                        n_within_pos = n_pos % epi_cols_dKV
-                        v = tTR_rdK_cast[None, 0, _i][_j]
-                        s_epi_dK[m_pos, n_within_pos, stage_pos] = v
-                cute.arch.fence_view_async_shared()
-                cute.arch.barrier(barrier_id=6, number_of_threads=cta_threads)
-                if leader_warp and wg_idx == 0:
-                    for _stage in cutlass.range_constexpr(total_epi_stages):
-                        sdK_stage = s_epi_dK[None, None, _stage]
-                        gdK_stage = gdK_tma_epi[None, None, _stage]
-                        td_sdK, td_gdK = cpasync.tma_partition(
-                            tma_atom_dK,
-                            0,
-                            cute.make_layout(1),
-                            cute.group_modes(sdK_stage, 0, 2),
-                            cute.group_modes(gdK_stage, 0, 2),
-                        )
-                        cute.copy(tma_atom_dK, td_sdK, td_gdK)
-                        cute.arch.cp_async_bulk_commit_group()
-                cute.arch.cp_async_bulk_wait_group(0, read=True)
-            else:
-                self.store(tTR_gdK, tTR_rdK, tTR_cdK, (K, D))
+        cdK = cute.domain_offset(
+            (n_block * self.tile_n, 0),
+            cute.make_identity_tensor((self.cta_tiler[0], self.cta_tiler[2])),
+        )
+        gdK = cute.local_tile(mdK_cur, (self.cta_tiler[0], self.cta_tiler[2]), (n_block, 0))
+        tdKcdK_t2r_p = thr_tmem_ld_dK.partition_D(cdK)
+        tdKcdK_t2r = self.split_wg(tdKcdK_t2r_p, wg_idx, num_wg)
+        tdKgdK_t2r_p = thr_tmem_ld_dK.partition_D(gdK)
+        tdKgdK_t2r = self.split_wg(tdKgdK_t2r_p, wg_idx, num_wg)
+        tdKrdK_t2r = cute.make_rmem_tensor(tdKcdK_t2r.shape, Float32)
 
+        cute.copy(tiled_tmem_ld_dK, tdKtdK_t2r, tdKrdK_t2r)
+        for i in cutlass.range(cute.size(tdKrdK_t2r), unroll_full=True):
+            tdKrdK_t2r[i] = softmax_scale * tdKrdK_t2r[i]
         cute.arch.fence_view_async_tmem_load()
-        dkdv_handle.release()
+        self.store(tdKgdK_t2r, tdKrdK_t2r, tdKcdK_t2r, (seqlen.seqlen_k, mdK.shape[1]))
 
-        return mma_compute_dKdV_consumer
+        cute.arch.sync_warp()
+        with cute.arch.elect_one():
+            pipeline_dKV.consumer_release(consumer_state_dKV)
+        consumer_state_dKV.advance()
 
-    def get_workspace_tensor(
+        return consumer_state_dKV
+
+    @cute.jit
+    def epilogue_dK_or_dV_atomic(
         self,
-        problem_shape: tuple[Int32, Int32, Int32, tuple[tuple[Int32, Int32], Int32]],
-        workspace: cute.Tensor,
-        acc_dtype: type[cutlass.Numeric],
-        varlen: bool,
-    ) -> tuple[cute.Tensor, cute.Tensor, cute.Tensor]:
-        """Get workspace tensor."""
-        D = problem_shape[2]
-        H, B = cute.size(problem_shape[3][0]), cute.size(problem_shape[3][1])
-        H_r, H_k = problem_shape[3][0]
-        D = cute.round_up(D, 8)
+        tidx: Int32,
+        batch_idx: Int32,
+        head_idx: Int32,
+        n_block: Int32,
+        seqlen,
+        tdKVtdKV: cute.Tensor,
+        mdKV: cute.Tensor,
+        pipeline_dKV: PipelineAsync,
+        consumer_state_dKV: cutlass.pipeline.PipelineState,
+        barrier_id: Int32,
+        mdKV_semaphore: Optional[cute.Tensor],
+        K_or_V: cutlass.Constexpr[str],
+    ) -> cutlass.pipeline.PipelineState:
+        assert K_or_V in ("K", "V")
+        tile_hdim = self.tile_hdim if const_expr(K_or_V == "K") else self.tile_hdimv
+        num_compute_threads = cute.arch.WARP_SIZE * len(self.compute_warp_ids)
+        wg_idx = (cute.arch.thread_idx()[0] % num_compute_threads) // 128
+        num_wg = num_compute_threads // 128
 
-        # b = 1 for varlen, else batch_size
-        b = workspace.shape[0]
-        # s_q_sum for varlen, else s_q_max, already rounded to 8
-        S_Q = workspace.shape[1]
-
-        acc_bytes = acc_dtype.width // 8
-        sum_OdO_bytes = cute.assume(b * H * S_Q * acc_bytes, divby=acc_bytes)
-        scaled_lse_bytes = cute.assume(b * H * S_Q * acc_bytes, divby=acc_bytes)
-
-        sum_OdO_iter = workspace.iterator
-        scaled_lse_iter = sum_OdO_iter + sum_OdO_bytes
-
-        sum_OdO_iter = cute.recast_ptr(sum_OdO_iter, dtype=self.acc_dtype)
-        scaled_lse_iter = cute.recast_ptr(scaled_lse_iter, dtype=self.acc_dtype)
-
-        sum_OdO = cute.make_tensor(
-            sum_OdO_iter,
-            cute.make_layout(
-                (S_Q, ((H_r, H_k), B)),
-                stride=(1, ((S_Q, S_Q * H_r), 0 if varlen else S_Q * H)),
-            ),
-        )
-        scaled_lse = cute.make_tensor(
-            scaled_lse_iter,
-            cute.make_layout(
-                (S_Q, ((H_r, H_k), B)),
-                stride=(1, ((S_Q, S_Q * H_r), 0 if varlen else S_Q * H)),
-            ),
+        head_idx_kv = head_idx // self.qhead_per_kvhead
+        n_block_group = n_block // self.cta_group_size
+        if const_expr(not seqlen.has_cu_seqlens_k):
+            mdKV_cur = mdKV[None, head_idx_kv, batch_idx]
+        else:
+            mdKV_cur = cute.domain_offset(
+                (seqlen.padded_offset_k * tile_hdim,), mdKV[None, head_idx_kv]
+            )
+        gdKV_p = cute.local_tile(
+            mdKV_cur,
+            (self.dKV_postprocess_tile_n * tile_hdim,),
+            (n_block_group,),
         )
 
-        return sum_OdO, scaled_lse
+        deterministic_KV = self.deterministic and self.qhead_per_kvhead > 1
+        if const_expr(deterministic_KV):
+            assert mdKV_semaphore is not None
+            mdKV_semaphore_cur = mdKV_semaphore[n_block, None, head_idx_kv, batch_idx]
 
-    @staticmethod
-    def _compute_sum_OdO_grid(
-        problem_shape: tuple[Int32, Int32, Int32, tuple[tuple[Int32, Int32], Int32]],
-        block_q: int,
-    ) -> tuple[Int32, Int32, Int32]:
-        """Compute grid shape for sum_OdO kernel."""
-        return (
-            cute.ceil_div(cute.size(problem_shape[0]), block_q),
-            cute.size(problem_shape[3][0]),  # H
-            cute.size(problem_shape[3][1]),  # B
+        tmem_load_atom = cute.make_copy_atom(
+            tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(self.dK_reduce_ncol)), Float32
         )
 
-    @staticmethod
-    def _compute_bwd_grid(
-        problem_shape: tuple[Int32, Int32, Int32, tuple[tuple[Int32, Int32], Int32]],
-        block_k: int,
-    ) -> tuple[Int32, Int32, Int32]:
-        """Compute grid shape for bwd kernel."""
-        K = problem_shape[1]
-        _, H_K = problem_shape[3][0]
-        B = problem_shape[3][1]
-        return (cute.ceil_div(K, block_k), cute.size(H_K), cute.size(B))
+        pipeline_dKV.consumer_wait(consumer_state_dKV)
+
+        if const_expr(deterministic_KV):
+            barrier.wait_eq(
+                mdKV_semaphore_cur.iterator, tidx, wg_idx, head_idx % self.qhead_per_kvhead
+            )
+            cute.arch.barrier(barrier_id=barrier_id + wg_idx, number_of_threads=128)
+
+        block_row_offset = n_block_group * self.dKV_postprocess_tile_n
+        tdKVtdKV = tdKVtdKV[(None, None), 0, 0]
+        tiled_tmem_ld_dKV = tcgen05.make_tmem_copy(tmem_load_atom, tdKVtdKV)
+        thr_tmem_ld_dKV = tiled_tmem_ld_dKV.get_slice(tidx)
+
+        tdKVtdKV_t2r_p = thr_tmem_ld_dKV.partition_S(tdKVtdKV)
+        tdKVtdKV_t2r = self.split_wg(tdKVtdKV_t2r_p, wg_idx, num_wg)
+
+        cKV = cute.domain_offset(
+            (n_block * self.tile_n, 0), cute.make_identity_tensor((self.cta_tiler[0], tile_hdim))
+        )
+        tdKVcKV_t2r_p = thr_tmem_ld_dKV.partition_D(cKV)
+        tdKVcKV_t2r = self.split_wg(tdKVcKV_t2r_p, wg_idx, num_wg)
+
+        tdKVrKV_t2r = cute.make_rmem_tensor(tdKVcKV_t2r.shape, Float32)
+        cute.copy(tiled_tmem_ld_dKV, tdKVtdKV_t2r, tdKVrKV_t2r)
+        cute.arch.fence_view_async_tmem_load()
+
+        for i in cutlass.range(cute.size(tdKVrKV_t2r) // 4, unroll_full=True):
+            frag_idx = 4 * i
+            row_idx = tdKVcKV_t2r[frag_idx][0] - block_row_offset
+            col_idx = tdKVcKV_t2r[frag_idx][1]
+            accum_idx = (col_idx // 4) * self.dKV_postprocess_tile_n * 4 + row_idx * 4
+            atomic_add_fp32x4_l2_evict_last(
+                tdKVrKV_t2r[frag_idx],
+                tdKVrKV_t2r[frag_idx + 1],
+                tdKVrKV_t2r[frag_idx + 2],
+                tdKVrKV_t2r[frag_idx + 3],
+                gdKV_p.iterator + accum_idx,
+            )
+
+        if const_expr(deterministic_KV):
+            cute.arch.barrier(barrier_id=barrier_id + wg_idx, number_of_threads=128)
+            barrier.arrive_inc(mdKV_semaphore_cur.iterator, tidx, wg_idx, 1)
+
+        cute.arch.sync_warp()
+        with cute.arch.elect_one():
+            pipeline_dKV.consumer_release(consumer_state_dKV)
+        consumer_state_dKV.advance()
+        return consumer_state_dKV
 
     @staticmethod
     def get_workspace_size(s_q: int, d: int, h: int, b: int, acc_dtype: type[cutlass.Numeric]):
@@ -3188,224 +2858,3 @@ class BlackwellFusedMultiHeadAttentionBackwardDKDVKernel:
         # FP32 versions of outputs that are churned (start off with Q only)
         workspace_bytes += d * acc_dtype.width // 8
         return (b, s_q, h, workspace_bytes)
-
-    def make_and_init_load_mma_K_pipeline(self, load_mma_K_mbar_ptr, cluster_layout_vmnk):
-        """Create and initialize barrier for load mma Q."""
-        load_mma_K_producer_group = pipeline.CooperativeGroup(
-            pipeline.Agent.Thread, len([self.load_warp_id])
-        )
-        load_mma_K_consumer_group = pipeline.CooperativeGroup(
-            pipeline.Agent.Thread, len([self.mma_warp_id])
-        )
-        return pipeline.PipelineTmaUmma.create(
-            barrier_storage=load_mma_K_mbar_ptr,
-            num_stages=self.load_mma_K_stage,
-            producer_group=load_mma_K_producer_group,
-            consumer_group=load_mma_K_consumer_group,
-            tx_count=self.tma_copy_K_bytes,
-            cta_layout_vmnk=cluster_layout_vmnk,
-        )
-
-    def make_and_init_load_mma_V_pipeline(self, load_mma_V_mbar_ptr, cluster_layout_vmnk):
-        """Create and initialize barrier for load mma Q."""
-        load_mma_V_producer_group = pipeline.CooperativeGroup(
-            pipeline.Agent.Thread, len([self.load_warp_id])
-        )
-        load_mma_V_consumer_group = pipeline.CooperativeGroup(
-            pipeline.Agent.Thread, len([self.mma_warp_id])
-        )
-        return pipeline.PipelineTmaUmma.create(
-            barrier_storage=load_mma_V_mbar_ptr,
-            num_stages=self.load_mma_V_stage,
-            producer_group=load_mma_V_producer_group,
-            consumer_group=load_mma_V_consumer_group,
-            tx_count=self.tma_copy_V_bytes,
-            cta_layout_vmnk=cluster_layout_vmnk,
-        )
-
-    def make_and_init_load_mma_Q_pipeline(self, load_mma_Q_mbar_ptr, cluster_layout_vmnk):
-        """Create and initialize barrier for load mma Q."""
-        load_mma_Q_producer_group = pipeline.CooperativeGroup(
-            pipeline.Agent.Thread, len([self.load_warp_id])
-        )
-        load_mma_Q_consumer_group = pipeline.CooperativeGroup(
-            pipeline.Agent.Thread, len([self.mma_warp_id])
-        )
-        return pipeline.PipelineTmaUmma.create(
-            barrier_storage=load_mma_Q_mbar_ptr,
-            num_stages=self.load_mma_Q_stage,
-            producer_group=load_mma_Q_producer_group,
-            consumer_group=load_mma_Q_consumer_group,
-            tx_count=self.tma_copy_Q_bytes,
-            cta_layout_vmnk=cluster_layout_vmnk,
-        )
-
-    def make_and_init_load_mma_QT_pipeline(self, load_mma_QT_mbar_ptr, cluster_layout_vmnk):
-        """Create and initialize barrier for load mma QT."""
-        load_mma_QT_producer_group = pipeline.CooperativeGroup(
-            pipeline.Agent.Thread, len([self.load_warp_id])
-        )
-        load_mma_QT_consumer_group = pipeline.CooperativeGroup(
-            pipeline.Agent.Thread, len([self.mma_warp_id])
-        )
-        return pipeline.PipelineTmaUmma.create(
-            barrier_storage=load_mma_QT_mbar_ptr,
-            num_stages=self.load_mma_QT_stage,
-            producer_group=load_mma_QT_producer_group,
-            consumer_group=load_mma_QT_consumer_group,
-            tx_count=self.tma_copy_Q_bytes,
-            cta_layout_vmnk=cluster_layout_vmnk,
-        )
-
-    def make_and_init_load_mma_dO_pipeline(self, load_mma_dO_mbar_ptr, cluster_layout_vmnk):
-        """Create and initialize barrier for load mma dO."""
-        load_mma_dO_producer_group = pipeline.CooperativeGroup(
-            pipeline.Agent.Thread, len([self.load_warp_id])
-        )
-        load_mma_dO_consumer_group = pipeline.CooperativeGroup(
-            pipeline.Agent.Thread, len([self.mma_warp_id])
-        )
-        return pipeline.PipelineTmaUmma.create(
-            barrier_storage=load_mma_dO_mbar_ptr,
-            num_stages=self.load_mma_dO_stage,
-            producer_group=load_mma_dO_producer_group,
-            consumer_group=load_mma_dO_consumer_group,
-            tx_count=self.tma_copy_dO_bytes,
-            cta_layout_vmnk=cluster_layout_vmnk,
-        )
-
-    def make_and_init_load_compute_LSE_pipeline(self, load_compute_lse_mbar_ptr):
-        """Create and initialize barrier for load compute lse."""
-        load_compute_lse_producer_group = pipeline.CooperativeGroup(
-            pipeline.Agent.Thread,
-            self.threads_per_warp,
-            # self.threads_per_warp,
-        )
-        load_compute_lse_consumer_group = pipeline.CooperativeGroup(
-            pipeline.Agent.Thread,
-            self.threads_per_warp * self.num_compute_warps,
-            # self.threads_per_warp * self.num_compute_warps,
-        )
-        return pipeline.PipelineCpAsync.create(
-            barrier_storage=load_compute_lse_mbar_ptr,
-            num_stages=self.load_compute_LSE_stage,
-            producer_group=load_compute_lse_producer_group,
-            consumer_group=load_compute_lse_consumer_group,
-        )
-
-    def make_and_init_load_compute_sum_OdO_pipeline(self, load_compute_sum_OdO_mbar_ptr):
-        """Create and initialize barrier for load sum OdO."""
-        load_compute_sum_OdO_producer_group = pipeline.CooperativeGroup(
-            pipeline.Agent.Thread,
-            self.threads_per_warp,
-            # self.threads_per_warp,
-        )
-        load_compute_sum_OdO_consumer_group = pipeline.CooperativeGroup(
-            pipeline.Agent.Thread,
-            self.threads_per_warp * self.num_compute_warps,
-            # self.threads_per_warp * self.num_compute_warps,
-        )
-        return pipeline.PipelineCpAsync.create(
-            barrier_storage=load_compute_sum_OdO_mbar_ptr,
-            num_stages=self.load_compute_sum_OdO_stage,
-            producer_group=load_compute_sum_OdO_producer_group,
-            consumer_group=load_compute_sum_OdO_consumer_group,
-        )
-
-    def make_and_init_mma_compute_S_pipeline(self, mma_compute_S_mbar_ptr, cluster_layout_vmnk):
-        """Create and initialize barrier for mma S."""
-        mma_compute_S_producer_group = pipeline.CooperativeGroup(
-            pipeline.Agent.Thread,
-            len([self.mma_warp_id]),
-        )
-        mma_compute_S_consumer_group = pipeline.CooperativeGroup(
-            pipeline.Agent.Thread,
-            self.num_compute_warps * self.threads_per_warp * cluster_layout_vmnk.shape[0][0],
-        )
-        return pipeline.PipelineUmmaAsync.create(
-            barrier_storage=mma_compute_S_mbar_ptr,
-            num_stages=self.mma_compute_S_stage,
-            producer_group=mma_compute_S_producer_group,
-            consumer_group=mma_compute_S_consumer_group,
-            cta_layout_vmnk=cluster_layout_vmnk,
-        )
-
-    #  Barrier to between dP = v * dO and consume of dP in compute()
-    def make_and_init_mma_compute_dP_pipeline(self, mma_compute_dP_mbar_ptr, cluster_layout_vmnk):
-        """Create and initialize barrier for mma Q."""
-        mma_compute_dP_producer_group = pipeline.CooperativeGroup(
-            pipeline.Agent.Thread,
-            len([self.mma_warp_id]),
-        )
-        mma_compute_dP_consumer_group = pipeline.CooperativeGroup(
-            pipeline.Agent.Thread,
-            self.num_compute_warps * self.threads_per_warp * cluster_layout_vmnk.shape[0][0],
-        )
-        return pipeline.PipelineUmmaAsync.create(
-            barrier_storage=mma_compute_dP_mbar_ptr,
-            num_stages=self.mma_compute_dP_stage,
-            producer_group=mma_compute_dP_producer_group,
-            consumer_group=mma_compute_dP_consumer_group,
-            cta_layout_vmnk=cluster_layout_vmnk,
-        )
-
-    def make_and_init_compute_mma_P_pipeline(self, compute_mma_P_mbar_ptr, cluster_layout_vmnk):
-        """Create and initialize barrier for mma P."""
-        compute_mma_P_producer_group = pipeline.CooperativeGroup(
-            pipeline.Agent.Thread,
-            self.num_compute_warps * self.threads_per_warp * cluster_layout_vmnk.shape[0][0],
-            # self.num_compute_warps * self.threads_per_warp,
-        )
-        compute_mma_P_consumer_group = pipeline.CooperativeGroup(
-            pipeline.Agent.Thread,
-            len([self.mma_warp_id]),
-        )
-        return pipeline.PipelineAsyncUmma.create(
-            barrier_storage=compute_mma_P_mbar_ptr,
-            num_stages=self.compute_mma_P_stage,
-            producer_group=compute_mma_P_producer_group,
-            consumer_group=compute_mma_P_consumer_group,
-            cta_layout_vmnk=cluster_layout_vmnk,
-        )
-
-    def make_and_init_compute_mma_dS_pipeline(self, compute_mma_dS_mbar_ptr, cluster_layout_vmnk):
-        """Create and initialize barrier for mma dS."""
-
-        compute_mma_dS_producer_group = pipeline.CooperativeGroup(
-            pipeline.Agent.Thread,
-            self.num_compute_warps * self.threads_per_warp * cluster_layout_vmnk.shape[0][0],
-            # self.num_compute_warps * self.threads_per_warp,
-        )
-        compute_mma_dS_consumer_group = pipeline.CooperativeGroup(
-            pipeline.Agent.Thread,
-            len([self.mma_warp_id]),
-        )
-
-        return pipeline.PipelineAsyncUmma.create(
-            barrier_storage=compute_mma_dS_mbar_ptr,
-            num_stages=self.compute_mma_dS_stage,
-            producer_group=compute_mma_dS_producer_group,
-            consumer_group=compute_mma_dS_consumer_group,
-            cta_layout_vmnk=cluster_layout_vmnk,
-        )
-
-    def make_and_init_mma_compute_dKdV_pipeline(
-        self, mma_compute_dKdV_mbar_ptr, cluster_layout_vmnk
-    ):
-        """Create and initialize barrier for mma dKdV."""
-        mma_compute_dKdV_producer_group = pipeline.CooperativeGroup(
-            pipeline.Agent.Thread,
-            len([self.mma_warp_id]),
-        )
-        mma_compute_dKdV_consumer_group = pipeline.CooperativeGroup(
-            pipeline.Agent.Thread,
-            self.num_compute_warps * self.threads_per_warp * cluster_layout_vmnk.shape[0][0],
-            # self.num_compute_warps * self.threads_per_warp,
-        )
-        return pipeline.PipelineUmmaAsync.create(
-            barrier_storage=mma_compute_dKdV_mbar_ptr,
-            num_stages=self.mma_compute_dKdV_stage,
-            producer_group=mma_compute_dKdV_producer_group,
-            consumer_group=mma_compute_dKdV_consumer_group,
-            cta_layout_vmnk=cluster_layout_vmnk,
-        )

--- a/flash_attn/cute/sm100_hd256_2cta_fmha_backward_dqkernel.py
+++ b/flash_attn/cute/sm100_hd256_2cta_fmha_backward_dqkernel.py
@@ -1,147 +1,235 @@
 # Copyright (c) 2025, Siyu Wang, Shengbin Di, Yuxi Chi, Johnsonms, Linfeng Zheng, Haoyan Huang, Lanbo Li, Yun Zhong, Man Yuan, Minmin Sun, Yong Li, Wei Lin.
 
-from typing import Type, Tuple, Optional
+from functools import partial
+from typing import Optional
 
 import cuda.bindings.driver as cuda
 
 import math
 import cutlass
 import cutlass.cute as cute
+from cutlass.cute import FastDivmodDivisor
 import cutlass.cute.nvgpu.tcgen05 as tcgen05
 from cutlass.cute.nvgpu import cpasync
-import cutlass.utils as utils
-import cutlass.pipeline as pipeline
-import cutlass.utils.blackwell_helpers as sm100_utils
-from cutlass.cute.typing import Int32, Int64, Float32
+from cutlass import const_expr
+import cutlass.utils as cutlass_utils
+from flash_attn.cute.cute_dsl_utils import assume_tensor_aligned
+from flash_attn.cute.blackwell_helpers import gemm_w_idx
+from flash_attn.cute import pipeline
+from flash_attn.cute import copy_utils
+from flash_attn.cute import utils
+import cutlass.utils.blackwell_helpers as sm100_utils_basic
+from cutlass.cute.typing import Int32, Float32
+import quack.activation
+from quack import layout_utils
 
-from cutlass.utils import ClcDynamicPersistentTileScheduler
 from flash_attn.cute.tile_scheduler import (
-    ClcState,
-    compute_sm100_fmha_grid as compute_grid,
-    compute_sm100_fmha_grid_clc as compute_grid_clc,
-    make_sm100_thread_cooperative_group as make_thread_cooperative_group,
-    Sm100FmhaStaticTileScheduler as FmhaStaticTileScheduler,
-    Sm100FmhaStaticTileSchedulerParams as FmhaStaticTileSchedulerParams,
-    Sm100FmhaClcDynamicTileScheduler as FmhaClcDynamicTileScheduler,
-    Sm100FmhaClcDynamicTileSchedulerParams as FmhaClcDynamicTileSchedulerParams,
+    TileSchedulerArguments,
+    SingleTileScheduler,
+    SingleTileVarlenScheduler,
+    SingleTileLPTBwdScheduler,
 )
-from flash_attn.cute.mask import (
-    Sm100FusedMask as FusedMask,
-)
-from flash_attn.cute.tile_scheduler import SM100_TMEM_CAPACITY_COLUMNS
-import flash_attn.cute.copy_utils as fa_copy_utils
+from flash_attn.cute.block_info import BlockInfo
+from flash_attn.cute.block_sparsity import BlockSparseTensors
+from flash_attn.cute.mask import AttentionMask
+from flash_attn.cute.seqlen_info import SeqlenInfoQK
+from flash_attn.cute.softmax import apply_score_mod_inner, apply_score_mod_bwd_inner
+
+
+@cute.jit
+def _producer_tail_with_cutlass_state(pipeline_obj, state):
+    tail_state = cutlass.pipeline.PipelineState(
+        state.stages,
+        Int32(0),
+        state.index,
+        state.phase,
+    )
+    pipeline_obj.producer_tail(tail_state)
 
 
 class BlackwellFusedMultiHeadAttentionBackwardDQKernel:
     def __init__(
         self,
-        acc_dtype: Type[cutlass.Numeric],
-        mma_tiler: Tuple[int, int, int],
-        is_causal: bool,
-        window_size_left: int | None,
-        window_size_right: int | None,
-        is_persistent: bool,
-        split_head: bool,
-        use_clc_scheduler: bool = False,
+        head_dim: int,
+        head_dim_v: Optional[int] = None,
+        is_causal: bool = False,
+        is_local: bool = False,
+        qhead_per_kvhead: cutlass.Constexpr[int] = 1,
+        tile_m: int = 128,
+        tile_n: int = 128,
+        is_persistent: bool = False,
+        deterministic: bool = False,
+        spt: Optional[bool] = None,
+        cluster_size: int = 2,
+        use_2cta_instrs: bool = True,
+        score_mod: cutlass.Constexpr | None = None,
+        score_mod_bwd: cutlass.Constexpr | None = None,
+        mask_mod: cutlass.Constexpr | None = None,
+        has_aux_tensors: cutlass.Constexpr = False,
+        subtile_factor: cutlass.Constexpr[int] = 1,
     ):
-        self.acc_dtype = acc_dtype
-        self.mma_tiler = mma_tiler
-        self.is_causal = is_causal
-        self.window_size_left = window_size_left
-        # Keep original behavior (known-good in this repo)
-        window_size_left = (
-            None
-            if (window_size_left is None or window_size_left < 0)
-            else cutlass.Int32(window_size_left)
-        )
-        window_size_right = (
-            None
-            if (window_size_right is None or window_size_right < 0)
-            else cutlass.Int32(window_size_right)
-        )
-        self.window_size_left = None if self.is_causal else window_size_left
-        self.window_size_right = cutlass.Int32(0) if self.is_causal else window_size_right
-        self.is_local = (not self.is_causal) and (
-            self.window_size_left is not None or self.window_size_right is not None
-        )
-        assert mma_tiler[0] == 128 and mma_tiler[1] == 128, "Only 128x128 tile impl is supported"
-        assert mma_tiler[2] == 256, "Only 256 is supported for 128x128 tile impl"
-        self.cta_tiler = (
-            mma_tiler[0],
-            mma_tiler[1],
-            mma_tiler[2],
-        )
-        self.qk_mma_tiler = (
-            2 * mma_tiler[0],
-            mma_tiler[1],
-            min(self.cta_tiler[2], 128) if split_head else self.cta_tiler[2],
-        )
-        self.dov_mma_tiler = self.qk_mma_tiler
-        self.dsk_mma_tiler = (
-            2 * mma_tiler[0],
-            min(self.cta_tiler[2], 128) if split_head else self.cta_tiler[2],
-            mma_tiler[1],
-        )
+        # padding head_dim to a multiple of 16 as k_block_size
+        hdim_multiple_of = 16
+        self.head_dim_padded = int(math.ceil(head_dim / hdim_multiple_of) * hdim_multiple_of)
+        head_dim_v = head_dim_v if head_dim_v is not None else head_dim
+        self.same_hdim_kv = head_dim == head_dim_v
+        self.head_dim_v_padded = int(math.ceil(head_dim_v / hdim_multiple_of) * hdim_multiple_of)
+        self.same_hdim_kv_padded = self.head_dim_padded == self.head_dim_v_padded
+        self.check_hdim_oob = head_dim != self.head_dim_padded
+        self.check_hdim_v_oob = head_dim_v != self.head_dim_v_padded
+        self.m_block_size = tile_m
+        self.n_block_size = tile_n
+        self.q_stage = 1
+        assert self.q_stage in [1, 2]
+        self.use_2cta_instrs = use_2cta_instrs
 
+        assert head_dim == 256
+        assert head_dim_v == 256
+        assert self.head_dim_padded == 256
+        assert self.head_dim_v_padded == 256
+        assert self.m_block_size == 128 and self.n_block_size == 128, (
+            "Only 128x128 tile impl is supported"
+        )
+        assert not is_persistent
+        assert cluster_size == 2
+        assert self.use_2cta_instrs
+
+        self.cta_group_size = 2 if self.use_2cta_instrs else 1
+        # cta_tiler M includes only 1 CTA, the scheduler will take into account the cluster shape
+        self.cta_tiler = (self.q_stage * self.m_block_size, self.n_block_size, self.head_dim_padded)
+        # With 2CTA, the MMA tiler M covers both CTAs, so it's cta_group_size * m_block_size.
+        # Each CTA owns m_block_size rows; the 2CTA MMA instruction spans both.
+        self.mma_tiler_qk = (
+            self.cta_group_size * self.m_block_size,
+            self.n_block_size,
+            self.head_dim_padded,
+        )
+        # dP = dO @ V.T
+        self.mma_tiler_dov = (
+            self.cta_group_size * self.m_block_size,
+            self.n_block_size,
+            self.head_dim_v_padded,
+        )
+        # dQ = dS @ K
+        self.mma_tiler_dsk = (
+            self.cta_group_size * self.m_block_size,
+            self.head_dim_padded,
+            self.n_block_size,
+        )
+        self.qk_acc_dtype = Float32
+        self.dov_acc_dtype = Float32
+        self.dsk_acc_dtype = Float32
+        self.acc_dtype = Float32
+        self.cluster_shape_mn = (2, 1) if self.use_2cta_instrs else (1, 1)
+        self.is_persistent = is_persistent
+        self.is_causal = is_causal
+        self.is_local = is_local
+        self.use_correction_warps_for_epi = False
+        self.qhead_per_kvhead = qhead_per_kvhead
+        self.is_split_kv = False
+        self.pack_gqa = False
+        self.q_subtile_factor = None
+        assert not (self.is_split_kv and self.head_dim_v_padded >= 192), (
+            "SplitKV is not supported for hdim >= 192"
+        )
+        self.score_mod = score_mod
+        self.score_mod_bwd = score_mod_bwd
+        self.mask_mod = mask_mod
+        self.score_vec_size: cutlass.Constexpr = getattr(
+            score_mod, "__vec_size__", 1 if cutlass.const_expr(has_aux_tensors) else 2
+        )
+        self.mask_vec_size: cutlass.Constexpr = getattr(mask_mod, "__vec_size__", 1)
+        self.s0_s1_barrier = False
+        self.overlap_sO_sQ = False
+        self.use_clc_scheduler = False
+        self.sched_stages = 1
+        self.shuffle_LSE = False
+        self.shuffle_dPsum = False
+
+        self.head_dim = head_dim
+        self.head_dim_v = head_dim_v
+        self.deterministic = deterministic
+        self.spt = spt
+        self.cluster_size = cluster_size
+        self.has_aux_tensors = has_aux_tensors
+        self.subtile_factor = subtile_factor
+        self.window_size_left = None
+        self.window_size_right = cutlass.Int32(0) if self.is_causal else None
+
+        self.tile_m = self.m_block_size
+        self.tile_n = self.n_block_size
+        self.tile_hdim = self.head_dim_padded
+        self.tile_hdimv = self.head_dim_v_padded
+        self.mma_tiler = self.cta_tiler
+        self.qk_mma_tiler = self.mma_tiler_qk
+        self.dov_mma_tiler = self.mma_tiler_dov
+        self.dsk_mma_tiler = self.mma_tiler_dsk
         self.dsk_block_tiler = (
             self.dsk_mma_tiler[0] // 2,
             self.dsk_mma_tiler[1],
             self.dsk_mma_tiler[2],
         )
-        self.iterations_qk = self.cta_tiler[2] // self.qk_mma_tiler[2]
-        self.iterations_dov = self.cta_tiler[2] // self.dov_mma_tiler[2]
-        self.iterations_dsk = self.cta_tiler[2] // self.dsk_mma_tiler[1]
-        self.cluster_shape_mn = (2, 1)
         self.tmem_warp_shape_mn = (4, 1)
-        self.is_persistent = is_persistent
-        self.use_clc_scheduler = use_clc_scheduler
         self.use_semantic_trip_range = self.is_causal or self.is_local
 
-        self.compute_warp_ids = (0, 1, 2, 3)
-        self.epilogue_warp_ids = (4, 5, 6, 7)
-        self.mma_warp_id = 8
-        self.load_warp_id = 9
-        self.empty_warp_id = (10, 11)
-        self.sched_warp_id = self.empty_warp_id[0] if use_clc_scheduler else None
-        self.tmem_alloc_cols = SM100_TMEM_CAPACITY_COLUMNS
+        # Warp layout (HD256 dQ-only): 8 warps -> 256 threads
+        self.compute_warp_ids = (0, 1, 2, 3)  # 4 warps
+        self.mma_warp_id = 4
+        self.load_warp_id = 5
+        self.empty_warp_id = (6, 7)
+        self.softmax0_warp_ids = self.compute_warp_ids
+        self.softmax1_warp_ids = ()
+        self.correction_warp_ids = ()
+        self.load_warp_ids = (self.load_warp_id,)
+        self.empty_warp_ids = self.empty_warp_id
+        self.sched_warp_id = self.empty_warp_id[0] if self.use_clc_scheduler else None
+        self.tmem_alloc_cols = cute.arch.get_max_tmem_alloc_cols("sm_100")
         self.num_compute_warps = len(self.compute_warp_ids)
 
         self.cta_sync_bar_id = 0
         self.tmem_alloc_sync_bar_id = 1
         self.compute_sync_bar_id = 2
+        self.epilogue_sync_bar_id = 3
 
-        self.threads_per_warp = 32
+        self.threads_per_warp = cute.arch.WARP_SIZE
         self.threads_per_cta = self.threads_per_warp * len(
             (
-                *self.compute_warp_ids,  # this is to get a round num threads
-                *self.epilogue_warp_ids,
+                *self.compute_warp_ids,
                 self.mma_warp_id,
                 self.load_warp_id,
                 *self.empty_warp_id,
             )
         )
 
-        self.tmem_alloc_barrier = pipeline.NamedBarrier(
-            barrier_id=1,
-            num_threads=self.threads_per_cta,
+        self.tmem_alloc_barrier = cutlass.pipeline.NamedBarrier(
+            barrier_id=self.tmem_alloc_sync_bar_id,
+            num_threads=cute.arch.WARP_SIZE * len((self.mma_warp_id, *self.compute_warp_ids)),
         )
 
-        self.tmem_s_offset = 0
-        self.tmem_dp_offset = 128
-        self.tmem_dq_offset = 256
+        self.tmem_s_offset = [0, self.n_block_size]  # e.g., 0, 128
+        self.tmem_dq_offset = self.tmem_s_offset[-1] + self.n_block_size  # e.g., 256
+        self.tmem_total = self.tmem_dq_offset + self.head_dim_padded
+        assert self.tmem_total <= self.tmem_alloc_cols
+        self.tmem_s_to_dp_offset = self.n_block_size
+        self.tmem_dp_offset = self.tmem_s_offset[0] + self.tmem_s_to_dp_offset
 
         self.num_regs_compute = 256
-        self.num_regs_epilogue = 160
         self.num_regs_other = 32
 
         self.buffer_align_bytes = 1024
 
     def _setup_attributes(self):
-        self.q_stage = self.iterations_qk
-        self.k_stage = self.iterations_qk
-        self.do_stage = self.iterations_dov
-        self.v_stage = self.iterations_dov
+        """Set up pipeline stages for the HD256 dQ kernel."""
+
+        self.q_stage = 1
+        self.k_stage = 1
+        self.do_stage = 1
+        self.v_stage = 1
         self.kt_stage = 1
+        self.Q_stage = self.q_stage
+        self.dO_stage = self.do_stage
+        self.single_stage = 1
+
         self.qk_acc_stage = 1
         self.dov_acc_stage = 1
         self.dsk_acc_stage = 1
@@ -152,422 +240,428 @@ class BlackwellFusedMultiHeadAttentionBackwardDQKernel:
             self.num_clc_stage = 1
             self.num_clc_response_bytes = 16
 
-    @cute.jit
-    def __call__(
-        self,
-        q_tensor: cute.Tensor,
-        k_tensor: cute.Tensor,
-        v_tensor: cute.Tensor,
-        dq_tensor: cute.Tensor,
-        do_tensor: cute.Tensor,
-        lse_tensor: cute.Tensor,
-        sum_odo_tensor: cute.Tensor,
-        cum_seqlen_q: Optional[cute.Tensor],
-        cum_seqlen_k: Optional[cute.Tensor],
-        scale_softmax: cutlass.Float32,
-        stream: cuda.CUstream,
-    ):
-        varlen = cum_seqlen_q is not None or cum_seqlen_k is not None
-        # Infer shape metadata from normalized 5D tensors (B, S, H_k, H_r, D),
-        # similar to the dedicated hd256 forward path.
-        s_q = q_tensor.shape[1]
-        s_k = k_tensor.shape[1]
-        d = q_tensor.shape[4]
-        h_k = q_tensor.shape[2]
-        h_r = q_tensor.shape[3]
-        if cutlass.const_expr(cum_seqlen_q is not None):
-            b = cum_seqlen_q.shape[0] - 1
-        elif cutlass.const_expr(cum_seqlen_k is not None):
-            b = cum_seqlen_k.shape[0] - 1
-        else:
-            b = q_tensor.shape[0]
-        # `lse_tensor` / `sum_odo_tensor` are preallocated FP32 buffers (lse_log2 / dpsum)
-        # whose sequence dimension is padded (rounded up) by the caller.
-        # Use their leading dimension as the LSE length to ensure correct batch strides.
-        s_lse = lse_tensor.shape[0]
-        s_q64 = Int64(s_q)
-        s_k64 = Int64(s_k)
-        s_lse64 = Int64(s_lse)
-        h_r64 = Int64(h_r)
-        h_k64 = Int64(h_k)
-        b64 = Int64(b)
-        # Packed-varlen representation uses batch-dim = 1 and sequence-dim = total_{q,k}.
-        # Keep the *physical* sequence extent in the tensor layouts so that applying
-        # `cuseqlen_*` offsets stays within the tensor domain.
-        s_q_total = q_tensor.shape[1] if cum_seqlen_q is not None else s_q64
-        s_k_total = k_tensor.shape[1] if cum_seqlen_k is not None else s_k64
-        b_lse = b64 if cum_seqlen_q is None else 1
-        stride_b_lse = h_r64 * h_k64 * s_lse64 if cum_seqlen_q is None else 0
+    def _get_tiled_mma(self):
+        self.cta_group = tcgen05.CtaGroup.TWO
 
-        # (s, d, ((h_r, h_k), b))
-        q_layout = cute.make_layout(
-            (s_q_total, d, ((h_r, h_k), b)),
-            stride=(
-                cute.assume(q_tensor.stride[1], divby=64),
-                q_tensor.stride[4],
-                (
-                    (q_tensor.stride[3], q_tensor.stride[2]),
-                    0 if cum_seqlen_q is not None else cute.assume(q_tensor.stride[0], divby=64),
-                ),
-            ),
-        )
-        q = cute.make_tensor(q_tensor.iterator, q_layout)
-        # (s, d, ((h_r, h_k), b))
-        do_layout = cute.make_layout(
-            (s_q_total, d, ((h_r, h_k), b)),
-            stride=(
-                cute.assume(do_tensor.stride[1], divby=64),
-                do_tensor.stride[4],
-                (
-                    (do_tensor.stride[3], do_tensor.stride[2]),
-                    0 if cum_seqlen_q is not None else cute.assume(do_tensor.stride[0], divby=64),
-                ),
-            ),
-        )
-        do = cute.make_tensor(do_tensor.iterator, do_layout)
-        # (s, d, ((h_r, h_k), b)), 0-stride for h_r to broadcast
-        k_layout = cute.make_layout(
-            (s_k_total, d, ((h_r, h_k), b)),
-            stride=(
-                cute.assume(k_tensor.stride[1], divby=64),
-                k_tensor.stride[4],
-                (
-                    (0, k_tensor.stride[2]),
-                    0 if cum_seqlen_k is not None else cute.assume(k_tensor.stride[0], divby=64),
-                ),
-            ),
-        )
-        k = cute.make_tensor(k_tensor.iterator, k_layout)
-        # (d, s, ((h_r, h_k), b)), 0-stride for h_r to broadcast
-        kt_layout = cute.make_layout(
-            (d, s_k_total, ((h_r, h_k), b)),
-            stride=(
-                k_tensor.stride[4],
-                cute.assume(k_tensor.stride[1], divby=64),
-                (
-                    (0, k_tensor.stride[2]),
-                    0 if cum_seqlen_k is not None else cute.assume(k_tensor.stride[0], divby=64),
-                ),
-            ),
-        )
-        kt = cute.make_tensor(k_tensor.iterator, kt_layout)
-        # (s, d, ((h_r, h_k), b)), 0-stride for h_r to broadcast
-        v_layout = cute.make_layout(
-            (s_k_total, d, ((h_r, h_k), b)),
-            stride=(
-                cute.assume(v_tensor.stride[1], divby=64),
-                v_tensor.stride[4],
-                (
-                    (0, v_tensor.stride[2]),
-                    0 if cum_seqlen_k is not None else cute.assume(v_tensor.stride[0], divby=64),
-                ),
-            ),
-        )
-        v = cute.make_tensor(v_tensor.iterator, v_layout)
-        # (s, ((h_r, h_k), b))
-        lse = cute.make_tensor(lse_tensor.iterator, lse_tensor.layout)
-        # (s, ((h_r, h_k), b))
-        sum_odo_layout = cute.make_layout(
-            (s_lse64, ((h_r, h_k), b_lse)),
-            stride=(1, ((s_lse64, h_r64 * s_lse64), stride_b_lse)),
-        )
-        sum_odo = cute.make_tensor(sum_odo_tensor.iterator, sum_odo_layout)
-        # (s, d, ((h_r, h_k), b))
-        dq_layout = cute.make_layout(
-            (s_q_total, d, ((h_r, h_k), b)),
-            stride=(
-                cute.assume(dq_tensor.stride[1], divby=64),
-                dq_tensor.stride[4],
-                (
-                    (dq_tensor.stride[3], dq_tensor.stride[2]),
-                    0 if cum_seqlen_q is not None else cute.assume(dq_tensor.stride[0], divby=64),
-                ),
-            ),
-        )
-        dq = cute.make_tensor(dq_tensor.iterator, dq_layout)
-
-        # setup static attributes before smem/grid/tma computation
-        self.q_dtype = q.element_type
-        self.k_dtype = k.element_type
-        self.v_dtype = v.element_type
-        self.do_dtype = do.element_type
-        self.dq_dtype = dq.element_type
-        self.tilePlikeFP32 = self.qk_mma_tiler[1] // Float32.width * self.q_dtype.width
-
-        if cutlass.const_expr(self.use_clc_scheduler):
-            self.tile_sched_params, grid = compute_grid_clc(
-                (s_q, dq.shape[1], dq.shape[2]) if cum_seqlen_q is not None else dq.shape,
-                self.cta_tiler,
-                (*self.cluster_shape_mn, 1),
-            )
-        else:
-            self.tile_sched_params, grid = compute_grid(
-                (s_q, dq.shape[1], dq.shape[2]) if cum_seqlen_q is not None else dq.shape,
-                self.cta_tiler,
-                self.is_persistent,
-            )
-
-        self.q_major_mode = utils.LayoutEnum.from_tensor(q).mma_major_mode()
-        self.do_major_mode = utils.LayoutEnum.from_tensor(do).mma_major_mode()
-        self.k_major_mode = utils.LayoutEnum.from_tensor(k).mma_major_mode()
-        self.v_major_mode = utils.LayoutEnum.from_tensor(v).mma_major_mode()
-        self.dq_layout = utils.LayoutEnum.from_tensor(dq)
-
-        if cutlass.const_expr(self.q_major_mode != tcgen05.OperandMajorMode.K):
-            raise RuntimeError("The layout of q is not supported")
-        if cutlass.const_expr(self.k_major_mode != tcgen05.OperandMajorMode.K):
-            raise RuntimeError("The layout of k is not supported")
-        if cutlass.const_expr(self.v_major_mode != tcgen05.OperandMajorMode.K):
-            raise RuntimeError("The layout of v is not supported")
-        if cutlass.const_expr(self.do_major_mode != tcgen05.OperandMajorMode.K):
-            raise RuntimeError("The layout of v is not supported")
-
-        # check type consistency
-        if cutlass.const_expr(self.q_dtype != self.k_dtype):
-            raise TypeError(f"Type mismatch: {self.q_dtype} != {self.k_dtype}")
-        if cutlass.const_expr(self.q_dtype != self.v_dtype):
-            raise TypeError(f"Type mismatch: {self.q_dtype} != {self.v_dtype}")
-        if cutlass.const_expr(self.q_dtype != self.do_dtype):
-            raise TypeError(f"Type mismatch: {self.q_dtype} != {self.do_dtype}")
-
-        self._setup_attributes()
-
-        cta_group = tcgen05.CtaGroup.TWO
-        # the intermediate tensor p is from tmem & k-major
-        ds_source = tcgen05.OperandSource.TMEM
-        ds_major_mode = tcgen05.OperandMajorMode.K
-        k_trans_major_mode = tcgen05.OperandMajorMode.MN
-        qk_tiled_mma = sm100_utils.make_trivial_tiled_mma(
+        # S = Q @ K.T
+        tiled_mma_S = sm100_utils_basic.make_trivial_tiled_mma(
             self.q_dtype,
-            self.q_major_mode,
-            self.k_major_mode,
+            tcgen05.OperandMajorMode.K,
+            tcgen05.OperandMajorMode.K,
             self.acc_dtype,
-            cta_group,
+            self.cta_group,
             self.qk_mma_tiler[:2],
         )
-        dov_tiled_mma = sm100_utils.make_trivial_tiled_mma(
+        # dP = dO @ V.T
+        tiled_mma_dP = sm100_utils_basic.make_trivial_tiled_mma(
             self.do_dtype,
-            self.do_major_mode,
-            self.v_major_mode,
+            tcgen05.OperandMajorMode.K,
+            tcgen05.OperandMajorMode.K,
             self.acc_dtype,
-            cta_group,
+            self.cta_group,
             self.dov_mma_tiler[:2],
         )
-        dsk_tiled_mma = sm100_utils.make_trivial_tiled_mma(
-            self.q_dtype,
-            ds_major_mode,
-            k_trans_major_mode,
+        # dQ = dS @ K. HD256 2CTA keeps dS as TMEM A and K.T as MN-major B;
+        # this is the intentional swapAB divergence from flash_bwd_sm100.py.
+        tiled_mma_dQ = sm100_utils_basic.make_trivial_tiled_mma(
+            self.k_dtype,
+            tcgen05.OperandMajorMode.K,
+            tcgen05.OperandMajorMode.MN,
             self.acc_dtype,
-            cta_group,
+            self.cta_group,
             self.dsk_mma_tiler[:2],
-            ds_source,
+            a_source=tcgen05.OperandSource.TMEM,
         )
+        return tiled_mma_S, tiled_mma_dP, tiled_mma_dQ
 
-        self.cluster_shape_mnk = (*self.cluster_shape_mn, 1)
-        self.cluster_layout_vmnk = cute.tiled_divide(
-            cute.make_layout(self.cluster_shape_mnk),
-            (qk_tiled_mma.thr_id.shape,),
-        )
-
-        self.epi_tile = self.dsk_block_tiler[:2]
-
-        q_smem_layout_staged = sm100_utils.make_smem_layout_a(
-            qk_tiled_mma,
+    def _setup_smem_layout(self):
+        # S = Q @ K.T
+        self.sQ_layout = sm100_utils_basic.make_smem_layout_a(
+            self.tiled_mma_S,
             self.qk_mma_tiler,
             self.q_dtype,
             self.q_stage,
         )
-        k_smem_layout_staged = sm100_utils.make_smem_layout_b(
-            qk_tiled_mma,
+        self.sK_layout = sm100_utils_basic.make_smem_layout_b(
+            self.tiled_mma_S,
             self.qk_mma_tiler,
             self.k_dtype,
             self.k_stage,
         )
-        do_smem_layout_staged = sm100_utils.make_smem_layout_a(
-            dov_tiled_mma,
+
+        # dP = dO @ V.T
+        self.sdO_layout = sm100_utils_basic.make_smem_layout_a(
+            self.tiled_mma_dP,
             self.dov_mma_tiler,
             self.do_dtype,
             self.do_stage,
         )
-        v_smem_layout_staged = sm100_utils.make_smem_layout_b(
-            dov_tiled_mma,
+        self.sV_layout = sm100_utils_basic.make_smem_layout_b(
+            self.tiled_mma_dP,
             self.dov_mma_tiler,
             self.v_dtype,
             self.v_stage,
         )
-        ds_tmem_layout_staged = sm100_utils.make_smem_layout_a(
-            dsk_tiled_mma,
+
+        # dQ = dS @ K
+        tdS_layout = sm100_utils_basic.make_smem_layout_a(
+            self.tiled_mma_dQ,
             self.dsk_mma_tiler,
             self.q_dtype,
             self.qk_acc_stage,
         )
-        ds_tmem_layout = cute.select(ds_tmem_layout_staged, mode=[0, 1, 2])
-        kt_smem_layout_staged = sm100_utils.make_smem_layout_b(
-            dsk_tiled_mma,
+        self.tdS_layout = cute.slice_(tdS_layout, (None, None, None, 0))
+        self.sKt_layout = sm100_utils_basic.make_smem_layout_b(
+            self.tiled_mma_dQ,
             self.dsk_mma_tiler,
             self.k_dtype,
             self.dsk_acc_stage,
         )
 
-        # TMA load for Q
-        tma_load_op = cute.nvgpu.cpasync.CopyBulkTensorTileG2SOp(cta_group)
+        self.sLSE_layout = cute.make_layout((self.cta_tiler[0], self.load_compute_LSE_stage))
+        self.sdPsum_layout = cute.make_layout((self.cta_tiler[0], self.load_compute_sum_OdO_stage))
 
-        q_smem_layout = cute.select(q_smem_layout_staged, mode=[0, 1, 2])
-        tma_atom_q, tma_tensor_q = cute.nvgpu.make_tiled_tma_atom_A(
-            tma_load_op,
-            q,
-            q_smem_layout,
-            self.qk_mma_tiler,
-            qk_tiled_mma,
-            self.cluster_layout_vmnk.shape,
+        self.epi_cols_dQ = math.gcd(128 // (self.dq_dtype.width // 8), self.epi_tile[1])
+        self.epi_tile_dQ = (self.epi_tile[0], self.epi_cols_dQ)
+        self.num_epi_stages_dQ = max(1, self.tile_hdim // self.epi_tile_dQ[1])
+        self.sdQ_epi_layout = sm100_utils_basic.make_smem_layout_epi(
+            self.dq_dtype,
+            self.dq_layout,
+            self.epi_tile_dQ,
+            1,
         )
-        # TMA load for K
-        k_smem_layout = cute.select(k_smem_layout_staged, mode=[0, 1, 2])
-        tma_atom_k, tma_tensor_k = cute.nvgpu.make_tiled_tma_atom_B(
-            tma_load_op,
-            k,
-            k_smem_layout,
-            self.qk_mma_tiler,
-            qk_tiled_mma,
-            self.cluster_layout_vmnk.shape,
-        )
-        # TMA load for dO
-        do_smem_layout = cute.select(do_smem_layout_staged, mode=[0, 1, 2])
-        tma_atom_do, tma_tensor_do = cute.nvgpu.make_tiled_tma_atom_A(
-            tma_load_op,
-            do,
-            do_smem_layout,
-            self.dov_mma_tiler,
-            dov_tiled_mma,
-            self.cluster_layout_vmnk.shape,
-        )
-        # TMA load for V
-        v_smem_layout = cute.select(v_smem_layout_staged, mode=[0, 1, 2])
-        tma_atom_v, tma_tensor_v = cute.nvgpu.make_tiled_tma_atom_B(
-            tma_load_op,
-            v,
-            v_smem_layout,
-            self.dov_mma_tiler,
-            dov_tiled_mma,
-            self.cluster_layout_vmnk.shape,
-        )
-        # TMA load for KT
-        kt_smem_layout = cute.select(kt_smem_layout_staged, mode=[0, 1, 2])
-        tma_atom_kt, tma_tensor_kt = cute.nvgpu.make_tiled_tma_atom_B(
-            tma_load_op,
-            kt,
-            kt_smem_layout,
-            self.dsk_mma_tiler,
-            dsk_tiled_mma,
-            self.cluster_layout_vmnk.shape,
-        )
-        lse_smem_layout = cute.make_layout((self.cta_tiler[0], self.load_compute_LSE_stage))
-        sum_odo_smem_layout = cute.make_layout((self.cta_tiler[0], self.load_compute_sum_OdO_stage))
 
-        q_copy_size = cute.size_in_bytes(self.q_dtype, q_smem_layout)
-        k_copy_size = cute.size_in_bytes(self.k_dtype, k_smem_layout)
-        do_copy_size = cute.size_in_bytes(self.do_dtype, do_smem_layout)
-        v_copy_size = cute.size_in_bytes(self.v_dtype, v_smem_layout)
-        kt_copy_size = cute.size_in_bytes(self.k_dtype, kt_smem_layout)
-        self.tma_copy_q_bytes = q_copy_size * cute.size(qk_tiled_mma.thr_id.shape)
-        self.tma_copy_k_bytes = k_copy_size * cute.size(qk_tiled_mma.thr_id.shape)
-        self.tma_copy_do_bytes = do_copy_size * cute.size(qk_tiled_mma.thr_id.shape)
-        self.tma_copy_v_bytes = v_copy_size * cute.size(qk_tiled_mma.thr_id.shape)
-        self.tma_copy_kt_bytes = kt_copy_size * cute.size(qk_tiled_mma.thr_id.shape)
+    @cute.jit
+    def __call__(
+        self,
+        mQ: cute.Tensor,
+        mK: cute.Tensor,
+        mV: cute.Tensor,
+        mdO: cute.Tensor,
+        mLSE: cute.Tensor,
+        mdPsum: cute.Tensor,
+        mdQaccum: cute.Tensor,
+        softmax_scale: Float32,
+        mCuSeqlensQ: Optional[cute.Tensor] = None,
+        mCuSeqlensK: Optional[cute.Tensor] = None,
+        mSeqUsedQ: Optional[cute.Tensor] = None,
+        mSeqUsedK: Optional[cute.Tensor] = None,
+        window_size_left: Int32 | int | None = None,
+        window_size_right: Int32 | int | None = None,
+        mdQ_semaphore: Optional[cute.Tensor] = None,
+        mdK_semaphore: Optional[cute.Tensor] = None,
+        mdV_semaphore: Optional[cute.Tensor] = None,
+        aux_data: utils.AuxData = utils.AuxData(),
+        # Block-sparse tensors (Q direction - for iterating m_blocks per n_block):
+        blocksparse_tensors: Optional[BlockSparseTensors] = None,
+        # Always keep stream as the last parameter (EnvStream: obtained implicitly via TVM FFI).
+        stream: cuda.CUstream = None,
+    ):
+        assert mdQ_semaphore is None
+        assert mdK_semaphore is None
+        assert mdV_semaphore is None
+        assert blocksparse_tensors is None
+
+        self.q_dtype = mQ.element_type
+        self.k_dtype = mK.element_type
+        self.v_dtype = mV.element_type
+        self.do_dtype = mdO.element_type
+        self.lse_dtype = mLSE.element_type
+        self.dpsum_dtype = mdPsum.element_type
+        self.dq_dtype = mdQaccum.element_type
+        self.ds_dtype = self.q_dtype
+
+        self.is_varlen_k = mCuSeqlensK is not None or mSeqUsedK is not None
+        self.is_varlen_q = mCuSeqlensQ is not None or mSeqUsedQ is not None
+
+        mdQaccum = assume_tensor_aligned(mdQaccum)
+
+        # (b, s, n, h) --> (s, h, n, b) or (t, n, h) -> (t, h, n)
+        Q_layout_transpose = [1, 3, 2, 0] if const_expr(mCuSeqlensQ is None) else [0, 2, 1]
+        mQ, mdO, mdQaccum = [
+            layout_utils.select(t, mode=Q_layout_transpose) for t in (mQ, mdO, mdQaccum)
+        ]
+
+        KV_layout_transpose = [1, 3, 2, 0] if const_expr(mCuSeqlensK is None) else [0, 2, 1]
+        mK, mV = [layout_utils.select(t, mode=KV_layout_transpose) for t in (mK, mV)]
+
+        # (b, n, s) --> (s, n, b) or (n, t) --> (t, n)
+        LSE_dPsum_transpose = [2, 1, 0] if const_expr(mCuSeqlensQ is None) else [1, 0]
+        mLSE, mdPsum = [layout_utils.select(t, mode=LSE_dPsum_transpose) for t in (mLSE, mdPsum)]
+        mdQ = mdQaccum
+        self.dq_layout = cutlass_utils.LayoutEnum.from_tensor(mdQ)
+
+        if const_expr(self.q_dtype != self.k_dtype):
+            raise TypeError(f"Type mismatch: {self.q_dtype} != {self.k_dtype}")
+        if const_expr(self.q_dtype != self.v_dtype):
+            raise TypeError(f"Type mismatch: {self.q_dtype} != {self.v_dtype}")
+        if const_expr(self.q_dtype != self.do_dtype):
+            raise TypeError(f"Type mismatch: {self.q_dtype} != {self.do_dtype}")
+
+        # Transposes for 2-CTA K paths (K follows K seqlens)
+        transpose_sh_k = [1, 0, 2, 3] if const_expr(mCuSeqlensK is None) else [1, 0, 2]
+
+        self.epi_tile = self.dsk_block_tiler[:2]
+
+        self._setup_attributes()
+        (self.tiled_mma_S, self.tiled_mma_dP, self.tiled_mma_dQ) = self._get_tiled_mma()
+        self._setup_smem_layout()
+        self.dQ_reduce_ncol = self.epi_tile_dQ[1]
+
+        self.cluster_shape_mnk = (*self.cluster_shape_mn, 1)
+        self.cluster_layout_vmnk = cute.tiled_divide(
+            cute.make_layout(self.cluster_shape_mnk),
+            (self.tiled_mma_S.thr_id.shape,),
+        )
+        self.num_mcast_ctas_b = cute.size(self.cluster_layout_vmnk.shape[1])
+        self.is_q_do_mcast = self.num_mcast_ctas_b > 1
 
         # dQ epilogue TMA store. Use a single (M, 64) SMEM stage and rotate it
         # across the hd=256 N dimension to stay within the SMEM budget.
-        tma_store_op = cpasync.CopyBulkTensorTileS2GOp()
-        epi_cols_dQ = math.gcd(128 // (dq.element_type.width // 8), self.epi_tile[1])
-        epi_tile_dQ = (self.epi_tile[0], epi_cols_dQ)
-        sdQ_epi_layout = sm100_utils.make_smem_layout_epi(
-            dq.element_type,
-            self.dq_layout,
-            epi_tile_dQ,
-            1,
+        tma_copy_op_dQ = cpasync.CopyBulkTensorTileS2GOp()
+        tma_atom_dQ, mdQ_tma = cpasync.make_tiled_tma_atom(
+            tma_copy_op_dQ,
+            mdQ,
+            cute.select(self.sdQ_epi_layout, mode=[0, 1]),
+            self.epi_tile_dQ,
         )
-        tma_atom_dQ, tma_tensor_dQ = cpasync.make_tiled_tma_atom(
-            tma_store_op,
-            dq,
-            cute.select(sdQ_epi_layout, mode=[0, 1]),
-            epi_tile_dQ,
+        thr_layout_r2s_dQ = cute.make_ordered_layout((128, 1), order=(1, 0))  # 128 threads
+        val_layout_r2s_dQ = cute.make_ordered_layout(
+            (1, 128 // self.dq_dtype.width), order=(1, 0)
+        )  # 4 or 8 vals for 16 byte store
+        copy_atom_r2s_dQ = cute.make_copy_atom(
+            cute.nvgpu.CopyUniversalOp(),
+            self.dq_dtype,
+            num_bits_per_copy=128,
         )
+        tiled_copy_r2s_dQ = cute.make_tiled_copy_tv(
+            copy_atom_r2s_dQ, thr_layout_r2s_dQ, val_layout_r2s_dQ
+        )
+
+        tma_load_op = cpasync.CopyBulkTensorTileG2SOp(self.cta_group)
+        # S = Q @ K.T
+        tma_atom_Q, tma_tensor_Q = cute.nvgpu.make_tiled_tma_atom_A(
+            tma_load_op,
+            mQ,
+            cute.select(self.sQ_layout, mode=[0, 1, 2]),
+            self.qk_mma_tiler,
+            self.tiled_mma_S,
+            self.cluster_layout_vmnk.shape,
+        )
+        tma_atom_dO, tma_tensor_do = cute.nvgpu.make_tiled_tma_atom_A(
+            tma_load_op,
+            mdO,
+            cute.select(self.sdO_layout, mode=[0, 1, 2]),
+            self.dov_mma_tiler,
+            self.tiled_mma_dP,
+            self.cluster_layout_vmnk.shape,
+        )
+
+        # ------------------------------------------------------------
+        # 2-CTA
+        # ------------------------------------------------------------
+        K_tma_op = sm100_utils_basic.cluster_shape_to_tma_atom_B(
+            self.cluster_shape_mnk, self.tiled_mma_S.thr_id
+        )
+        tma_atom_K, tma_tensor_K = cute.nvgpu.make_tiled_tma_atom_B(
+            K_tma_op,
+            mK,
+            cute.select(self.sK_layout, mode=[0, 1, 2]),
+            self.qk_mma_tiler,
+            self.tiled_mma_S,
+            self.cluster_layout_vmnk.shape,
+        )
+        V_tma_op = sm100_utils_basic.cluster_shape_to_tma_atom_B(
+            self.cluster_shape_mnk, self.tiled_mma_dP.thr_id
+        )
+        tma_atom_V, tma_tensor_V = cute.nvgpu.make_tiled_tma_atom_B(
+            V_tma_op,
+            mV,
+            cute.select(self.sV_layout, mode=[0, 1, 2]),
+            self.dov_mma_tiler,
+            self.tiled_mma_dP,
+            self.cluster_layout_vmnk.shape,
+        )
+        Kt_tma_op = sm100_utils_basic.cluster_shape_to_tma_atom_B(
+            self.cluster_shape_mnk, self.tiled_mma_dQ.thr_id
+        )
+        tma_atom_Kt, tma_tensor_Kt = cute.nvgpu.make_tiled_tma_atom_B(
+            Kt_tma_op,
+            layout_utils.select(mK, mode=transpose_sh_k),
+            cute.select(self.sKt_layout, mode=[0, 1, 2]),
+            self.mma_tiler_dsk,
+            self.tiled_mma_dQ,
+            self.cluster_layout_vmnk.shape,
+        )
+
+        self.tma_copy_bytes = {
+            name: self.cta_group_size
+            * cute.size_in_bytes(mX.element_type, cute.select(layout, mode=[0, 1, 2]))
+            for name, mX, layout in [
+                ("Q", mQ, self.sQ_layout),
+                ("K", mK, self.sK_layout),
+                ("V", mV, self.sV_layout),
+                ("dO", mdO, self.sdO_layout),
+                ("Kt", layout_utils.select(mK, mode=transpose_sh_k), self.sKt_layout),
+            ]
+        }
+        self.tma_copy_bytes["LSE"] = self.tile_m * Float32.width // 8
+        self.tma_copy_bytes["dPsum"] = self.tile_m * Float32.width // 8
+        self.tma_copy_bytes["dQ"] = self.tile_m * self.dQ_reduce_ncol * Float32.width // 8
+
+        # TileScheduler = SingleTileScheduler
+        if const_expr(self.is_varlen_q):
+            TileScheduler = SingleTileVarlenScheduler
+        elif const_expr(self.deterministic):
+            TileScheduler = SingleTileLPTBwdScheduler
+        else:
+            TileScheduler = SingleTileScheduler
+
+        tile_sched_args = TileSchedulerArguments(
+            cute.ceil_div(cute.size(mQ.shape[0]), self.cta_tiler[0]),  # num_blocks
+            cute.size(mQ.shape[2]),  # num_heads = num_query_heads
+            cute.size(mQ.shape[3])
+            if const_expr(mCuSeqlensQ is None)
+            else cute.size(mCuSeqlensQ.shape[0] - 1),  # num_batches
+            1,  # num_splits
+            cute.size(mQ.shape[0]),  # pass seqlen_q or total_q for seqlen_k
+            mQ.shape[1],  # headdim
+            mV.shape[1],  # headdim_v
+            total_q=cute.size(mQ.shape[0])  # pass total_k for total_q
+            if const_expr(mCuSeqlensQ is not None)
+            else cute.size(mQ.shape[0]) * cute.size(mQ.shape[3]),
+            tile_shape_mn=self.cta_tiler[:2],  # (tile_n, tile_m)
+            cluster_shape_mn=self.cluster_shape_mnk[:2],
+            mCuSeqlensQ=mCuSeqlensQ,
+            mSeqUsedQ=mSeqUsedQ,
+            qhead_per_kvhead_packgqa=self.qhead_per_kvhead
+            if const_expr(self.pack_gqa)
+            else 1,  # pack_gqa disabled for bwd
+            element_size=self.k_dtype.width // 8,
+            is_persistent=self.is_persistent,  # persistent mode not tested
+            lpt=self.is_causal or self.is_local,
+            use_cluster_idx=False,
+        )
+
+        tile_sched_params = TileScheduler.to_underlying_arguments(tile_sched_args)
+        self.tile_scheduler_cls = TileScheduler
+        grid_dim = TileScheduler.get_grid_shape(tile_sched_params)
 
         @cute.struct
         class SharedStorage:
-            # TMA G2S load barriers: LOAD warp (producer) -> MMA warp (consumer)
-            load_q_mbar_ptr: cute.struct.MemRange[
-                Int64, self.q_stage * 2
-            ]  # load_q_{producer,consumer}
-            load_do_mbar_ptr: cute.struct.MemRange[
-                Int64, self.do_stage * 2
-            ]  # load_do_{producer,consumer}
-            load_k_mbar_ptr: cute.struct.MemRange[
-                Int64, self.k_stage * 2
-            ]  # load_k_{producer,consumer}
-            load_kt_mbar_ptr: cute.struct.MemRange[
-                Int64, self.kt_stage * 2
-            ]  # load_kt_{producer,consumer}
-            load_v_mbar_ptr: cute.struct.MemRange[
-                Int64, self.v_stage * 2
-            ]  # load_v_{producer,consumer}
-            mma_s_mbar_ptr: cute.struct.MemRange[Int64, self.qk_acc_stage * 2]
-            mma_dp_mbar_ptr: cute.struct.MemRange[Int64, self.dov_acc_stage * 2]
-            mma_dq_mbar_ptr: cute.struct.MemRange[Int64, self.epi_stage * 2]
-            ds_mma_mbar_ptr: cute.struct.MemRange[Int64, self.dsk_acc_stage * 2]
-            lse_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.load_compute_LSE_stage * 2]
-            sum_odo_mbar_ptr: cute.struct.MemRange[
-                cutlass.Int64, self.load_compute_sum_OdO_stage * 2
-            ]
-            # A CTA-wide "TMEM lifetime" barrier used to safely deallocate TMEM after all users finish.
-            tmem_dealloc_mbar: Int64
-            # Tmem holding buffer
+            Q_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2 * self.q_stage]
+            dO_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2 * self.do_stage]
+            LSE_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2 * self.load_compute_LSE_stage]
+            dPsum_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2 * self.load_compute_sum_OdO_stage]
+            S_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2 * self.qk_acc_stage]
+            dP_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2 * self.dov_acc_stage]
+            dS_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2 * self.dsk_acc_stage]
+            dQ_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2 * self.epi_stage]
             tmem_holding_buf: Int32
-            # CLC pipeline barriers and response buffer
-            clc_mbar_ptr: cute.struct.MemRange[Int64, 2]
+            tmem_dealloc_mbar: cutlass.Int64
+
+            # 2-CTA
+            K_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2 * self.k_stage]
+            Kt_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2 * self.kt_stage]
+            V_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2 * self.v_stage]
+
+            clc_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2]
             clc_response: cute.struct.MemRange[Int32, 4]
+
+            sQ: cute.struct.Align[
+                cute.struct.MemRange[self.q_dtype, cute.cosize(self.sQ_layout)],
+                self.buffer_align_bytes,
+            ]
+            sK: cute.struct.Align[
+                cute.struct.MemRange[self.k_dtype, cute.cosize(self.sK_layout)],
+                self.buffer_align_bytes,
+            ]
+            sV: cute.struct.Align[
+                cute.struct.MemRange[self.v_dtype, cute.cosize(self.sV_layout)],
+                self.buffer_align_bytes,
+            ]
+            sdO: cute.struct.Align[
+                cute.struct.MemRange[self.do_dtype, cute.cosize(self.sdO_layout)],
+                self.buffer_align_bytes,
+            ]
+            sKt: cute.struct.Align[
+                cute.struct.MemRange[self.k_dtype, cute.cosize(self.sKt_layout)],
+                self.buffer_align_bytes,
+            ]
+            sLSE: cute.struct.Align[
+                cute.struct.MemRange[self.lse_dtype, cute.cosize(self.sLSE_layout)],
+                128,
+            ]
+            sdPsum: cute.struct.Align[
+                cute.struct.MemRange[self.dpsum_dtype, cute.cosize(self.sdPsum_layout)],
+                128,
+            ]
 
         self.shared_storage = SharedStorage
 
-        grid = cute.round_up(grid, self.cluster_shape_mnk)
+        LOG2_E = math.log2(math.e)
+        if const_expr(self.score_mod is None):
+            # Without score_mod: bake scale into log2
+            softmax_scale_log2 = softmax_scale * LOG2_E
+        else:
+            # With score_mod: score_mod applied to S * softmax_scale, then use LOG2_E only
+            softmax_scale_log2 = LOG2_E
+
+        if const_expr(window_size_left is not None):
+            window_size_left = Int32(window_size_left)
+        if const_expr(window_size_right is not None):
+            window_size_right = Int32(window_size_right)
+
+        fastdiv_mods = None
+        if const_expr(aux_data.tensors is not None):
+            seqlen_q = cute.size(mQ.shape[0])
+            seqlen_k = cute.size(mK.shape[0])
+            seqlen_q_divmod = FastDivmodDivisor(seqlen_q)
+            seqlen_k_divmod = FastDivmodDivisor(seqlen_k)
+            fastdiv_mods = (seqlen_q_divmod, seqlen_k_divmod)
+
         # Launch the kernel synchronously
         self.kernel(
-            qk_tiled_mma,
-            dov_tiled_mma,
-            dsk_tiled_mma,
-            tma_atom_q,
-            tma_tensor_q,
-            tma_atom_k,
-            tma_tensor_k,
-            tma_atom_v,
-            tma_tensor_v,
-            tma_atom_do,
+            tma_tensor_Q,
+            tma_tensor_K,
+            tma_tensor_Kt,
+            tma_tensor_V,
+            mLSE,
+            mdPsum,
             tma_tensor_do,
-            tma_atom_kt,
-            tma_tensor_kt,
+            mdQ,
+            mdQ_tma,
+            mCuSeqlensQ,
+            mCuSeqlensK,
+            mSeqUsedQ,
+            mSeqUsedK,
+            tma_atom_Q,
+            tma_atom_K,
+            tma_atom_Kt,
+            tma_atom_V,
+            tma_atom_dO,
             tma_atom_dQ,
-            tma_tensor_dQ,
-            lse,
-            sum_odo,
-            dq,
-            cum_seqlen_q,
-            cum_seqlen_k,
-            scale_softmax,
-            self.window_size_left,
-            self.window_size_right,
-            self.cluster_layout_vmnk,
-            q_smem_layout_staged,
-            k_smem_layout_staged,
-            v_smem_layout_staged,
-            do_smem_layout_staged,
-            kt_smem_layout_staged,
-            ds_tmem_layout,
-            sdQ_epi_layout,
-            lse_smem_layout,
-            sum_odo_smem_layout,
-            self.tile_sched_params,
+            self.sQ_layout,
+            self.sK_layout,
+            self.sKt_layout,
+            self.sV_layout,
+            self.sLSE_layout,
+            self.sdPsum_layout,
+            self.sdO_layout,
+            self.tdS_layout,
+            self.sdQ_epi_layout,
+            self.tiled_mma_S,
+            self.tiled_mma_dP,
+            self.tiled_mma_dQ,
+            tiled_copy_r2s_dQ,
+            softmax_scale,
+            window_size_left,
+            window_size_right,
+            tile_sched_params,
+            aux_data,
+            fastdiv_mods,
         ).launch(
-            grid=grid,
+            grid=grid_dim,
             block=[self.threads_per_cta, 1, 1],
             cluster=self.cluster_shape_mnk,
             stream=stream,
@@ -578,1740 +672,1660 @@ class BlackwellFusedMultiHeadAttentionBackwardDQKernel:
     @cute.kernel
     def kernel(
         self,
-        qk_tiled_mma: cute.TiledMma,
-        dov_tiled_mma: cute.TiledMma,
-        dsk_tiled_mma: cute.TiledMma,
-        tma_atom_q: cute.CopyAtom,
-        mQ_qdl: cute.Tensor,
-        tma_atom_k: cute.CopyAtom,
-        mK_kdl: cute.Tensor,
-        tma_atom_v: cute.CopyAtom,
-        mV_dkl: cute.Tensor,
-        tma_atom_do: cute.CopyAtom,
-        mdO_qdl: cute.Tensor,
-        tma_atom_kt: cute.CopyAtom,
-        mK_dkl: cute.Tensor,
-        tma_atom_dQ: cute.CopyAtom,
-        mdQ_tma: cute.Tensor,
+        mQ: cute.Tensor,
+        mK: cute.Tensor,
+        mKt: cute.Tensor,
+        mV: cute.Tensor,
         mLSE: cute.Tensor,
-        mSum_OdO: cute.Tensor,
-        mdQ_qdl: cute.Tensor,
-        cum_seqlen_q: Optional[cute.Tensor],
-        cum_seqlen_k: Optional[cute.Tensor],
+        mdPsum: cute.Tensor,
+        mdO: cute.Tensor,
+        mdQ: cute.Tensor,
+        mdQ_tma: cute.Tensor,
+        mCuSeqlensQ: Optional[cute.Tensor],
+        mCuSeqlensK: Optional[cute.Tensor],
+        mSeqUsedQ: Optional[cute.Tensor],
+        mSeqUsedK: Optional[cute.Tensor],
+        tma_atom_Q: cute.CopyAtom,
+        tma_atom_K: cute.CopyAtom,
+        tma_atom_Kt: cute.CopyAtom,
+        tma_atom_V: cute.CopyAtom,
+        tma_atom_dO: cute.CopyAtom,
+        tma_atom_dQ: cute.CopyAtom,
+        sQ_layout: cute.ComposedLayout,
+        sK_layout: cute.ComposedLayout,
+        sKt_layout: cute.ComposedLayout,
+        sV_layout: cute.ComposedLayout,
+        sLSE_layout: cute.Layout,
+        sdPsum_layout: cute.Layout,
+        sdO_layout: cute.ComposedLayout,
+        tdS_layout: cute.ComposedLayout,
+        sdQ_epi_layout: cute.ComposedLayout,
+        tiled_mma_S: cute.TiledMma,
+        tiled_mma_dP: cute.TiledMma,
+        tiled_mma_dQ: cute.TiledMma,
+        tiled_copy_r2s_dQ: cute.TiledCopy,
         scale_softmax: Float32,
         window_size_left: Optional[Int32],
         window_size_right: Optional[Int32],
-        cluster_layout_vmnk: cute.Layout,
-        q_smem_layout_staged: cute.ComposedLayout,
-        k_smem_layout_staged: cute.ComposedLayout,
-        v_smem_layout_staged: cute.ComposedLayout,
-        do_smem_layout_staged: cute.ComposedLayout,
-        kt_smem_layout_staged: cute.ComposedLayout,
-        ds_tmem_layout_staged: cute.ComposedLayout,
-        sdQ_epi_layout: cute.ComposedLayout,
-        lse_smem_layout: cute.Layout,
-        sum_odo_smem_layout: cute.Layout,
-        tile_sched_params: FmhaStaticTileSchedulerParams | FmhaClcDynamicTileSchedulerParams,
+        tile_sched_params: SingleTileScheduler.Params
+        | SingleTileVarlenScheduler.Params
+        | SingleTileLPTBwdScheduler.Params,
+        aux_data: utils.AuxData = utils.AuxData(),
+        fastdiv_mods=(None, None),
     ):
-        # llvm.inline_asm(
-        #     None,
-        #     [],
-        #     '.pragma "global knob CommonIntoMultiBlockLoop=1";',
-        #     "",
-        #     has_side_effects=True,
-        #     is_align_stack=False,
-        #     asm_dialect=llvm.AsmDialect.AD_ATT,
-        # )
-
         warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
-        #
-        # Prefetch tma desc
-        #
-        if warp_idx == self.load_warp_id:
-            cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_q)
-            cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_k)
-            cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_v)
-            cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_do)
-            cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_kt)
-            cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_dQ)
-
-        bidx, bidy, bidz = cute.arch.block_idx()
+        bidx, _, _ = cute.arch.block_idx()
         tidx, _, _ = cute.arch.thread_idx()
-        varlen = cum_seqlen_q is not None or cum_seqlen_k is not None
-        mma_tile_coord_v = bidx % cute.size(qk_tiled_mma.thr_id.shape)
+        mma_tile_coord_v = bidx % self.cta_group_size
+        is_leader_cta = mma_tile_coord_v == 0
         cta_rank_in_cluster = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster())
+
+        # Prefetch tma descriptor
+        if warp_idx == self.load_warp_id:
+            with cute.arch.elect_one():
+                cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_Q)
+                cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_K)
+                cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_V)
+                cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_dO)
+                cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_Kt)
+                cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_dQ)
+
+        cluster_layout_vmnk = cute.tiled_divide(
+            cute.make_layout(self.cluster_shape_mnk),
+            (tiled_mma_S.thr_id.shape,),
+        )
         block_in_cluster_coord_vmnk = cluster_layout_vmnk.get_flat_coord(cta_rank_in_cluster)
 
         # Alloc
-        smem = utils.SmemAllocator()
+        smem = cutlass.utils.SmemAllocator()
         storage = smem.allocate(self.shared_storage)
+        clc = None
 
-        load_q_producer, load_q_consumer = pipeline.PipelineTmaUmma.create(
-            num_stages=self.q_stage,
-            producer_group=make_thread_cooperative_group(len([self.load_warp_id])),
-            consumer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
-            tx_count=self.tma_copy_q_bytes,
-            barrier_storage=storage.load_q_mbar_ptr.data_ptr(),
-            cta_layout_vmnk=cluster_layout_vmnk,
-            defer_sync=True,
-        ).make_participants()
-        load_k_producer, load_k_consumer = pipeline.PipelineTmaUmma.create(
-            num_stages=self.k_stage,
-            producer_group=make_thread_cooperative_group(len([self.load_warp_id])),
-            consumer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
-            tx_count=self.tma_copy_k_bytes,
-            barrier_storage=storage.load_k_mbar_ptr.data_ptr(),
-            cta_layout_vmnk=cluster_layout_vmnk,
-            defer_sync=True,
-        ).make_participants()
-        load_v_producer, load_v_consumer = pipeline.PipelineTmaUmma.create(
-            num_stages=self.v_stage,
-            producer_group=make_thread_cooperative_group(len([self.load_warp_id])),
-            consumer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
-            tx_count=self.tma_copy_v_bytes,
-            barrier_storage=storage.load_v_mbar_ptr.data_ptr(),
-            cta_layout_vmnk=cluster_layout_vmnk,
-            defer_sync=True,
-        ).make_participants()
-        load_do_producer, load_do_consumer = pipeline.PipelineTmaUmma.create(
-            num_stages=self.do_stage,
-            producer_group=make_thread_cooperative_group(len([self.load_warp_id])),
-            consumer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
-            tx_count=self.tma_copy_do_bytes,
-            barrier_storage=storage.load_do_mbar_ptr.data_ptr(),
-            cta_layout_vmnk=cluster_layout_vmnk,
-            defer_sync=True,
-        ).make_participants()
-        load_kt_producer, load_kt_consumer = pipeline.PipelineTmaUmma.create(
-            num_stages=self.kt_stage,
-            producer_group=make_thread_cooperative_group(len([self.load_warp_id])),
-            consumer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
-            tx_count=self.tma_copy_kt_bytes,
-            barrier_storage=storage.load_kt_mbar_ptr.data_ptr(),
-            cta_layout_vmnk=cluster_layout_vmnk,
-            defer_sync=True,
-        ).make_participants()
-        mma_s_producer, mma_s_consumer = pipeline.PipelineUmmaAsync.create(
-            num_stages=self.qk_acc_stage,
-            producer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
-            consumer_group=make_thread_cooperative_group(
-                len(self.compute_warp_ids) * self.threads_per_warp * self.cluster_shape_mnk[0],
-            ),
-            barrier_storage=storage.mma_s_mbar_ptr.data_ptr(),
-            cta_layout_vmnk=cluster_layout_vmnk,
-            defer_sync=True,
-        ).make_participants()
-        mma_dp_producer, mma_dp_consumer = pipeline.PipelineUmmaAsync.create(
-            num_stages=self.dov_acc_stage,
-            producer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
-            consumer_group=make_thread_cooperative_group(
-                len(self.compute_warp_ids) * self.threads_per_warp * self.cluster_shape_mnk[0],
-            ),
-            barrier_storage=storage.mma_dp_mbar_ptr.data_ptr(),
-            cta_layout_vmnk=cluster_layout_vmnk,
-            defer_sync=True,
-        ).make_participants()
-        ds_mma_producer, ds_mma_consumer = pipeline.PipelineAsyncUmma.create(
-            num_stages=self.dsk_acc_stage,
-            producer_group=make_thread_cooperative_group(
-                len(self.compute_warp_ids) * self.threads_per_warp * self.cluster_shape_mnk[0],
-            ),
-            consumer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
-            barrier_storage=storage.ds_mma_mbar_ptr.data_ptr(),
-            cta_layout_vmnk=cluster_layout_vmnk,
-            defer_sync=True,
-        ).make_participants()
-        mma_dq_producer, mma_dq_consumer = pipeline.PipelineUmmaAsync.create(
-            num_stages=self.epi_stage,
-            producer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
-            consumer_group=make_thread_cooperative_group(
-                len(self.epilogue_warp_ids) * self.threads_per_warp * self.cluster_shape_mnk[0],
-            ),
-            barrier_storage=storage.mma_dq_mbar_ptr.data_ptr(),
-            cta_layout_vmnk=cluster_layout_vmnk,
-            defer_sync=True,
-        ).make_participants()
-
-        load_lse_producer, load_lse_consumer = pipeline.PipelineCpAsync.create(
-            num_stages=self.load_compute_LSE_stage,
-            producer_group=make_thread_cooperative_group(self.threads_per_warp),
-            consumer_group=make_thread_cooperative_group(
-                self.threads_per_warp * self.num_compute_warps
-            ),
-            barrier_storage=storage.lse_mbar_ptr.data_ptr(),
-        ).make_participants()
-        load_sum_odo_producer, load_sum_odo_consumer = pipeline.PipelineCpAsync.create(
-            num_stages=self.load_compute_sum_OdO_stage,
-            producer_group=make_thread_cooperative_group(self.threads_per_warp),
-            consumer_group=make_thread_cooperative_group(
-                self.threads_per_warp * self.num_compute_warps
-            ),
-            barrier_storage=storage.sum_odo_mbar_ptr.data_ptr(),
-        ).make_participants()
-
-        # Tensor memory dealloc barrier init
-        tmem = utils.TmemAllocator(
+        tmem = cutlass.utils.TmemAllocator(
             storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=self.tmem_alloc_barrier,
-            allocator_warp_id=self.epilogue_warp_ids[0],
+            allocator_warp_id=self.mma_warp_id,
             is_two_cta=True,
             two_cta_tmem_dealloc_mbar_ptr=storage.tmem_dealloc_mbar.ptr,
         )
-        tmem.allocate(self.tmem_alloc_cols)
-        tmem.wait_for_alloc()
-        tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
 
-        # Initialize CLC state if using dynamic scheduler
-        if cutlass.const_expr(self.use_clc_scheduler):
-            clc_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
-            cluster_size = cute.size(self.cluster_shape_mnk)
-            num_clc_consumer_threads = self.threads_per_warp * (
-                1  # sched_warp (CTA 0 only)
-                + cluster_size
-                * (
-                    len(self.compute_warp_ids)
-                    + len(self.epilogue_warp_ids)
-                    + 1  # mma_warp
-                    + 1  # load_warp
-                )
-            )
-            clc_pipeline_consumer_group = pipeline.CooperativeGroup(
-                pipeline.Agent.Thread, num_clc_consumer_threads
-            )
-            clc_response_ptr = storage.clc_response.data_ptr()
-            clc = ClcState.create(
-                hw_scheduler=ClcDynamicPersistentTileScheduler.create(
-                    self.tile_sched_params.clc_hw_params(),
-                    cute.arch.block_idx(),
-                    cute.arch.grid_dim(),
-                    clc_response_ptr,
-                ),
-                pipeline=pipeline.PipelineClcFetchAsync.create(
-                    barrier_storage=storage.clc_mbar_ptr.data_ptr(),
-                    num_stages=self.num_clc_stage,
-                    producer_group=clc_pipeline_producer_group,
-                    consumer_group=clc_pipeline_consumer_group,
-                    tx_count=self.num_clc_response_bytes,
-                    cta_layout_vmnk=cluster_layout_vmnk,
-                    defer_sync=True,
-                ),
-                consumer_state=pipeline.make_pipeline_state(
-                    pipeline.PipelineUserType.Consumer, self.num_clc_stage
-                ),
-                producer_state=pipeline.make_pipeline_state(
-                    pipeline.PipelineUserType.Producer, self.num_clc_stage
-                ),
-            )
-        else:
-            clc = None
-            clc_response_ptr = None
+        # UMMA producers and AsyncThread consumers
+        pipeline_producer_group_MMA_AsyncThread = cutlass.pipeline.CooperativeGroup(
+            cutlass.pipeline.Agent.Thread, len([self.mma_warp_id])
+        )
+        pipeline_consumer_group_MMA_AsyncThread = cutlass.pipeline.CooperativeGroup(
+            cutlass.pipeline.Agent.Thread,
+            len(self.compute_warp_ids) * self.threads_per_warp * self.cluster_shape_mnk[0],
+        )
+
+        pipeline_S_P = cutlass.pipeline.PipelineUmmaAsync.create(
+            num_stages=self.qk_acc_stage,
+            producer_group=pipeline_producer_group_MMA_AsyncThread,
+            consumer_group=pipeline_consumer_group_MMA_AsyncThread,
+            barrier_storage=storage.S_mbar_ptr.data_ptr(),
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        )
+
+        pipeline_dP = cutlass.pipeline.PipelineUmmaAsync.create(
+            num_stages=self.dov_acc_stage,
+            producer_group=pipeline_producer_group_MMA_AsyncThread,
+            consumer_group=pipeline_consumer_group_MMA_AsyncThread,
+            barrier_storage=storage.dP_mbar_ptr.data_ptr(),
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        )
+
+        pipeline_consumer_group_MMA_AsyncThread_dQ = cutlass.pipeline.CooperativeGroup(
+            cutlass.pipeline.Agent.Thread,
+            len(self.compute_warp_ids) * self.cluster_shape_mnk[0],
+        )
+
+        pipeline_dQ = cutlass.pipeline.PipelineUmmaAsync.create(
+            num_stages=self.epi_stage,
+            producer_group=pipeline_producer_group_MMA_AsyncThread,
+            consumer_group=pipeline_consumer_group_MMA_AsyncThread_dQ,
+            barrier_storage=storage.dQ_mbar_ptr.data_ptr(),
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        )
+
+        # AsyncThread producers and UMMA consumers
+        # Only 1 thread per warp will signal
+        pipeline_PdS_producer_group = cutlass.pipeline.CooperativeGroup(
+            cutlass.pipeline.Agent.Thread,
+            len(self.compute_warp_ids) * self.threads_per_warp * self.cluster_shape_mnk[0],
+        )  # Compute
+        pipeline_PdS_consumer_group = cutlass.pipeline.CooperativeGroup(
+            cutlass.pipeline.Agent.Thread, len([self.mma_warp_id])
+        )  # MMA
+        pipeline_dS = cutlass.pipeline.PipelineAsyncUmma.create(
+            num_stages=self.dsk_acc_stage,
+            producer_group=pipeline_PdS_producer_group,
+            consumer_group=pipeline_PdS_consumer_group,
+            barrier_storage=storage.dS_mbar_ptr.data_ptr(),
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        )
+
+        # TMA producer and UMMA consumers
+        pipeline_producer_group = cutlass.pipeline.CooperativeGroup(
+            cutlass.pipeline.Agent.Thread, len([self.load_warp_id])
+        )
+        # The arrive count is the number of mcast size
+        pipeline_consumer_group = cutlass.pipeline.CooperativeGroup(
+            cutlass.pipeline.Agent.Thread, len([self.mma_warp_id]) * self.num_mcast_ctas_b
+        )
+        pipeline_consumer_group_compute = cutlass.pipeline.CooperativeGroup(
+            cutlass.pipeline.Agent.Thread,
+            len(self.compute_warp_ids) * 1,
+        )
+        pipeline_LSE = cutlass.pipeline.PipelineTmaAsync.create(
+            barrier_storage=storage.LSE_mbar_ptr.data_ptr(),
+            num_stages=self.Q_stage,
+            producer_group=pipeline_producer_group,
+            consumer_group=pipeline_consumer_group_compute,
+            tx_count=self.tma_copy_bytes["LSE"],
+            defer_sync=True,
+        )
+        pipeline_dPsum = cutlass.pipeline.PipelineTmaAsync.create(
+            barrier_storage=storage.dPsum_mbar_ptr.data_ptr(),
+            num_stages=self.dO_stage,
+            producer_group=pipeline_producer_group,
+            consumer_group=pipeline_consumer_group_compute,
+            tx_count=self.tma_copy_bytes["dPsum"],
+            defer_sync=True,
+        )
+
+        pipeline_Q = pipeline.PipelineTmaUmma.create(
+            barrier_storage=storage.Q_mbar_ptr.data_ptr(),
+            num_stages=self.Q_stage,
+            producer_group=pipeline_producer_group,
+            consumer_group=pipeline_consumer_group,
+            tx_count=self.tma_copy_bytes["Q"],
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        )
+
+        pipeline_K = pipeline.PipelineTmaUmma.create(
+            barrier_storage=storage.K_mbar_ptr.data_ptr(),
+            num_stages=self.k_stage,
+            producer_group=pipeline_producer_group,
+            consumer_group=pipeline_consumer_group,
+            tx_count=self.tma_copy_bytes["K"],
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        )
+
+        pipeline_V = pipeline.PipelineTmaUmma.create(
+            barrier_storage=storage.V_mbar_ptr.data_ptr(),
+            num_stages=self.v_stage,
+            producer_group=pipeline_producer_group,
+            consumer_group=pipeline_consumer_group,
+            tx_count=self.tma_copy_bytes["V"],
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        )
+
+        pipeline_Kt = pipeline.PipelineTmaUmma.create(
+            barrier_storage=storage.Kt_mbar_ptr.data_ptr(),
+            num_stages=self.single_stage,
+            producer_group=pipeline_producer_group,
+            consumer_group=pipeline_consumer_group,
+            tx_count=self.tma_copy_bytes["K"],
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        )
+
+        pipeline_dO = pipeline.PipelineTmaUmma.create(
+            barrier_storage=storage.dO_mbar_ptr.data_ptr(),
+            num_stages=self.dO_stage,
+            producer_group=pipeline_producer_group,
+            consumer_group=pipeline_consumer_group,
+            tx_count=self.tma_copy_bytes["dO"],
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=False,
+        )
 
         # Cluster arrive after barrier init
-        pipeline.pipeline_init_arrive(cluster_shape_mn=cluster_layout_vmnk, is_relaxed=True)
+        cutlass.pipeline.pipeline_init_arrive(cluster_shape_mn=cluster_layout_vmnk, is_relaxed=True)
 
-        sQ = smem.allocate_tensor(
-            element_type=self.q_dtype,
-            layout=q_smem_layout_staged.outer,
-            swizzle=q_smem_layout_staged.inner,
-            byte_alignment=128,
+        sQ = storage.sQ.get_tensor(sQ_layout.outer, swizzle=sQ_layout.inner, dtype=self.q_dtype)
+        sK = storage.sK.get_tensor(sK_layout.outer, swizzle=sK_layout.inner)
+        sV = storage.sV.get_tensor(sV_layout.outer, swizzle=sV_layout.inner)
+        sdO = storage.sdO.get_tensor(
+            sdO_layout.outer, swizzle=sdO_layout.inner, dtype=self.do_dtype
         )
-        sK = smem.allocate_tensor(
-            element_type=self.k_dtype,
-            layout=k_smem_layout_staged.outer,
-            swizzle=k_smem_layout_staged.inner,
-            byte_alignment=128,
-        )
-        # K and V now use separate memory since we removed the transform stage
-        sV = smem.allocate_tensor(
-            element_type=self.v_dtype,
-            layout=v_smem_layout_staged.outer,
-            swizzle=v_smem_layout_staged.inner,
-            byte_alignment=128,
-        )
-        sdO = smem.allocate_tensor(
-            element_type=self.do_dtype,
-            layout=do_smem_layout_staged.outer,
-            swizzle=do_smem_layout_staged.inner,
-            byte_alignment=128,
-        )
-        sKT = smem.allocate_tensor(
-            element_type=self.k_dtype,
-            layout=kt_smem_layout_staged.outer,
-            swizzle=kt_smem_layout_staged.inner,
-            byte_alignment=128,
-        )
-        sLSE = smem.allocate_tensor(
-            element_type=self.acc_dtype,
-            layout=lse_smem_layout,
-            byte_alignment=128,
-        )
-        sSum_OdO = smem.allocate_tensor(
-            element_type=self.acc_dtype,
-            layout=sum_odo_smem_layout,
-            byte_alignment=128,
-        )
+        sKT = storage.sKt.get_tensor(sKt_layout.outer, swizzle=sKt_layout.inner)
+        sLSE = storage.sLSE.get_tensor(sLSE_layout)
+        sdPsum = storage.sdPsum.get_tensor(sdPsum_layout)
         # Alias the dQ TMA epilogue staging buffer onto sdO.  A standalone
         # (128, 64) bf16 allocation exceeds B200's per-block SMEM limit for
-        # this kernel, while sdO is no longer needed by the epilogue warp once
-        # the dQ accumulator is ready to store.
-        s_epi_dQ = cute.make_tensor(
+        # this kernel, while sdO is no longer needed once the dQ accumulator
+        # is ready to store.
+        sdQ = cute.make_tensor(
             cute.recast_ptr(sdO.iterator, sdQ_epi_layout.inner, self.dq_dtype),
             sdQ_epi_layout.outer,
         )
-        qk_thr_mma = qk_tiled_mma.get_slice(mma_tile_coord_v)  # default 1sm
-        dov_thr_mma = dov_tiled_mma.get_slice(mma_tile_coord_v)  # default 1sm
-        dsk_thr_mma = dsk_tiled_mma.get_slice(mma_tile_coord_v)  # default 1sm
-        tSrQ = qk_thr_mma.make_fragment_A(sQ)
-        tSrK = qk_thr_mma.make_fragment_B(sK)
-        tdPrdO = dov_thr_mma.make_fragment_A(sdO)
-        tdPrV = dov_thr_mma.make_fragment_B(sV)
-        tdQrKT = dsk_thr_mma.make_fragment_B(sKT)
-        qk_acc_shape = qk_thr_mma.partition_shape_C((self.qk_mma_tiler[0], self.qk_mma_tiler[1]))
-        tStS = qk_thr_mma.make_fragment_C(cute.append(qk_acc_shape, self.qk_acc_stage))
-        dov_acc_shape = dov_thr_mma.partition_shape_C(
-            (self.dov_mma_tiler[0], self.dov_mma_tiler[1])
-        )
-        tdPtdP = dov_thr_mma.make_fragment_C(cute.append(dov_acc_shape, self.dov_acc_stage))
-        dsk_acc_shape = dsk_thr_mma.partition_shape_C(
-            (self.dsk_mma_tiler[0], self.dsk_mma_tiler[1])
-        )
-        tdQtdQ = dsk_thr_mma.make_fragment_C(dsk_acc_shape)
-        tdQtdQ_layout = cute.append(
-            tdQtdQ.layout,
-            cute.make_layout(
-                self.iterations_dsk,
-                stride=self.dsk_mma_tiler[1] // self.tmem_warp_shape_mn[1],
-            ),
-        )
-        tStS = cute.make_tensor(tStS.iterator + self.tmem_s_offset, tStS.layout)
-        tdPtdP = cute.make_tensor(tdPtdP.iterator + self.tmem_dp_offset, tdPtdP.layout)
-        tdQtdQ_staged = cute.make_tensor(tdQtdQ.iterator + self.tmem_dq_offset, tdQtdQ_layout)
 
-        # ///////////////////////////////////////////////////////////////////////////////
+        # TMEM
+        # This is a fake tensor, by right need to retrieve tmem_ptr. But we know that we always
+        # request 512 columns of tmem, so we know that it starts at 0.
+        tmem_ptr = cute.make_ptr(Float32, 0, mem_space=cute.AddressSpace.tmem, assumed_align=16)
+
+        thr_mma_S = tiled_mma_S.get_slice(mma_tile_coord_v)  # default 1sm
+        thr_mma_dP = tiled_mma_dP.get_slice(mma_tile_coord_v)  # default 1sm
+        thr_mma_dQ = tiled_mma_dQ.get_slice(mma_tile_coord_v)  # default 1sm
+        qk_acc_shape = thr_mma_S.partition_shape_C((self.qk_mma_tiler[0], self.qk_mma_tiler[1]))
+        tStS = thr_mma_S.make_fragment_C(cute.append(qk_acc_shape, self.qk_acc_stage))
+        dov_acc_shape = thr_mma_dP.partition_shape_C((self.dov_mma_tiler[0], self.dov_mma_tiler[1]))
+        tdPtdP = thr_mma_dP.make_fragment_C(cute.append(dov_acc_shape, self.dov_acc_stage))
+        dsk_acc_shape = thr_mma_dQ.partition_shape_C((self.dsk_mma_tiler[0], self.dsk_mma_tiler[1]))
+        tdQtdQ = thr_mma_dQ.make_fragment_C(dsk_acc_shape)
+        tStS = cute.make_tensor(tStS.iterator + self.tmem_s_offset[0], tStS.layout)
+        tdPtdP = cute.make_tensor(tdPtdP.iterator + self.tmem_dp_offset, tdPtdP.layout)
+        tdQtdQ = cute.make_tensor(tdQtdQ.iterator + self.tmem_dq_offset, tdQtdQ.layout)
+
+        block_info = BlockInfo(
+            self.qk_mma_tiler[0],
+            self.qk_mma_tiler[1],
+            self.is_causal,
+            self.is_local,
+            False,  # is_split_kv
+            window_size_left,
+            window_size_right,
+            qhead_per_kvhead_packgqa=1,
+        )
+
+        SeqlenInfoCls = partial(
+            SeqlenInfoQK.create,
+            seqlen_q_static=mQ.shape[0],
+            seqlen_k_static=mK.shape[0],
+            mCuSeqlensQ=mCuSeqlensQ,
+            mCuSeqlensK=mCuSeqlensK,
+            mSeqUsedQ=mSeqUsedQ,
+            mSeqUsedK=mSeqUsedK,
+            tile_m=self.cta_tiler[0],
+            tile_n=self.cta_tiler[1],
+        )
+        TileSchedulerCls = partial(self.tile_scheduler_cls.create, tile_sched_params)
+
+        AttentionMaskCls = partial(
+            AttentionMask,
+            self.tile_m,
+            self.tile_n * self.cta_group_size,
+            swap_AB=True,
+            window_size_left=window_size_left,
+            window_size_right=window_size_right,
+        )
+
         #  EMPTY
-        # ///////////////////////////////////////////////////////////////////////////////
+        # (6, 7)
         for _i in cutlass.range_constexpr(len(self.empty_warp_id)):
             if warp_idx == self.empty_warp_id[_i]:
-                cute.arch.warpgroup_reg_dealloc(self.num_regs_other)
-
-        if cutlass.const_expr(self.use_clc_scheduler):
-            tile_sched = FmhaClcDynamicTileScheduler.create(
-                tile_sched_params,
-                cute.arch.block_idx(),
-                cute.arch.grid_dim(),
-                clc_response_ptr,
-                clc,
-            )
-        else:
-            blk_idx = cute.arch.block_idx()
-            tile_sched = FmhaStaticTileScheduler(
-                tile_sched_params, blk_idx[0], blk_idx, cute.arch.grid_dim()
-            )
-        work_tile = tile_sched.initial_work_tile_info()
+                cute.arch.setmaxregister_decrease(self.num_regs_other)
 
         # Cluster wait
-        pipeline.pipeline_init_wait(cluster_shape_mn=cluster_layout_vmnk)
+        cutlass.pipeline.pipeline_init_wait(cluster_shape_mn=cluster_layout_vmnk)
 
-        # ///////////////////////////////////////////////////////////////////////////////
         #  LOAD
-        # ///////////////////////////////////////////////////////////////////////////////
+        # (5)
         if warp_idx == self.load_warp_id:
-            cute.arch.warpgroup_reg_dealloc(self.num_regs_other)
+            cute.arch.setmaxregister_decrease(self.num_regs_other)
+            self.load(
+                tiled_mma_S,
+                thr_mma_S,
+                thr_mma_dP,
+                thr_mma_dQ,
+                mQ,
+                mK,
+                mKt,
+                mV,
+                mdO,
+                mLSE,
+                mdPsum,
+                cluster_layout_vmnk,
+                block_info,
+                SeqlenInfoCls,
+                TileSchedulerCls,
+                sQ,
+                sK,
+                sKT,
+                sV,
+                sdO,
+                sLSE,
+                sdPsum,
+                tma_atom_Q,
+                tma_atom_K,
+                tma_atom_Kt,
+                tma_atom_V,
+                tma_atom_dO,
+                pipeline_Q,
+                pipeline_K,
+                pipeline_Kt,
+                pipeline_V,
+                pipeline_dO,
+                pipeline_LSE,
+                pipeline_dPsum,
+            )
 
-            while work_tile.is_valid_tile:
-                curr_block_coord = work_tile.tile_idx
-                mma_block_coord = (
-                    curr_block_coord[0] // cute.size(qk_tiled_mma.thr_id.shape),
-                    curr_block_coord[1],
-                    curr_block_coord[2],
-                )
-                batch_coord = curr_block_coord[2][1]
-                seqlen_q = mQ_qdl.shape[0]
-                seqlen_k = mK_kdl.shape[0]
-                cuseqlen_q = Int32(0)
-                cuseqlen_k = Int32(0)
-                is_valid_q = True
-                if cutlass.const_expr(cum_seqlen_q is not None):
-                    cuseqlen_q = cum_seqlen_q[batch_coord]
-                    seqlen_q = cum_seqlen_q[batch_coord + 1] - cuseqlen_q
-                    is_valid_q = FmhaStaticTileScheduler.check_valid_work_for_seqlen_q(
-                        self.qk_mma_tiler[0],
-                        mma_block_coord[0],
-                        seqlen_q,
-                    )
-                if cutlass.const_expr(cum_seqlen_k is not None):
-                    cuseqlen_k = cum_seqlen_k[batch_coord]
-                    seqlen_k = cum_seqlen_k[batch_coord + 1] - cuseqlen_k
-                seqlen_kv_loop_start, seqlen_kv_loop_steps = (
-                    FusedMask.get_trip_start_count_via_block_info(
-                        mma_block_coord,
-                        self.qk_mma_tiler,
-                        seqlen_q,
-                        seqlen_k,
-                        self.is_causal,
-                        self.is_local,
-                        window_size_left,
-                        window_size_right,
-                    )
-                )
-                is_valid_k = seqlen_kv_loop_steps > 0
-                has_work = is_valid_q and is_valid_k
-
-                if has_work:
-                    block_offset = (
-                        cuseqlen_q,
-                        cuseqlen_k,
-                        Int32(0),
-                        ((Int32(0), Int32(0)), Int32(0)),
-                    )
-                    mQ_qdl_ = cute.domain_offset(cute.select(block_offset, mode=[0, 2, 3]), mQ_qdl)
-                    mK_kdl_ = cute.domain_offset(cute.select(block_offset, mode=[1, 2, 3]), mK_kdl)
-                    mdO_qdl_ = cute.domain_offset(
-                        cute.select(block_offset, mode=[0, 2, 3]), mdO_qdl
-                    )
-                    mV_dkl_ = cute.domain_offset(cute.select(block_offset, mode=[1, 2, 3]), mV_dkl)
-                    mK_dkl_ = cute.domain_offset(cute.select(block_offset, mode=[2, 1, 3]), mK_dkl)
-                    block_offset_stats = block_offset
-                    if cutlass.const_expr(cum_seqlen_q is not None):
-                        cuseqlen_q_stats = cute.assume(
-                            (cuseqlen_q + batch_coord * self.cta_tiler[0])
-                            // self.cta_tiler[0]
-                            * self.cta_tiler[0],
-                            divby=self.cta_tiler[0],
-                        )
-                        block_offset_stats = (
-                            cuseqlen_q_stats,
-                            block_offset[1],
-                            block_offset[2],
-                            block_offset[3],
-                        )
-                    LSE = cute.domain_offset(cute.select(block_offset_stats, mode=[0, 3]), mLSE)
-                    sum_OdO = cute.domain_offset(
-                        cute.select(block_offset_stats, mode=[0, 3]), mSum_OdO
-                    )
-
-                    # Local tile partition global tensors
-                    q_cta_layout = cute.make_layout(
-                        cute.slice_(cluster_layout_vmnk, (0, 0, None, 0)).shape
-                    )
-                    # (bM, bK, loopM, loopK, loopL)
-                    gQ_qdl = cute.flat_divide(mQ_qdl_, cute.select(self.qk_mma_tiler, mode=[0, 2]))
-                    tSgQ_qdl = qk_thr_mma.partition_A(gQ_qdl)
-                    tQsQ, tQgQ_qdl = cute.nvgpu.cpasync.tma_partition(
-                        tma_atom_q,
-                        block_in_cluster_coord_vmnk[2],
-                        q_cta_layout,
-                        cute.group_modes(sQ, 0, 3),
-                        cute.group_modes(tSgQ_qdl, 0, 3),
-                    )
-                    k_cta_layout = cute.make_layout(
-                        cute.slice_(cluster_layout_vmnk, (0, None, 0, 0)).shape
-                    )
-                    gK_kdl = cute.flat_divide(mK_kdl_, cute.select(self.qk_mma_tiler, mode=[1, 2]))
-                    tSgK_kdl = qk_thr_mma.partition_B(gK_kdl)
-                    tKsK, tKgK_kdl = cute.nvgpu.cpasync.tma_partition(
-                        tma_atom_k,
-                        block_in_cluster_coord_vmnk[1],
-                        k_cta_layout,
-                        cute.group_modes(sK, 0, 3),
-                        cute.group_modes(tSgK_kdl, 0, 3),
-                    )
-                    do_cta_layout = cute.make_layout(
-                        cute.slice_(cluster_layout_vmnk, (0, 0, None, 0)).shape
-                    )
-                    # (bM, bK, loopM, loopK, loopL)
-                    gdO_qdl = cute.flat_divide(
-                        mdO_qdl_, cute.select(self.dov_mma_tiler, mode=[0, 2])
-                    )
-                    tdPgdO_qdl = dov_thr_mma.partition_A(gdO_qdl)
-                    tdOsdO, tdOgdO_qdl = cute.nvgpu.cpasync.tma_partition(
-                        tma_atom_do,
-                        block_in_cluster_coord_vmnk[2],
-                        do_cta_layout,
-                        cute.group_modes(sdO, 0, 3),
-                        cute.group_modes(tdPgdO_qdl, 0, 3),
-                    )
-                    v_cta_layout = cute.make_layout(
-                        cute.slice_(cluster_layout_vmnk, (0, None, 0, 0)).shape
-                    )
-                    gV_dkl = cute.flat_divide(mV_dkl_, cute.select(self.dov_mma_tiler, mode=[1, 2]))
-                    tSgV_dkl = dov_thr_mma.partition_B(gV_dkl)
-                    tVsV, tVgV_dkl = cute.nvgpu.cpasync.tma_partition(
-                        tma_atom_v,
-                        block_in_cluster_coord_vmnk[1],
-                        v_cta_layout,
-                        cute.group_modes(sV, 0, 3),
-                        cute.group_modes(tSgV_dkl, 0, 3),
-                    )
-                    # kt layout
-                    kt_cta_layout = cute.make_layout(
-                        cute.slice_(cluster_layout_vmnk, (0, 0, None, 0)).shape
-                    )
-                    gK_dkl = cute.flat_divide(mK_dkl_, cute.select(self.dsk_mma_tiler, mode=[1, 2]))
-                    tdQgK_dkl = dsk_thr_mma.partition_B(gK_dkl)
-                    tKTsKT, tKgK_dkl = cute.nvgpu.cpasync.tma_partition(
-                        tma_atom_kt,
-                        block_in_cluster_coord_vmnk[1],
-                        kt_cta_layout,
-                        cute.group_modes(sKT, 0, 3),
-                        cute.group_modes(tdQgK_dkl, 0, 3),
-                    )
-                    # ((atom_v, rest_v), RestK)
-                    tQgQ = tQgQ_qdl[None, mma_block_coord[0], None, mma_block_coord[2]]
-                    # ((atom_v, rest_v), RestK)
-                    tdOgdO = tdOgdO_qdl[None, mma_block_coord[0], None, mma_block_coord[2]]
-                    # ((atom_v, rest_v), RestN, RestK)
-                    tKgK = tKgK_kdl[None, None, None, mma_block_coord[2]]
-                    # ((atom_v, rest_v), RestN, RestK)
-                    tVgV = tVgV_dkl[None, None, None, mma_block_coord[2]]
-                    # ((atom_v, rest_v), RestN, RestK)
-                    tKTgKT = tKgK_dkl[None, None, None, mma_block_coord[2]]
-
-                    # LSE
-                    lse_handle = load_lse_producer.acquire_and_advance()
-                    # 32 threads loading 128 values of 32b each
-                    # so 4*32b = 128b
-                    thread_idx = tidx % self.threads_per_warp
-                    async_copy_num_elts = sLSE.shape[0] // self.threads_per_warp
-                    atom_async_copy = cute.make_copy_atom(
-                        cpasync.CopyG2SOp(cache_mode=cpasync.LoadCacheMode.ALWAYS),
-                        self.acc_dtype,
-                        num_bits_per_copy=self.acc_dtype.width,
-                    )
-                    sLSE_for_copy = cute.flat_divide(sLSE, (1,))
-                    LSE_for_copy = cute.flat_divide(LSE, (1,))
-                    for i in cutlass.range_constexpr(async_copy_num_elts):
-                        LSE_idx = (
-                            self.cta_tiler[0] * curr_block_coord[0]
-                            + thread_idx * async_copy_num_elts
-                        )
-                        if cute.elem_less(LSE_idx + i, seqlen_q):
-                            cute.copy(
-                                atom_async_copy,
-                                LSE_for_copy[None, LSE_idx + i, curr_block_coord[2]],
-                                sLSE_for_copy[
-                                    None,
-                                    thread_idx * async_copy_num_elts + i,
-                                    lse_handle.index,
-                                ],
-                            )
-                        else:
-                            sLSE_for_copy[
-                                None,
-                                thread_idx * async_copy_num_elts + i,
-                                lse_handle.index,
-                            ].fill(0.0)
-                    lse_handle.commit()
-
-                    sum_odo_handle = load_sum_odo_producer.acquire_and_advance()
-                    sSum_OdO_for_copy = cute.flat_divide(sSum_OdO, (1,))
-                    sum_OdO_for_copy = cute.flat_divide(sum_OdO, (1,))
-                    for i in cutlass.range_constexpr(async_copy_num_elts):
-                        sum_OdO_idx = (
-                            self.cta_tiler[0] * curr_block_coord[0]
-                            + thread_idx * async_copy_num_elts
-                        )
-                        if cute.elem_less(sum_OdO_idx + i, seqlen_q):
-                            cute.copy(
-                                atom_async_copy,
-                                sum_OdO_for_copy[None, sum_OdO_idx + i, curr_block_coord[2]],
-                                sSum_OdO_for_copy[
-                                    None,
-                                    thread_idx * async_copy_num_elts + i,
-                                    sum_odo_handle.index,
-                                ],
-                            )
-                        else:
-                            sSum_OdO_for_copy[
-                                None,
-                                thread_idx * async_copy_num_elts + i,
-                                sum_odo_handle.index,
-                            ].fill(0.0)
-                    sum_odo_handle.commit()
-
-                    # Q
-                    for iter in cutlass.range(self.iterations_qk, unroll=1):
-                        q_handle = load_q_producer.acquire_and_advance()
-                        cute.copy(
-                            tma_atom_q,
-                            tQgQ[None, iter],
-                            tQsQ[None, q_handle.index],
-                            tma_bar_ptr=q_handle.barrier,
-                        )
-                    # dO
-                    for iter in cutlass.range(self.iterations_dov, unroll=1):
-                        do_handle = load_do_producer.acquire_and_advance()
-                        cute.copy(
-                            tma_atom_do,
-                            tdOgdO[None, iter],
-                            tdOsdO[None, do_handle.index],
-                            tma_bar_ptr=do_handle.barrier,
-                        )
-
-                    kv_coord = seqlen_kv_loop_start
-                    for i in cutlass.range(0, seqlen_kv_loop_steps, 1, unroll=1):
-                        # Ki
-                        for iter in cutlass.range(self.iterations_qk, unroll=1):
-                            k_handle = load_k_producer.acquire_and_advance()
-                            cute.copy(
-                                tma_atom_k,
-                                tKgK[None, kv_coord, iter],
-                                tKsK[None, k_handle.index],
-                                tma_bar_ptr=k_handle.barrier,
-                            )
-                        # Vi
-                        for iter in cutlass.range(self.iterations_dov, unroll=1):
-                            v_handle = load_v_producer.acquire_and_advance()
-                            cute.copy(
-                                tma_atom_v,
-                                tVgV[None, kv_coord, iter],
-                                tVsV[None, v_handle.index],
-                                tma_bar_ptr=v_handle.barrier,
-                            )
-                        # KTi
-                        for iter in cutlass.range(self.iterations_dsk, unroll=1):
-                            kt_handle = load_kt_producer.acquire_and_advance()
-                            cute.copy(
-                                tma_atom_kt,
-                                tKTgKT[None, iter, kv_coord],
-                                tKTsKT[None, kt_handle.index],
-                                tma_bar_ptr=kt_handle.barrier,
-                            )
-                        kv_coord += 1
-
-                work_tile = tile_sched.advance_to_next_work()
-                # End of persistent scheduler loop
-            load_k_producer.tail()
-            load_v_producer.tail()
-            load_kt_producer.tail()
-            load_q_producer.tail()
-            load_do_producer.tail()
-            load_lse_producer.tail()
-            load_sum_odo_producer.tail()
-
-        # ///////////////////////////////////////////////////////////////////////////////
         #  MMA
-        # ///////////////////////////////////////////////////////////////////////////////
+        # (4)
         if warp_idx == self.mma_warp_id:
-            cute.arch.warpgroup_reg_dealloc(self.num_regs_other)
+            cute.arch.setmaxregister_decrease(self.num_regs_other)
 
-            cta_rank_in_cluster = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster())
-            is_leader_cta = cta_rank_in_cluster % 2 == 0
+            # Alloc tmem buffer
+            tmem.allocate(self.tmem_alloc_cols)
+            tmem.wait_for_alloc()
+            tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
 
-            while work_tile.is_valid_tile:
-                curr_block_coord = work_tile.tile_idx
-                mma_block_coord = (
-                    curr_block_coord[0] // cute.size(qk_tiled_mma.thr_id.shape),
-                    curr_block_coord[1],
-                    curr_block_coord[2],
-                )
-                seqlen_q = mQ_qdl.shape[0]
-                seqlen_k = mK_kdl.shape[0]
-                batch_coord = curr_block_coord[2][1]
-                is_valid_q = True
-                if cutlass.const_expr(cum_seqlen_q is not None):
-                    cuseqlen_q = cum_seqlen_q[batch_coord]
-                    seqlen_q = cum_seqlen_q[batch_coord + 1] - cuseqlen_q
-                    is_valid_q = FmhaStaticTileScheduler.check_valid_work_for_seqlen_q(
-                        self.qk_mma_tiler[0],
-                        mma_block_coord[0],
-                        seqlen_q,
-                    )
-                if cutlass.const_expr(cum_seqlen_k is not None):
-                    cuseqlen_k = cum_seqlen_k[batch_coord]
-                    seqlen_k = cum_seqlen_k[batch_coord + 1] - cuseqlen_k
-                seqlen_kv_loop_start, seqlen_kv_loop_steps = (
-                    FusedMask.get_trip_start_count_via_block_info(
-                        mma_block_coord,
-                        self.qk_mma_tiler,
-                        seqlen_q,
-                        seqlen_k,
-                        self.is_causal,
-                        self.is_local,
-                        window_size_left,
-                        window_size_right,
-                    )
-                )
-                is_valid_k = seqlen_kv_loop_steps > 0
-                has_work = is_valid_q and is_valid_k
+            self.mma(
+                tiled_mma_S,
+                tiled_mma_dP,
+                tiled_mma_dQ,
+                sQ,
+                sK,
+                sKT,
+                sV,
+                sdO,
+                tStS,
+                tdPtdP,
+                tdQtdQ,
+                tdS_layout,
+                pipeline_Q,
+                pipeline_K,
+                pipeline_V,
+                pipeline_dO,
+                pipeline_Kt,
+                pipeline_S_P,
+                pipeline_dP,
+                pipeline_dS,
+                pipeline_dQ,
+                block_info,
+                SeqlenInfoCls,
+                TileSchedulerCls,
+            )
+            # Dealloc the tensor memory buffer
+            tmem.relinquish_alloc_permit()
+            self.tmem_alloc_barrier.arrive_and_wait()
+            tmem.free(tmem_ptr)
 
-                if has_work:
-                    # dq_handle = mma_dq_producer.acquire_and_advance()
-                    load_q_releaser = load_q_consumer.clone()
-                    load_do_releaser = load_do_consumer.clone()
-                    dsk_tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
-
-                    num_innerloop = 8
-
-                    if is_leader_cta:
-                        dq_handle = mma_dq_producer.acquire_and_advance()
-                        if seqlen_kv_loop_steps > 1:
-                            # QK0
-                            s_handle = mma_s_producer.acquire_and_advance()
-                            tStS_slice = tStS[None, None, None, s_handle.index]
-                            qk_tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
-                            for iter in cutlass.range(self.iterations_qk, unroll=1):
-                                load_q_consumer.wait_and_advance()
-                                tSrQ_slice = tSrQ[None, None, None, iter]
-
-                                k_handle = load_k_consumer.wait_and_advance()
-                                tSrK_trans_slice = tSrK[None, None, None, k_handle.index]
-                                num_kphases = cute.size(tSrQ_slice, mode=[2])
-                                if cutlass.const_expr(num_kphases % num_innerloop == 0):
-                                    num_outer_iter = num_kphases // num_innerloop
-                                    for outer_iter in cutlass.range(num_outer_iter, unroll=1):
-                                        for kphase_idx in cutlass.range(
-                                            num_innerloop, unroll_full=True
-                                        ):
-                                            kphase_coord = (
-                                                None,
-                                                None,
-                                                outer_iter * num_innerloop + kphase_idx,
-                                            )
-                                            cute.gemm(
-                                                qk_tiled_mma,
-                                                tStS_slice,
-                                                tSrQ_slice[kphase_coord],
-                                                tSrK_trans_slice[kphase_coord],
-                                                tStS_slice,
-                                            )
-                                            qk_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
-                                else:
-                                    for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
-                                        kphase_coord = (None, None, kphase_idx)
-                                        cute.gemm(
-                                            qk_tiled_mma,
-                                            tStS_slice,
-                                            tSrQ_slice[kphase_coord],
-                                            tSrK_trans_slice[kphase_coord],
-                                            tStS_slice,
-                                        )
-                                        qk_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
-                                k_handle.release()
-                            cute.arch.fence_view_async_tmem_store()
-                            s_handle.commit()
-
-                            # dOV0
-                            dp_handle = mma_dp_producer.acquire_and_advance()
-                            tdPtdP_slice = tdPtdP[None, None, None, dp_handle.index]
-                            dov_tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
-                            for iter in cutlass.range(self.iterations_dov, unroll=1):
-                                load_do_consumer.wait_and_advance()
-                                tdPrdO_slice = tdPrdO[None, None, None, iter]
-                                v_handle = load_v_consumer.wait_and_advance()
-                                tdPrV_trans_slice = tdPrV[None, None, None, v_handle.index]
-                                num_kphases = cute.size(tdPrdO_slice, mode=[2])
-                                if cutlass.const_expr(num_kphases % num_innerloop == 0):
-                                    num_outer_iter = num_kphases // num_innerloop
-                                    for outer_iter in cutlass.range(num_outer_iter, unroll=1):
-                                        for kphase_idx in cutlass.range(
-                                            num_innerloop, unroll_full=True
-                                        ):
-                                            kphase_coord = (
-                                                None,
-                                                None,
-                                                outer_iter * num_innerloop + kphase_idx,
-                                            )
-                                            cute.gemm(
-                                                dov_tiled_mma,
-                                                tdPtdP_slice,
-                                                tdPrdO_slice[kphase_coord],
-                                                tdPrV_trans_slice[kphase_coord],
-                                                tdPtdP_slice,
-                                            )
-                                            dov_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
-                                else:
-                                    for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
-                                        kphase_coord = (None, None, kphase_idx)
-                                        cute.gemm(
-                                            dov_tiled_mma,
-                                            tdPtdP_slice,
-                                            tdPrdO_slice[kphase_coord],
-                                            tdPrV_trans_slice[kphase_coord],
-                                            tdPtdP_slice,
-                                        )
-                                        dov_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
-                                v_handle.release()
-                            cute.arch.fence_view_async_tmem_store()
-                            dp_handle.commit()
-
-                            for i in cutlass.range(1, seqlen_kv_loop_steps - 1, 1, unroll=1):
-                                # QKi
-                                s_handle = mma_s_producer.acquire_and_advance()
-
-                                tStS_slice = tStS[None, None, None, s_handle.index]
-                                qk_tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
-                                for iter in cutlass.range(self.iterations_qk, unroll=1):
-                                    tSrQ_slice = tSrQ[None, None, None, iter]
-                                    k_handle = load_k_consumer.wait_and_advance()
-                                    tSrK_trans_slice = tSrK[None, None, None, k_handle.index]
-                                    num_kphases = cute.size(tSrQ_slice, mode=[2])
-                                    if cutlass.const_expr(num_kphases % num_innerloop == 0):
-                                        num_outer_iter = num_kphases // num_innerloop
-                                        for outer_iter in cutlass.range(num_outer_iter, unroll=1):
-                                            for kphase_idx in cutlass.range(
-                                                num_innerloop, unroll_full=True
-                                            ):
-                                                kphase_coord = (
-                                                    None,
-                                                    None,
-                                                    outer_iter * num_innerloop + kphase_idx,
-                                                )
-                                                cute.gemm(
-                                                    qk_tiled_mma,
-                                                    tStS_slice,
-                                                    tSrQ_slice[kphase_coord],
-                                                    tSrK_trans_slice[kphase_coord],
-                                                    tStS_slice,
-                                                )
-                                                qk_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
-                                    else:
-                                        for kphase_idx in cutlass.range(
-                                            num_kphases, unroll_full=True
-                                        ):
-                                            kphase_coord = (None, None, kphase_idx)
-                                            cute.gemm(
-                                                qk_tiled_mma,
-                                                tStS_slice,
-                                                tSrQ_slice[kphase_coord],
-                                                tSrK_trans_slice[kphase_coord],
-                                                tStS_slice,
-                                            )
-                                            qk_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
-                                    k_handle.release()
-                                s_handle.commit()
-
-                                # dSKTi
-                                ds_handle = ds_mma_consumer.wait_and_advance()
-                                dsk_whether_acc = dsk_tiled_mma.get(tcgen05.Field.ACCUMULATE)
-                                for iter in cutlass.range(self.iterations_dsk, unroll=1):
-                                    kt_handle = load_kt_consumer.wait_and_advance()
-                                    dsk_tiled_mma.set(tcgen05.Field.ACCUMULATE, dsk_whether_acc)
-                                    tdQtdQ_slice = tdQtdQ_staged[None, None, None, iter]
-                                    tdStdS_slice = tdPtdP[None, None, None, ds_handle.index]
-                                    tdS = cute.make_tensor(
-                                        tdStdS_slice.iterator, ds_tmem_layout_staged.outer
-                                    )
-                                    tdQrdS = dsk_thr_mma.make_fragment_A(tdS)
-                                    tdQrdS_slice = cute.make_tensor(
-                                        cute.recast_ptr(tdStdS_slice.iterator, dtype=self.q_dtype),
-                                        tdQrdS.layout,
-                                    )
-
-                                    tdQrKT_slice = tdQrKT[None, None, None, kt_handle.index]
-                                    num_kphases = cute.size(tdQrKT_slice, mode=[2])
-                                    if cutlass.const_expr(num_kphases % num_innerloop == 0):
-                                        num_outer_iter = num_kphases // num_innerloop
-                                        for outer_iter in cutlass.range(num_outer_iter, unroll=1):
-                                            for kphase_idx in cutlass.range(
-                                                num_innerloop, unroll_full=True
-                                            ):
-                                                kphase_coord = (
-                                                    None,
-                                                    None,
-                                                    outer_iter * num_innerloop + kphase_idx,
-                                                )
-                                                cute.gemm(
-                                                    dsk_tiled_mma,
-                                                    tdQtdQ_slice,
-                                                    tdQrdS_slice[kphase_coord],
-                                                    tdQrKT_slice[kphase_coord],
-                                                    tdQtdQ_slice,
-                                                )
-                                                dsk_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
-                                    else:
-                                        for kphase_idx in cutlass.range(
-                                            num_kphases, unroll_full=True
-                                        ):
-                                            kphase_coord = (None, None, kphase_idx)
-                                            cute.gemm(
-                                                dsk_tiled_mma,
-                                                tdQtdQ_slice,
-                                                tdQrdS_slice[kphase_coord],
-                                                tdQrKT_slice[kphase_coord],
-                                                tdQtdQ_slice,
-                                            )
-                                            dsk_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
-                                    kt_handle.release()
-                                ds_handle.release()
-
-                                # dOVi
-                                dp_handle = mma_dp_producer.acquire_and_advance()
-                                tdPtdP_slice = tdPtdP[None, None, None, dp_handle.index]
-                                dov_tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
-                                for iter in cutlass.range(self.iterations_dov, unroll=1):
-                                    tdPrdO_slice = tdPrdO[None, None, None, iter]
-                                    v_handle = load_v_consumer.wait_and_advance()
-                                    tdPrV_trans_slice = tdPrV[None, None, None, v_handle.index]
-                                    num_kphases = cute.size(tdPrdO_slice, mode=[2])
-                                    if cutlass.const_expr(num_kphases % num_innerloop == 0):
-                                        num_outer_iter = num_kphases // num_innerloop
-                                        for outer_iter in cutlass.range(num_outer_iter, unroll=1):
-                                            for kphase_idx in cutlass.range(
-                                                num_innerloop, unroll_full=True
-                                            ):
-                                                kphase_coord = (
-                                                    None,
-                                                    None,
-                                                    outer_iter * num_innerloop + kphase_idx,
-                                                )
-                                                cute.gemm(
-                                                    dov_tiled_mma,
-                                                    tdPtdP_slice,
-                                                    tdPrdO_slice[kphase_coord],
-                                                    tdPrV_trans_slice[kphase_coord],
-                                                    tdPtdP_slice,
-                                                )
-                                                dov_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
-                                    else:
-                                        for kphase_idx in cutlass.range(
-                                            num_kphases, unroll_full=True
-                                        ):
-                                            kphase_coord = (None, None, kphase_idx)
-                                            cute.gemm(
-                                                dov_tiled_mma,
-                                                tdPtdP_slice,
-                                                tdPrdO_slice[kphase_coord],
-                                                tdPrV_trans_slice[kphase_coord],
-                                                tdPtdP_slice,
-                                            )
-                                            dov_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
-                                    v_handle.release()
-                                dp_handle.commit()
-
-                            # QKend
-                            s_handle = mma_s_producer.acquire_and_advance()
-                            tStS_slice = tStS[None, None, None, s_handle.index]
-                            qk_tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
-                            for iter in cutlass.range(self.iterations_qk, unroll=1):
-                                tSrQ_slice = tSrQ[None, None, None, iter]
-                                k_handle = load_k_consumer.wait_and_advance()
-
-                                tSrK_trans_slice = tSrK[None, None, None, k_handle.index]
-
-                                num_kphases = cute.size(tSrQ_slice, mode=[2])
-                                if cutlass.const_expr(num_kphases % num_innerloop == 0):
-                                    num_outer_iter = num_kphases // num_innerloop
-                                    for outer_iter in cutlass.range(num_outer_iter, unroll=1):
-                                        for kphase_idx in cutlass.range(
-                                            num_innerloop, unroll_full=True
-                                        ):
-                                            kphase_coord = (
-                                                None,
-                                                None,
-                                                outer_iter * num_innerloop + kphase_idx,
-                                            )
-                                            cute.gemm(
-                                                qk_tiled_mma,
-                                                tStS_slice,
-                                                tSrQ_slice[kphase_coord],
-                                                tSrK_trans_slice[kphase_coord],
-                                                tStS_slice,
-                                            )
-                                            qk_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
-                                else:
-                                    for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
-                                        kphase_coord = (None, None, kphase_idx)
-                                        cute.gemm(
-                                            qk_tiled_mma,
-                                            tStS_slice,
-                                            tSrQ_slice[kphase_coord],
-                                            tSrK_trans_slice[kphase_coord],
-                                            tStS_slice,
-                                        )
-                                        qk_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
-                                k_handle.release()
-                                load_q_releaser.release()
-                                load_q_releaser.advance()
-                            s_handle.commit()
-
-                            # dSKTend - 1
-                            ds_handle = ds_mma_consumer.wait_and_advance()
-                            dsk_whether_acc = dsk_tiled_mma.get(tcgen05.Field.ACCUMULATE)
-                            for iter in cutlass.range(self.iterations_dsk, unroll=1):
-                                kt_handle = load_kt_consumer.wait_and_advance()
-                                dsk_tiled_mma.set(tcgen05.Field.ACCUMULATE, dsk_whether_acc)
-                                tdQtdQ_slice = tdQtdQ_staged[None, None, None, iter]
-                                tdStdS_slice = tdPtdP[None, None, None, ds_handle.index]
-                                tdS = cute.make_tensor(
-                                    tdStdS_slice.iterator, ds_tmem_layout_staged.outer
-                                )
-                                tdQrdS = dsk_thr_mma.make_fragment_A(tdS)
-                                tdQrdS_slice = cute.make_tensor(
-                                    cute.recast_ptr(tdStdS_slice.iterator, dtype=self.q_dtype),
-                                    tdQrdS.layout,
-                                )
-
-                                tdQrKT_slice = tdQrKT[None, None, None, kt_handle.index]
-                                num_kphases = cute.size(tdQrKT_slice, mode=[2])
-                                if cutlass.const_expr(num_kphases % num_innerloop == 0):
-                                    num_outer_iter = num_kphases // num_innerloop
-                                    for outer_iter in cutlass.range(num_outer_iter, unroll=1):
-                                        for kphase_idx in cutlass.range(
-                                            num_innerloop, unroll_full=True
-                                        ):
-                                            kphase_coord = (
-                                                None,
-                                                None,
-                                                outer_iter * num_innerloop + kphase_idx,
-                                            )
-                                            cute.gemm(
-                                                dsk_tiled_mma,
-                                                tdQtdQ_slice,
-                                                tdQrdS_slice[kphase_coord],
-                                                tdQrKT_slice[kphase_coord],
-                                                tdQtdQ_slice,
-                                            )
-                                            dsk_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
-                                else:
-                                    for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
-                                        kphase_coord = (None, None, kphase_idx)
-                                        cute.gemm(
-                                            dsk_tiled_mma,
-                                            tdQtdQ_slice,
-                                            tdQrdS_slice[kphase_coord],
-                                            tdQrKT_slice[kphase_coord],
-                                            tdQtdQ_slice,
-                                        )
-                                        dsk_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
-                                kt_handle.release()
-                            ds_handle.release()
-
-                            # dOVend
-                            dp_handle = mma_dp_producer.acquire_and_advance()
-                            tdPtdP_slice = tdPtdP[None, None, None, dp_handle.index]
-                            dov_tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
-                            for iter in cutlass.range(self.iterations_dov, unroll=1):
-                                tdPrdO_slice = tdPrdO[None, None, None, iter]
-                                v_handle = load_v_consumer.wait_and_advance()
-                                tdPrV_trans_slice = tdPrV[None, None, None, v_handle.index]
-                                num_kphases = cute.size(tdPrdO_slice, mode=[2])
-                                if cutlass.const_expr(num_kphases % num_innerloop == 0):
-                                    num_outer_iter = num_kphases // num_innerloop
-                                    for outer_iter in cutlass.range(num_outer_iter, unroll=1):
-                                        for kphase_idx in cutlass.range(
-                                            num_innerloop, unroll_full=True
-                                        ):
-                                            kphase_coord = (
-                                                None,
-                                                None,
-                                                outer_iter * num_innerloop + kphase_idx,
-                                            )
-                                            cute.gemm(
-                                                dov_tiled_mma,
-                                                tdPtdP_slice,
-                                                tdPrdO_slice[kphase_coord],
-                                                tdPrV_trans_slice[kphase_coord],
-                                                tdPtdP_slice,
-                                            )
-                                            dov_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
-                                else:
-                                    for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
-                                        kphase_coord = (None, None, kphase_idx)
-                                        cute.gemm(
-                                            dov_tiled_mma,
-                                            tdPtdP_slice,
-                                            tdPrdO_slice[kphase_coord],
-                                            tdPrV_trans_slice[kphase_coord],
-                                            tdPtdP_slice,
-                                        )
-                                        dov_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
-                                v_handle.release()
-                                load_do_releaser.release()
-                                load_do_releaser.advance()
-                            dp_handle.commit()
-                            # dSKTend
-                            ds_handle = ds_mma_consumer.wait_and_advance()
-                            dsk_whether_acc = dsk_tiled_mma.get(tcgen05.Field.ACCUMULATE)
-                            for iter in cutlass.range(self.iterations_dsk, unroll=1):
-                                kt_handle = load_kt_consumer.wait_and_advance()
-                                dsk_tiled_mma.set(tcgen05.Field.ACCUMULATE, dsk_whether_acc)
-                                tdQtdQ_slice = tdQtdQ_staged[None, None, None, iter]
-                                tdStdS_slice = tdPtdP[None, None, None, ds_handle.index]
-                                tdS = cute.make_tensor(
-                                    tdStdS_slice.iterator, ds_tmem_layout_staged.outer
-                                )
-                                tdQrdS = dsk_thr_mma.make_fragment_A(tdS)
-                                tdQrdS_slice = cute.make_tensor(
-                                    cute.recast_ptr(tdStdS_slice.iterator, dtype=self.q_dtype),
-                                    tdQrdS.layout,
-                                )
-
-                                tdQrKT_slice = tdQrKT[None, None, None, kt_handle.index]
-                                num_kphases = cute.size(tdQrKT_slice, mode=[2])
-                                if cutlass.const_expr(num_kphases % num_innerloop == 0):
-                                    num_outer_iter = num_kphases // num_innerloop
-                                    for outer_iter in cutlass.range(num_outer_iter, unroll=1):
-                                        for kphase_idx in cutlass.range(
-                                            num_innerloop, unroll_full=True
-                                        ):
-                                            kphase_coord = (
-                                                None,
-                                                None,
-                                                outer_iter * num_innerloop + kphase_idx,
-                                            )
-                                            cute.gemm(
-                                                dsk_tiled_mma,
-                                                tdQtdQ_slice,
-                                                tdQrdS_slice[kphase_coord],
-                                                tdQrKT_slice[kphase_coord],
-                                                tdQtdQ_slice,
-                                            )
-                                            dsk_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
-                                else:
-                                    for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
-                                        kphase_coord = (None, None, kphase_idx)
-                                        cute.gemm(
-                                            dsk_tiled_mma,
-                                            tdQtdQ_slice,
-                                            tdQrdS_slice[kphase_coord],
-                                            tdQrKT_slice[kphase_coord],
-                                            tdQtdQ_slice,
-                                        )
-                                        dsk_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
-                                kt_handle.release()
-                            ds_handle.release()
-                        else:
-                            # QK0
-                            s_handle = mma_s_producer.acquire_and_advance()
-                            tStS_slice = tStS[None, None, None, s_handle.index]
-                            qk_tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
-
-                            for iter in cutlass.range(self.iterations_qk, unroll=1):
-                                load_q_consumer.wait_and_advance()
-                                tSrQ_slice = tSrQ[None, None, None, iter]
-                                k_handle = load_k_consumer.wait_and_advance()
-                                tSrK_trans_slice = tSrK[None, None, None, k_handle.index]
-                                num_kphases = cute.size(tSrQ_slice, mode=[2])
-                                if cutlass.const_expr(num_kphases % num_innerloop == 0):
-                                    num_outer_iter = num_kphases // num_innerloop
-                                    for outer_iter in cutlass.range(num_outer_iter, unroll=1):
-                                        for kphase_idx in cutlass.range(
-                                            num_innerloop, unroll_full=True
-                                        ):
-                                            kphase_coord = (
-                                                None,
-                                                None,
-                                                outer_iter * num_innerloop + kphase_idx,
-                                            )
-                                            cute.gemm(
-                                                qk_tiled_mma,
-                                                tStS_slice,
-                                                tSrQ_slice[kphase_coord],
-                                                tSrK_trans_slice[kphase_coord],
-                                                tStS_slice,
-                                            )
-                                            qk_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
-                                else:
-                                    for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
-                                        kphase_coord = (None, None, kphase_idx)
-                                        cute.gemm(
-                                            qk_tiled_mma,
-                                            tStS_slice,
-                                            tSrQ_slice[kphase_coord],
-                                            tSrK_trans_slice[kphase_coord],
-                                            tStS_slice,
-                                        )
-                                        qk_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
-                                k_handle.release()
-                                load_q_releaser.release()
-                                load_q_releaser.advance()
-                            s_handle.commit()
-
-                            # dOV0
-                            dp_handle = mma_dp_producer.acquire_and_advance()
-                            tdPtdP_slice = tdPtdP[None, None, None, dp_handle.index]
-                            dov_tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
-                            for iter in cutlass.range(self.iterations_dov, unroll=1):
-                                load_do_consumer.wait_and_advance()
-                                tdPrdO_slice = tdPrdO[None, None, None, iter]
-                                v_handle = load_v_consumer.wait_and_advance()
-                                tdPrV_trans_slice = tdPrV[None, None, None, v_handle.index]
-                                num_kphases = cute.size(tdPrdO_slice, mode=[2])
-                                if cutlass.const_expr(num_kphases % num_innerloop == 0):
-                                    num_outer_iter = num_kphases // num_innerloop
-                                    for outer_iter in cutlass.range(num_outer_iter, unroll=1):
-                                        for kphase_idx in cutlass.range(
-                                            num_innerloop, unroll_full=True
-                                        ):
-                                            kphase_coord = (
-                                                None,
-                                                None,
-                                                outer_iter * num_innerloop + kphase_idx,
-                                            )
-                                            cute.gemm(
-                                                dov_tiled_mma,
-                                                tdPtdP_slice,
-                                                tdPrdO_slice[kphase_coord],
-                                                tdPrV_trans_slice[kphase_coord],
-                                                tdPtdP_slice,
-                                            )
-                                            dov_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
-                                else:
-                                    for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
-                                        kphase_coord = (None, None, kphase_idx)
-                                        cute.gemm(
-                                            dov_tiled_mma,
-                                            tdPtdP_slice,
-                                            tdPrdO_slice[kphase_coord],
-                                            tdPrV_trans_slice[kphase_coord],
-                                            tdPtdP_slice,
-                                        )
-                                        dov_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
-                                v_handle.release()
-                                load_do_releaser.release()
-                                load_do_releaser.advance()
-                            dp_handle.commit()
-
-                            # dSKT0
-                            ds_handle = ds_mma_consumer.wait_and_advance()
-                            dsk_whether_acc = dsk_tiled_mma.get(tcgen05.Field.ACCUMULATE)
-                            for iter in cutlass.range(self.iterations_dsk, unroll=1):
-                                kt_handle = load_kt_consumer.wait_and_advance()
-                                dsk_tiled_mma.set(tcgen05.Field.ACCUMULATE, dsk_whether_acc)
-                                tdQtdQ_slice = tdQtdQ_staged[None, None, None, iter]
-                                tdStdS_slice = tdPtdP[None, None, None, ds_handle.index]
-                                tdS = cute.make_tensor(
-                                    tdStdS_slice.iterator, ds_tmem_layout_staged.outer
-                                )
-                                tdQrdS = dsk_thr_mma.make_fragment_A(tdS)
-                                tdQrdS_slice = cute.make_tensor(
-                                    cute.recast_ptr(tdStdS_slice.iterator, dtype=self.q_dtype),
-                                    tdQrdS.layout,
-                                )
-
-                                tdQrKT_slice = tdQrKT[None, None, None, kt_handle.index]
-                                num_kphases = cute.size(tdQrKT_slice, mode=[2])
-                                if cutlass.const_expr(num_kphases % num_innerloop == 0):
-                                    num_outer_iter = num_kphases // num_innerloop
-                                    for outer_iter in cutlass.range(num_outer_iter, unroll=1):
-                                        for kphase_idx in cutlass.range(
-                                            num_innerloop, unroll_full=True
-                                        ):
-                                            kphase_coord = (
-                                                None,
-                                                None,
-                                                outer_iter * num_innerloop + kphase_idx,
-                                            )
-                                            cute.gemm(
-                                                dsk_tiled_mma,
-                                                tdQtdQ_slice,
-                                                tdQrdS_slice[kphase_coord],
-                                                tdQrKT_slice[kphase_coord],
-                                                tdQtdQ_slice,
-                                            )
-                                            dsk_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
-                                else:
-                                    for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
-                                        kphase_coord = (None, None, kphase_idx)
-                                        cute.gemm(
-                                            dsk_tiled_mma,
-                                            tdQtdQ_slice,
-                                            tdQrdS_slice[kphase_coord],
-                                            tdQrKT_slice[kphase_coord],
-                                            tdQtdQ_slice,
-                                        )
-                                        dsk_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
-                                kt_handle.release()
-                            ds_handle.release()
-                        dq_handle.commit()
-                work_tile = tile_sched.advance_to_next_work()
-            # End of persistent scheduler loop
-            mma_s_producer.tail()
-            mma_dp_producer.tail()
-            mma_dq_producer.tail()
-
-        # Softmax and dSoftmax warp
+        # Compute
+        # (0, 1, 2, 3) --> 4 warps
         if warp_idx >= self.compute_warp_ids[0] and warp_idx <= self.compute_warp_ids[-1]:
-            # increase register after decreasing
-            cute.arch.warpgroup_reg_alloc(self.num_regs_compute)
-            while work_tile.is_valid_tile:
-                curr_block_coord = work_tile.tile_idx
-                mma_block_coord = (
-                    curr_block_coord[0] // cute.size(qk_tiled_mma.thr_id.shape),
-                    curr_block_coord[1],
-                    curr_block_coord[2],
-                )
-                batch_coord = curr_block_coord[2][1]
-                seqlen_q = mQ_qdl.shape[0]
-                seqlen_k = mK_kdl.shape[0]
-                cuseqlen_q = Int32(0)
-                is_valid_q = True
-                if cutlass.const_expr(cum_seqlen_q is not None):
-                    cuseqlen_q = cum_seqlen_q[batch_coord]
-                    seqlen_q = cum_seqlen_q[batch_coord + 1] - cuseqlen_q
-                    is_valid_q = FmhaStaticTileScheduler.check_valid_work_for_seqlen_q(
-                        self.qk_mma_tiler[0],
-                        mma_block_coord[0],
-                        seqlen_q,
-                    )
-                if cutlass.const_expr(cum_seqlen_k is not None):
-                    cuseqlen_k = cum_seqlen_k[batch_coord]
-                    seqlen_k = cum_seqlen_k[batch_coord + 1] - cuseqlen_k
-                start_count, trip_count = FusedMask.get_trip_start_count_via_block_info(
-                    mma_block_coord,
-                    self.qk_mma_tiler,
-                    seqlen_q,
-                    seqlen_k,
-                    self.is_causal,
-                    self.is_local,
-                    window_size_left,
-                    window_size_right,
-                )
-                is_valid_k = trip_count > 0
-                has_work = is_valid_q and is_valid_k
-
-                if has_work:
-                    end_count = start_count + trip_count
-                    if cutlass.const_expr(self.use_semantic_trip_range):
-                        n_block_min_causal_local_mask, n_block_min_before_local_mask = (
-                            FusedMask.get_trip_mask_bounds_via_block_info(
-                                mma_block_coord,
-                                self.qk_mma_tiler,
-                                seqlen_q,
-                                seqlen_k,
-                                self.is_causal,
-                                self.is_local,
-                                window_size_left,
-                                window_size_right,
-                            )
-                        )
-
-                    cS_base = cute.make_identity_tensor(
-                        (self.qk_mma_tiler[0], self.qk_mma_tiler[1])
-                    )
-                    cS = cute.domain_offset((mma_block_coord[0] * self.qk_mma_tiler[0], 0), cS_base)
-                    tScS = qk_thr_mma.partition_C(cS)
-
-                    cdP_base = cute.make_identity_tensor(
-                        (self.dov_mma_tiler[0], self.dov_mma_tiler[1])
-                    )
-                    cdP = cute.domain_offset(
-                        (mma_block_coord[0] * self.dov_mma_tiler[0], 0), cdP_base
-                    )
-                    tdPcdP = dov_thr_mma.partition_C(cdP)
-
-                    lse_handle = load_lse_consumer.wait_and_advance()
-                    sum_odo_handle = load_sum_odo_consumer.wait_and_advance()
-                    for step in cutlass.range(start_count, end_count, 1, unroll=1):
-                        cS_iter = cute.domain_offset((0, step * self.qk_mma_tiler[1]), cS)
-                        tScS_iter = qk_thr_mma.partition_C(cS_iter)
-
-                        cdP_iter = cute.domain_offset((0, step * self.dov_mma_tiler[1]), cdP)
-
-                        tdPcdP_iter = dov_thr_mma.partition_C(cdP_iter)
-
-                        # Si, dPi -> dSi
-                        if cutlass.const_expr(self.use_semantic_trip_range):
-                            need_apply_mask = (
-                                step >= n_block_min_causal_local_mask
-                                or step < n_block_min_before_local_mask
-                            )
-                        else:
-                            need_apply_mask = step == end_count - 1
-                        mma_s_consumer, mma_dp_consumer, ds_mma_producer = self.compute_step(
-                            (need_apply_mask, window_size_left, window_size_right),
-                            (
-                                seqlen_q,
-                                seqlen_k,
-                                scale_softmax,
-                                batch_coord,
-                                curr_block_coord[0],
-                                varlen,
-                            ),
-                            (tStS, tScS_iter, tdPtdP, tdPcdP_iter, sLSE, sSum_OdO),
-                            (
-                                mma_s_consumer,
-                                mma_dp_consumer,
-                                ds_mma_producer,
-                                lse_handle,
-                                sum_odo_handle,
-                            ),
-                            step,
-                        )
-                    lse_handle.release()
-                    sum_odo_handle.release()
-
-                work_tile = tile_sched.advance_to_next_work()
-            ds_mma_producer.tail()
-
-        # ///////////////////////////////////////////////////////////////////////////////
-        #  Epilogue
-        # ///////////////////////////////////////////////////////////////////////////////
-        if warp_idx >= self.epilogue_warp_ids[0] and warp_idx <= self.epilogue_warp_ids[-1]:
-            cute.arch.warpgroup_reg_dealloc(self.num_regs_epilogue)
-
-            while work_tile.is_valid_tile:
-                curr_block_coord = work_tile.tile_idx
-                mma_block_coord = (
-                    curr_block_coord[0] // cute.size(qk_tiled_mma.thr_id.shape),
-                    curr_block_coord[1],
-                    curr_block_coord[2],
-                )
-                batch_coord = curr_block_coord[2][1]
-                # cute.printf("batch_coord={}", batch_coord)
-                seqlen_q = mQ_qdl.shape[0]
-                seqlen_k = mK_kdl.shape[0]
-                cuseqlen_q = Int32(0)
-                is_valid_q = True
-                if cutlass.const_expr(cum_seqlen_q is not None):
-                    cuseqlen_q = cum_seqlen_q[batch_coord]
-                    seqlen_q = cum_seqlen_q[batch_coord + 1] - cuseqlen_q
-                    is_valid_q = FmhaStaticTileScheduler.check_valid_work_for_seqlen_q(
-                        self.qk_mma_tiler[0],
-                        mma_block_coord[0],
-                        seqlen_q,
-                    )
-                if cutlass.const_expr(cum_seqlen_k is not None):
-                    cuseqlen_k = cum_seqlen_k[batch_coord]
-                    seqlen_k = cum_seqlen_k[batch_coord + 1] - cuseqlen_k
-                seqlen_kv_loop_start, seqlen_kv_loop_steps = (
-                    FusedMask.get_trip_start_count_via_block_info(
-                        mma_block_coord,
-                        self.qk_mma_tiler,
-                        seqlen_q,
-                        seqlen_k,
-                        self.is_causal,
-                        self.is_local,
-                        window_size_left,
-                        window_size_right,
-                    )
-                )
-                is_valid_k = seqlen_kv_loop_steps > 0
-                has_work = is_valid_q and is_valid_k
-
-                mdQ_qdl_eff = mdQ_qdl
-                if cutlass.const_expr(cum_seqlen_q is not None):
-                    block_offset_dQ = (cuseqlen_q,) + (None,) * 2
-                    mdQ_qdl_eff = cute.domain_offset(block_offset_dQ, mdQ_qdl)
-
-                # (bM, bN, loopM, loopN, loopL)
-                gdQ_qdl = cute.flat_divide(
-                    mdQ_qdl_eff, cute.select(self.dsk_block_tiler, mode=[0, 1])
-                )
-                cdQ_qdl = cute.flat_divide(
-                    cute.make_identity_tensor(mdQ_qdl_eff.shape),
-                    cute.select(self.dsk_block_tiler, mode=[0, 1]),
-                )
-
-                gdQ_staged = gdQ_qdl[None, None, curr_block_coord[0], None, curr_block_coord[2]]
-                cdQ_staged = cdQ_qdl[None, None, curr_block_coord[0], None, curr_block_coord[2]]
-                gdQ_tma_staged = gdQ_staged
-
-                if cutlass.const_expr(not varlen):
-                    gdQ_tma_qdl = cute.flat_divide(
-                        mdQ_tma, cute.select(self.dsk_block_tiler, mode=[0, 1])
-                    )
-                    gdQ_tma_staged = gdQ_tma_qdl[
-                        None, None, curr_block_coord[0], None, curr_block_coord[2]
-                    ]
-
-                if has_work:
-                    # dQ TMEM to GMEM
-                    mma_dq_consumer = self.dQ_epilogue(
-                        seqlen_q,
-                        (mma_dq_consumer, gdQ_staged, cdQ_staged, tdQtdQ_staged),
-                        self.epi_tile,
-                        (tma_atom_dQ, gdQ_tma_staged, s_epi_dQ, varlen),
-                    )
-                else:
-                    self.dQ_epilogue_write_zero(
-                        seqlen_q,
-                        gdQ_staged,
-                        cdQ_staged,
-                    )
-
-                work_tile = tile_sched.advance_to_next_work()
-            # NOTE: tmem.free() moved to kernel end to enable cluster-wide sync
-
-        # ///////////////////////////////////////////////////////////////////////////////
-        #  Scheduler Warp (only for CLC dynamic scheduler)
-        # ///////////////////////////////////////////////////////////////////////////////
-        if cutlass.const_expr(self.use_clc_scheduler):
-            is_first_cta_in_cluster = cta_rank_in_cluster == 0
-
-            if warp_idx == self.sched_warp_id and is_first_cta_in_cluster:
-                cute.arch.warpgroup_reg_dealloc(self.num_regs_other)
-                while work_tile.is_valid_tile:
-                    tile_sched.prefetch_next_work()
-                    work_tile = tile_sched.advance_to_next_work()
-                tile_sched.producer_tail()
-
-        # ///////////////////////////////////////////////////////////////////////////////
-        #  Empty warps reg dealloc
-        # ///////////////////////////////////////////////////////////////////////////////
-        if cutlass.const_expr(self.use_clc_scheduler):
-            if warp_idx > self.load_warp_id:
-                if not (warp_idx == self.sched_warp_id and is_first_cta_in_cluster):
-                    cute.arch.warpgroup_reg_dealloc(self.num_regs_other)
-        else:
-            if warp_idx > self.load_warp_id:
-                cute.arch.warpgroup_reg_dealloc(self.num_regs_other)
-
-        # ///////////////////////////////////////////////////////////////////////////////
-        #  Cooperative TMEM Deallocation (2CTA)
-        # ///////////////////////////////////////////////////////////////////////////////
-        # All warps (including scheduler) have finished by this point.
-        # Cluster-wide sync ensures both CTAs reach here before dealloc.
-        cute.arch.cluster_arrive()
-        cute.arch.cluster_wait()
-        tmem.relinquish_alloc_permit()
-        tmem.free(tmem_ptr)
+            cute.arch.setmaxregister_increase(self.num_regs_compute)
+            tmem.wait_for_alloc()
+            tmem.retrieve_ptr(self.acc_dtype)
+            self.compute_loop(
+                tiled_mma_S,
+                thr_mma_S,
+                thr_mma_dP,
+                thr_mma_dQ,
+                scale_softmax,
+                tStS,
+                tdPtdP,
+                tdQtdQ,
+                mdQ,
+                mdQ_tma,
+                sdQ,
+                tma_atom_dQ,
+                tiled_copy_r2s_dQ,
+                sLSE,
+                sdPsum,
+                pipeline_S_P,
+                pipeline_dP,
+                pipeline_dS,
+                pipeline_dQ,
+                pipeline_LSE,
+                pipeline_dPsum,
+                block_info,
+                SeqlenInfoCls,
+                TileSchedulerCls,
+                aux_data,
+                fastdiv_mods,
+            )
+            self.tmem_alloc_barrier.arrive()
 
         return
 
     @cute.jit
-    def compute_step(
+    def load(
         self,
-        mask_args: Tuple,
-        value_args: Tuple,
-        tensor_args: Tuple,
-        pipeline_args: Tuple,
-        step: Int32,
-    ) -> Tuple[Float32, Float32, pipeline.PipelineConsumer, pipeline.PipelineProducer]:
-        need_apply_mask, window_size_left, window_size_right = mask_args
-        seqlen_q, seqlen_k, scale_softmax, batch_coord, block_m_idx, varlen = value_args
-        tStS, tScS, tdPtdP, tdPcdP, sLSE, sSum_OdO = tensor_args
-        mma_s_consumer, mma_dp_consumer, ds_mma_producer, lse_handle, sum_odo_handle = pipeline_args
+        tiled_mma_S,
+        thr_mma_S,
+        thr_mma_dP,
+        thr_mma_dQ,
+        mQ,
+        mK,
+        mKt,
+        mV,
+        mdO,
+        mLSE,
+        mdPsum,
+        cluster_layout_vmnk,
+        block_info,
+        SeqlenInfoCls,
+        TileSchedulerCls,
+        sQ,
+        sK,
+        sKT,
+        sV,
+        sdO,
+        sLSE,
+        sdPsum,
+        tma_atom_Q,
+        tma_atom_K,
+        tma_atom_Kt,
+        tma_atom_V,
+        tma_atom_dO,
+        pipeline_Q,
+        pipeline_K,
+        pipeline_Kt,
+        pipeline_V,
+        pipeline_dO,
+        pipeline_LSE,
+        pipeline_dPsum,
+    ):
+        producer_state_Q = cutlass.pipeline.make_pipeline_state(
+            cutlass.pipeline.PipelineUserType.Producer, self.Q_stage
+        )
+        producer_state_K = cutlass.pipeline.make_pipeline_state(
+            cutlass.pipeline.PipelineUserType.Producer, self.k_stage
+        )
+        producer_state_Kt = cutlass.pipeline.make_pipeline_state(
+            cutlass.pipeline.PipelineUserType.Producer, self.single_stage
+        )
+        producer_state_V = cutlass.pipeline.make_pipeline_state(
+            cutlass.pipeline.PipelineUserType.Producer, self.v_stage
+        )
+        producer_state_dO = cutlass.pipeline.make_pipeline_state(
+            cutlass.pipeline.PipelineUserType.Producer, self.dO_stage
+        )
+        producer_state_LSE = cutlass.pipeline.make_pipeline_state(
+            cutlass.pipeline.PipelineUserType.Producer, self.load_compute_LSE_stage
+        )
+        producer_state_dPsum = cutlass.pipeline.make_pipeline_state(
+            cutlass.pipeline.PipelineUserType.Producer, self.load_compute_sum_OdO_stage
+        )
 
-        bidx = block_m_idx
+        cta_rank_in_cluster = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster())
+        block_in_cluster_coord_vmnk = cluster_layout_vmnk.get_flat_coord(cta_rank_in_cluster)
+        q_do_mcast_mask = None
+        if const_expr(self.is_q_do_mcast):
+            q_do_mcast_mask = cpasync.create_tma_multicast_mask(
+                cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=1
+            )
         tidx, _, _ = cute.arch.thread_idx()
-        thread_idx = tidx % (self.threads_per_warp * len(self.compute_warp_ids))
-        s_handle = mma_s_consumer.wait_and_advance()
-        tStS_slice = tStS[(None, None), 0, 0, s_handle.index]
-        tScS_slice = tScS[(None, None), 0, 0]
-        tmem_load_atom = cute.make_copy_atom(
-            tcgen05.Ld32x32bOp(tcgen05.Repetition(16)), self.acc_dtype
-        )
-        tmem_tiled_load = tcgen05.make_tmem_copy(tmem_load_atom, tStS_slice)
-        thr_load = tmem_tiled_load.get_slice(thread_idx)
-        tTMEM_LOADtS = thr_load.partition_S(tStS_slice)
-        tTMEM_LOADcS = thr_load.partition_D(tScS_slice)
-        tTMEM_LOADrS = cute.make_rmem_tensor(tTMEM_LOADcS.shape, self.acc_dtype)
-        cute.copy(tmem_tiled_load, tTMEM_LOADtS, tTMEM_LOADrS)
-        cute.arch.fence_view_async_tmem_load()
-        s_handle.release()
-        if need_apply_mask:
-            FusedMask.apply_mask_via_causal_local(
-                tTMEM_LOADrS,
-                tTMEM_LOADcS,
-                seqlen_q,
-                seqlen_k,
-                self.use_semantic_trip_range,
-                self.is_causal,
-                self.is_local,
-                window_size_left,
-                window_size_right,
+
+        tile_scheduler = TileSchedulerCls()
+        work_tile = tile_scheduler.initial_work_tile_info()
+
+        while work_tile.is_valid_tile:
+            m_block, head_idx, batch_idx, _ = work_tile.tile_idx
+            head_idx_kv = head_idx // self.qhead_per_kvhead
+            m_block_cta_group = m_block // self.cta_group_size
+            seqlen = SeqlenInfoCls(batch_idx)
+            n_block_min, n_block_max = block_info.get_n_block_min_max(
+                seqlen, m_block_cta_group, Int32(0), Int32(1)
             )
 
-        log2_e = cutlass.Float32(math.log2(math.e))
-        softmax_scale_log2_e = scale_softmax * log2_e
-        tTMEM_STORErP = cute.make_rmem_tensor(tTMEM_LOADrS.shape, self.q_dtype)
-        for k in cutlass.range(0, cute.size(tTMEM_LOADrS), 2, unroll_full=True):
-            lse = (
-                -sLSE[
-                    cute.get(tTMEM_LOADcS[k], mode=[0]) - bidx * self.cta_tiler[0],
-                    lse_handle.index,
-                ],
-                -sLSE[
-                    cute.get(tTMEM_LOADcS[k + 1], mode=[0]) - bidx * self.cta_tiler[0],
-                    lse_handle.index,
-                ],
-            )
-            tTMEM_LOADrS[k], tTMEM_LOADrS[k + 1] = cute.arch.fma_packed_f32x2(
-                (tTMEM_LOADrS[k], tTMEM_LOADrS[k + 1]),
-                (softmax_scale_log2_e, softmax_scale_log2_e),
-                lse,
-            )
-            tTMEM_LOADrS[k] = cute.math.exp2(tTMEM_LOADrS[k], fastmath=True)
-            tTMEM_LOADrS[k + 1] = cute.math.exp2(tTMEM_LOADrS[k + 1], fastmath=True)
-
-        dp_handle = mma_dp_consumer.wait_and_advance()
-        tdPtdP_slice = tdPtdP[(None, None), 0, 0, dp_handle.index]
-        tdPcdP_slice = tdPcdP[(None, None), 0, 0]
-        thr_load = tmem_tiled_load.get_slice(thread_idx)
-        tTMEM_LOADtdP = thr_load.partition_S(tdPtdP_slice)
-        tTMEM_LOADcdP = thr_load.partition_D(tdPcdP_slice)
-        tTMEM_LOADrdP = cute.make_rmem_tensor(tTMEM_LOADcdP.shape, self.acc_dtype)
-        cute.copy(tmem_tiled_load, tTMEM_LOADtdP, tTMEM_LOADrdP)
-        cute.arch.fence_view_async_tmem_load()
-        dp_handle.release()
-        tTMEM_STORErdP = cute.make_rmem_tensor(tTMEM_LOADrdP.shape, self.q_dtype)
-
-        for k in cutlass.range(0, cute.size(tTMEM_LOADrdP), 2, unroll_full=True):
-            dpsum_0 = -sSum_OdO[
-                cute.get(tTMEM_LOADcdP[k], mode=[0]) - bidx * self.cta_tiler[0],
-                sum_odo_handle.index,
+            # GMEM tensors (varlen-aware)
+            mQ_cur = seqlen.offset_batch_Q(mQ, batch_idx, dim=3)[None, None, head_idx]
+            mK_cur = seqlen.offset_batch_K(mK, batch_idx, dim=3)[None, None, head_idx_kv]
+            mV_cur = seqlen.offset_batch_K(mV, batch_idx, dim=3)[None, None, head_idx_kv]
+            mdO_cur = seqlen.offset_batch_Q(mdO, batch_idx, dim=3)[None, None, head_idx]
+            mLSE_cur = seqlen.offset_batch_Q(mLSE, batch_idx, dim=2, padded=True)[None, head_idx]
+            mdPsum_cur = seqlen.offset_batch_Q(mdPsum, batch_idx, dim=2, padded=True)[
+                None, head_idx
             ]
-            dpsum_1 = -sSum_OdO[
-                cute.get(tTMEM_LOADcdP[k + 1], mode=[0]) - bidx * self.cta_tiler[0],
-                sum_odo_handle.index,
-            ]
-            if cutlass.const_expr(varlen):
-                if not cute.elem_less(cute.get(tTMEM_LOADcdP[k], mode=[0]), seqlen_q):
-                    dpsum_0 = 0.0
-                if not cute.elem_less(cute.get(tTMEM_LOADcdP[k + 1], mode=[0]), seqlen_q):
-                    dpsum_1 = 0.0
-            tTMEM_LOADrdP[k], tTMEM_LOADrdP[k + 1] = cute.arch.add_packed_f32x2(
-                (tTMEM_LOADrdP[k], tTMEM_LOADrdP[k + 1]),
-                (dpsum_0, dpsum_1),
-            )
-            tTMEM_LOADrdP[k], tTMEM_LOADrdP[k + 1] = cute.arch.mul_packed_f32x2(
-                (tTMEM_LOADrdP[k], tTMEM_LOADrdP[k + 1]), (tTMEM_LOADrS[k], tTMEM_LOADrS[k + 1])
-            )
-            tTMEM_LOADrdP[k], tTMEM_LOADrdP[k + 1] = cute.arch.mul_packed_f32x2(
-                (tTMEM_LOADrdP[k], tTMEM_LOADrdP[k + 1]), (scale_softmax, scale_softmax)
-            )
-        dp_vec = tTMEM_LOADrdP.load()
-        tTMEM_STORErdP.store(dp_vec.to(self.q_dtype))
+            gLSE = cute.local_tile(mLSE_cur, (self.tile_m,), (None,))
+            gdPsum = cute.local_tile(mdPsum_cur, (self.tile_m,), (None,))
+            if cutlass.const_expr(not seqlen.has_cu_seqlens_k):
+                mKt_cur = mKt[None, None, head_idx_kv, batch_idx]
+            else:
+                mKt_cur = cute.domain_offset((0, seqlen.offset_k, 0), mKt)[None, None, head_idx_kv]
 
-        ds_handle = ds_mma_producer.acquire_and_advance()
-        tmem_store_atom = cute.make_copy_atom(
-            tcgen05.St32x32bOp(tcgen05.Repetition(32)), self.acc_dtype
-        )
-        tilePlikeFP32 = tdPtdP_slice.shape[1] // Float32.width * self.q_dtype.width
-        tdPtdP_dS_layout = cute.composition(
-            tdPtdP_slice.layout, cute.make_layout((tdPtdP_slice.shape[0], tilePlikeFP32))
-        )
-        tdPtdP_dS = cute.make_tensor(tdPtdP_slice.iterator, tdPtdP_dS_layout)
-        tdPcdP_dS_layout = cute.composition(
-            tdPcdP_slice.layout, cute.make_layout((tdPcdP_slice.shape[0], tilePlikeFP32))
-        )
-        tdPcdP_dS = cute.make_tensor(tdPcdP_slice.iterator, tdPcdP_dS_layout)
-        tmem_tiled_store = tcgen05.make_tmem_copy(tmem_store_atom, tdPtdP_dS)
+            # (1) S = Q @ K.T
+            gQ = cute.local_tile(
+                mQ_cur, cute.select(self.qk_mma_tiler, mode=[0, 2]), (m_block_cta_group, 0)
+            )
+            tSgQ = thr_mma_S.partition_A(gQ)
 
-        thr_store = tmem_tiled_store.get_slice(thread_idx)
-        tTMEM_STOREtdS = thr_store.partition_D(tdPtdP_dS)
-        tTMEM_STOREcdP = thr_store.partition_S(tdPcdP_dS)
-        tTMEM_STORErdS_ = cute.make_tensor(
-            cute.recast_ptr(tTMEM_STORErdP.iterator, dtype=self.acc_dtype),
-            tTMEM_STOREcdP.shape,
-        )
-        cute.copy(tmem_tiled_store, tTMEM_STORErdS_, tTMEM_STOREtdS)
-        cute.arch.fence_view_async_tmem_store()
-        ds_handle.commit()
-        return mma_s_consumer, mma_dp_consumer, ds_mma_producer
+            a_cta_layout = cute.make_layout(cute.slice_(cluster_layout_vmnk, (0, 0, None, 0)).shape)
+            load_Q, _, _ = copy_utils.tma_get_copy_fn(
+                tma_atom_Q,
+                cta_coord=block_in_cluster_coord_vmnk[2],
+                cta_layout=a_cta_layout,
+                src_tensor=tSgQ,
+                dst_tensor=sQ,
+                mcast_mask=q_do_mcast_mask,
+                single_stage=True,
+            )
+
+            gK = cute.local_tile(mK_cur, cute.select(self.qk_mma_tiler, mode=[1, 2]), (None, 0))
+            tSgK = thr_mma_S.partition_B(gK)
+
+            b_cta_layout = cute.make_layout(cute.slice_(cluster_layout_vmnk, (0, None, 0, 0)).shape)
+            load_K, _, _ = copy_utils.tma_get_copy_fn(
+                tma_atom_K,
+                cta_coord=block_in_cluster_coord_vmnk[1],
+                cta_layout=b_cta_layout,
+                src_tensor=tSgK,
+                dst_tensor=sK,
+            )
+            load_K = copy_utils.tma_producer_copy_fn(load_K, pipeline_K)
+
+            # (2) dP = dO @ V.T
+            gdO = cute.local_tile(
+                mdO_cur, cute.select(self.dov_mma_tiler, mode=[0, 2]), (m_block_cta_group, 0)
+            )
+            tdPgdO = thr_mma_dP.partition_A(gdO)
+
+            load_dO, _, _ = copy_utils.tma_get_copy_fn(
+                tma_atom_dO,
+                cta_coord=block_in_cluster_coord_vmnk[2],
+                cta_layout=a_cta_layout,
+                src_tensor=tdPgdO,
+                dst_tensor=sdO,
+                mcast_mask=q_do_mcast_mask,
+                single_stage=True,
+            )
+
+            gV = cute.local_tile(mV_cur, cute.select(self.dov_mma_tiler, mode=[1, 2]), (None, 0))
+            tSgV = thr_mma_dP.partition_B(gV)
+
+            load_V, _, _ = copy_utils.tma_get_copy_fn(
+                tma_atom_V,
+                cta_coord=block_in_cluster_coord_vmnk[1],
+                cta_layout=b_cta_layout,
+                src_tensor=tSgV,
+                dst_tensor=sV,
+            )
+            load_V = copy_utils.tma_producer_copy_fn(load_V, pipeline_V)
+
+            # (3) dQ = dS @ K
+            gKt = cute.local_tile(mKt_cur, cute.select(self.dsk_mma_tiler, mode=[1, 2]), (0, None))
+            tdQgK = thr_mma_dQ.partition_B(gKt)
+
+            load_Kt, _, _ = copy_utils.tma_get_copy_fn(
+                tma_atom_Kt,
+                cta_coord=block_in_cluster_coord_vmnk[1],
+                cta_layout=b_cta_layout,
+                src_tensor=tdQgK,
+                dst_tensor=sKT,
+            )
+            load_Kt = copy_utils.tma_producer_copy_fn(load_Kt, pipeline_Kt)
+
+            copy_atom_stats = cute.make_copy_atom(cpasync.CopyBulkG2SOp(), Float32)
+            copy_stats = partial(cute.copy, copy_atom_stats)
+
+            process_tile = (
+                const_expr(not self.is_local and not self.is_varlen_q and not self.is_varlen_k)
+                or n_block_min < n_block_max
+            )
+
+            if process_tile:
+                first_n_block = n_block_min
+
+                #### Prologue ####
+                # Q (for S)
+                pipeline_Q.producer_acquire(producer_state_Q)
+                load_Q(tma_bar_ptr=pipeline_Q.producer_get_barrier(producer_state_Q))
+                pipeline_Q.producer_commit(producer_state_Q)
+                producer_state_Q.advance()
+
+                # K (for S)
+                pipeline_K.producer_acquire(producer_state_K)
+                load_K(first_n_block, producer_state=producer_state_K)
+                pipeline_K.producer_commit(producer_state_K)
+                producer_state_K.advance()
+
+                # LSE
+                pipeline_LSE.producer_acquire(producer_state_LSE)
+                with cute.arch.elect_one():
+                    copy_stats(
+                        gLSE[None, m_block],
+                        sLSE[None, producer_state_LSE.index],
+                        mbar_ptr=pipeline_LSE.producer_get_barrier(producer_state_LSE),
+                    )
+                producer_state_LSE.advance()
+
+                # dO (for dP)
+                pipeline_dO.producer_acquire(producer_state_dO)
+                load_dO(tma_bar_ptr=pipeline_dO.producer_get_barrier(producer_state_dO))
+                pipeline_dO.producer_commit(producer_state_dO)
+                producer_state_dO.advance()
+
+                # V (for dP)
+                pipeline_V.producer_acquire(producer_state_V)
+                load_V(first_n_block, producer_state=producer_state_V)
+                pipeline_V.producer_commit(producer_state_V)
+                producer_state_V.advance()
+
+                # dPsum
+                pipeline_dPsum.producer_acquire(producer_state_dPsum)
+                with cute.arch.elect_one():
+                    copy_stats(
+                        gdPsum[None, m_block],
+                        sdPsum[None, producer_state_dPsum.index],
+                        mbar_ptr=pipeline_dPsum.producer_get_barrier(producer_state_dPsum),
+                    )
+                producer_state_dPsum.advance()
+
+                # Kt (for dQ)
+                pipeline_Kt.producer_acquire(producer_state_Kt)
+                load_Kt(first_n_block, producer_state=producer_state_Kt)
+                pipeline_Kt.producer_commit(producer_state_Kt)
+                producer_state_Kt.advance()
+
+                #### Main Loop ####
+                for n_block in cutlass.range(n_block_min + 1, n_block_max, unroll=1):
+                    # K (for S)
+                    pipeline_K.producer_acquire(producer_state_K)
+                    load_K(n_block, producer_state=producer_state_K)
+                    pipeline_K.producer_commit(producer_state_K)
+                    producer_state_K.advance()
+
+                    # LSE
+                    pipeline_LSE.producer_acquire(producer_state_LSE)
+                    with cute.arch.elect_one():
+                        copy_stats(
+                            gLSE[None, m_block],
+                            sLSE[None, producer_state_LSE.index],
+                            mbar_ptr=pipeline_LSE.producer_get_barrier(producer_state_LSE),
+                        )
+                    producer_state_LSE.advance()
+
+                    # V (for dP)
+                    pipeline_V.producer_acquire(producer_state_V)
+                    load_V(n_block, producer_state=producer_state_V)
+                    pipeline_V.producer_commit(producer_state_V)
+                    producer_state_V.advance()
+
+                    # dPsum
+                    pipeline_dPsum.producer_acquire(producer_state_dPsum)
+                    with cute.arch.elect_one():
+                        copy_stats(
+                            gdPsum[None, m_block],
+                            sdPsum[None, producer_state_dPsum.index],
+                            mbar_ptr=pipeline_dPsum.producer_get_barrier(producer_state_dPsum),
+                        )
+                    producer_state_dPsum.advance()
+
+                    # Kt (for dQ)
+                    pipeline_Kt.producer_acquire(producer_state_Kt)
+                    load_Kt(n_block, producer_state=producer_state_Kt)
+                    pipeline_Kt.producer_commit(producer_state_Kt)
+                    producer_state_Kt.advance()
+
+            tile_scheduler.prefetch_next_work()
+            tile_scheduler.advance_to_next_work()
+            work_tile = tile_scheduler.get_current_work()
+            # End of persistent scheduler loop
+        pipeline_K.producer_tail(producer_state_K)
+        pipeline_V.producer_tail(producer_state_V)
+        pipeline_Kt.producer_tail(producer_state_Kt)
+        pipeline_Q.producer_tail(producer_state_Q)
+        pipeline_dO.producer_tail(producer_state_dO)
+        pipeline_LSE.producer_tail(producer_state_LSE)
+        pipeline_dPsum.producer_tail(producer_state_dPsum)
 
     @cute.jit
-    def dQ_epilogue(
+    def mma(
         self,
-        seqlen_q: int,
-        dq_args: Tuple,
-        epi_tile: cute.Tile,
-        tma_args: Tuple,
-    ) -> Tuple[pipeline.PipelineConsumer, pipeline.PipelineProducer]:
-        (mma_dq_consumer, gdQ_staged, cdQ_staged, tdQtdQ_staged) = dq_args
-        tma_atom_dQ, gdQ_tma_staged, s_epi_dQ, varlen = tma_args
-        dq_handle = mma_dq_consumer.wait_and_advance()
-        tidx, _, _ = cute.arch.thread_idx()
-        bidx, bidy, bidz = cute.arch.block_idx()
-        cta_rank_in_cluster = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster())
-        cute.arch.fence_view_async_shared()
+        tiled_mma_S,
+        tiled_mma_dP,
+        tiled_mma_dQ,
+        sQ,
+        sK,
+        sKT,
+        sV,
+        sdO,
+        tStS,
+        tdPtdP,
+        tdQtdQ,
+        tdS_layout,
+        pipeline_Q,
+        pipeline_K,
+        pipeline_V,
+        pipeline_dO,
+        pipeline_Kt,
+        pipeline_S_P,
+        pipeline_dP,
+        pipeline_dS,
+        pipeline_dQ,
+        block_info,
+        SeqlenInfoCls,
+        TileSchedulerCls,
+    ):
+        # [2025-10-21] For reasons I don't understand, putting these partitioning in the main
+        # kernel (before warp specialization) is a lot slower tha putting them here.
+        # Partition smem / tmem tensors
+        bidx, _, _ = cute.arch.block_idx()
+        mma_tile_coord_v = bidx % self.cta_group_size
+        thr_mma_S = tiled_mma_S.get_slice(mma_tile_coord_v)
+        thr_mma_dP = tiled_mma_dP.get_slice(mma_tile_coord_v)
+        thr_mma_dQ = tiled_mma_dQ.get_slice(mma_tile_coord_v)
+        # S = Q @ K.T
+        tSrQ = thr_mma_S.make_fragment_A(sQ)[None, None, None, 0]
+        tSrK = thr_mma_S.make_fragment_B(sK)
+        # dP = dO @ V.T
+        tdPrdO = thr_mma_dP.make_fragment_A(sdO)[None, None, None, 0]
+        tdPrV = thr_mma_dP.make_fragment_B(sV)
+        # dQ = dS @ K
+        tdQrKT = thr_mma_dQ.make_fragment_B(sKT)
 
-        epi_cols_dQ = math.gcd(128 // (self.dq_dtype.width // 8), epi_tile[1])
-        num_epi_stages_dQ = epi_tile[1] // epi_cols_dQ
-        epi_tile_dQ = (epi_tile[0], epi_cols_dQ)
+        mma_qk_fn = partial(
+            gemm_w_idx,
+            tiled_mma_S,
+            tStS[None, None, None, 0],
+            tSrQ,
+            tSrK,
+            zero_init=True,
+            num_unroll_groups=2,
+        )
+        mma_dov_fn = partial(
+            gemm_w_idx,
+            tiled_mma_dP,
+            tdPtdP[None, None, None, 0],
+            tdPrdO,
+            tdPrV,
+            zero_init=True,
+            num_unroll_groups=2,
+        )
+        num_unroll_groups = 2 if const_expr(self.use_2cta_instrs) else 1
+        mma_dsk_fn = partial(
+            gemm_w_idx,
+            tiled_mma_dQ,
+            tCrB=tdQrKT,
+            num_unroll_groups=num_unroll_groups,
+        )
+
+        consumer_state_Q = cutlass.pipeline.make_pipeline_state(
+            cutlass.pipeline.PipelineUserType.Consumer, self.Q_stage
+        )
+        consumer_state_K = cutlass.pipeline.make_pipeline_state(
+            cutlass.pipeline.PipelineUserType.Consumer, self.single_stage
+        )
+        consumer_state_V = cutlass.pipeline.make_pipeline_state(
+            cutlass.pipeline.PipelineUserType.Consumer, self.single_stage
+        )
+        consumer_state_dO = cutlass.pipeline.make_pipeline_state(
+            cutlass.pipeline.PipelineUserType.Consumer, self.dO_stage
+        )
+        consumer_state_Kt = cutlass.pipeline.make_pipeline_state(
+            cutlass.pipeline.PipelineUserType.Consumer, self.single_stage
+        )
+        producer_phase_acc = Int32(1)  # For S and dP
+        producer_phase_dQ = Int32(1)
+        consumer_state_dS = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer, self.dsk_acc_stage
+        )
+        cta_group = pipeline_S_P.cta_group
+
+        tile_scheduler = TileSchedulerCls()
+        work_tile = tile_scheduler.initial_work_tile_info()
+        while work_tile.is_valid_tile:
+            n_block, head_idx, batch_idx, _ = work_tile.tile_idx
+            n_block_cta_group = n_block // cute.size(tiled_mma_S.thr_id.shape)
+            seqlen = SeqlenInfoCls(batch_idx)
+            n_block_min, n_block_max = block_info.get_n_block_min_max(
+                seqlen, n_block_cta_group, Int32(0), Int32(1)
+            )
+            block_iter_count = n_block_max - n_block_min
+            process_tile = const_expr(
+                not self.is_local and not self.is_varlen_q and not self.is_varlen_k
+            ) or (
+                n_block_cta_group < cute.ceil_div(seqlen.seqlen_q, self.qk_mma_tiler[0])
+                and n_block_min < n_block_max
+            )
+
+            cta_rank_in_cluster = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster())
+            is_leader_cta = cta_rank_in_cluster % 2 == 0
+
+            if is_leader_cta and process_tile:
+                consumer_state_Q_releaser = consumer_state_Q.clone()
+                consumer_state_dO_releaser = consumer_state_dO.clone()
+                accumulate_dQ = False
+
+                pipeline_dQ.sync_object_empty.wait(0, producer_phase_dQ)
+
+                # -----------------------------------------------------------
+                ###### Prologue
+                # -----------------------------------------------------------
+                # 1. S  = Q @ K.T
+                # 2. dP = dO @ V.T
+
+                # 1) S = Q @ K.T
+                pipeline_Q.consumer_wait(consumer_state_Q)
+                consumer_state_Q.advance()
+                pipeline_K.consumer_wait(consumer_state_K)
+                pipeline_S_P.sync_object_empty.wait(0, producer_phase_acc)
+                mma_qk_fn(B_idx=consumer_state_K.index)
+                pipeline_S_P.sync_object_full.arrive(0, pipeline_S_P.producer_mask, cta_group)
+                pipeline_K.consumer_release(consumer_state_K)
+                consumer_state_K.advance()
+
+                # 2) dP = dO @ V.T
+                pipeline_dO.consumer_wait(consumer_state_dO)
+                consumer_state_dO.advance()
+                pipeline_V.consumer_wait(consumer_state_V)
+                pipeline_dP.sync_object_empty.wait(0, producer_phase_acc)
+                mma_dov_fn(B_idx=consumer_state_V.index)
+                pipeline_dP.sync_object_full.arrive(0, pipeline_dP.producer_mask, cta_group)
+                pipeline_V.consumer_release(consumer_state_V)
+                consumer_state_V.advance()
+                producer_phase_acc ^= 1
+
+                # -----------------------------------------------------------
+                ###### Main Loop
+                # -----------------------------------------------------------
+                # 1. S  = Q    @ K.T  (next)
+                # 2. dQ = dS   @ K    (cur)
+                # 3. dP = dO   @ V.T  (next)
+
+                main_loop_iters = block_iter_count - 1
+                for _ in cutlass.range(main_loop_iters, unroll=1):
+                    # (1) S = Q @ K.T (next)
+                    pipeline_K.consumer_wait(consumer_state_K)
+                    pipeline_S_P.sync_object_empty.wait(0, producer_phase_acc)
+                    mma_qk_fn(B_idx=consumer_state_K.index)
+                    pipeline_S_P.sync_object_full.arrive(0, pipeline_S_P.producer_mask, cta_group)
+                    pipeline_K.consumer_release(consumer_state_K)
+                    consumer_state_K.advance()
+
+                    # (2) dQ += dS @ K (cur)
+                    pipeline_dS.consumer_wait(consumer_state_dS)
+                    pipeline_Kt.consumer_wait(consumer_state_Kt)
+                    tdStdS = tdPtdP[None, None, None, consumer_state_dS.index]
+                    tdS = cute.make_tensor(tdStdS.iterator, tdS_layout.outer)
+                    tdQrdS = thr_mma_dQ.make_fragment_A(tdS)
+                    tdQrdS = cute.make_tensor(
+                        cute.recast_ptr(tdStdS.iterator, dtype=self.q_dtype),
+                        tdQrdS.layout,
+                    )
+                    mma_dsk_fn(
+                        tdQtdQ,
+                        tdQrdS,
+                        B_idx=consumer_state_Kt.index,
+                        zero_init=not accumulate_dQ,
+                    )
+                    accumulate_dQ = True
+                    pipeline_Kt.consumer_release(consumer_state_Kt)
+                    consumer_state_Kt.advance()
+                    pipeline_dS.consumer_release(consumer_state_dS)
+                    consumer_state_dS.advance()
+
+                    # (3) dP = dO @ V.T (next)
+                    pipeline_V.consumer_wait(consumer_state_V)
+                    pipeline_dP.sync_object_empty.wait(0, producer_phase_acc)
+                    mma_dov_fn(B_idx=consumer_state_V.index)
+                    pipeline_dP.sync_object_full.arrive(0, pipeline_dP.producer_mask, cta_group)
+                    pipeline_V.consumer_release(consumer_state_V)
+                    consumer_state_V.advance()
+                    producer_phase_acc ^= 1
+
+                # Release Q / dO after the final S and dP that reuse them are issued.
+                pipeline_Q.consumer_release(consumer_state_Q_releaser)
+                consumer_state_Q_releaser.advance()
+                pipeline_dO.consumer_release(consumer_state_dO_releaser)
+                consumer_state_dO_releaser.advance()
+
+                # -----------------------------------------------------------
+                # Tail: remaining dQ
+                # -----------------------------------------------------------
+                pipeline_dS.consumer_wait(consumer_state_dS)
+                pipeline_Kt.consumer_wait(consumer_state_Kt)
+                tdStdS = tdPtdP[None, None, None, consumer_state_dS.index]
+                tdS = cute.make_tensor(tdStdS.iterator, tdS_layout.outer)
+                tdQrdS = thr_mma_dQ.make_fragment_A(tdS)
+                tdQrdS = cute.make_tensor(
+                    cute.recast_ptr(tdStdS.iterator, dtype=self.q_dtype),
+                    tdQrdS.layout,
+                )
+                mma_dsk_fn(
+                    tdQtdQ,
+                    tdQrdS,
+                    B_idx=consumer_state_Kt.index,
+                    zero_init=not accumulate_dQ,
+                )
+                pipeline_dQ.sync_object_full.arrive(0, pipeline_dQ.producer_mask, cta_group)
+                producer_phase_dQ ^= 1
+                pipeline_Kt.consumer_release(consumer_state_Kt)
+                consumer_state_Kt.advance()
+                pipeline_dS.consumer_release(consumer_state_dS)
+                consumer_state_dS.advance()
+
+            tile_scheduler.advance_to_next_work()
+            work_tile = tile_scheduler.get_current_work()
+        # End of persistent scheduler loop
+
+    @cute.jit
+    def split_wg(
+        self,
+        t: cute.Tensor,
+        wg_idx: cutlass.Int32,
+        num_wg: cutlass.Constexpr[int],
+    ):
+        reduced_shape = cute.product_each(t.shape)
+        rank = len(reduced_shape)
+        if const_expr(reduced_shape[1] > 1):
+            assert rank >= 2, "Need rank >= 2 for t in split_wg"
+            t = cute.logical_divide(t, (reduced_shape[0], reduced_shape[1] // num_wg))
+            coord = (None, (None, wg_idx)) + (None,) * (rank - 2)
+        else:
+            assert rank >= 3, "Need rank >= 3 for t in split_wg"
+            if const_expr(rank == 3):
+                t = cute.logical_divide(
+                    t, (reduced_shape[0], reduced_shape[1], reduced_shape[2] // num_wg)
+                )
+                coord = (
+                    None,
+                    None,
+                    (None, wg_idx),
+                ) + (None,) * (rank - 3)
+            else:
+                t = cute.logical_divide(
+                    t,
+                    (
+                        reduced_shape[0],
+                        reduced_shape[1],
+                        reduced_shape[2],
+                        reduced_shape[3] // num_wg,
+                    ),
+                )
+                coord = (
+                    None,
+                    None,
+                    None,
+                    (None, wg_idx),
+                ) + (None,) * (rank - 4)
+        return t[coord]
+
+    @cute.jit
+    def apply_score_mod(
+        self,
+        tSrS_t2r,
+        thr_copy_t2r,
+        thr_mma_S,
+        batch_idx,
+        head_idx,
+        m_block,
+        n_block,
+        softmax_scale,
+        seqlen_info,
+        aux_data: utils.AuxData = utils.AuxData(),
+        fastdiv_mods=(None, None),
+    ):
+        """Apply forward score modification for SM100 backward pass."""
+        cS = cute.make_identity_tensor((self.qk_mma_tiler[0], self.qk_mma_tiler[1]))
+        cS = cute.domain_offset(
+            (m_block * self.qk_mma_tiler[0], n_block * self.qk_mma_tiler[1]), cS
+        )
+        tScS = thr_mma_S.partition_C(cS)
+        tScS_idx = thr_copy_t2r.partition_D(tScS)
+
+        apply_score_mod_inner(
+            tSrS_t2r,
+            tScS_idx,
+            self.score_mod,
+            batch_idx,
+            head_idx,
+            softmax_scale,
+            self.score_vec_size,
+            self.qk_acc_dtype,
+            aux_data,
+            fastdiv_mods,
+            seqlen_info,
+            constant_q_idx=None,
+            qhead_per_kvhead=self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
+        )
+
+    @cute.jit
+    def apply_score_mod_bwd(
+        self,
+        grad_tensor,
+        score_tensor,
+        index_tensor,
+        batch_idx,
+        head_idx,
+        softmax_scale,
+        seqlen_info,
+        aux_data: utils.AuxData = utils.AuxData(),
+        fastdiv_mods=(None, None),
+    ):
+        """Apply backward score modification (joint graph) for SM100."""
+        apply_score_mod_bwd_inner(
+            grad_tensor,
+            score_tensor,
+            index_tensor,
+            self.score_mod_bwd,
+            batch_idx,
+            head_idx,
+            softmax_scale,
+            self.score_vec_size,
+            self.qk_acc_dtype,
+            aux_data,
+            fastdiv_mods,
+            seqlen_info,
+            constant_q_idx=None,
+            qhead_per_kvhead=self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
+        )
+
+    @cute.jit
+    def compute_loop(
+        self,
+        tiled_mma_S,
+        thr_mma_S,
+        thr_mma_dP,
+        thr_mma_dQ,
+        scale_softmax,
+        tStS,
+        tdPtdP,
+        tdQtdQ,
+        mdQ,
+        mdQ_tma,
+        sdQ,
+        tma_atom_dQ,
+        tiled_copy_r2s_dQ,
+        sLSE,
+        sdPsum,
+        pipeline_S_P,
+        pipeline_dP,
+        pipeline_dS,
+        pipeline_dQ,
+        pipeline_LSE,
+        pipeline_dPsum,
+        block_info,
+        SeqlenInfoCls,
+        TileSchedulerCls,
+        aux_data: utils.AuxData = utils.AuxData(),
+        fastdiv_mods=(None, None),
+    ):
+        # This dQ kernel computes S = Q @ K.T, so accumulator coordinates are (q, k).
+        # Keep LSE/dPsum indexed by q; flash_bwd_sm100.py transposes these views because
+        # its main loop computes S.T = K @ Q.T.
+        sLSE_2D = cute.make_tensor(
+            sLSE.iterator,
+            cute.make_layout(
+                (self.tile_m, self.tile_n, self.Q_stage),
+                stride=(1, 0, cute.round_up(self.tile_m, 64)),
+            ),
+        )
+        sdPsum_2D = cute.make_tensor(
+            sdPsum.iterator,
+            cute.make_layout(
+                (self.tile_m, self.tile_n, self.dO_stage),
+                stride=(1, 0, cute.round_up(self.tile_m, 64)),
+            ),
+        )
+
+        # tix: [0...128] 4 warps
+        tidx = cute.arch.thread_idx()[0] % (cute.arch.WARP_SIZE * len(self.compute_warp_ids))
+        num_wg = len(self.compute_warp_ids) // 4
+        cta_rank_in_cluster = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster())
+        cta_rank_offset = cta_rank_in_cluster * self.cta_tiler[0]
+        # Stats SMEM is CTA-local, while 2CTA MMA C coordinates cover both CTA rows.
+        sLSE_2D = cute.domain_offset((Int32(0) - cta_rank_offset, Int32(0), Int32(0)), sLSE_2D)
+        sdPsum_2D = cute.domain_offset((Int32(0) - cta_rank_offset, Int32(0), Int32(0)), sdPsum_2D)
+
+        tileP_f32_like = self.cta_tiler[1] // 32 * self.v_dtype.width
+        # tdS overlaps with tdP in TMEM. dQ-only does not materialize P in TMEM.
+        tScS = thr_mma_S.partition_C(cute.make_identity_tensor(self.qk_mma_tiler[:2]))
+        tdPtdS = cute.composition(tdPtdP, (cute.make_layout((self.tile_n, tileP_f32_like)), 1, 1))
+        tdPcdP = thr_mma_dP.partition_C(cute.make_identity_tensor(self.dov_mma_tiler[:2]))
+        tdPcdS = cute.composition(tdPcdP, (cute.make_layout((self.tile_n, tileP_f32_like)), 1, 1))
+
+        # 2-CTA assumes: repetition should always be 32 & 16.
+        tmem_load_atom = cute.make_copy_atom(
+            tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(32)), Float32
+        )
+        tmem_store_atom = cute.make_copy_atom(
+            tcgen05.copy.St32x32bOp(tcgen05.copy.Repetition(16)), Float32
+        )
+
+        # tmem -> rmem
+        thr_copy_t2r = copy_utils.make_tmem_copy(tmem_load_atom, num_wg).get_slice(tidx)
+        tStS_t2r = thr_copy_t2r.partition_S(tStS)
+        tdPtdP_t2r = thr_copy_t2r.partition_S(tdPtdP)
+        tScS_t2r = thr_copy_t2r.partition_D(tScS)
+        t0ScS_t2r = thr_copy_t2r.get_slice(0).partition_D(tScS)
+        tSsLSE = thr_copy_t2r.partition_D(thr_mma_S.partition_C(sLSE_2D))
+        tSsdPsum = thr_copy_t2r.partition_D(thr_mma_dP.partition_C(sdPsum_2D))
+        # rmem -> tmem
+        thr_copy_r2t = copy_utils.make_tmem_copy(tmem_store_atom, num_wg).get_slice(tidx)
+        tdPcdS_r2t = thr_copy_r2t.partition_S(tdPcdS)
+        tdPtdS_r2t = thr_copy_r2t.partition_D(tdPtdS)
+
+        consumer_state_S_P = pipeline.make_pipeline_state(
+            cutlass.pipeline.PipelineUserType.Consumer, self.qk_acc_stage
+        )
+        consumer_state_dP = pipeline.make_pipeline_state(
+            cutlass.pipeline.PipelineUserType.Consumer, self.dov_acc_stage
+        )
+        producer_state_dS = pipeline.make_pipeline_state(
+            cutlass.pipeline.PipelineUserType.Producer, self.dsk_acc_stage
+        )
+        consumer_state_dQ = cutlass.pipeline.make_pipeline_state(
+            cutlass.pipeline.PipelineUserType.Consumer, self.epi_stage
+        )
+        consumer_state_LSE = cutlass.pipeline.make_pipeline_state(
+            cutlass.pipeline.PipelineUserType.Consumer, self.Q_stage
+        )
+        consumer_state_dPsum = pipeline.make_pipeline_state(
+            cutlass.pipeline.PipelineUserType.Consumer, self.dO_stage
+        )
+        LOG2_E = math.log2(math.e)
+        if const_expr(self.score_mod is None):
+            softmax_scale_log2 = scale_softmax * LOG2_E
+        else:
+            softmax_scale_log2 = LOG2_E
+
+        tile_scheduler = TileSchedulerCls()
+        work_tile = tile_scheduler.initial_work_tile_info()
+        while work_tile.is_valid_tile:
+            m_block, head_idx, batch_idx, _ = work_tile.tile_idx
+            m_block_cta_group = m_block // cute.size(tiled_mma_S.thr_id.shape)
+            seqlen = SeqlenInfoCls(batch_idx)
+            seqlen_q = seqlen.seqlen_q
+            recompute_fastdiv_mods_q = const_expr(
+                aux_data.tensors is not None and (seqlen.has_cu_seqlens_q or seqlen.has_seqused_q)
+            )
+            recompute_fastdiv_mods_k = const_expr(
+                aux_data.tensors is not None and (seqlen.has_cu_seqlens_k or seqlen.has_seqused_k)
+            )
+            if const_expr(fastdiv_mods is not None and fastdiv_mods[0] is not None):
+                seqlen_q_divmod, seqlen_k_divmod = fastdiv_mods
+                fastdiv_mods = (
+                    seqlen_q_divmod
+                    if not recompute_fastdiv_mods_q
+                    else FastDivmodDivisor(seqlen.seqlen_q),
+                    seqlen_k_divmod
+                    if not recompute_fastdiv_mods_k
+                    else FastDivmodDivisor(seqlen.seqlen_k),
+                )
+            n_block_min, n_block_max = block_info.get_n_block_min_max(
+                seqlen, m_block_cta_group, Int32(0), Int32(1)
+            )
+            mask = AttentionMask(
+                self.qk_mma_tiler[0],
+                self.qk_mma_tiler[1],
+                seqlen,
+                window_size_left=block_info.window_size_left,
+                window_size_right=block_info.window_size_right,
+            )
+            mask_fn = partial(
+                mask.apply_mask_sm100,
+                m_block=m_block_cta_group,
+                thr_mma=thr_mma_S,
+                mask_seqlen=True,
+                mask_causal=self.is_causal,
+                mask_local=self.is_local,
+                mask_mod=None,
+                batch_idx=batch_idx,
+                head_idx=head_idx,
+                aux_data=aux_data,
+                fastdiv_mods=fastdiv_mods,
+                head_divmod=None,
+                vec_size=self.mask_vec_size,
+                r2p=True,
+                rBitmask=None,
+            )
+
+            prefetch_LSE = False
+            loop_count = n_block_max - n_block_min
+            process_tile = (
+                const_expr(not self.is_local and not self.is_varlen_q and not self.is_varlen_k)
+                or n_block_min < n_block_max
+            )
+
+            # Mainloop
+            for iter_idx in cutlass.range(loop_count, unroll=1):
+                n_block = n_block_min + iter_idx
+
+                # S = Q @ K.T in this kernel, so S/dP accumulator coordinates are (q, k).
+                # flash_bwd_sm100.py consumes S.T as (k, q); do not transpose the row-indexed
+                # LSE/dPsum path when mirroring its loop structure here.
+                # ---------------------------------------------
+                #### P = exp(S - LSE)
+                # ---------------------------------------------
+                pipeline_LSE.consumer_wait(consumer_state_LSE)
+                tSrLSE_s2r = cute.make_rmem_tensor(tScS_t2r[None, 0, 0, 0].shape, Float32)
+                if const_expr(prefetch_LSE and not self.shuffle_LSE):
+                    cute.autovec_copy(tSsLSE[None, 0, 0, 0, consumer_state_LSE.index], tSrLSE_s2r)
+
+                pipeline_S_P.consumer_wait(consumer_state_S_P)
+                tSrS_t2r = cute.make_rmem_tensor(tScS_t2r.shape, Float32)
+                cute.copy(
+                    thr_copy_t2r,
+                    tStS_t2r[None, None, None, None, consumer_state_S_P.index],
+                    tSrS_t2r,
+                )
+                cute.arch.fence_view_async_tmem_load()
+                pipeline_S_P.consumer_release(consumer_state_S_P)
+                consumer_state_S_P.advance()
+                num_stages = cute.size(tScS_t2r, mode=[1])
+                if const_expr(self.score_mod_bwd is not None):
+                    tSrS_pre = cute.make_fragment_like(tSrS_t2r)
+                    cute.autovec_copy(tSrS_t2r, tSrS_pre)
+                if const_expr(self.score_mod is not None):
+                    self.apply_score_mod(
+                        tSrS_t2r,
+                        thr_copy_t2r,
+                        thr_mma_S,
+                        batch_idx,
+                        head_idx,
+                        m_block_cta_group,
+                        n_block,
+                        scale_softmax,
+                        seqlen,
+                        aux_data=aux_data,
+                        fastdiv_mods=fastdiv_mods,
+                    )
+                check_q_boundary = (m_block_cta_group + 1) * self.qk_mma_tiler[0] > seqlen_q
+                if const_expr(
+                    self.mask_mod is not None and not self.is_causal and not self.is_local
+                ):
+                    assert self.mask_vec_size % 32 == 0 or 32 % self.mask_vec_size == 0, (
+                        "vec_size must divide 32 or be a multiple of 32"
+                    )
+                    if const_expr(self.mask_vec_size == 1):
+                        mask.apply_mask_mod_sm100_scalar(
+                            tSrS_t2r,
+                            tScS_t2r,
+                            m_block_cta_group,
+                            n_block,
+                            True,
+                            self.mask_mod,
+                            batch_idx,
+                            head_idx,
+                            aux_data,
+                            fastdiv_mods,
+                            None,
+                            check_q_boundary,
+                        )
+                    else:
+                        mask.apply_mask_mod_sm100_vector(
+                            tSrS_t2r,
+                            tScS_t2r,
+                            m_block_cta_group,
+                            n_block,
+                            True,
+                            self.mask_mod,
+                            batch_idx,
+                            head_idx,
+                            self.mask_vec_size,
+                            aux_data,
+                            fastdiv_mods,
+                            None,
+                            check_q_boundary,
+                        )
+                else:
+                    mask_fn(
+                        tSrS_t2r,
+                        n_block=n_block,
+                        thr_tmem_load=thr_copy_t2r,
+                        check_q_boundary=check_q_boundary,
+                    )
+                lane_idx = cute.arch.lane_idx()
+                for stage in cutlass.range_constexpr(num_stages):
+                    tSrS_cur = tSrS_t2r[None, stage, 0, 0]
+                    tSsLSE_cur = tSsLSE[None, stage, 0, 0, consumer_state_LSE.index]
+                    if const_expr(not self.shuffle_LSE):
+                        if const_expr(stage > 0 or not prefetch_LSE):
+                            cute.autovec_copy(tSsLSE_cur, tSrLSE_s2r)
+                        tSrLSE = tSrLSE_s2r
+                    else:
+                        tSrLSE = tSsLSE_cur[lane_idx]
+                    for v in cutlass.range_constexpr(cute.size(tSrS_t2r, mode=[0]) // 2):
+                        if const_expr(not self.shuffle_LSE):
+                            lse_pair = (tSrLSE[2 * v], tSrLSE[2 * v + 1])
+                        else:
+                            lse_pair = (
+                                utils.shuffle_sync(tSrLSE, offset=2 * v),
+                                utils.shuffle_sync(tSrLSE, offset=2 * v + 1),
+                            )
+                        tSrS_cur[2 * v], tSrS_cur[2 * v + 1] = cute.arch.fma_packed_f32x2(
+                            (tSrS_cur[2 * v], tSrS_cur[2 * v + 1]),
+                            (softmax_scale_log2, softmax_scale_log2),
+                            (-lse_pair[0], -lse_pair[1]),
+                        )
+                        tSrS_cur[2 * v] = cute.math.exp2(tSrS_cur[2 * v], fastmath=True)
+                        tSrS_cur[2 * v + 1] = cute.math.exp2(tSrS_cur[2 * v + 1], fastmath=True)
+                pipeline_LSE.consumer_release(consumer_state_LSE)
+                consumer_state_LSE.advance()
+
+                # ---------------------------------------------
+                #### dS = P * (dP - dPsum)
+                # ---------------------------------------------
+                pipeline_dPsum.consumer_wait(consumer_state_dPsum)
+                pipeline_dP.consumer_wait(consumer_state_dP)
+                pipeline_dS.producer_acquire(producer_state_dS)
+
+                for stage in cutlass.range_constexpr(num_stages):
+                    tdPrdP_t2r = cute.make_rmem_tensor(tScS_t2r[None, 0, None, None].shape, Float32)
+                    cute.copy(
+                        thr_copy_t2r,
+                        tdPtdP_t2r[None, stage, None, None, consumer_state_dP.index],
+                        tdPrdP_t2r,
+                    )
+                    cute.arch.fence_view_async_tmem_load()
+                    tdPrdP_cur = tdPrdP_t2r[None, 0, 0]
+                    tSrS_cur = tSrS_t2r[None, stage, 0, 0]
+                    tSsdPsum_cur = tSsdPsum[None, stage, 0, 0, consumer_state_dPsum.index]
+                    if const_expr(not self.shuffle_dPsum):
+                        tSrdPsum = cute.make_fragment_like(tSsdPsum_cur, Float32)
+                        cute.autovec_copy(tSsdPsum_cur, tSrdPsum)
+                    else:
+                        tSrdPsum = tSsdPsum_cur[lane_idx]
+                    for v in cutlass.range_constexpr(cute.size(tdPrdP_t2r, mode=[0]) // 2):
+                        if const_expr(not self.shuffle_dPsum):
+                            dPsum_pair = (tSrdPsum[2 * v], tSrdPsum[2 * v + 1])
+                        else:
+                            dPsum_pair = (
+                                utils.shuffle_sync(tSrdPsum, offset=2 * v),
+                                utils.shuffle_sync(tSrdPsum, offset=2 * v + 1),
+                            )
+                        tdPrdP_cur[2 * v], tdPrdP_cur[2 * v + 1] = (
+                            quack.activation.sub_packed_f32x2(
+                                (tdPrdP_cur[2 * v], tdPrdP_cur[2 * v + 1]), dPsum_pair
+                            )
+                        )
+                        tdPrdP_cur[2 * v], tdPrdP_cur[2 * v + 1] = cute.arch.mul_packed_f32x2(
+                            (tSrS_cur[2 * v], tSrS_cur[2 * v + 1]),
+                            (tdPrdP_cur[2 * v], tdPrdP_cur[2 * v + 1]),
+                        )
+                    if const_expr(self.score_mod_bwd is not None):
+                        tSrS_pre_cur = tSrS_pre[None, stage, 0, 0]
+                        cS_bwd = cute.make_identity_tensor(
+                            (self.qk_mma_tiler[0], self.qk_mma_tiler[1])
+                        )
+                        cS_bwd = cute.domain_offset(
+                            (
+                                m_block_cta_group * self.qk_mma_tiler[0],
+                                n_block * self.qk_mma_tiler[1],
+                            ),
+                            cS_bwd,
+                        )
+                        tScS_bwd = thr_mma_S.partition_C(cS_bwd)
+                        tScS_idx_bwd = thr_copy_t2r.partition_D(tScS_bwd)
+                        tScS_idx_cur = tScS_idx_bwd[None, stage, 0, 0]
+                        self.apply_score_mod_bwd(
+                            tdPrdP_cur,
+                            tSrS_pre_cur,
+                            tScS_idx_cur,
+                            batch_idx,
+                            head_idx,
+                            scale_softmax,
+                            seqlen,
+                            aux_data=aux_data,
+                            fastdiv_mods=fastdiv_mods,
+                        )
+                        for i in cutlass.range(cute.size(tdPrdP_cur), unroll_full=True):
+                            kv_idx = tScS_idx_cur[i][1]
+                            tdPrdP_cur[i] = 0.0 if kv_idx >= seqlen.seqlen_k else tdPrdP_cur[i]
+                    for v in cutlass.range_constexpr(cute.size(tdPrdP_t2r, mode=[0]) // 2):
+                        tdPrdP_cur[2 * v], tdPrdP_cur[2 * v + 1] = cute.arch.mul_packed_f32x2(
+                            (tdPrdP_cur[2 * v], tdPrdP_cur[2 * v + 1]),
+                            (scale_softmax, scale_softmax),
+                        )
+
+                    tdPrdS_cvt = cute.make_fragment_like(tdPrdP_cur, self.ds_dtype)
+                    utils.cvt_f16(tdPrdP_cur, tdPrdS_cvt)
+                    tdPrdS_r2t = cute.recast_tensor(tdPrdS_cvt, Float32)
+                    cute.copy(thr_copy_r2t, tdPrdS_r2t, tdPtdS_r2t[None, stage, 0, 0])
+                cute.arch.fence_view_async_tmem_store()
+                pipeline_dP.consumer_release(consumer_state_dP)
+                consumer_state_dP.advance()
+                pipeline_dS.producer_commit(producer_state_dS)
+                producer_state_dS.advance()
+                pipeline_dPsum.consumer_release(consumer_state_dPsum)
+                consumer_state_dPsum.advance()
+
+            # Epilogue
+            if process_tile:
+                if const_expr(not seqlen.has_cu_seqlens_q):
+                    thr_copy_r2s_dQ = tiled_copy_r2s_dQ.get_slice(tidx)
+                    consumer_state_dQ = self.epilogue_dQ_tma(
+                        tidx,
+                        batch_idx,
+                        head_idx,
+                        m_block,
+                        seqlen,
+                        thr_mma_dQ,
+                        tdQtdQ,
+                        mdQ_tma,
+                        sdQ,
+                        tma_atom_dQ,
+                        thr_copy_r2s_dQ,
+                        pipeline_dQ,
+                        consumer_state_dQ,
+                        None,  # Don't scale
+                        self.epilogue_sync_bar_id,
+                        None,
+                    )
+                else:
+                    consumer_state_dQ = self.epilogue_dQ(
+                        tidx,
+                        batch_idx,
+                        head_idx,
+                        m_block,
+                        seqlen,
+                        thr_mma_dQ,
+                        tdQtdQ,
+                        mdQ,
+                        pipeline_dQ,
+                        consumer_state_dQ,
+                    )
+            # Zero dQ for empty tiles (local attention or zero-length K).
+            if const_expr(self.is_local or self.is_varlen_k):
+                should_zero_dQ = n_block_min >= n_block_max
+
+                if should_zero_dQ:
+                    gmem_tiled_copy_zero_dQ = copy_utils.tiled_copy_2d(
+                        self.dq_dtype,
+                        math.gcd(64, self.tile_hdim),
+                        128,
+                    )
+                    gmem_thr_copy_zero_dQ = gmem_tiled_copy_zero_dQ.get_slice(tidx)
+                    mdQ_cur = seqlen.offset_batch_Q(mdQ, batch_idx, dim=3)[None, None, head_idx]
+                    gdQ = cute.local_tile(
+                        mdQ_cur, cute.select(self.dsk_block_tiler, mode=[0, 1]), (m_block, 0)
+                    )
+                    tdQgdQ = gmem_thr_copy_zero_dQ.partition_D(gdQ)
+                    cdQ = cute.local_tile(
+                        cute.make_identity_tensor(mdQ_cur.shape),
+                        cute.select(self.dsk_block_tiler, mode=[0, 1]),
+                        (m_block, 0),
+                    )
+                    tdQcdQ = gmem_thr_copy_zero_dQ.partition_D(cdQ)
+                    zero = cute.make_fragment_like(tdQgdQ[None, 0, 0])
+                    zero.fill(0.0)
+                    for i in cutlass.range_constexpr(tdQgdQ.shape[1]):
+                        row_idx = tdQcdQ[0, i, 0][0]
+                        if row_idx < seqlen.seqlen_q:
+                            for j in cutlass.range_constexpr(tdQgdQ.shape[2]):
+                                cute.copy(gmem_tiled_copy_zero_dQ, zero, tdQgdQ[None, i, j])
+            tile_scheduler.advance_to_next_work()
+            work_tile = tile_scheduler.get_current_work()
+        _producer_tail_with_cutlass_state(pipeline_dS, producer_state_dS)
+
+    @cute.jit
+    def epilogue_dQ_tma(
+        self,
+        tidx: Int32,
+        batch_idx: Int32,
+        head_idx: Int32,
+        m_block: Int32,
+        seqlen,
+        thr_mma,
+        tdQtdQ: cute.Tensor,
+        mdQ: cute.Tensor,
+        sdQ: cute.Tensor,
+        tma_atom_dQ: cute.CopyAtom,
+        thr_copy_r2s_dQ: cute.TiledCopy,
+        pipeline_dQ,
+        consumer_state_dQ,
+        scale: Optional[Float32],
+        barrier_id: Int32,
+        mdQ_semaphore: Optional[cute.Tensor],
+    ) -> cutlass.pipeline.PipelineState:
+        tile_hdim = self.tile_hdim
+        dtype = self.dq_dtype
+        epi_tile = self.epi_tile_dQ
+        num_compute_threads = cute.arch.WARP_SIZE * len(self.compute_warp_ids)
+        wg_idx = (cute.arch.thread_idx()[0] % num_compute_threads) // 128
+        num_wg = num_compute_threads // 128
         leader_warp = (cute.arch.make_warp_uniform(cute.arch.warp_idx()) % 4) == 0
 
-        for iter in cutlass.range(self.iterations_dsk):
-            gdQ = gdQ_staged[None, None, iter]
-            cdQ = cdQ_staged[None, None, iter]
-            tdQtdQ = tdQtdQ_staged[(None, None), 0, 0, iter]
-            tdQtdQ_epi = cute.zipped_divide(tdQtdQ, epi_tile)
-            cdQ_epi = cute.zipped_divide(cdQ, epi_tile)
-            gdQ_epi = cute.zipped_divide(gdQ, epi_tile)
-            cdQ_local = cute.make_identity_tensor(epi_tile)
-            cdQ_local_epi = cute.zipped_divide(cdQ_local, epi_tile)
-            tidx, _, _ = cute.arch.thread_idx()
-            thread_idx = tidx % (self.threads_per_warp * len(self.epilogue_warp_ids))
-            tmem_copy_atom = cute.make_copy_atom(
-                tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(32)), self.acc_dtype
-            )
-            tiled_tmem_load = tcgen05.make_tmem_copy(tmem_copy_atom, tdQtdQ_epi)
-            thr_tmem_load = tiled_tmem_load.get_slice(thread_idx)
-            tTMEM_LOADtdQ = thr_tmem_load.partition_S(tdQtdQ_epi)
-            tTMEM_LOADgdQ = thr_tmem_load.partition_D(gdQ_epi)
-            tTMEM_LOADcdQ = thr_tmem_load.partition_D(cdQ_epi)
-            tTMEM_LOADcdQ_local = thr_tmem_load.partition_D(cdQ_local_epi)
+        assert scale is None
+        assert mdQ_semaphore is None
 
-            if cutlass.const_expr(not varlen):
-                gdQ_tma = gdQ_tma_staged[None, None, iter]
-                gdQ_tma_epi = cute.local_tile(gdQ_tma, epi_tile_dQ, (0, None))
-                sdQ_stage = s_epi_dQ[None, None, 0]
+        sdQ = sdQ[None, None, wg_idx]  # (tile_m, 64) for bf16
 
-                for stage_k in cutlass.range_constexpr(num_epi_stages_dQ):
-                    for i in cutlass.range(cute.size(tTMEM_LOADtdQ, mode=[1]), unroll_full=True):
-                        tTMEM_LOADtdQ_i = tTMEM_LOADtdQ[None, i, 0]
-                        tTMEM_LOADcdQ_i_local = tTMEM_LOADcdQ_local[None, i, 0]
-                        tTMrdQ = cute.make_rmem_tensor(tTMEM_LOADcdQ_i_local.shape, self.acc_dtype)
-                        cute.copy(tiled_tmem_load, tTMEM_LOADtdQ_i, tTMrdQ)
-                        tSMrdQ = cute.make_rmem_tensor(tTMrdQ.shape, self.q_dtype)
-                        dq_vec = tTMrdQ.load()
-                        tSMrdQ.store(dq_vec.to(self.q_dtype))
-                        for j in cutlass.range_constexpr(cute.size(tTMEM_LOADcdQ_i_local)):
-                            c = tTMEM_LOADcdQ_i_local[j]
-                            m_pos = c[0]
-                            n_pos = c[1]
-                            if n_pos // epi_cols_dQ == stage_k:
-                                s_epi_dQ[m_pos, n_pos % epi_cols_dQ, 0] = tSMrdQ[j]
+        # (8, tile_m / 128, 64 / 8) = (8, 1, 8)
+        tdQsdQ_r2s = thr_copy_r2s_dQ.partition_D(sdQ)
 
-                    cute.arch.fence_view_async_shared()
-                    cute.arch.barrier(barrier_id=3, number_of_threads=128)
+        assert not seqlen.has_cu_seqlens_q, "varlen uses non tma store path"
+        mdQ_cur = mdQ[None, None, head_idx, batch_idx]  # (seqlen, hdim)
+        gdQ_p = cute.local_tile(mdQ_cur, (self.tile_m, tile_hdim), (m_block, 0))
+        gdQ = self.split_wg(gdQ_p, wg_idx, num_wg)  # (tile_m, hdim)
+        gdQ_epi = cute.local_tile(gdQ, epi_tile, (0, None))  # (tile_m, 64, epi_stage)
 
-                    if leader_warp:
-                        gdQ_stage = gdQ_tma_epi[None, None, stage_k]
-                        td_sdQ, td_gdQ = cpasync.tma_partition(
-                            tma_atom_dQ,
-                            0,
-                            cute.make_layout(1),
-                            cute.group_modes(sdQ_stage, 0, 2),
-                            cute.group_modes(gdQ_stage, 0, 2),
-                        )
-                        cute.copy(tma_atom_dQ, td_sdQ, td_gdQ)
-                        cute.arch.cp_async_bulk_commit_group()
-                        cute.arch.cp_async_bulk_wait_group(0, read=True)
-                    # Non-issuing threads must not rotate the SMEM buffer
-                    # until the leader warp's TMA read has completed.
-                    cute.arch.barrier(barrier_id=3, number_of_threads=128)
-            else:
-                for i in cutlass.range(cute.size(tTMEM_LOADtdQ, mode=[1]), unroll_full=True):
-                    tTMEM_LOADtdQ_i = tTMEM_LOADtdQ[None, i, 0]
-                    tTMEM_LOADgdQ_i = tTMEM_LOADgdQ[None, i, 0]
-                    tTMEM_LOADcdQ_i = tTMEM_LOADcdQ[None, i, 0]
-                    tTMrdQ = cute.make_rmem_tensor(tTMEM_LOADcdQ[None, 0, i].shape, self.acc_dtype)
-                    cute.copy(tiled_tmem_load, tTMEM_LOADtdQ_i, tTMrdQ)
-                    tSMrdQ = cute.make_rmem_tensor(tTMrdQ.shape, self.q_dtype)
-                    dq_vec = tTMrdQ.load()
-                    tSMrdQ.store(dq_vec.to(self.q_dtype))
-                    if cute.elem_less(tTMEM_LOADcdQ_i[0][0], seqlen_q):
-                        cute.autovec_copy(tSMrdQ, tTMEM_LOADgdQ_i)
-        dq_handle.release()
-        return mma_dq_consumer
+        tdQsdQ, tdQgdQ = cpasync.tma_partition(
+            tma_atom_dQ,
+            0,  # no multicast
+            cute.make_layout(1),
+            cute.group_modes(sdQ, 0, 2),
+            cute.group_modes(gdQ_epi, 0, 2),
+        )  # (TMA) and (TMA, EPI_STAGE)
+        assert len(tdQsdQ.shape) == 1, "Wrong rank for SMEM fragment tdQsdQ"
+        assert len(tdQgdQ.shape) == 2, "Wrong rank for GMEM fragment tdQgdQ"
+        num_epi_stages = cute.size(tdQgdQ.shape[1])
+        assert num_epi_stages == self.num_epi_stages_dQ, "Epi stage calculation is wrong (Q)"
 
-    @cute.jit
-    def dQ_epilogue_write_zero(
-        self,
-        seqlen_q,
-        gdQ_staged,
-        cdQ_staged,
-    ):
-        num_epi_threads = self.threads_per_warp * len(self.epilogue_warp_ids)
-        tidx = cute.arch.thread_idx()[0] % num_epi_threads
-
-        tiled_copy_r2g = fa_copy_utils.tiled_copy_2d(
-            self.dq_dtype, cute.size(gdQ_staged.shape[1]), num_epi_threads
+        tmem_load_atom = cute.make_copy_atom(
+            tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(self.dQ_reduce_ncol)), Float32
         )
 
-        thr_copy_r2g = tiled_copy_r2g.get_slice(tidx)
-        tdQgdQ_staged = thr_copy_r2g.partition_D(gdQ_staged)
-        tdQcdQ_staged = thr_copy_r2g.partition_D(cdQ_staged)
+        read_flag = const_expr(True)
 
-        tdQrdQ = cute.make_rmem_tensor_like(tdQgdQ_staged[None, 0, None, 0])
-        tdQrdQ.fill(self.dq_dtype(0.0))
+        pipeline_dQ.consumer_wait(consumer_state_dQ)
 
-        for iter in cutlass.range(self.iterations_dsk, unroll_full=True):
-            tdQgdQ = tdQgdQ_staged[None, None, None, iter]
-            tdQcdQ = tdQcdQ_staged[None, None, None, iter]
-            for m in cutlass.range(cute.size(tdQgdQ.shape[1]), unroll_full=True):
-                if cute.elem_less(tdQcdQ[0, m, 0][0], seqlen_q):
-                    cute.copy(tiled_copy_r2g, tdQrdQ, tdQgdQ[None, m, None])
+        for epi_stage in cutlass.range_constexpr(num_epi_stages):
+            # TMEM -> RMEM -- setup
+            thr_copy_t2r = tcgen05.make_tmem_copy(tmem_load_atom, tdQtdQ).get_slice(tidx)
+            tdQtdQ_t2r_p = thr_copy_t2r.partition_S(tdQtdQ)
+            tdQtdQ_t2r = self.split_wg(tdQtdQ_t2r_p, wg_idx, num_wg)[None, None, 0, 0]
+            if const_expr(num_epi_stages > 1):
+                tdQtdQ_t2r = tdQtdQ_t2r[None, epi_stage]
+
+            cdQ = cute.make_identity_tensor((self.tile_m, tile_hdim))
+            tdQcdQ = thr_mma.partition_C(cdQ)
+            tdQcdQ_t2r_p = thr_copy_t2r.partition_D(tdQcdQ)
+            tdQcdQ_t2r = self.split_wg(tdQcdQ_t2r_p, wg_idx, num_wg)[None, None, 0, 0]
+            if const_expr(num_epi_stages > 1):
+                tdQcdQ_t2r = tdQcdQ_t2r[None, epi_stage]
+
+            tdQrdQ_t2r = cute.make_rmem_tensor(tdQcdQ_t2r.shape, Float32)
+
+            assert cute.size(tdQrdQ_t2r) == cute.size(tdQtdQ_t2r) // cute.arch.WARP_SIZE, (
+                "RMEM<->TMEM fragment size mismatch"
+            )
+
+            # TMEM -> RMEM -- copy and fence
+            cute.copy(thr_copy_t2r, tdQtdQ_t2r, tdQrdQ_t2r)
+            cute.arch.fence_view_async_tmem_load()
+
+            # RMEM -- convert
+            tdQrdQ = cute.make_rmem_tensor(tdQrdQ_t2r.shape, dtype)  # (64 columns)
+            tdQrdQ.store(tdQrdQ_t2r.load().to(dtype))
+
+            # RMEM -> SMEM -- copy, fence and barrier
+            tdQrdQ_r2s = cute.make_tensor(tdQrdQ.iterator, tdQsdQ_r2s.shape)
+            cute.copy(thr_copy_r2s_dQ, tdQrdQ_r2s, tdQsdQ_r2s)
+            cute.arch.fence_view_async_shared()
+            cute.arch.barrier(barrier_id=barrier_id + wg_idx, number_of_threads=128)
+
+            # SMEM -> GMEM
+            if leader_warp:
+                cute.copy(tma_atom_dQ, tdQsdQ, tdQgdQ[None, epi_stage])
+                if const_expr(epi_stage < num_epi_stages - 1):
+                    cute.arch.cp_async_bulk_commit_group()
+                    cute.arch.cp_async_bulk_wait_group(0, read=read_flag)
+                cute.arch.barrier_arrive(
+                    barrier_id=barrier_id + wg_idx, number_of_threads=128 + cute.arch.WARP_SIZE
+                )
+
+            # Barrier since all warps need to wait for SMEM to be freed
+            cute.arch.fence_view_async_shared()
+            cute.arch.barrier(
+                barrier_id=barrier_id + wg_idx, number_of_threads=128 + cute.arch.WARP_SIZE
+            )
+
+        cute.arch.sync_warp()
+        with cute.arch.elect_one():
+            pipeline_dQ.consumer_release(consumer_state_dQ)
+        consumer_state_dQ.advance()
+        return consumer_state_dQ
+
+    @cute.jit
+    def epilogue_dQ(
+        self,
+        tidx: Int32,
+        batch_idx: Int32,
+        head_idx: Int32,
+        m_block: Int32,
+        seqlen,
+        thr_mma,
+        tdQtdQ: cute.Tensor,
+        mdQ: cute.Tensor,
+        pipeline_dQ,
+        consumer_state_dQ,
+    ) -> cutlass.pipeline.PipelineState:
+        num_compute_threads = cute.arch.WARP_SIZE * len(self.compute_warp_ids)
+        wg_idx = (cute.arch.thread_idx()[0] % num_compute_threads) // 128
+        thread_idx = tidx % 128
+        epi_tile = self.epi_tile
+        mdQ_cur = seqlen.offset_batch_Q(mdQ, batch_idx, dim=3)[None, None, head_idx]
+        gdQ = cute.local_tile(mdQ_cur, cute.select(self.dsk_block_tiler, mode=[0, 1]), (m_block, 0))
+        cdQ = cute.local_tile(
+            cute.make_identity_tensor(mdQ_cur.shape),
+            cute.select(self.dsk_block_tiler, mode=[0, 1]),
+            (m_block, 0),
+        )
+        tdQtdQ = tdQtdQ[(None, None), 0, 0]
+        tdQtdQ_epi = cute.zipped_divide(tdQtdQ, epi_tile)
+        gdQ_epi = cute.zipped_divide(gdQ, epi_tile)
+        cdQ_epi = cute.zipped_divide(cdQ, epi_tile)
+
+        tmem_load_atom = cute.make_copy_atom(
+            tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(32)), Float32
+        )
+        thr_copy_t2r = tcgen05.make_tmem_copy(tmem_load_atom, tdQtdQ_epi).get_slice(thread_idx)
+        tdQtdQ_t2r = thr_copy_t2r.partition_S(tdQtdQ_epi)
+        tdQgdQ_t2r = thr_copy_t2r.partition_D(gdQ_epi)
+        tdQcdQ_t2r = thr_copy_t2r.partition_D(cdQ_epi)
+
+        pipeline_dQ.consumer_wait(consumer_state_dQ)
+
+        for epi_stage in cutlass.range(cute.size(tdQtdQ_t2r, mode=[1]), unroll_full=True):
+            # TMEM -> RMEM -- copy and fence
+            tdQtdQ_t2r_cur = tdQtdQ_t2r[None, epi_stage, 0]
+            tdQgdQ_t2r_cur = tdQgdQ_t2r[None, epi_stage, 0]
+            tdQcdQ_t2r_cur = tdQcdQ_t2r[None, epi_stage, 0]
+            tdQrdQ_t2r = cute.make_rmem_tensor(tdQcdQ_t2r_cur.shape, Float32)
+            cute.copy(thr_copy_t2r, tdQtdQ_t2r_cur, tdQrdQ_t2r)
+            cute.arch.fence_view_async_tmem_load()
+
+            # RMEM -> GMEM
+            tdQrdQ = cute.make_rmem_tensor(tdQrdQ_t2r.shape, self.dq_dtype)
+            tdQrdQ.store(tdQrdQ_t2r.load().to(self.dq_dtype))
+            if cute.elem_less(tdQcdQ_t2r_cur[0][0], seqlen.seqlen_q):
+                cute.autovec_copy(tdQrdQ, tdQgdQ_t2r_cur)
+
+        cute.arch.sync_warp()
+        with cute.arch.elect_one():
+            pipeline_dQ.consumer_release(consumer_state_dQ)
+        consumer_state_dQ.advance()
+        return consumer_state_dQ

--- a/flash_attn/cute/sm100_hd256_2cta_fmha_forward.py
+++ b/flash_attn/cute/sm100_hd256_2cta_fmha_forward.py
@@ -1,35 +1,78 @@
 # Copyright (c) 2025, Siyu Wang, Shengbin Di, Yuxi Chi, Johnsonms, Linfeng Zheng, Haoyan Huang, Lanbo Li, Yun Zhong, Man Yuan, Minmin Sun, Yong Li, Wei Lin.
 
+# Supported features:
+# - BF16 & FP16 dtype
+# - noncausal & causal attention
+# - MHA, GQA, MQA
+# - hdim 256
+# - varlen
+# - sliding window
+# - learnable sink
+# - softcap / custom score_mod
+# - mask_mod
+# - block sparsity
+# - TMA paged KV
+# Unsupported features that will be added later:
+# - non-TMA paged KV
+# - split-kv
+
 import math
-from typing import Tuple, Optional
+from functools import partial
+from typing import Callable, Tuple, Optional, Literal
 
 import cuda.bindings.driver as cuda
 
 import cutlass
 import cutlass.cute as cute
 import cutlass.cute.nvgpu.tcgen05 as tcgen05
-import cutlass.utils as utils
 import cutlass.pipeline as pipeline
-import cutlass.utils.blackwell_helpers as sm100_utils
+import flash_attn.cute.pipeline as pipeline_custom
+from cutlass import const_expr
+from cutlass.cute import FastDivmodDivisor
+from cutlass.cute.nvgpu import cpasync
+from cutlass.pipeline import pipeline_init_arrive, pipeline_init_wait
+import cutlass.utils.blackwell_helpers as sm100_utils_basic
 from cutlass.cute.typing import Int32, Int64, Float32
 
-from cutlass.utils import ClcDynamicPersistentTileScheduler
+from quack import copy_utils
+from quack.cute_dsl_utils import ParamsBase
+
+from flash_attn.cute import utils
+from flash_attn.cute.cute_dsl_utils import assume_tensor_aligned
 from flash_attn.cute.tile_scheduler import (
-    ClcState,
-    compute_sm100_fmha_grid as compute_grid,
-    compute_sm100_fmha_grid_clc as compute_grid_clc,
-    make_sm100_thread_cooperative_group as make_thread_cooperative_group,
-    Sm100FmhaStaticTileScheduler as FmhaStaticTileScheduler,
-    Sm100FmhaStaticTileSchedulerParams as FmhaStaticTileSchedulerParams,
-    Sm100FmhaClcDynamicTileScheduler as FmhaClcDynamicTileScheduler,
-    Sm100FmhaClcDynamicTileSchedulerParams as FmhaClcDynamicTileSchedulerParams,
+    SchedulingMode,
+    TileSchedulerArguments,
+    TileSchedulerProtocol,
+    SingleTileScheduler,
+    SingleTileVarlenScheduler,
 )
-from flash_attn.cute.mask import (
-    Sm100FusedMask as FusedMask,
+from flash_attn.cute.block_info import BlockInfo
+from flash_attn.cute.block_sparsity import BlockSparseTensors
+from flash_attn.cute.block_sparse_utils import (
+    get_total_block_count,
+    produce_block_sparse_loads_sm100_qk_ahead,
+    softmax_block_sparse_sm100,
 )
-from flash_attn.cute.tile_scheduler import SM100_TMEM_CAPACITY_COLUMNS
+from flash_attn.cute.mask import AttentionMask
+from flash_attn.cute import blackwell_helpers as sm100_utils
+from flash_attn.cute import mma_sm100_desc as sm100_desc
+from flash_attn.cute.named_barrier import NamedBarrierFwdSm100
+from flash_attn.cute.pack_gqa import pack_gqa_layout
+from flash_attn.cute.seqlen_info import SeqlenInfoQK
+from flash_attn.cute.softmax import SoftmaxSm100, apply_score_mod_inner
 from flash_attn.cute.flash_fwd_sm100 import DescaleTensors, _TUNING_CONFIG
-from flash_attn.cute.utils import ex2_emulation_2, as_bshkrd_tensor, AuxData
+from flash_attn.cute.utils import AuxData
+
+
+@cute.jit
+def _producer_tail_with_cutlass_state(pipeline_obj, state):
+    tail_state = cutlass.pipeline.PipelineState(
+        state.stages,
+        Int32(0),
+        state.index,
+        state.phase,
+    )
+    pipeline_obj.producer_tail(tail_state)
 
 
 class BlackwellFusedMultiHeadAttentionForward:
@@ -37,7 +80,7 @@ class BlackwellFusedMultiHeadAttentionForward:
         self,
         head_dim: int,
         head_dim_v: Optional[int] = None,
-        qhead_per_kvhead: int = 1,
+        qhead_per_kvhead: cutlass.Constexpr[int] = 1,
         is_causal: bool = False,
         is_local: bool = False,
         is_split_kv: bool = False,
@@ -46,30 +89,31 @@ class BlackwellFusedMultiHeadAttentionForward:
         kv_subtile_factor: int = 1,
         m_block_size: int = 128,
         n_block_size: int = 128,
-        q_stage: int = 2,
+        q_stage: cutlass.Constexpr[int] = 2,
         is_persistent: bool = True,
-        score_mod=None,
-        mask_mod=None,
-        has_aux_tensors: bool = False,
+        score_mod: cutlass.Constexpr | None = None,
+        mask_mod: cutlass.Constexpr | None = None,
+        has_aux_tensors: cutlass.Constexpr = False,
         paged_kv_non_tma: bool = False,
         is_varlen_q: bool = False,
         use_2cta_instrs: bool = False,
         use_clc_scheduler: bool = False,
     ):
-        head_dim_v = head_dim if head_dim_v is None else head_dim_v
+        self.use_tma_KV = not paged_kv_non_tma
+        # padding head_dim to a multiple of 16 as k_block_size
+        hdim_multiple_of = 16
+        head_dim_v = head_dim_v if head_dim_v is not None else head_dim
         assert head_dim == 256 and head_dim_v == 256, (
             "SM100 dedicated kernel only supports (head_dim, head_dim_v) = (256, 256)"
         )
-        assert score_mod is None, "SM100 forward with head_dim=256 does not support score_mod"
-        assert mask_mod is None, "SM100 forward with head_dim=256 does not support mask_mod"
-        assert not has_aux_tensors, "SM100 forward with head_dim=256 does not support aux tensors"
+        assert head_dim % hdim_multiple_of == 0 and head_dim_v % hdim_multiple_of == 0
         assert not paged_kv_non_tma, (
-            "SM100 hd256 2CTA supports TMA paged KV only (page_size must equal tile_n=128)"
+            "SM100 forward with head_dim=256 does not support non-TMA paged KV"
         )
         assert not pack_gqa, "SM100 forward with head_dim=256 does not support pack_gqa"
         assert not is_split_kv, "SM100 forward with head_dim=256 does not support SplitKV"
-        assert q_subtile_factor == 1, (
-            "SM100 forward with head_dim=256 does not support q_subtile_factor"
+        assert not use_clc_scheduler, (
+            "SM100 forward with head_dim=256 does not support CLC scheduler"
         )
         assert kv_subtile_factor == 1, (
             "SM100 forward with head_dim=256 does not support kv_subtile_factor"
@@ -77,92 +121,108 @@ class BlackwellFusedMultiHeadAttentionForward:
         assert m_block_size == 128 and n_block_size == 128, (
             "SM100 dedicated kernel only supports tile_m=128 and tile_n=128"
         )
-        # q_stage / persistence / scheduler knobs are accepted for interface parity,
-        # but this dedicated kernel uses fixed internal settings.
+        assert use_2cta_instrs, "SM100 forward with head_dim=256 requires use_2cta_instrs=True"
+        self.head_dim_padded = head_dim
+        self.same_hdim_kv = head_dim == head_dim_v
+        self.head_dim_v_padded = head_dim_v
+        self.same_hdim_kv_padded = self.head_dim_padded == self.head_dim_v_padded
+        self.check_hdim_oob = head_dim != self.head_dim_padded
+        self.check_hdim_v_oob = head_dim_v != self.head_dim_v_padded
+        self.m_block_size = m_block_size
+        self.n_block_size = n_block_size
+        self.q_stage = q_stage
+        self.use_2cta_instrs = use_2cta_instrs
+        self.cta_group_size = 2 if self.use_2cta_instrs else 1
 
-        qk_acc_dtype = cutlass.Float32
-        pv_acc_dtype = cutlass.Float32
-        mma_tiler = (128, 128, head_dim)
-        self.qk_acc_dtype = qk_acc_dtype
-        self.pv_acc_dtype = pv_acc_dtype
-        self.qhead_per_kvhead = qhead_per_kvhead
-        self.mma_tiler = mma_tiler
-        assert mma_tiler[0] == 128 and mma_tiler[1] == 128, "Only 128x128 tile impl is supported"
-        assert mma_tiler[2] == 256, "Only 256 is supported for 128x128 tile impl"
-        self.cta_tiler = (
-            mma_tiler[0],
-            mma_tiler[1],
-            mma_tiler[2],
-        )
-        self.qk_mma_tiler = (
-            2 * mma_tiler[0],
-            mma_tiler[1],
+        self.cta_tiler = (m_block_size, n_block_size, self.head_dim_padded)
+        self.mma_tiler_qk = (
+            self.cta_group_size * m_block_size,
+            n_block_size,
             min(self.cta_tiler[2], 128),
         )
-        self.pv_mma_tiler = self.qk_mma_tiler
-        self.pv_block_tiler = (
-            self.pv_mma_tiler[0] // 2,
-            self.pv_mma_tiler[1],
-            self.pv_mma_tiler[2],
+        self.mma_tiler_pv = self.mma_tiler_qk
+        self.qk_acc_dtype = Float32
+        self.pv_acc_dtype = Float32
+        self.block_tiler_pv = (
+            self.mma_tiler_pv[0] // 2,
+            self.mma_tiler_pv[1],
+            self.mma_tiler_pv[2],
         )
-        self.iterations_qk = self.cta_tiler[2] // self.qk_mma_tiler[2]
-        self.iterations_pv = self.cta_tiler[2] // self.pv_mma_tiler[1]
-        self.cluster_shape_mn = (2, 1)
+        self.q_load_stage = self.cta_tiler[2] // self.mma_tiler_qk[2]
+        self.qk_hdim_stage = self.q_load_stage
+        self.pv_hdim_stage = self.cta_tiler[2] // self.mma_tiler_pv[1]
+        self.cluster_shape_mn = (self.cta_group_size, 1)
         self.tmem_warp_shape_mn = (4, 1)
-        # Dedicated hd256 kernel uses fixed scheduling policy.
         self.is_persistent = False
         self.is_causal = is_causal
         self.is_local = is_local
-        self.use_semantic_trip_range = is_causal or is_local
+        self.is_varlen_q = is_varlen_q
+        self.qhead_per_kvhead = qhead_per_kvhead
+        self.is_split_kv = is_split_kv
+        self.use_correction_warps_for_epi = is_varlen_q
+        self.pack_gqa = pack_gqa
+        self.q_subtile_factor = q_subtile_factor
+        self.score_mod = score_mod
+        self.mask_mod = mask_mod
+        self.score_vec_size: cutlass.Constexpr = getattr(
+            score_mod, "__vec_size__", 1 if cutlass.const_expr(has_aux_tensors) else 2
+        )
+        self.mask_vec_size: cutlass.Constexpr = getattr(mask_mod, "__vec_size__", 1)
         self.use_clc_scheduler = False
+        self.scheduling_mode = SchedulingMode.STATIC
+        self.use_tma_Q = True
+
+        if is_varlen_q:
+            self.TileScheduler = SingleTileVarlenScheduler
+        else:
+            self.TileScheduler = SingleTileScheduler
 
         self.softmax_warp_ids = (0, 1, 2, 3)
         self.correction_warp_ids = (4, 5, 6, 7)
         self.mma_warp_id = 8
-        self.load_warp_id = 9
-        self.empty_warp_id = (10, 11)
-        self.sched_warp_id = self.empty_warp_id[0] if use_clc_scheduler else None
-        self.tmem_alloc_cols = SM100_TMEM_CAPACITY_COLUMNS
+        self.load_warp_ids = (9,)
+        self.epilogue_warp_ids = (10,)
+        self.empty_warp_ids = (11,)
+        self.tmem_alloc_cols = cute.arch.get_max_tmem_alloc_cols("sm_100")
 
-        self.threads_per_warp = 32
+        self.threads_per_warp = cute.arch.WARP_SIZE
         self.threads_per_cta = self.threads_per_warp * len(
             (
-                *self.softmax_warp_ids,  # this is to get a round num threads
+                *self.softmax_warp_ids,
                 *self.correction_warp_ids,
                 self.mma_warp_id,
-                self.load_warp_id,
-                *self.empty_warp_id,
+                *self.load_warp_ids,
+                *self.epilogue_warp_ids,
+                *self.empty_warp_ids,
             )
         )
-
-        self.tmem_alloc_barrier = pipeline.NamedBarrier(
-            barrier_id=1,
-            num_threads=self.threads_per_cta,
-        )
+        if self.use_correction_warps_for_epi:
+            self.empty_warp_ids = self.empty_warp_ids + self.epilogue_warp_ids
+            self.epilogue_warp_ids = self.correction_warp_ids
 
         self.tmem_s_offset = 0
         self.tmem_o_offset = 256
+        self.tmem_total = self.tmem_o_offset + self.head_dim_v_padded
+        assert self.tmem_total <= self.tmem_alloc_cols
         self.tmem_p_offset = self.tmem_s_offset
 
-        _tune_key = (True, is_causal, 256, False)  # hd256: always 2cta, no sm103 variant
-        _tune = _TUNING_CONFIG.get(_tune_key, {})
-        self.num_regs_softmax = _tune.get("num_regs_softmax", 256)
-        self.num_regs_correction = _tune.get("num_regs_correction", 160)
-        self.num_regs_other = 32  # fixed for hd256; not derived from 512 budget like other kernels
-        self.ex2_emu_freq = _tune.get("ex2_emu_freq", 4)
-        self.ex2_emu_res = _tune.get("ex2_emu_res", 3)
-        self.ex2_emu_start_frg = _tune.get("ex2_emu_start_frg", 0)
+        # Look up tuning config for register counts and ex2_emu params
+        self.is_sm103 = False
+        _tune_key = (self.use_2cta_instrs, self.is_causal, self.head_dim_padded, self.is_sm103)
+        self._tune = _TUNING_CONFIG.get(_tune_key, {})
+        self.num_regs_softmax = self._tune.get("num_regs_softmax", 256)
+        self.num_regs_correction = self._tune.get("num_regs_correction", 160)
+        self.num_regs_other = 32
+        self.ex2_emu_freq = self._tune.get("ex2_emu_freq", 4)
+        self.ex2_emu_res = self._tune.get("ex2_emu_res", 3)
+        self.ex2_emu_start_frg = self._tune.get("ex2_emu_start_frg", 0)
 
         self.buffer_align_bytes = 1024
 
     def _setup_attributes(self):
-        self.q_stage = self.iterations_qk
         self.kv_stage = 4
-        self.qk_acc_stage = 2
-        self.mma_corr_stage = 1
-        if cutlass.const_expr(self.use_clc_scheduler):
-            self.num_clc_stage = 1
-            self.num_clc_response_bytes = 16
+        self.s_stage = 2
+        self.o_stage = 1
 
     @cute.jit
     def __call__(
@@ -182,404 +242,336 @@ class BlackwellFusedMultiHeadAttentionForward:
         window_size_right: Int32 | int | None = None,
         learnable_sink: Optional[cute.Tensor] = None,
         descale_tensors: Optional[DescaleTensors] = None,
-        blocksparse_tensors: Optional[cute.Tensor] = None,
+        blocksparse_tensors: Optional[BlockSparseTensors] = None,
         aux_data: AuxData = AuxData(),
         stream: cuda.CUstream = None,
     ):
-        # Keep parity with FlashAttentionForwardSm100.__call__ interface.
-        # (TODO@wangsiyu) Implement these features.
-        assert mSeqUsedQ is None and mSeqUsedK is None, (
-            "SM100 forward with head_dim=256 does not support seqused_q/seqused_k"
-        )
-        assert learnable_sink is None, (
-            "SM100 forward with head_dim=256 does not support learnable_sink"
-        )
-        assert blocksparse_tensors is None, (
-            "SM100 forward with head_dim=256 does not support block sparsity"
-        )
-        assert aux_data.tensors is None, (
-            "SM100 forward with head_dim=256 does not support aux_tensors"
-        )
-        assert aux_data.scalars is None, (
-            "SM100 forward with head_dim=256 does not support aux_scalars"
-        )
-        assert not self.is_local, (
-            "SM100 forward with head_dim=256 does not support local attention yet"
-        )
-        assert window_size_left is None and window_size_right is None, (
-            "SM100 forward with head_dim=256 does not support runtime window_size overrides"
-        )
         assert descale_tensors is None, (
             "SM100 forward with head_dim=256 does not support descale_tensors"
         )
 
-        q_tensor, k_tensor, v_tensor, o_tensor = mQ, mK, mV, mO
-        lse_tensor = mLSE
-        cum_seqlen_q = mCuSeqlensQ
-        cum_seqlen_k = mCuSeqlensK
-
-        q_rank = len(mQ.shape)
-        k_rank = len(mK.shape)
-        if cutlass.const_expr(cum_seqlen_q is not None):
-            # Varlen path accepts either legacy 5D tensors or standard 3D tensors.
-            if cutlass.const_expr(q_rank == 5):
-                s_q = mQ.shape[1]
-                h_q = mQ.shape[2] * mQ.shape[3]
-                d = mQ.shape[4]
-            elif cutlass.const_expr(q_rank == 3):
-                s_q = mQ.shape[0]
-                h_q = mQ.shape[1]
-                d = mQ.shape[2]
-            else:
-                raise RuntimeError(f"hd256 forward varlen expects q rank 3 or 5, got rank {q_rank}")
-        else:
-            # Non-varlen path accepts either legacy 5D tensors or standard 4D tensors.
-            if cutlass.const_expr(q_rank == 5):
-                s_q = mQ.shape[1]
-                h_q = mQ.shape[2] * mQ.shape[3]
-                d = mQ.shape[4]
-            elif cutlass.const_expr(q_rank == 4):
-                s_q = mQ.shape[1]
-                h_q = mQ.shape[2]
-                d = mQ.shape[3]
-            else:
-                raise RuntimeError(
-                    f"hd256 forward non-varlen expects q rank 4 or 5, got rank {q_rank}"
-                )
-
-        if cutlass.const_expr(cum_seqlen_k is not None):
-            if cutlass.const_expr(k_rank == 5):
-                s_k = mK.shape[1]
-                h_k = mK.shape[2]
-            elif cutlass.const_expr(k_rank == 3):
-                s_k = mK.shape[0]
-                h_k = mK.shape[1]
-            else:
-                raise RuntimeError(f"hd256 forward varlen expects k rank 3 or 5, got rank {k_rank}")
-        else:
-            if cutlass.const_expr(k_rank == 5):
-                s_k = mK.shape[1]
-                h_k = mK.shape[2]
-            elif cutlass.const_expr(k_rank == 4):
-                s_k = mK.shape[1]
-                h_k = mK.shape[2]
-            else:
-                raise RuntimeError(
-                    f"hd256 forward non-varlen expects k rank 4 or 5, got rank {k_rank}"
-                )
-        if cutlass.const_expr(cum_seqlen_q is not None):
-            b = mCuSeqlensQ.shape[0] - 1
-        elif cutlass.const_expr(cum_seqlen_k is not None):
-            b = mCuSeqlensK.shape[0] - 1
-        else:
-            b = mQ.shape[0]
-
-        scale_softmax = softmax_scale
-        scale_softmax_log2 = softmax_scale * math.log2(math.exp(1.0))
-        scale_output = 1.0
-        s_lse = s_q
-        h_r = h_q // h_k
-        s_q64 = Int64(s_q)
-        s_k64 = Int64(s_k)
-        s_lse64 = Int64(s_lse)
-        h_r64 = Int64(h_r)
-        h_k64 = Int64(h_k)
-        b64 = Int64(b)
-        s_q_total = (
-            q_tensor.shape[1]
-            if cum_seqlen_q is not None and q_rank == 5
-            else (q_tensor.shape[0] if cum_seqlen_q is not None else s_q64)
-        )
-        s_k_total = (
-            k_tensor.shape[1]
-            if cum_seqlen_k is not None and k_rank == 5
-            else (k_tensor.shape[0] if cum_seqlen_k is not None else s_k64)
-        )
-        b_lse = b64 if cum_seqlen_q is None else 1
-        stride_b_lse = h_r64 * h_k64 * s_lse64 if cum_seqlen_q is None else 0
-
-        varlen_q = cum_seqlen_q is not None
-        varlen_k = cum_seqlen_k is not None
-        q_norm = as_bshkrd_tensor(q_tensor, h_k, h_r, varlen_q)
-        o_norm = as_bshkrd_tensor(o_tensor, h_k, h_r, varlen_q)
-
-        # Forward layout: (s, d, ((h_r, h_k), b)). Stride picks from canonical
-        # positions 1=S, 4=D, 3=H_r, 2=H_k, 0=B.
-        q = cute.make_tensor(
-            q_norm.iterator,
-            cute.make_layout(
-                (s_q_total, d, ((h_r, h_k), b)),
-                stride=(
-                    q_norm.stride[1],
-                    q_norm.stride[4],
-                    ((q_norm.stride[3], q_norm.stride[2]), q_norm.stride[0]),
-                ),
-            ),
-        )
-        if cutlass.const_expr(mPageTable is not None):
-            # Paged: input k/v are rank-4 (num_pages, page_size, h_k, d); the kernel
-            # consumes K as (page_size, d, h_k, num_pages) and V as
-            # (d, page_size, h_k, num_pages).
-            # cute.select reorders modes while preserving input strides
-            page_size = k_tensor.shape[1]
-            max_seqlen_k_paged = Int32(mPageTable.shape[1] * page_size)
-            k = cute.make_tensor(k_tensor.iterator, cute.select(k_tensor.layout, mode=[1, 3, 2, 0]))
-            v = cute.make_tensor(v_tensor.iterator, cute.select(v_tensor.layout, mode=[3, 1, 2, 0]))
-            page_table = cute.make_tensor(
-                mPageTable.iterator,
-                cute.make_layout(
-                    (b, mPageTable.shape[1]),
-                    stride=(mPageTable.stride[0], mPageTable.stride[1]),
-                ),
-            )
-        else:
-            # K/V have no h_r dim; pass h_r=1 to the normalizer and override the
-            # h_r stride to 0 below to broadcast across the query-grouped heads.
-            k_norm = as_bshkrd_tensor(k_tensor, h_k, 1, varlen_k)
-            v_norm = as_bshkrd_tensor(v_tensor, h_k, 1, varlen_k)
-            # (s, d, ((h_r, h_k), b)), 0-stride for h_r to broadcast
-            k = cute.make_tensor(
-                k_norm.iterator,
-                cute.make_layout(
-                    (s_k_total, d, ((h_r, h_k), b)),
-                    stride=(
-                        k_norm.stride[1],
-                        k_norm.stride[4],
-                        ((0, k_norm.stride[2]), k_norm.stride[0]),
-                    ),
-                ),
-            )
-            # (d, s, ((h_r, h_k), b)), 0-stride for h_r to broadcast
-            v = cute.make_tensor(
-                v_norm.iterator,
-                cute.make_layout(
-                    (d, s_k_total, ((h_r, h_k), b)),
-                    stride=(
-                        v_norm.stride[4],
-                        v_norm.stride[1],
-                        ((0, v_norm.stride[2]), v_norm.stride[0]),
-                    ),
-                ),
-            )
-            page_table = None
-            max_seqlen_k_paged = None
-        # (s, d, ((h_r, h_k), b))
-        o = cute.make_tensor(
-            o_norm.iterator,
-            cute.make_layout(
-                (s_q_total, d, ((h_r, h_k), b)),
-                stride=(
-                    o_norm.stride[1],
-                    o_norm.stride[4],
-                    ((o_norm.stride[3], o_norm.stride[2]), o_norm.stride[0]),
-                ),
-            ),
-        )
-        if cutlass.const_expr(lse_tensor is not None):
-            # (s, ((h_r, h_k), b))
-            lse_layout = cute.make_layout(
-                (s_lse64, ((h_r, h_k), b_lse)),
-                stride=(1, ((s_lse64, h_r64 * s_lse64), stride_b_lse)),
-            )
-            lse = cute.make_tensor(lse_tensor.iterator, lse_layout)
-        else:
-            lse = None
-
         # setup static attributes before smem/grid/tma computation
-        self.q_dtype = q.element_type
-        self.k_dtype = k.element_type
-        self.v_dtype = v.element_type
-        self.o_dtype = o.element_type
-        self.tilePlikeFP32 = self.qk_mma_tiler[1] // Float32.width * self.q_dtype.width
-
-        if cutlass.const_expr(self.use_clc_scheduler):
-            self.tile_sched_params, grid = compute_grid_clc(
-                (s_q, o.shape[1], o.shape[2]) if cum_seqlen_q is not None else o.shape,
-                self.cta_tiler,
-                (*self.cluster_shape_mn, 1),
-            )
-        else:
-            self.tile_sched_params, grid = compute_grid(
-                (s_q, o.shape[1], o.shape[2]) if cum_seqlen_q is not None else o.shape,
-                self.cta_tiler,
-                self.is_persistent,
-            )
-
-        self.q_major_mode = utils.LayoutEnum.from_tensor(q).mma_major_mode()
-        self.k_major_mode = utils.LayoutEnum.from_tensor(k).mma_major_mode()
-        self.v_major_mode = utils.LayoutEnum.from_tensor(v).mma_major_mode()
-        self.o_layout = utils.LayoutEnum.from_tensor(o)
-
-        if cutlass.const_expr(self.q_major_mode != tcgen05.OperandMajorMode.K):
-            raise RuntimeError("The layout of q is not supported")
-        if cutlass.const_expr(self.k_major_mode != tcgen05.OperandMajorMode.K):
-            raise RuntimeError("The layout of k is not supported")
-        if cutlass.const_expr(self.v_major_mode != tcgen05.OperandMajorMode.MN):
-            raise RuntimeError("The layout of v is not supported")
+        self.q_dtype = mQ.element_type
+        self.k_dtype = mK.element_type
+        self.v_dtype = mV.element_type
+        self.o_dtype = mO.element_type
+        mQ, mK, mV, mO = [assume_tensor_aligned(t) for t in (mQ, mK, mV, mO)]
+        Q_layout_transpose = [1, 3, 2, 0] if const_expr(mCuSeqlensQ is None) else [0, 2, 1]
+        mQ = cute.make_tensor(mQ.iterator, cute.select(mQ.layout, mode=Q_layout_transpose))
+        # (s_k, d, h_k, b_k) or (total_k, d, h_k) if there's cu_seqlens_k
+        KV_layout_transpose = [1, 3, 2, 0] if const_expr(mCuSeqlensK is None) else [0, 2, 1]
+        mK, mV = [
+            cute.make_tensor(t.iterator, cute.select(t.layout, mode=KV_layout_transpose))
+            for t in (mK, mV)
+        ]
+        O_layout_transpose = [1, 3, 2, 0] if const_expr(mCuSeqlensQ is None) else [0, 2, 1]
+        LSE_layout_transpose = [2, 1, 0] if const_expr(mCuSeqlensQ is None) else [1, 0]
+        num_splits = Int32(1)
+        mO = cute.make_tensor(mO.iterator, cute.select(mO.layout, mode=O_layout_transpose))
+        mLSE = (
+            cute.make_tensor(mLSE.iterator, cute.select(mLSE.layout, mode=LSE_layout_transpose))
+            if const_expr(mLSE is not None)
+            else None
+        )
+        # (s, d, h, b) -> (d, s, h, b)
+        V_layout_transpose = [1, 0, 2, 3] if const_expr(mCuSeqlensK is None) else [1, 0, 2]
+        mV = cute.make_tensor(mV.iterator, cute.select(mV.layout, mode=V_layout_transpose))
 
         # check type consistency
-        if cutlass.const_expr(self.q_dtype != self.k_dtype):
+        if const_expr(self.q_dtype != self.k_dtype):
             raise TypeError(f"Type mismatch: {self.q_dtype} != {self.k_dtype}")
-        if cutlass.const_expr(self.q_dtype != self.v_dtype):
+        if const_expr(self.q_dtype != self.v_dtype):
             raise TypeError(f"Type mismatch: {self.q_dtype} != {self.v_dtype}")
         self._setup_attributes()
 
-        cta_group = tcgen05.CtaGroup.TWO
-        # the intermediate tensor p is from tmem & k-major
+        cta_group = tcgen05.CtaGroup.TWO if self.use_2cta_instrs else tcgen05.CtaGroup.ONE
+        q_major_mode = tcgen05.OperandMajorMode.K
+        k_major_mode = tcgen05.OperandMajorMode.K
+        v_major_mode = tcgen05.OperandMajorMode.MN
+        self.o_layout = cutlass.utils.LayoutEnum.from_tensor(mO)
+        # the intermediate tensor p is from tmem & mK-major
         p_source = tcgen05.OperandSource.TMEM
         p_major_mode = tcgen05.OperandMajorMode.K
-        qk_tiled_mma = sm100_utils.make_trivial_tiled_mma(
+        tiled_mma_qk = sm100_utils_basic.make_trivial_tiled_mma(
             self.q_dtype,
-            self.q_major_mode,
-            self.k_major_mode,
+            q_major_mode,
+            k_major_mode,
             self.qk_acc_dtype,
             cta_group,
-            self.qk_mma_tiler[:2],
+            self.mma_tiler_qk[:2],
         )
-        pv_tiled_mma = sm100_utils.make_trivial_tiled_mma(
+        tiled_mma_pv = sm100_utils_basic.make_trivial_tiled_mma(
             self.v_dtype,
             p_major_mode,
-            self.v_major_mode,
+            v_major_mode,
             self.pv_acc_dtype,
             cta_group,
-            self.pv_mma_tiler[:2],
+            self.mma_tiler_pv[:2],
             p_source,
         )
 
         self.cluster_shape_mnk = (*self.cluster_shape_mn, 1)
-        self.cluster_layout_vmnk = cute.tiled_divide(
-            cute.make_layout(self.cluster_shape_mnk),
-            (qk_tiled_mma.thr_id.shape,),
+        cta_layout_vmnk = cute.tiled_divide(
+            cute.make_layout(self.cluster_shape_mnk), (tiled_mma_qk.thr_id.shape,)
         )
 
-        self.epi_tile = self.pv_block_tiler[:2]
+        self.epi_tile = (self.m_block_size, self.head_dim_v_padded)
 
-        q_smem_layout_staged = sm100_utils.make_smem_layout_a(
-            qk_tiled_mma,
-            self.qk_mma_tiler,
+        sQ_layout = sm100_utils_basic.make_smem_layout_a(
+            tiled_mma_qk,
+            self.mma_tiler_qk,
             self.q_dtype,
-            self.q_stage,
+            self.q_load_stage,
         )
-        k_smem_layout_staged = sm100_utils.make_smem_layout_b(
-            qk_tiled_mma,
-            self.qk_mma_tiler,
+        sK_layout = sm100_utils_basic.make_smem_layout_b(
+            tiled_mma_qk,
+            self.mma_tiler_qk,
             self.k_dtype,
             self.kv_stage,
         )
-        p_tmem_layout_staged = sm100_utils.make_smem_layout_a(
-            pv_tiled_mma,
-            self.pv_mma_tiler,
-            self.q_dtype,
-            self.qk_acc_stage,
+        tP_layout = cute.select(
+            sm100_utils_basic.make_smem_layout_a(
+                tiled_mma_pv,
+                self.mma_tiler_pv,
+                self.q_dtype,
+                self.s_stage,
+            ),
+            mode=[0, 1, 2],
         )
-        p_tmem_layout = cute.select(p_tmem_layout_staged, mode=[0, 1, 2])
-        v_smem_layout_staged = sm100_utils.make_smem_layout_b(
-            pv_tiled_mma,
-            self.pv_mma_tiler,
+        sV_layout = sm100_utils_basic.make_smem_layout_b(
+            tiled_mma_pv,
+            self.mma_tiler_pv,
             self.v_dtype,
             self.kv_stage,
         )
-        # TMA load for Q
-        tma_load_op = cute.nvgpu.cpasync.CopyBulkTensorTileG2SOp(cta_group)
+        sO_layout = sm100_utils_basic.make_smem_layout_epi(
+            self.o_dtype,
+            self.o_layout,
+            self.epi_tile,
+            self.o_stage,
+        )
+        if const_expr(self.pack_gqa):
+            nheads_kv = mK.shape[2]
+            mQ = pack_gqa_layout(mQ, self.qhead_per_kvhead, nheads_kv, head_idx=2)
+            mO = pack_gqa_layout(mO, self.qhead_per_kvhead, nheads_kv, head_idx=2)
+            if const_expr(mLSE is not None):
+                mLSE = pack_gqa_layout(mLSE, self.qhead_per_kvhead, nheads_kv, head_idx=1)
 
-        q_smem_layout = cute.select(q_smem_layout_staged, mode=[0, 1, 2])
-        tma_atom_q, tma_tensor_q = cute.nvgpu.make_tiled_tma_atom_A(
+        self.tma_copy_bytes = {
+            name: cute.size_in_bytes(mX.element_type, cute.select(layout, mode=[0, 1, 2]))
+            for name, mX, layout in [
+                ("Q", mQ, sQ_layout),
+                ("K", mK, sK_layout),
+                ("V", mV, sV_layout),
+            ]
+        }
+        for name in ("Q", "K", "V"):
+            self.tma_copy_bytes[name] *= self.cta_group_size
+
+        tma_load_op = cpasync.CopyBulkTensorTileG2SOp(cta_group)
+        tma_store_op = cpasync.CopyBulkTensorTileS2GOp()
+
+        # TMA load for Q
+        tma_atom_Q, mQ = cute.nvgpu.make_tiled_tma_atom_A(
             tma_load_op,
-            q,
-            q_smem_layout,
-            self.qk_mma_tiler,
-            qk_tiled_mma,
-            self.cluster_layout_vmnk.shape,
+            mQ,
+            cute.select(sQ_layout, mode=[0, 1, 2]),
+            self.mma_tiler_qk,
+            tiled_mma_qk,
+            cta_layout_vmnk.shape,
         )
 
         # TMA load for K
-        k_smem_layout = cute.select(k_smem_layout_staged, mode=[0, 1, 2])
-        tma_atom_k, tma_tensor_k = cute.nvgpu.make_tiled_tma_atom_B(
+        tma_atom_K, mK = cute.nvgpu.make_tiled_tma_atom_B(
             tma_load_op,
-            k,
-            k_smem_layout,
-            self.qk_mma_tiler,
-            qk_tiled_mma,
-            self.cluster_layout_vmnk.shape,
+            mK,
+            cute.select(sK_layout, mode=[0, 1, 2]),
+            self.mma_tiler_qk,
+            tiled_mma_qk,
+            cta_layout_vmnk.shape,
         )
         # TMA load for V
-        v_smem_layout = cute.select(v_smem_layout_staged, mode=[0, 1, 2])
-        tma_atom_v, tma_tensor_v = cute.nvgpu.make_tiled_tma_atom_B(
+        tma_atom_V, mV = cute.nvgpu.make_tiled_tma_atom_B(
             tma_load_op,
-            v,
-            v_smem_layout,
-            self.pv_mma_tiler,
-            pv_tiled_mma,
-            self.cluster_layout_vmnk.shape,
+            mV,
+            cute.select(sV_layout, mode=[0, 1, 2]),
+            self.mma_tiler_pv,
+            tiled_mma_pv,
+            cta_layout_vmnk.shape,
         )
 
-        q_copy_size = cute.size_in_bytes(self.q_dtype, q_smem_layout)
-        k_copy_size = cute.size_in_bytes(self.k_dtype, k_smem_layout)
-        self.tma_copy_q_bytes = q_copy_size * cute.size(qk_tiled_mma.thr_id.shape)
-        self.tma_copy_kv_bytes = k_copy_size * cute.size(qk_tiled_mma.thr_id.shape)
+        self.num_epilogue_threads = cute.arch.WARP_SIZE * len(self.epilogue_warp_ids)
+        self.use_tma_O = mCuSeqlensQ is None and mSeqUsedQ is None
+        if const_expr(self.use_tma_O):
+            tma_atom_O, mO = cpasync.make_tiled_tma_atom(
+                tma_store_op,
+                mO,
+                cute.select(sO_layout, mode=[0, 1]),
+                self.epi_tile,
+            )
+            gmem_tiled_copy_O = None
+        else:
+            tma_atom_O = None
+            universal_copy_bits = 128
+            async_copy_elems = universal_copy_bits // self.o_dtype.width
+            atom_universal_copy = cute.make_copy_atom(
+                cute.nvgpu.CopyUniversalOp(),
+                self.o_dtype,
+                num_bits_per_copy=universal_copy_bits,
+            )
+            tO_shape_dim_1 = sO_layout.outer.shape[1][0] // async_copy_elems
+            tO_layout = cute.make_ordered_layout(
+                (self.num_epilogue_threads // tO_shape_dim_1, tO_shape_dim_1),
+                order=(1, 0),
+            )
+            assert self.m_block_size % tO_layout.shape[0] == 0
+            vO_layout = cute.make_layout((1, async_copy_elems))
+            gmem_tiled_copy_O = cute.make_tiled_copy_tv(atom_universal_copy, tO_layout, vO_layout)
+
+        TileScheduler = self.TileScheduler
+        _num_block_divisor = self.cta_tiler[0] * (
+            self.cta_group_size if not self.is_persistent and self.cta_group_size > 1 else 1
+        )
+        tile_sched_args = TileSchedulerArguments(
+            cute.ceil_div(cute.size(mQ.shape[0]), _num_block_divisor),
+            cute.size(mQ.shape[2]),
+            cute.size(mQ.shape[3])
+            if const_expr(mCuSeqlensQ is None)
+            else cute.size(mCuSeqlensQ.shape[0] - 1),
+            Int32(1),
+            cute.size(mK.shape[0])
+            if const_expr(mPageTable is None)
+            else mK.shape[0] * mPageTable.shape[1],
+            mQ.shape[1],
+            mV.shape[0],
+            total_q=cute.size(mQ.shape[0])
+            if const_expr(mCuSeqlensQ is not None)
+            else cute.size(mQ.shape[0]) * cute.size(mQ.shape[3]),
+            tile_shape_mn=self.cta_tiler[:2],
+            mCuSeqlensQ=mCuSeqlensQ,
+            mSeqUsedQ=mSeqUsedQ,
+            qhead_per_kvhead_packgqa=self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
+            element_size=self.k_dtype.width // 8,
+            is_persistent=self.is_persistent,
+            lpt=self.is_causal or self.is_local,
+            is_split_kv=False,
+            cluster_shape_mn=self.cluster_shape_mn,
+            use_cluster_idx=not self.is_persistent and self.cta_group_size > 1,
+        )
+        tile_sched_params = TileScheduler.to_underlying_arguments(
+            tile_sched_args, scheduling_mode=self.scheduling_mode
+        )
+        self.tile_scheduler_cls = TileScheduler
+        grid_dim = TileScheduler.get_grid_shape(tile_sched_params)
+
+        sO_size = 0
+        sQ_size = cutlass.max(
+            cute.cosize(sQ_layout),
+            cute.cosize(sO_layout) * self.o_dtype.width // self.q_dtype.width,
+        )
 
         @cute.struct
         class SharedStorage:
-            # TMA G2S load barriers: LOAD warp (producer) -> MMA warp (consumer)
-            load_q_mbar_ptr: cute.struct.MemRange[
-                Int64, self.q_stage * 2
-            ]  # load_q_{producer,consumer}
-            load_kv_mbar_ptr: cute.struct.MemRange[
-                Int64, self.kv_stage * 2
-            ]  # load_kv_{producer,consumer}
-            mma_s_mbar_ptr: cute.struct.MemRange[Int64, self.qk_acc_stage * 2]
-            p_mma_mbar_ptr: cute.struct.MemRange[Int64, self.qk_acc_stage * 2]
-            # Softmax -> Correction signaling barriers (row_max/row_sum vec ready)
-            s_corr_mbar_ptr: cute.struct.MemRange[
-                Int64, self.qk_acc_stage * 2
-            ]  # s_corr_{producer,consumer}
-            sum_mbar_ptr: cute.struct.MemRange[Int64, 2]
-            # MMA -> Correction ownership barriers for O_partial tokens (online rescale/finalize)
-            mma_corr_mbar_ptr: cute.struct.MemRange[
-                Int64, self.mma_corr_stage * 2
-            ]  # mma_corr_{producer,consumer}
-            # A CTA-wide "TMEM lifetime" barrier used to safely deallocate TMEM after all users finish.
+            # m_barriers for pipelines
+            mbar_load_Q: cute.struct.MemRange[Int64, self.q_load_stage * 2]
+            mbar_load_KV: cute.struct.MemRange[Int64, self.kv_stage * 2]
+            mbar_S_full_P_full_O_rescaled: cute.struct.MemRange[Int64, self.s_stage * 2]
+            mbar_P_full_lastsplit: cute.struct.MemRange[Int64, self.s_stage * 2]
+            mbar_O_full: cute.struct.MemRange[Int64, self.o_stage * 2]
+            mbar_softmax_stats: cute.struct.MemRange[Int64, self.s_stage * 2]
+            mbar_O_epi: cute.struct.MemRange[Int64, self.o_stage * 2]
+            # Tmem dealloc cluster barrier
             tmem_dealloc_mbar: Int64
             # Tmem holding buffer
             tmem_holding_buf: Int32
-            # CLC pipeline barriers and response buffer
-            clc_mbar_ptr: cute.struct.MemRange[Int64, 2]
-            clc_response: cute.struct.MemRange[Int32, 4]
+            # Smem tensors
+            # store correction scale, row sum and row max
+            sScale: cute.struct.MemRange[
+                self.qk_acc_dtype,
+                len(self.softmax_warp_ids) * self.threads_per_warp * 3,
+            ]
+            sO: cute.struct.Align[
+                cute.struct.MemRange[self.o_dtype, sO_size],
+                self.buffer_align_bytes,
+            ]
+            sQ: cute.struct.Align[
+                cute.struct.MemRange[self.q_dtype, sQ_size],
+                self.buffer_align_bytes,
+            ]
+            sK: cute.struct.Align[
+                cute.struct.MemRange[self.k_dtype, cute.cosize(sK_layout)],
+                self.buffer_align_bytes,
+            ]
+            sV: cute.struct.Align[
+                cute.struct.MemRange[self.v_dtype, cute.cosize(sV_layout)],
+                self.buffer_align_bytes,
+            ]
 
         self.shared_storage = SharedStorage
 
-        grid = cute.round_up(grid, self.cluster_shape_mnk)
+        gmem_tiled_copy_Q = None
+        softmax_scale_log2, softmax_scale = utils.compute_softmax_scale_log2(
+            softmax_scale, self.score_mod
+        )
+        window_size_left = Int32(window_size_left) if window_size_left is not None else None
+        window_size_right = Int32(window_size_right) if window_size_right is not None else None
+        fastdiv_mods = utils.compute_fastdiv_mods(
+            mQ, mK, self.qhead_per_kvhead, self.pack_gqa, aux_data.tensors, mPageTable
+        )
+        head_divmod = None
+        if cutlass.const_expr(self.pack_gqa):
+            head_divmod = FastDivmodDivisor(self.qhead_per_kvhead)
+
+        self.use_block_sparsity = cutlass.const_expr(blocksparse_tensors is not None)
+        if cutlass.const_expr(self.use_block_sparsity and mPageTable is not None):
+            raise NotImplementedError("Block sparsity + paged KV not supported on SM100")
+        if cutlass.const_expr(self.use_block_sparsity and self.is_varlen_q):
+            assert const_expr(blocksparse_tensors.cu_total_m_blocks is not None), (
+                "blocksparse_tensors.cu_total_m_blocks must be provided for varlen blocksparsity"
+            )
+
+        grid_dim = cute.round_up(grid_dim, self.cluster_shape_mnk)
         # Launch the kernel synchronously
         self.kernel(
-            qk_tiled_mma,
-            pv_tiled_mma,
-            tma_atom_q,
-            tma_tensor_q,
-            tma_atom_k,
-            tma_tensor_k,
-            tma_atom_v,
-            tma_tensor_v,
-            o,
-            cum_seqlen_q,
-            cum_seqlen_k,
-            lse,
-            scale_softmax_log2,
-            scale_softmax,
-            scale_output,
-            page_table,
-            max_seqlen_k_paged,
+            mQ,
+            mK,
+            mV,
+            mO,
+            mLSE,
+            mCuSeqlensQ,
+            mCuSeqlensK,
+            mSeqUsedQ,
+            mSeqUsedK,
+            mPageTable,
+            tma_atom_Q,
+            tma_atom_K,
+            tma_atom_V,
+            tma_atom_O,
+            softmax_scale_log2,
+            softmax_scale,
             window_size_left,
             window_size_right,
-            self.cluster_layout_vmnk,
-            q_smem_layout_staged,
-            k_smem_layout_staged,
-            p_tmem_layout,
-            v_smem_layout_staged,
-            self.tile_sched_params,
+            learnable_sink,
+            descale_tensors,
+            blocksparse_tensors,
+            sQ_layout,
+            sK_layout,
+            tP_layout,
+            sV_layout,
+            sO_layout,
+            gmem_tiled_copy_Q,
+            gmem_tiled_copy_O,
+            tiled_mma_qk,
+            tiled_mma_pv,
+            tile_sched_params,
+            num_splits,
+            aux_data,
+            fastdiv_mods,
+            head_divmod,
         ).launch(
-            grid=grid,
+            grid=grid_dim,
             block=[self.threads_per_cta, 1, 1],
-            cluster=self.cluster_shape_mnk,
+            cluster=self.cluster_shape_mnk if cute.size(self.cluster_shape_mnk) > 1 else None,
             stream=stream,
             min_blocks_per_mp=1,
         )
@@ -588,1331 +580,1999 @@ class BlackwellFusedMultiHeadAttentionForward:
     @cute.kernel
     def kernel(
         self,
-        qk_tiled_mma: cute.TiledMma,
-        pv_tiled_mma: cute.TiledMma,
-        tma_atom_q: cute.CopyAtom,
-        mQ_qdl: cute.Tensor,
-        tma_atom_k: cute.CopyAtom,
-        mK_kdl: cute.Tensor,
-        tma_atom_v: cute.CopyAtom,
-        mV_dkl: cute.Tensor,
-        mO_qdl: cute.Tensor,
-        cum_seqlen_q: Optional[cute.Tensor],
-        cum_seqlen_k: Optional[cute.Tensor],
+        mQ: cute.Tensor,  # (s_q, d, h, b) or (total_q, d, h) if there is cu_seqlens_q
+        mK: cute.Tensor,  # (s_k, d, h_k, b_k) or (total_k, d, h_k) if there is cu_seqlens_k
+        mV: cute.Tensor,  # (d, s_k, h_k, b_k) or (d, total_k, h_k) if there is cu_seqlens_k
+        mO: cute.Tensor,  # (s_q, dv, h, b) or (total_q, dv, h) if there is cu_seqlens_q
         mLSE: Optional[cute.Tensor],
-        scale_softmax_log2: Float32,
-        scale_softmax: Float32,
-        scale_output: Float32,
+        mCuSeqlensQ: Optional[cute.Tensor],
+        mCuSeqlensK: Optional[cute.Tensor],
+        mSeqUsedQ: Optional[cute.Tensor],
+        mSeqUsedK: Optional[cute.Tensor],
         mPageTable: Optional[cute.Tensor],
-        max_seqlen_k: Optional[Int32],
+        tma_atom_Q: Optional[cute.CopyAtom],
+        tma_atom_K: Optional[cute.CopyAtom],
+        tma_atom_V: Optional[cute.CopyAtom],
+        tma_atom_O: Optional[cute.CopyAtom],
+        softmax_scale_log2: Float32,
+        softmax_scale: Float32 | None,
         window_size_left: Optional[Int32],
         window_size_right: Optional[Int32],
-        cluster_layout_vmnk: cute.Layout,
-        q_smem_layout_staged: cute.ComposedLayout,
-        k_smem_layout_staged: cute.ComposedLayout,
-        p_tmem_layout_staged: cute.ComposedLayout,
-        v_smem_layout_staged: cute.ComposedLayout,
-        tile_sched_params: FmhaStaticTileSchedulerParams | FmhaClcDynamicTileSchedulerParams,
+        learnable_sink: Optional[cute.Tensor],
+        descale_tensors: Optional[DescaleTensors],
+        blocksparse_tensors: Optional[BlockSparseTensors],
+        sQ_layout: cute.ComposedLayout,
+        sK_layout: cute.ComposedLayout,
+        tP_layout: cute.ComposedLayout,
+        sV_layout: cute.ComposedLayout,
+        sO_layout: Optional[cute.ComposedLayout],
+        gmem_tiled_copy_Q: Optional[cute.TiledCopy],
+        gmem_tiled_copy_O: Optional[cute.TiledCopy],
+        tiled_mma_qk: cute.TiledMma,
+        tiled_mma_pv: cute.TiledMma,
+        tile_sched_params: ParamsBase,
+        num_splits: Int32,
+        aux_data: AuxData = AuxData(),
+        fastdiv_mods=(None, None),
+        head_divmod=None,
     ):
+        """The device kernel implementation of the Fused Multi-Head Attention.
+
+        This kernel coordinates multiple specialized warps to perform different phases
+        of the hd256 2CTA FMHA computation:
+        1. Load warp: Loads Q, K, V data from global memory to shared memory using TMA
+        2. MMA warp: Performs matrix multiplications (Q*K^T and P*V)
+        3. Softmax warps: Compute softmax normalization on attention scores
+        4. Correction warps: Rescale, normalize, and store O
+
+        The kernel uses TMA for Q/K/V loads, warp specialization for different
+        computation phases, and the hd256-specific split-hdim TMEM layout.
+        """
+
         warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
 
-        #
-        # Prefetch tma desc
-        #
-        if warp_idx == self.load_warp_id:
-            cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_q)
-            cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_k)
-            cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_v)
+        # Prefetch tma descriptor
+        if warp_idx == 0:
+            for tma_atom in (tma_atom_Q, tma_atom_K, tma_atom_V, tma_atom_O):
+                if const_expr(tma_atom is not None):
+                    cpasync.prefetch_descriptor(tma_atom)
 
+        cta_layout_vmnk = cute.tiled_divide(
+            cute.make_layout(self.cluster_shape_mnk), (tiled_mma_qk.thr_id.shape,)
+        )
+        # Setup cta/thread coordinates
         bidx, _, _ = cute.arch.block_idx()
-        mma_tile_coord_v = bidx % cute.size(qk_tiled_mma.thr_id.shape)
+        if const_expr(cute.size(tiled_mma_qk.thr_id.shape) == 1):
+            mma_tile_coord_v = 0
+        else:
+            mma_tile_coord_v = bidx % cute.size(tiled_mma_qk.thr_id.shape)
+        is_leader_cta = mma_tile_coord_v == 0
         cta_rank_in_cluster = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster())
-        block_in_cluster_coord_vmnk = cluster_layout_vmnk.get_flat_coord(cta_rank_in_cluster)
+        block_in_cluster_coord_vmnk = cta_layout_vmnk.get_flat_coord(cta_rank_in_cluster)
 
         # Alloc
-        smem = utils.SmemAllocator()
+        smem = cutlass.utils.SmemAllocator()
         storage = smem.allocate(self.shared_storage)
 
-        load_q_producer, load_q_consumer = pipeline.PipelineTmaUmma.create(
-            num_stages=self.q_stage,
-            producer_group=make_thread_cooperative_group(len([self.load_warp_id])),
-            consumer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
-            tx_count=self.tma_copy_q_bytes,
-            barrier_storage=storage.load_q_mbar_ptr.data_ptr(),
-            cta_layout_vmnk=cluster_layout_vmnk,
-            defer_sync=True,
-        ).make_participants()
-        load_kv_producer, load_kv_consumer = pipeline.PipelineTmaUmma.create(
-            num_stages=self.kv_stage,
-            producer_group=make_thread_cooperative_group(len([self.load_warp_id])),
-            consumer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
-            tx_count=self.tma_copy_kv_bytes,
-            barrier_storage=storage.load_kv_mbar_ptr.data_ptr(),
-            cta_layout_vmnk=cluster_layout_vmnk,
-            defer_sync=True,
-        ).make_participants()
-        mma_s_producer, mma_s_consumer = pipeline.PipelineUmmaAsync.create(
-            num_stages=self.qk_acc_stage,
-            producer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
-            consumer_group=make_thread_cooperative_group(
-                len(self.softmax_warp_ids) * self.threads_per_warp * self.cluster_shape_mnk[0],
-            ),
-            barrier_storage=storage.mma_s_mbar_ptr.data_ptr(),
-            cta_layout_vmnk=cluster_layout_vmnk,
-            defer_sync=True,
-        ).make_participants()
-        p_mma_producer, p_mma_consumer = pipeline.PipelineAsyncUmma.create(
-            num_stages=self.qk_acc_stage,
-            producer_group=make_thread_cooperative_group(
-                len(self.softmax_warp_ids) * self.threads_per_warp * self.cluster_shape_mnk[0],
-            ),
-            consumer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
-            barrier_storage=storage.p_mma_mbar_ptr.data_ptr(),
-            cta_layout_vmnk=cluster_layout_vmnk,
-            defer_sync=True,
-        ).make_participants()
-        s_corr_producer, s_corr_consumer = pipeline.PipelineAsync.create(
-            num_stages=self.qk_acc_stage,
-            producer_group=make_thread_cooperative_group(
-                self.threads_per_warp * len(self.softmax_warp_ids)
-            ),
-            consumer_group=make_thread_cooperative_group(
-                self.threads_per_warp * len(self.correction_warp_ids)
-            ),
-            barrier_storage=storage.s_corr_mbar_ptr.data_ptr(),
-            defer_sync=True,
-        ).make_participants()
-        sum_producer, sum_consumer = pipeline.PipelineAsync.create(
-            num_stages=1,
-            producer_group=make_thread_cooperative_group(
-                self.threads_per_warp * len(self.softmax_warp_ids)
-            ),
-            consumer_group=make_thread_cooperative_group(
-                self.threads_per_warp * len(self.correction_warp_ids)
-            ),
-            barrier_storage=storage.sum_mbar_ptr.data_ptr(),
-            defer_sync=True,
-        ).make_participants()
-        mma_corr_producer, mma_corr_consumer = pipeline.PipelineUmmaAsync.create(
-            num_stages=self.mma_corr_stage,
-            producer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
-            consumer_group=make_thread_cooperative_group(
-                len(self.correction_warp_ids) * self.threads_per_warp * self.cluster_shape_mnk[0],
-            ),
-            barrier_storage=storage.mma_corr_mbar_ptr.data_ptr(),
-            cta_layout_vmnk=cluster_layout_vmnk,
-            defer_sync=True,
-        ).make_participants()
-        # Tensor memory dealloc barrier init
-        tmem = utils.TmemAllocator(
+        tmem_alloc_barrier = pipeline.NamedBarrier(
+            barrier_id=int(NamedBarrierFwdSm100.TmemPtr),
+            num_threads=cute.arch.WARP_SIZE
+            * len((self.mma_warp_id, *self.softmax_warp_ids, *self.correction_warp_ids)),
+        )
+        tmem = cutlass.utils.TmemAllocator(
             storage.tmem_holding_buf.ptr,
-            barrier_for_retrieve=self.tmem_alloc_barrier,
-            allocator_warp_id=self.correction_warp_ids[0],
-            is_two_cta=True,
+            barrier_for_retrieve=tmem_alloc_barrier,
+            allocator_warp_id=self.mma_warp_id,
+            is_two_cta=self.use_2cta_instrs,
             two_cta_tmem_dealloc_mbar_ptr=storage.tmem_dealloc_mbar.ptr,
         )
-        tmem.allocate(self.tmem_alloc_cols)
-        tmem.wait_for_alloc()
-        tmem_ptr = tmem.retrieve_ptr(self.qk_acc_dtype)
-        # Initialize CLC state if using dynamic scheduler
-        if cutlass.const_expr(self.use_clc_scheduler):
-            clc_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
-            cluster_size = cute.size(self.cluster_shape_mnk)
-            num_clc_consumer_threads = self.threads_per_warp * (
-                1  # sched_warp (CTA 0 only)
-                + cluster_size
-                * (
-                    len(self.softmax_warp_ids)
-                    + len(self.correction_warp_ids)
-                    + 1  # mma_warp
-                    + 1  # load_warp
-                )
+
+        ThreadCooperativeGroup = partial(pipeline.CooperativeGroup, pipeline.Agent.Thread)
+        mma_warp = ThreadCooperativeGroup(len([self.mma_warp_id]))
+        tma_warp = ThreadCooperativeGroup(1)
+        softmax_threads = ThreadCooperativeGroup(cute.arch.WARP_SIZE * len(self.softmax_warp_ids))
+        correction_threads = ThreadCooperativeGroup(
+            cute.arch.WARP_SIZE * len(self.correction_warp_ids)
+        )
+        epilogue_threads = ThreadCooperativeGroup(cute.arch.WARP_SIZE * len(self.epilogue_warp_ids))
+        # For UMMA-bridging pipelines: the non-MMA side spans both CTAs in the cluster,
+        # so the thread count must include warps from both CTAs.
+        softmax_threads_cluster = ThreadCooperativeGroup(
+            cute.arch.WARP_SIZE * len(self.softmax_warp_ids) * self.cta_group_size
+        )
+        correction_threads_cluster = ThreadCooperativeGroup(
+            cute.arch.WARP_SIZE * len(self.correction_warp_ids) * self.cta_group_size
+        )
+
+        pipeline_q = pipeline_custom.PipelineTmaUmma.create(
+            barrier_storage=storage.mbar_load_Q.data_ptr(),
+            num_stages=self.q_load_stage,
+            producer_group=tma_warp,
+            consumer_group=mma_warp,
+            tx_count=self.tma_copy_bytes["Q"],
+            cta_layout_vmnk=cta_layout_vmnk,
+            defer_sync=True,
+        )
+        pipeline_kv = pipeline_custom.PipelineTmaUmma.create(
+            barrier_storage=storage.mbar_load_KV.data_ptr(),
+            num_stages=self.kv_stage,
+            producer_group=tma_warp,
+            consumer_group=mma_warp,
+            tx_count=self.tma_copy_bytes["K"],
+            cta_layout_vmnk=cta_layout_vmnk,
+            defer_sync=True,
+        )
+        # This pipeline is not the typical producer-consumer pipeline. The "producer" mma warp
+        # uses it to signal that S is ready, and the softmax threads wait for S to be ready.
+        # When softmax threads write P to tmem, they signal as "consumer". The mma warp then
+        # waits for that signal to do the P @ V gemm. The hd256 path keeps correction on the
+        # separate O pipeline, so correction threads are not participants here.
+        pipeline_s_p_o = pipeline_custom.PipelineUmmaAsync.create(
+            barrier_storage=storage.mbar_S_full_P_full_O_rescaled.data_ptr(),
+            num_stages=self.s_stage,
+            producer_group=mma_warp,
+            consumer_group=softmax_threads_cluster,
+            cta_layout_vmnk=cta_layout_vmnk,
+            defer_sync=True,
+        )
+        pipeline_p_lastsplit = pipeline_custom.PipelineAsyncUmma.create(
+            barrier_storage=storage.mbar_P_full_lastsplit.data_ptr(),
+            num_stages=self.s_stage,
+            producer_group=softmax_threads_cluster,
+            consumer_group=mma_warp,
+            cta_layout_vmnk=cta_layout_vmnk,
+            defer_sync=True,
+        )
+        # MMA warp uses this to signal to the correction warps that O is ready.
+        pipeline_o_acc = pipeline_custom.PipelineUmmaAsync.create(
+            barrier_storage=storage.mbar_O_full.data_ptr(),
+            num_stages=self.o_stage,
+            producer_group=mma_warp,
+            consumer_group=correction_threads_cluster,
+            cta_layout_vmnk=cta_layout_vmnk,
+            defer_sync=True,
+        )
+        pipeline_sm_stats = pipeline_custom.PipelineAsync.create(
+            barrier_storage=storage.mbar_softmax_stats.data_ptr(),
+            num_stages=self.s_stage,
+            producer_group=softmax_threads,
+            consumer_group=correction_threads,
+            defer_sync=True,
+        )
+        sm_stats_barrier = pipeline_custom.NamedBarrier(
+            barrier_id=int(NamedBarrierFwdSm100.SoftmaxStatsW0),
+            num_threads=cute.arch.WARP_SIZE * 2,
+        )
+        pipeline_o_epi = None
+        if const_expr(not self.use_correction_warps_for_epi):
+            pipeline_o_epi = pipeline_custom.PipelineAsync.create(
+                barrier_storage=storage.mbar_O_epi.data_ptr(),
+                num_stages=self.o_stage,
+                producer_group=correction_threads,
+                consumer_group=epilogue_threads,
+                defer_sync=True,
             )
-            clc_pipeline_consumer_group = pipeline.CooperativeGroup(
-                pipeline.Agent.Thread, num_clc_consumer_threads
-            )
-            clc_response_ptr = storage.clc_response.data_ptr()
-            clc = ClcState.create(
-                hw_scheduler=ClcDynamicPersistentTileScheduler.create(
-                    self.tile_sched_params.clc_hw_params(),
-                    cute.arch.block_idx(),
-                    cute.arch.grid_dim(),
-                    clc_response_ptr,
-                ),
-                pipeline=pipeline.PipelineClcFetchAsync.create(
-                    barrier_storage=storage.clc_mbar_ptr.data_ptr(),
-                    num_stages=self.num_clc_stage,
-                    producer_group=clc_pipeline_producer_group,
-                    consumer_group=clc_pipeline_consumer_group,
-                    tx_count=self.num_clc_response_bytes,
-                    cta_layout_vmnk=cluster_layout_vmnk,
-                    defer_sync=True,
-                ),
-                consumer_state=pipeline.make_pipeline_state(
-                    pipeline.PipelineUserType.Consumer, self.num_clc_stage
-                ),
-                producer_state=pipeline.make_pipeline_state(
-                    pipeline.PipelineUserType.Producer, self.num_clc_stage
-                ),
-            )
-        else:
-            clc = None
-            clc_response_ptr = None
 
         # Cluster arrive after barrier init
-        pipeline.pipeline_init_arrive(cluster_shape_mn=cluster_layout_vmnk, is_relaxed=True)
+        pipeline_init_arrive(cluster_shape_mn=cta_layout_vmnk, is_relaxed=True)
 
-        sQ = smem.allocate_tensor(
-            element_type=self.q_dtype,
-            layout=q_smem_layout_staged.outer,
-            swizzle=q_smem_layout_staged.inner,
-            byte_alignment=128,
+        # Generate smem tensor Q/K/V/O.
+        # (MMA, MMA_Q, MMA_D, PIPE)
+        sQ = storage.sQ.get_tensor(sQ_layout.outer, swizzle=sQ_layout.inner)
+        # (MMA, MMA_K, MMA_D, PIPE)
+        sK = storage.sK.get_tensor(sK_layout.outer, swizzle=sK_layout.inner)
+        # (MMA, MMA_K, MMA_D, PIPE)
+        sV = storage.sV.get_tensor(sV_layout.outer, swizzle=sV_layout.inner)
+        sO = cute.make_tensor(
+            cute.recast_ptr(sQ.iterator, sO_layout.inner, self.o_dtype),
+            sO_layout.outer,
         )
-        sK = smem.allocate_tensor(
-            element_type=self.k_dtype,
-            layout=k_smem_layout_staged.outer,
-            swizzle=k_smem_layout_staged.inner,
-            byte_alignment=128,
-        )
-        # K and V now use separate memory since we removed the transform stage
-        sV = smem.allocate_tensor(
-            element_type=self.v_dtype,
-            layout=v_smem_layout_staged.outer,
-            swizzle=v_smem_layout_staged.inner,
-            byte_alignment=128,
+        sScale = storage.sScale.get_tensor(
+            cute.make_layout(len(self.softmax_warp_ids) * self.threads_per_warp * 3)
         )
 
-        sSum = smem.allocate_tensor(
-            element_type=self.qk_acc_dtype,
-            layout=cute.make_layout(len(self.softmax_warp_ids) * self.threads_per_warp),
-            byte_alignment=128,
-        )
-        qk_thr_mma = qk_tiled_mma.get_slice(mma_tile_coord_v)  # default 1sm
-        pv_thr_mma = pv_tiled_mma.get_slice(mma_tile_coord_v)  # default 1sm
-        tSrQ = qk_thr_mma.make_fragment_A(sQ)
-        tSrK = qk_thr_mma.make_fragment_B(sK)
-        tOrV = pv_thr_mma.make_fragment_B(sV)
-        qk_acc_shape = qk_thr_mma.partition_shape_C((self.qk_mma_tiler[0], self.qk_mma_tiler[1]))
-        tStS = qk_thr_mma.make_fragment_C(cute.append(qk_acc_shape, self.qk_acc_stage))
-        pv_acc_shape = pv_thr_mma.partition_shape_C((self.pv_mma_tiler[0], self.pv_mma_tiler[1]))
-        tOtO = pv_thr_mma.make_fragment_C(pv_acc_shape)
+        thr_mma_qk = tiled_mma_qk.get_slice(mma_tile_coord_v)
+        thr_mma_pv = tiled_mma_pv.get_slice(mma_tile_coord_v)
+
+        qk_acc_shape = thr_mma_qk.partition_shape_C(self.mma_tiler_qk[:2])
+        # This is a fake tensor, by right we need to retrieve tmem_ptr. But we know that we always
+        # request 512 columns of tmem, so we know that it starts at 0.
+        tStS = thr_mma_qk.make_fragment_C(cute.append(qk_acc_shape, self.s_stage))
+        pv_acc_shape = thr_mma_pv.partition_shape_C(self.mma_tiler_pv[:2])
+        tOtO = thr_mma_pv.make_fragment_C(pv_acc_shape)
         tOtO_layout = cute.append(
             tOtO.layout,
             cute.make_layout(
-                self.iterations_pv,
-                stride=self.pv_mma_tiler[1] // self.tmem_warp_shape_mn[1],
+                self.pv_hdim_stage,
+                stride=self.mma_tiler_pv[1] // self.tmem_warp_shape_mn[1],
             ),
         )
         tStS = cute.make_tensor(tStS.iterator + self.tmem_s_offset, tStS.layout)
-        tOtO_staged = cute.make_tensor(tOtO.iterator + self.tmem_o_offset, tOtO_layout)
+        tOtO = cute.make_tensor(tOtO.iterator + self.tmem_o_offset, tOtO_layout)
+        tP = cute.make_tensor(tStS.iterator, tP_layout.outer)
+        tOrP = thr_mma_pv.make_fragment_A(tP)
+        tP_width_ratio = Float32.width // self.v_dtype.width
+        tP_stage_stride = self.mma_tiler_qk[1] * tP_width_ratio
+        tOrP = cute.make_tensor(
+            tOrP.iterator + self.tmem_p_offset * tP_width_ratio,
+            cute.append(
+                tOrP.layout,
+                cute.make_layout((self.s_stage,), stride=(tP_stage_stride,)),
+            ),
+        )
+
+        block_info = BlockInfo(
+            # This is the logical 2CTA Q tile height.
+            self.cta_tiler[0] * self.cta_group_size,
+            self.cta_tiler[1],
+            self.is_causal,
+            self.is_local,
+            self.is_split_kv,
+            window_size_left,
+            window_size_right,
+            qhead_per_kvhead_packgqa=self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
+        )
+        SeqlenInfoCls = partial(
+            SeqlenInfoQK.create,
+            seqlen_q_static=mQ.shape[0] if const_expr(not self.pack_gqa) else mQ.shape[0][1],
+            seqlen_k_static=mK.shape[0]
+            if const_expr(mPageTable is None)
+            else mK.shape[0] * mPageTable.shape[1],
+            mCuSeqlensQ=mCuSeqlensQ,
+            mCuSeqlensK=mCuSeqlensK,
+            mSeqUsedQ=mSeqUsedQ,
+            mSeqUsedK=mSeqUsedK,
+            mCuTotalMBlocks=(
+                blocksparse_tensors.cu_total_m_blocks if blocksparse_tensors is not None else None
+            ),
+            mCuBlockIdxOffsets=(
+                blocksparse_tensors.cu_block_idx_offsets
+                if blocksparse_tensors is not None
+                else None
+            ),
+        )
+        AttentionMaskCls = partial(
+            AttentionMask,
+            self.m_block_size,
+            self.n_block_size,
+            window_size_left=window_size_left,
+            window_size_right=window_size_right,
+            qhead_per_kvhead_packgqa=self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
+        )
+
+        # Cluster wait before tensor memory alloc
+        pipeline_init_wait(cluster_shape_mn=cta_layout_vmnk)
+
+        tile_scheduler = self.tile_scheduler_cls.create(tile_sched_params)
+        assert isinstance(tile_scheduler, TileSchedulerProtocol), (
+            f"tile_scheduler is not a TileSchedulerProtocol: {type(tile_scheduler)}"
+        )
 
         # ///////////////////////////////////////////////////////////////////////////////
         #  EMPTY
         # ///////////////////////////////////////////////////////////////////////////////
-        for _i in cutlass.range_constexpr(len(self.empty_warp_id)):
-            if warp_idx == self.empty_warp_id[_i]:
-                cute.arch.warpgroup_reg_dealloc(self.num_regs_other)
-
-        if cutlass.const_expr(self.use_clc_scheduler):
-            tile_sched = FmhaClcDynamicTileScheduler.create(
-                tile_sched_params,
-                cute.arch.block_idx(),
-                cute.arch.grid_dim(),
-                clc_response_ptr,
-                clc,
-            )
-        else:
-            blk_idx = cute.arch.block_idx()
-            tile_sched = FmhaStaticTileScheduler(
-                tile_sched_params, blk_idx[0], blk_idx, cute.arch.grid_dim()
-            )
-        work_tile = tile_sched.initial_work_tile_info()
-
-        # Cluster wait
-        pipeline.pipeline_init_wait(cluster_shape_mn=cluster_layout_vmnk)
+        for i in cutlass.range_constexpr(len(self.empty_warp_ids)):
+            if warp_idx == self.empty_warp_ids[i]:
+                cute.arch.setmaxregister_decrease(self.num_regs_other)
 
         # ///////////////////////////////////////////////////////////////////////////////
         #  LOAD
         # ///////////////////////////////////////////////////////////////////////////////
-        if warp_idx == self.load_warp_id:
-            cute.arch.warpgroup_reg_dealloc(self.num_regs_other)
-            while work_tile.is_valid_tile:
-                curr_block_coord = work_tile.tile_idx  # (q_tile_idx, 0, (head_idx, batch_idx))
-                mma_block_coord = (
-                    curr_block_coord[0] // cute.size(qk_tiled_mma.thr_id.shape),
-                    curr_block_coord[1],
-                    curr_block_coord[2],
-                )
-                continue_cond = False
-                batch_coord = curr_block_coord[2][1]
-                seqlen_q = mQ_qdl.shape[0]
-                seqlen_k = (
-                    mK_kdl.shape[0] if cutlass.const_expr(mPageTable is None) else max_seqlen_k
-                )
-                cuseqlen_q = Int32(0)
-                cuseqlen_k = Int32(0)
-                block_offset = (
-                    Int32(0),
-                    Int32(0),
-                    Int32(0),
-                    ((Int32(0), Int32(0)), Int32(0)),
-                )
-                if cutlass.const_expr(cum_seqlen_q is not None):
-                    cuseqlen_q = cum_seqlen_q[batch_coord]
-                    seqlen_q = cum_seqlen_q[batch_coord + 1] - cuseqlen_q
-                    if cutlass.const_expr(cum_seqlen_k is not None):
-                        cuseqlen_k = cum_seqlen_k[batch_coord]
-                        seqlen_k = cum_seqlen_k[batch_coord + 1] - cuseqlen_k
-                    block_offset = (
-                        cuseqlen_q,
-                        cuseqlen_k,
-                        Int32(0),
-                        ((Int32(0), Int32(0)), Int32(0)),
-                    )
-                    continue_cond = not FmhaStaticTileScheduler.check_valid_work_for_seqlen_q(
-                        self.qk_mma_tiler[0],
-                        mma_block_coord[0],
-                        seqlen_q,
-                    )
-                if not continue_cond:
-                    mQ_qdl_ = cute.domain_offset(cute.select(block_offset, mode=[0, 2, 3]), mQ_qdl)
-                    # Local tile partition global tensors
-                    q_cta_layout = cute.make_layout(
-                        cute.slice_(cluster_layout_vmnk, (0, 0, None, 0)).shape
-                    )
-                    # (bM, bK, loopM, loopK, loopL)
-                    gQ_qdl = cute.flat_divide(mQ_qdl_, cute.select(self.qk_mma_tiler, mode=[0, 2]))
-                    tSgQ_qdl = qk_thr_mma.partition_A(gQ_qdl)
-                    tQsQ, tQgQ_qdl = cute.nvgpu.cpasync.tma_partition(
-                        tma_atom_q,
-                        block_in_cluster_coord_vmnk[2],
-                        q_cta_layout,
-                        cute.group_modes(sQ, 0, 3),
-                        cute.group_modes(tSgQ_qdl, 0, 3),
-                    )
-                    kv_cta_layout = cute.make_layout(
-                        cute.slice_(cluster_layout_vmnk, (0, None, 0, 0)).shape
-                    )
-                    if cutlass.const_expr(mPageTable is None):
-                        # Dense path: domain_offset K/V by batch block, select batch via mma_block_coord[2].
-                        mK_kdl_ = cute.domain_offset(
-                            cute.select(block_offset, mode=[1, 2, 3]), mK_kdl
-                        )
-                        mV_dkl_ = cute.domain_offset(
-                            cute.select(block_offset, mode=[2, 1, 3]), mV_dkl
-                        )
-                        gK_kdl = cute.flat_divide(
-                            mK_kdl_, cute.select(self.qk_mma_tiler, mode=[1, 2])
-                        )
-                        tSgK_kdl = qk_thr_mma.partition_B(gK_kdl)
-                        tKsK, tKgK_kdl = cute.nvgpu.cpasync.tma_partition(
-                            tma_atom_k,
-                            block_in_cluster_coord_vmnk[1],
-                            kv_cta_layout,
-                            cute.group_modes(sK, 0, 3),
-                            cute.group_modes(tSgK_kdl, 0, 3),
-                        )
-                        gV_dkl = cute.flat_divide(
-                            mV_dkl_, cute.select(self.pv_mma_tiler, mode=[1, 2])
-                        )
-                        tSgV_dkl = pv_thr_mma.partition_B(gV_dkl)
-                        tVsV, tVgV_dkl = cute.nvgpu.cpasync.tma_partition(
-                            tma_atom_v,
-                            block_in_cluster_coord_vmnk[1],
-                            kv_cta_layout,
-                            cute.group_modes(sV, 0, 3),
-                            cute.group_modes(tSgV_dkl, 0, 3),
-                        )
-                        # ((atom_v, rest_v), RestN, RestK)
-                        tKgK = tKgK_kdl[None, None, None, mma_block_coord[2]]
-                        tVgV = tVgV_dkl[None, None, None, mma_block_coord[2]]
-                    else:
-                        # Paged path: slice K/V by KV head, keep num_pages dim for page_idx-based TMA.
-                        head_kv_coord = curr_block_coord[2][0] // self.qhead_per_kvhead
-                        mK_kdl_ = mK_kdl[None, None, head_kv_coord, None]
-                        mV_dkl_ = mV_dkl[None, None, head_kv_coord, None]
-                        gK_kdl = cute.flat_divide(
-                            mK_kdl_, cute.select(self.qk_mma_tiler, mode=[1, 2])
-                        )
-                        tSgK_kdl = qk_thr_mma.partition_B(gK_kdl)
-                        tKsK, tKgK_kdl = cute.nvgpu.cpasync.tma_partition(
-                            tma_atom_k,
-                            block_in_cluster_coord_vmnk[1],
-                            kv_cta_layout,
-                            cute.group_modes(sK, 0, 3),
-                            cute.group_modes(tSgK_kdl, 0, 3),
-                        )
-                        gV_dkl = cute.flat_divide(
-                            mV_dkl_, cute.select(self.pv_mma_tiler, mode=[1, 2])
-                        )
-                        tSgV_dkl = pv_thr_mma.partition_B(gV_dkl)
-                        tVsV, tVgV_dkl = cute.nvgpu.cpasync.tma_partition(
-                            tma_atom_v,
-                            block_in_cluster_coord_vmnk[1],
-                            kv_cta_layout,
-                            cute.group_modes(sV, 0, 3),
-                            cute.group_modes(tSgV_dkl, 0, 3),
-                        )
-                        tKgK = tKgK_kdl
-                        tVgV = tVgV_dkl
-                    # ((atom_v, rest_v), RestK)
-                    tQgQ = tQgQ_qdl[None, mma_block_coord[0], None, mma_block_coord[2]]
-
-                    seqlen_kv_loop_start, seqlen_kv_loop_steps = (
-                        FusedMask.get_trip_start_count_via_block_info(
-                            mma_block_coord,
-                            self.qk_mma_tiler,
-                            seqlen_q,
-                            seqlen_k,
-                            self.is_causal,
-                            self.is_local,
-                            window_size_left,
-                            window_size_right,
-                        )
-                    )
-                    seqlen_kv_loop_end = seqlen_kv_loop_start + seqlen_kv_loop_steps
-                    # Q
-                    for iter in cutlass.range(self.iterations_qk, unroll=1):
-                        q_handle = load_q_producer.acquire_and_advance()
-                        cute.copy(
-                            tma_atom_q,
-                            tQgQ[None, iter],
-                            tQsQ[None, q_handle.index],
-                            tma_bar_ptr=q_handle.barrier,
-                        )
-
-                    # K0
-                    kv_coord = seqlen_kv_loop_start
-                    k_page_idx = (
-                        mPageTable[batch_coord, kv_coord]
-                        if cutlass.const_expr(mPageTable is not None)
-                        else None
-                    )
-                    for iter in cutlass.range(self.iterations_qk, unroll=1):
-                        k_handle = load_kv_producer.acquire_and_advance()
-                        cute.copy(
-                            tma_atom_k,
-                            tKgK[None, kv_coord, iter]
-                            if cutlass.const_expr(mPageTable is None)
-                            else tKgK[None, 0, iter, k_page_idx],
-                            tKsK[None, k_handle.index],
-                            tma_bar_ptr=k_handle.barrier,
-                        )
-                    kv_coord += 1
-                    # v_page_idx_prev carries K[i-1]'s page index for use as V[i-1]'s page
-                    # (K and V for the same KV block share the same physical page).
-                    # Also serves as the Vend page index when seqlen_kv_loop_steps == 1.
-                    v_page_idx_prev = (
-                        k_page_idx if cutlass.const_expr(mPageTable is not None) else None
-                    )
-                    # Prefetch K1 page after K0 TMA dispatch to hide L2 latency.
-                    if cutlass.const_expr(mPageTable is not None):
-                        if seqlen_kv_loop_steps > 1:
-                            k_page_idx = mPageTable[batch_coord, kv_coord]
-
-                    for i in cutlass.range(1, seqlen_kv_loop_steps, 1, unroll=1):
-                        # Ki: k_page_idx was prefetched at end of previous iteration
-                        # (or in the prologue for i==1); L2 latency already hidden.
-                        for iter in cutlass.range(self.iterations_qk, unroll=1):
-                            k_handle = load_kv_producer.acquire_and_advance()
-                            cute.copy(
-                                tma_atom_k,
-                                tKgK[None, kv_coord, iter]
-                                if cutlass.const_expr(mPageTable is None)
-                                else tKgK[None, 0, iter, k_page_idx],
-                                tKsK[None, k_handle.index],
-                                tma_bar_ptr=k_handle.barrier,
-                            )
-                        # Vi-1: reuse v_page_idx_prev (= K[i-1]'s page), no extra GMEM read.
-                        for iter in cutlass.range(self.iterations_pv, unroll=1):
-                            v_handle = load_kv_producer.acquire_and_advance()
-                            cute.copy(
-                                tma_atom_v,
-                                tVgV[None, iter, kv_coord - 1]
-                                if cutlass.const_expr(mPageTable is None)
-                                else tVgV[None, iter, 0, v_page_idx_prev],
-                                tVsV[None, v_handle.index],
-                                tma_bar_ptr=v_handle.barrier,
-                            )
-                        v_page_idx_prev = (
-                            k_page_idx if cutlass.const_expr(mPageTable is not None) else None
-                        )
-                        kv_coord += 1
-                        # Prefetch next K page while V TMA is in flight.
-                        if cutlass.const_expr(mPageTable is not None):
-                            if kv_coord < seqlen_kv_loop_end:
-                                k_page_idx = mPageTable[batch_coord, kv_coord]
-                    # Vend: reuse v_page_idx_prev (= K[end-1]'s page), no extra GMEM read.
-                    for iter in cutlass.range(self.iterations_pv, unroll=1):
-                        v_handle = load_kv_producer.acquire_and_advance()
-                        cute.copy(
-                            tma_atom_v,
-                            tVgV[None, iter, seqlen_kv_loop_end - 1]
-                            if cutlass.const_expr(mPageTable is None)
-                            else tVgV[None, iter, 0, v_page_idx_prev],
-                            tVsV[None, v_handle.index],
-                            tma_bar_ptr=v_handle.barrier,
-                        )
-
-                work_tile = tile_sched.advance_to_next_work()
-                # End of persistent scheduler loop
-            load_kv_producer.tail()
-            load_q_producer.tail()
+        if warp_idx >= self.load_warp_ids[0] and warp_idx <= self.load_warp_ids[-1]:
+            cute.arch.setmaxregister_decrease(self.num_regs_other)
+            self.load(
+                thr_mma_qk,
+                thr_mma_pv,
+                mQ,
+                mK,
+                mV,
+                mPageTable,
+                sQ,
+                sK,
+                sV,
+                tma_atom_Q,
+                tma_atom_K,
+                tma_atom_V,
+                pipeline_q,
+                pipeline_kv,
+                block_info,
+                num_splits,
+                SeqlenInfoCls,
+                blocksparse_tensors,
+                tile_scheduler=tile_scheduler,
+            )
 
         # ///////////////////////////////////////////////////////////////////////////////
         #  MMA
         # ///////////////////////////////////////////////////////////////////////////////
         if warp_idx == self.mma_warp_id:
-            cute.arch.warpgroup_reg_dealloc(self.num_regs_other)
+            cute.arch.setmaxregister_decrease(self.num_regs_other)
+            # Alloc tensor memory buffer
+            tmem.allocate(self.tmem_alloc_cols)
+            tmem.wait_for_alloc()
+            tmem_ptr = tmem.retrieve_ptr(self.qk_acc_dtype)
+            self.mma(
+                tiled_mma_qk,
+                tiled_mma_pv,
+                sQ,
+                sK,
+                sV,
+                tStS,
+                tOtO,
+                tOrP,
+                pipeline_q,
+                pipeline_kv,
+                pipeline_s_p_o,
+                pipeline_p_lastsplit,
+                pipeline_o_acc,
+                block_info,
+                num_splits,
+                SeqlenInfoCls,
+                blocksparse_tensors,
+                tile_scheduler=tile_scheduler,
+            )
+            # Dealloc the tensor memory buffer
+            tmem.relinquish_alloc_permit()
+            tmem_alloc_barrier.arrive_and_wait()
+            tmem.free(tmem_ptr)
 
-            cta_rank_in_cluster = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster())
-            is_leader_cta = cta_rank_in_cluster % 2 == 0
-
-            while work_tile.is_valid_tile:
-                curr_block_coord = work_tile.tile_idx
-                mma_block_coord = (
-                    curr_block_coord[0] // cute.size(qk_tiled_mma.thr_id.shape),
-                    curr_block_coord[1],
-                    curr_block_coord[2],
+        # ///////////////////////////////////////////////////////////////////////////////
+        #  Epilogue
+        # ///////////////////////////////////////////////////////////////////////////////
+        if const_expr(not self.use_correction_warps_for_epi):
+            if warp_idx >= self.epilogue_warp_ids[0] and warp_idx <= self.epilogue_warp_ids[-1]:
+                cute.arch.setmaxregister_decrease(self.num_regs_other)
+                self.epilogue_s2g(
+                    mO,
+                    sO,
+                    gmem_tiled_copy_O,
+                    tma_atom_O,
+                    pipeline_o_epi,
+                    block_info,
+                    num_splits,
+                    SeqlenInfoCls,
+                    mma_tile_coord_v,
+                    tile_scheduler=tile_scheduler,
                 )
-                continue_cond = False
-                seqlen_q = mQ_qdl.shape[0]
-                seqlen_k = (
-                    mK_kdl.shape[0] if cutlass.const_expr(mPageTable is None) else max_seqlen_k
-                )
-                batch_coord = curr_block_coord[2][1]
-                if cutlass.const_expr(cum_seqlen_q is not None):
-                    cuseqlen_q = cum_seqlen_q[batch_coord]
-                    seqlen_q = cum_seqlen_q[batch_coord + 1] - cuseqlen_q
-                    continue_cond = not FmhaStaticTileScheduler.check_valid_work_for_seqlen_q(
-                        self.qk_mma_tiler[0],
-                        mma_block_coord[0],
-                        seqlen_q,
-                    )
 
-                if not continue_cond:
-                    if cutlass.const_expr(cum_seqlen_k is not None):
-                        cuseqlen_k = cum_seqlen_k[batch_coord]
-                        seqlen_k = cum_seqlen_k[batch_coord + 1] - cuseqlen_k
-
-                    seqlen_kv_loop_start, seqlen_kv_loop_steps = (
-                        FusedMask.get_trip_start_count_via_block_info(
-                            mma_block_coord,
-                            self.qk_mma_tiler,
-                            seqlen_q,
-                            seqlen_k,
-                            self.is_causal,
-                            self.is_local,
-                            window_size_left,
-                            window_size_right,
-                        )
-                    )
-                    seqlen_kv_loop_end = seqlen_kv_loop_start + seqlen_kv_loop_steps
-
-                    load_q_releaser = load_q_consumer.clone()
-                    pv_tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
-                    if seqlen_kv_loop_steps > 1:
-                        # QK0
-                        if is_leader_cta:
-                            s_handle = mma_s_producer.acquire_and_advance()
-                            tStS_slice = tStS[None, None, None, s_handle.index]
-                            qk_tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
-                            for iter in cutlass.range(self.iterations_qk, unroll=1):
-                                load_q_consumer.wait_and_advance()
-                                tSrQ_slice = tSrQ[None, None, None, iter]
-                                k_handle = load_kv_consumer.wait_and_advance()
-                                tSrK_trans_slice = tSrK[None, None, None, k_handle.index]
-                                num_kphases = cute.size(tSrQ_slice, mode=[2])
-                                for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
-                                    kphase_coord = (None, None, kphase_idx)
-                                    cute.gemm(
-                                        qk_tiled_mma,
-                                        tStS_slice,
-                                        tSrQ_slice[kphase_coord],
-                                        tSrK_trans_slice[kphase_coord],
-                                        tStS_slice,
-                                    )
-                                    qk_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
-                                k_handle.release()
-                            s_handle.commit()
-                        for i in cutlass.range(1, seqlen_kv_loop_steps - 1, 1, unroll=1):
-                            # QKi
-                            if is_leader_cta:
-                                s_handle = mma_s_producer.acquire_and_advance()
-                                tStS_slice = tStS[None, None, None, s_handle.index]
-                                qk_tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
-                                for iter in cutlass.range(self.iterations_qk, unroll=1):
-                                    tSrQ_slice = tSrQ[None, None, None, iter]
-                                    k_handle = load_kv_consumer.wait_and_advance()
-                                    tSrK_trans_slice = tSrK[None, None, None, k_handle.index]
-                                    num_kphases = cute.size(tSrQ_slice, mode=[2])
-                                    for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
-                                        kphase_coord = (None, None, kphase_idx)
-                                        cute.gemm(
-                                            qk_tiled_mma,
-                                            tStS_slice,
-                                            tSrQ_slice[kphase_coord],
-                                            tSrK_trans_slice[kphase_coord],
-                                            tStS_slice,
-                                        )
-                                        qk_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
-                                    k_handle.release()
-                                s_handle.commit()
-
-                                # PVi-1
-                                p_handle = p_mma_consumer.wait_and_advance()
-                                o_handle = mma_corr_producer.acquire_and_advance()
-                                pv_whether_acc = pv_tiled_mma.get(tcgen05.Field.ACCUMULATE)
-                                for iter in cutlass.range(self.iterations_pv, unroll=1):
-                                    v_handle = load_kv_consumer.wait_and_advance()
-                                    pv_tiled_mma.set(tcgen05.Field.ACCUMULATE, pv_whether_acc)
-                                    tOtO_slice = tOtO_staged[None, None, None, iter]
-                                    tStS_slice = tStS[None, None, None, p_handle.index]
-                                    tP = cute.make_tensor(
-                                        tStS_slice.iterator, p_tmem_layout_staged.outer
-                                    )
-                                    tOrP = pv_thr_mma.make_fragment_A(tP)
-                                    tOrP_slice = cute.make_tensor(
-                                        cute.recast_ptr(tStS_slice.iterator, dtype=self.q_dtype),
-                                        tOrP.layout,
-                                    )
-                                    tOrV_slice = tOrV[None, None, None, v_handle.index]
-                                    num_kphases = cute.size(tOrV_slice, mode=[2])
-                                    for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
-                                        kphase_coord = (None, None, kphase_idx)
-                                        cute.gemm(
-                                            pv_tiled_mma,
-                                            tOtO_slice,
-                                            tOrP_slice[kphase_coord],
-                                            tOrV_slice[kphase_coord],
-                                            tOtO_slice,
-                                        )
-                                        pv_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
-                                    v_handle.release()
-                                o_handle.commit()
-                                p_handle.release()
-                        if is_leader_cta:
-                            # QKend
-                            s_handle = mma_s_producer.acquire_and_advance()
-                            tStS_slice = tStS[None, None, None, s_handle.index]
-                            qk_tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
-                            for iter in cutlass.range(self.iterations_qk, unroll=1):
-                                tSrQ_slice = tSrQ[None, None, None, iter]
-                                k_handle = load_kv_consumer.wait_and_advance()
-                                tSrK_trans_slice = tSrK[None, None, None, k_handle.index]
-                                num_kphases = cute.size(tSrQ_slice, mode=[2])
-                                for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
-                                    kphase_coord = (None, None, kphase_idx)
-                                    cute.gemm(
-                                        qk_tiled_mma,
-                                        tStS_slice,
-                                        tSrQ_slice[kphase_coord],
-                                        tSrK_trans_slice[kphase_coord],
-                                        tStS_slice,
-                                    )
-                                    qk_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
-                                k_handle.release()
-                                load_q_releaser.release()
-                                load_q_releaser.advance()
-                            s_handle.commit()
-
-                            # PVend-1
-                            p_handle = p_mma_consumer.wait_and_advance()
-                            o_handle = mma_corr_producer.acquire_and_advance()
-                            pv_whether_acc = pv_tiled_mma.get(tcgen05.Field.ACCUMULATE)
-                            for iter in cutlass.range(self.iterations_pv, unroll=1):
-                                v_handle = load_kv_consumer.wait_and_advance()
-                                pv_tiled_mma.set(tcgen05.Field.ACCUMULATE, pv_whether_acc)
-                                tOtO_slice = tOtO_staged[None, None, None, iter]
-                                tStS_slice = tStS[None, None, None, p_handle.index]
-                                tP = cute.make_tensor(
-                                    tStS_slice.iterator, p_tmem_layout_staged.outer
-                                )
-                                tOrP = pv_thr_mma.make_fragment_A(tP)
-                                tOrP_slice = cute.make_tensor(
-                                    cute.recast_ptr(tStS_slice.iterator, dtype=self.q_dtype),
-                                    tOrP.layout,
-                                )
-                                tOrV_slice = tOrV[None, None, None, v_handle.index]
-                                num_kphases = cute.size(tOrV_slice, mode=[2])
-                                for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
-                                    kphase_coord = (None, None, kphase_idx)
-                                    cute.gemm(
-                                        pv_tiled_mma,
-                                        tOtO_slice,
-                                        tOrP_slice[kphase_coord],
-                                        tOrV_slice[kphase_coord],
-                                        tOtO_slice,
-                                    )
-                                    pv_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
-                                v_handle.release()
-                            o_handle.commit()
-                            p_handle.release()
-                    else:
-                        if is_leader_cta:
-                            # QK0
-                            s_handle = mma_s_producer.acquire_and_advance()
-                            tStS_slice = tStS[None, None, None, s_handle.index]
-                            qk_tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
-                            for iter in cutlass.range(self.iterations_qk, unroll=1):
-                                load_q_consumer.wait_and_advance()
-                                tSrQ_slice = tSrQ[None, None, None, iter]
-                                k_handle = load_kv_consumer.wait_and_advance()
-                                tSrK_trans_slice = tSrK[None, None, None, k_handle.index]
-                                num_kphases = cute.size(tSrQ_slice, mode=[2])
-                                for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
-                                    kphase_coord = (None, None, kphase_idx)
-                                    cute.gemm(
-                                        qk_tiled_mma,
-                                        tStS_slice,
-                                        tSrQ_slice[kphase_coord],
-                                        tSrK_trans_slice[kphase_coord],
-                                        tStS_slice,
-                                    )
-                                    qk_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
-                                k_handle.release()
-                                load_q_releaser.release()
-                                load_q_releaser.advance()
-                            s_handle.commit()
-
-                    if is_leader_cta:
-                        # PVend
-                        p_handle = p_mma_consumer.wait_and_advance()
-                        o_handle = mma_corr_producer.acquire_and_advance()
-                        pv_whether_acc = pv_tiled_mma.get(tcgen05.Field.ACCUMULATE)
-                        for iter in cutlass.range(self.iterations_pv, unroll=1):
-                            v_handle = load_kv_consumer.wait_and_advance()
-                            pv_tiled_mma.set(tcgen05.Field.ACCUMULATE, pv_whether_acc)
-                            tOtO_slice = tOtO_staged[None, None, None, iter]
-                            tStS_slice = tStS[None, None, None, p_handle.index]
-                            tP = cute.make_tensor(tStS_slice.iterator, p_tmem_layout_staged.outer)
-                            tOrP = pv_thr_mma.make_fragment_A(tP)
-                            tOrP_slice = cute.make_tensor(
-                                cute.recast_ptr(tStS_slice.iterator, dtype=self.q_dtype),
-                                tOrP.layout,
-                            )
-                            tOrV_slice = tOrV[None, None, None, v_handle.index]
-                            num_kphases = cute.size(tOrV_slice, mode=[2])
-                            for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
-                                kphase_coord = (None, None, kphase_idx)
-                                cute.gemm(
-                                    pv_tiled_mma,
-                                    tOtO_slice,
-                                    tOrP_slice[kphase_coord],
-                                    tOrV_slice[kphase_coord],
-                                    tOtO_slice,
-                                )
-                                pv_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
-                            v_handle.release()
-                        o_handle.commit()
-                        p_handle.release()
-                work_tile = tile_sched.advance_to_next_work()
-            # End of persistent scheduler loop
-            mma_s_producer.tail()
-            mma_corr_producer.tail()
-
+        # ///////////////////////////////////////////////////////////////////////////////
+        #  Softmax
+        # ///////////////////////////////////////////////////////////////////////////////
         if warp_idx < self.correction_warp_ids[0] and warp_idx >= self.softmax_warp_ids[0]:
             # increase register after decreasing
-            cute.arch.warpgroup_reg_alloc(self.num_regs_softmax)
+            cute.arch.setmaxregister_increase(self.num_regs_softmax)
+            # sync with mma warp before retrieving tmem ptr
+            tmem.wait_for_alloc()
+            tmem_ptr = tmem.retrieve_ptr(self.qk_acc_dtype)
+            softmax_loop = partial(
+                self.softmax_loop,
+                softmax_scale_log2=softmax_scale_log2,
+                softmax_scale=softmax_scale,
+                descale_tensors=descale_tensors,
+                thr_mma_qk=thr_mma_qk,
+                sScale=sScale,
+                mLSE=mLSE,
+                pipeline_s_p_o=pipeline_s_p_o,
+                pipeline_p_lastsplit=pipeline_p_lastsplit,
+                pipeline_sm_stats=pipeline_sm_stats,
+                sm_stats_barrier=sm_stats_barrier,
+                pipeline_s0_s1_sequence=None,
+                learnable_sink=learnable_sink,
+                block_info=block_info,
+                num_splits=num_splits,
+                SeqlenInfoCls=SeqlenInfoCls,
+                AttentionMaskCls=AttentionMaskCls,
+                aux_data=aux_data,
+                fastdiv_mods=fastdiv_mods,
+                head_divmod=head_divmod,
+                blocksparse_tensors=blocksparse_tensors,
+                tile_scheduler=tile_scheduler,
+            )
+            stage = Int32(0)
+            softmax_loop(stage=stage, tStS=tStS)
 
-            while work_tile.is_valid_tile:
-                curr_block_coord = work_tile.tile_idx
-                mma_block_coord = (
-                    curr_block_coord[0] // cute.size(qk_tiled_mma.thr_id.shape),
-                    curr_block_coord[1],
-                    curr_block_coord[2],
-                )
-                batch_coord = curr_block_coord[2][1]
-                continue_cond = False
-                seqlen_q = mQ_qdl.shape[0]
-                seqlen_k = (
-                    mK_kdl.shape[0] if cutlass.const_expr(mPageTable is None) else max_seqlen_k
-                )
-                cuseqlen_q = Int32(0)
-                if cutlass.const_expr(cum_seqlen_q is not None):
-                    cuseqlen_q = cum_seqlen_q[batch_coord]
-                    seqlen_q = cum_seqlen_q[batch_coord + 1] - cuseqlen_q
-                    continue_cond = not FmhaStaticTileScheduler.check_valid_work_for_seqlen_q(
-                        self.qk_mma_tiler[0],
-                        mma_block_coord[0],
-                        seqlen_q,
-                    )
-                if not continue_cond:
-                    if cutlass.const_expr(cum_seqlen_k is not None):
-                        cuseqlen_k = cum_seqlen_k[batch_coord]
-                        seqlen_k = cum_seqlen_k[batch_coord + 1] - cuseqlen_k
-
-                    row_max = -Float32.inf
-                    row_max_prev = -Float32.inf
-                    row_sum = 0.0
-
-                    start_count, trip_count = FusedMask.get_trip_start_count_via_block_info(
-                        mma_block_coord,
-                        self.qk_mma_tiler,
-                        seqlen_q,
-                        seqlen_k,
-                        self.is_causal,
-                        self.is_local,
-                        window_size_left,
-                        window_size_right,
-                    )
-                    end_count = start_count + trip_count
-                    # require at least one softmax iteration for zero trip_count case;
-                    # rely on masking this iteration for correctness
-                    if end_count <= start_count:
-                        start_count = 0
-                        end_count = 1
-                    if cutlass.const_expr(self.use_semantic_trip_range):
-                        n_block_min_causal_local_mask, n_block_min_before_local_mask = (
-                            FusedMask.get_trip_mask_bounds_via_block_info(
-                                mma_block_coord,
-                                self.qk_mma_tiler,
-                                seqlen_q,
-                                seqlen_k,
-                                self.is_causal,
-                                self.is_local,
-                                window_size_left,
-                                window_size_right,
-                            )
-                        )
-                    cS_base = cute.make_identity_tensor(
-                        (self.qk_mma_tiler[0], self.qk_mma_tiler[1])
-                    )
-                    cS = cute.domain_offset((mma_block_coord[0] * self.qk_mma_tiler[0], 0), cS_base)
-                    tScS = qk_thr_mma.partition_C(cS)
-
-                    for step in cutlass.range(start_count, end_count, 1, unroll=1):
-                        cS_iter = cute.domain_offset((0, step * self.qk_mma_tiler[1]), cS)
-                        tScS_iter = qk_thr_mma.partition_C(cS_iter)
-                        if cutlass.const_expr(self.use_semantic_trip_range):
-                            need_apply_mask = (
-                                step >= n_block_min_causal_local_mask
-                                or step < n_block_min_before_local_mask
-                                or step == end_count - 1
-                            )
-                        else:
-                            # Residual path only needs seqlen masking on the last K tile.
-                            need_apply_mask = step == end_count - 1
-                        # Si -> Pi
-                        (
-                            row_max,
-                            row_sum,
-                            mma_s_consumer,
-                            p_mma_producer,
-                            s_corr_producer,
-                        ) = self.softmax_step(
-                            (need_apply_mask, window_size_left, window_size_right),
-                            (
-                                row_max_prev,
-                                row_sum,
-                                seqlen_q,
-                                seqlen_k,
-                                scale_softmax_log2,
-                            ),
-                            (tStS, tScS_iter),
-                            (mma_s_consumer, p_mma_producer, s_corr_producer),
-                        )
-                        row_max_prev = row_max
-                    sum_producer = self.store_sum_max(
-                        row_max,
-                        mLSE,
-                        row_sum,
-                        sSum,
-                        sum_producer,
-                        curr_block_coord,
-                        seqlen_q,
-                        cum_seqlen_q,
-                        cuseqlen_q,
-                        scale_softmax,
-                    )
-                work_tile = tile_sched.advance_to_next_work()
-            p_mma_producer.tail()
-            s_corr_producer.tail()
+            tmem_alloc_barrier.arrive()
 
         # ///////////////////////////////////////////////////////////////////////////////
         #  Correction
         # ///////////////////////////////////////////////////////////////////////////////
         if warp_idx >= self.correction_warp_ids[0] and warp_idx < self.mma_warp_id:
-            cute.arch.warpgroup_reg_dealloc(self.num_regs_correction)
-
-            while work_tile.is_valid_tile:
-                curr_block_coord = work_tile.tile_idx
-                mma_block_coord = (
-                    curr_block_coord[0] // cute.size(qk_tiled_mma.thr_id.shape),
-                    curr_block_coord[1],
-                    curr_block_coord[2],
-                )
-                batch_coord = curr_block_coord[2][1]
-                seqlen_q = mQ_qdl.shape[0]
-                seqlen_k = (
-                    mK_kdl.shape[0] if cutlass.const_expr(mPageTable is None) else max_seqlen_k
-                )
-                continue_cond = False
-                cuseqlen_q = Int32(0)
-                if cutlass.const_expr(cum_seqlen_q is not None):
-                    cuseqlen_q = cum_seqlen_q[batch_coord]
-                    seqlen_q = cum_seqlen_q[batch_coord + 1] - cuseqlen_q
-                    continue_cond = not FmhaStaticTileScheduler.check_valid_work_for_seqlen_q(
-                        self.qk_mma_tiler[0],
-                        mma_block_coord[0],
-                        seqlen_q,
-                    )
-
-                if not continue_cond:
-                    if cutlass.const_expr(cum_seqlen_k is not None):
-                        cuseqlen_k = cum_seqlen_k[batch_coord]
-                        seqlen_k = cum_seqlen_k[batch_coord + 1] - cuseqlen_k
-
-                    mO_qdl_eff = mO_qdl
-                    if cutlass.const_expr(cum_seqlen_q is not None):
-                        block_offset_o = (
-                            cuseqlen_q,
-                            Int32(0),
-                            Int32(0),
-                            ((Int32(0), Int32(0)), Int32(0)),
-                        )
-                        mO_qdl_eff = cute.domain_offset(
-                            cute.select(block_offset_o, mode=[0, 2, 3]), mO_qdl
-                        )
-
-                    # (bM, bN, loopM, loopN, loopL)
-                    gO_qdl = cute.flat_divide(
-                        mO_qdl_eff, cute.select(self.pv_block_tiler, mode=[0, 1])
-                    )
-                    cO_qdl = cute.flat_divide(
-                        cute.make_identity_tensor(mO_qdl_eff.shape),
-                        cute.select(self.pv_block_tiler, mode=[0, 1]),
-                    )
-
-                    _, seqlen_kv_loop_steps = FusedMask.get_trip_start_count_via_block_info(
-                        mma_block_coord,
-                        self.qk_mma_tiler,
-                        seqlen_q,
-                        seqlen_k,
-                        self.is_causal,
-                        self.is_local,
-                        window_size_left,
-                        window_size_right,
-                    )
-                    gO_staged = gO_qdl[None, None, curr_block_coord[0], None, curr_block_coord[2]]
-                    cO_staged = cO_qdl[None, None, curr_block_coord[0], None, curr_block_coord[2]]
-                    cS = cute.make_identity_tensor((self.qk_mma_tiler[0], self.qk_mma_tiler[1]))
-                    tScS = qk_thr_mma.partition_C(cS)
-
-                    # Empty step as the first step is no need for correction
-                    stats_handle = s_corr_consumer.wait_and_advance()
-                    stats_handle.release()
-                    for step in cutlass.range(1, seqlen_kv_loop_steps, 1, unroll=1):
-                        # Oi-1 -> Oi
-                        mma_corr_consumer, s_corr_consumer = self.correction_rescale(
-                            scale_softmax_log2,
-                            (s_corr_consumer, tStS, tScS),
-                            (mma_corr_consumer, tOtO_staged, cO_staged),
-                            self.epi_tile,
-                        )
-                    # O_partial -> O_final
-                    mma_corr_consumer, sum_consumer = self.correction_epilog(
-                        (seqlen_q, scale_output),
-                        (sum_consumer, sSum),
-                        (mma_corr_consumer, gO_staged, cO_staged, tOtO_staged),
-                        self.epi_tile,
-                    )
-                work_tile = tile_sched.advance_to_next_work()
-            # NOTE: tmem.free() moved to kernel end to enable cluster-wide sync
-
-        # ///////////////////////////////////////////////////////////////////////////////
-        #  Scheduler Warp (only for CLC dynamic scheduler)
-        # ///////////////////////////////////////////////////////////////////////////////
-        if cutlass.const_expr(self.use_clc_scheduler):
-            is_first_cta_in_cluster = cta_rank_in_cluster == 0
-
-            if warp_idx == self.sched_warp_id and is_first_cta_in_cluster:
-                cute.arch.warpgroup_reg_dealloc(self.num_regs_other)
-                while work_tile.is_valid_tile:
-                    tile_sched.prefetch_next_work()
-                    work_tile = tile_sched.advance_to_next_work()
-                tile_sched.producer_tail()
-
-        # ///////////////////////////////////////////////////////////////////////////////
-        #  Empty warps reg dealloc
-        # ///////////////////////////////////////////////////////////////////////////////
-        if cutlass.const_expr(self.use_clc_scheduler):
-            if warp_idx > self.load_warp_id:
-                if not (warp_idx == self.sched_warp_id and is_first_cta_in_cluster):
-                    cute.arch.warpgroup_reg_dealloc(self.num_regs_other)
-        else:
-            if warp_idx > self.load_warp_id:
-                cute.arch.warpgroup_reg_dealloc(self.num_regs_other)
-
-        # ///////////////////////////////////////////////////////////////////////////////
-        #  Cooperative TMEM Deallocation (2CTA)
-        # ///////////////////////////////////////////////////////////////////////////////
-        # All warps (including scheduler) have finished by this point.
-        # Cluster-wide sync ensures both CTAs reach here before dealloc.
-        cute.arch.cluster_arrive()
-        cute.arch.cluster_wait()
-        tmem.relinquish_alloc_permit()
-        tmem.free(tmem_ptr)
+            cute.arch.setmaxregister_decrease(self.num_regs_correction)
+            # sync with mma warp before retrieving tmem ptr
+            tmem.wait_for_alloc()
+            tmem_ptr = tmem.retrieve_ptr(self.qk_acc_dtype)
+            self.correction_loop(
+                thr_mma_qk,
+                thr_mma_pv,
+                tStS,
+                tOtO,
+                sScale,
+                mO,
+                mLSE,
+                sO,
+                gmem_tiled_copy_O,
+                pipeline_o_acc,
+                pipeline_sm_stats,
+                sm_stats_barrier,
+                pipeline_o_epi,
+                learnable_sink,
+                softmax_scale_log2,
+                block_info,
+                num_splits,
+                SeqlenInfoCls,
+                blocksparse_tensors,
+                tile_scheduler=tile_scheduler,
+            )
+            tmem_alloc_barrier.arrive()
 
         return
 
     @cute.jit
-    def softmax_step(
+    def _kv_head_idx(self, head_idx: Int32) -> Int32:
+        if cutlass.const_expr(self.pack_gqa):
+            return head_idx
+        return head_idx // self.qhead_per_kvhead
+
+    def load_Q(
         self,
-        mask_args: Tuple,
-        value_args: Tuple,
-        tensor_args: Tuple,
-        pipeline_args: Tuple,
-    ) -> Tuple[Float32, Float32, pipeline.PipelineConsumer, pipeline.PipelineProducer]:
-        need_apply_mask, window_size_left, window_size_right = mask_args
-        row_max, row_sum, seqlen_q, seqlen_k, scale_softmax_log2 = value_args
-        tStS, tScS = tensor_args
-        mma_s_consumer, p_mma_producer, s_corr_producer = pipeline_args
-        tidx, _, _ = cute.arch.thread_idx()
-        thread_idx = tidx % (self.threads_per_warp * len(self.softmax_warp_ids))
-        s_handle = mma_s_consumer.wait_and_advance()
-        tStS_slice = tStS[(None, None), 0, 0, s_handle.index]
-        tScS_slice = tScS[(None, None), 0, 0]
-        tmem_load_atom = cute.make_copy_atom(
-            tcgen05.Ld32x32bOp(tcgen05.Repetition(32)), self.qk_acc_dtype
+        load_Q_fn: Callable,
+        pipeline_q: pipeline.PipelineAsync,
+        block: Int32,
+        stage: int,
+        phase: Int32,
+    ):
+        pipeline_q.producer_acquire_w_index_phase(stage, phase)
+        load_Q_fn(
+            src_idx=block,
+            dst_idx=stage,
+            tma_bar_ptr=pipeline_q.sync_object_full.get_barrier(stage),
         )
-        tmem_tiled_load = tcgen05.make_tmem_copy(tmem_load_atom, tStS_slice)
-        thr_load = tmem_tiled_load.get_slice(thread_idx)
-        tTMEM_LOADtS = thr_load.partition_S(tStS_slice)
-        tTMEM_LOADcS = thr_load.partition_D(tScS_slice)
-        tTMEM_LOADrS = cute.make_rmem_tensor(tTMEM_LOADcS.shape, self.qk_acc_dtype)
-        cute.copy(tmem_tiled_load, tTMEM_LOADtS, tTMEM_LOADrS)
 
-        cute.arch.fence_view_async_tmem_load()
-        s_handle.release()
-        if need_apply_mask:
-            FusedMask.apply_mask_via_causal_local(
-                tTMEM_LOADrS,
-                tTMEM_LOADcS,
-                seqlen_q,
-                seqlen_k,
-                self.use_semantic_trip_range,
-                self.is_causal,
-                self.is_local,
-                window_size_left,
-                window_size_right,
-            )
-        old_row_max = row_max
-        row_max = tTMEM_LOADrS.load().reduce(cute.ReductionOp.MAX, row_max, 0)
-        row_max_safe = row_max
-        if row_max == -cutlass.Float32.inf:
-            row_max_safe = 0.0
-
-        stats_handle = s_corr_producer.acquire_and_advance()
-        stats_layout = cute.composition(
-            tStS_slice.layout, cute.make_layout((tStS_slice.shape[0], 2))
-        )
-        stats_c_layout = cute.composition(
-            tScS_slice.layout, cute.make_layout((tScS_slice.shape[0], 2))
-        )
-        tOtStats = cute.make_tensor(tStS_slice.iterator + self.tilePlikeFP32, stats_layout)
-        tOcStats = cute.make_tensor(tScS_slice.iterator, stats_c_layout)
-        tmem_store_stats_atom = cute.make_copy_atom(
-            tcgen05.copy.St32x32bOp(tcgen05.copy.Repetition(2)),
-            self.qk_acc_dtype,
-        )
-        tiled_tmem_store_stats = tcgen05.make_tmem_copy(tmem_store_stats_atom, tOtStats)
-        thr_tmem_store_stats = tiled_tmem_store_stats.get_slice(thread_idx)
-        tTMEM_STOREcStats = thr_tmem_store_stats.partition_S(tOcStats)
-        tTMEM_STORErStats = cute.make_rmem_tensor(tTMEM_STOREcStats.shape, self.qk_acc_dtype)
-        tTMEM_STORErStats[0] = old_row_max
-        tTMEM_STORErStats[1] = row_max_safe
-        tTMEM_STOREtStats = thr_tmem_store_stats.partition_D(tOtStats)
-        cute.copy(tiled_tmem_store_stats, tTMEM_STORErStats, tTMEM_STOREtStats)
-        cute.arch.fence_view_async_tmem_store()
-        stats_handle.commit()
-
-        scale = scale_softmax_log2
-        minus_row_max_scale = (0.0 - row_max_safe) * scale
-        # Acquire P write slot early — overlaps any pipeline stall with exp2 compute
-        p_handle = p_mma_producer.acquire_and_advance()
-        # Fragment-based FMA + exp2 + bf16 conversion
-        # Trades SFU for FMA via polynomial emulation on a fraction of elements
-        ex2_frg_tile = 32
-        ex2_frg_cnt = cute.size(tTMEM_LOADrS) // ex2_frg_tile
-        tTMEM_LOADrS_ex2 = cute.logical_divide(tTMEM_LOADrS, cute.make_layout(ex2_frg_tile))
-        tTMEM_STORErP = cute.make_rmem_tensor(tTMEM_LOADrS.shape, self.q_dtype)
-        tTMEM_STORErP_ex2 = cute.logical_divide(tTMEM_STORErP, cute.make_layout(ex2_frg_tile))
-        for j in cutlass.range_constexpr(ex2_frg_cnt):
-            for k in cutlass.range_constexpr(0, ex2_frg_tile, 2):
-                tTMEM_LOADrS_ex2[k, j], tTMEM_LOADrS_ex2[k + 1, j] = cute.arch.fma_packed_f32x2(
-                    (tTMEM_LOADrS_ex2[k, j], tTMEM_LOADrS_ex2[k + 1, j]),
-                    (scale, scale),
-                    (minus_row_max_scale, minus_row_max_scale),
-                )
-                if cutlass.const_expr(self.ex2_emu_freq == 0):
-                    tTMEM_LOADrS_ex2[k, j] = cute.math.exp2(tTMEM_LOADrS_ex2[k, j], fastmath=True)
-                    tTMEM_LOADrS_ex2[k + 1, j] = cute.math.exp2(
-                        tTMEM_LOADrS_ex2[k + 1, j], fastmath=True
+    @cute.jit
+    def load_KV(
+        self,
+        tma_atom: cute.CopyAtom,
+        tXgX: cute.Tensor,
+        tXsX: cute.Tensor,
+        block: Int32,
+        K_or_V: Literal["K", "V"],
+        pipeline_kv: pipeline.PipelineAsync,
+        producer_state: pipeline.PipelineState,
+        hdim_stage: Optional[Int32] = None,
+        hdim_stage_count: cutlass.Constexpr[int] = 1,
+        page_idx: Optional[Int32] = None,
+    ):
+        assert K_or_V in ("K", "V")
+        if const_expr(hdim_stage is None):
+            for iter in cutlass.range_constexpr(hdim_stage_count):
+                stage = producer_state.index
+                pipeline_kv.producer_acquire(producer_state)
+                if const_expr(page_idx is None):
+                    tXgX_cur = (
+                        tXgX[None, block, iter]
+                        if const_expr(K_or_V == "K")
+                        else tXgX[None, iter, block]
                     )
                 else:
-                    if cutlass.const_expr(
-                        k % self.ex2_emu_freq < self.ex2_emu_freq - self.ex2_emu_res
-                        or j >= ex2_frg_cnt - 1
-                        or j < self.ex2_emu_start_frg
-                    ):
-                        tTMEM_LOADrS_ex2[k, j] = cute.math.exp2(
-                            tTMEM_LOADrS_ex2[k, j], fastmath=True
+                    # TMA paged-KV requires page_size == tile_n. The logical
+                    # n-block therefore always selects tile 0 within page_idx.
+                    tXgX_cur = (
+                        tXgX[None, 0, iter, page_idx]
+                        if const_expr(K_or_V == "K")
+                        else tXgX[None, iter, 0, page_idx]
+                    )
+                tXsX_cur = tXsX[None, stage]
+                cute.copy(
+                    tma_atom,
+                    tXgX_cur,
+                    tXsX_cur,
+                    tma_bar_ptr=pipeline_kv.producer_get_barrier(producer_state),
+                )
+                if const_expr(iter < hdim_stage_count - 1):
+                    producer_state.advance()
+        else:
+            stage = producer_state.index
+            pipeline_kv.producer_acquire(producer_state)
+            if const_expr(page_idx is None):
+                tXgX_cur = (
+                    tXgX[None, block, hdim_stage]
+                    if const_expr(K_or_V == "K")
+                    else tXgX[None, hdim_stage, block]
+                )
+            else:
+                tXgX_cur = (
+                    tXgX[None, 0, hdim_stage, page_idx]
+                    if const_expr(K_or_V == "K")
+                    else tXgX[None, hdim_stage, 0, page_idx]
+                )
+            tXsX_cur = tXsX[None, stage]
+            cute.copy(
+                tma_atom,
+                tXgX_cur,
+                tXsX_cur,
+                tma_bar_ptr=pipeline_kv.producer_get_barrier(producer_state),
+            )
+
+    @cute.jit
+    def load(
+        self,
+        thr_mma_qk,
+        thr_mma_pv,
+        mQ: cute.Tensor,
+        mK: cute.Tensor,
+        mV: cute.Tensor,
+        mPageTable: Optional[cute.Tensor],
+        sQ: cute.Tensor,
+        sK: cute.Tensor,
+        sV: cute.Tensor,
+        tma_atom_Q: cute.CopyAtom,
+        tma_atom_K: cute.CopyAtom,
+        tma_atom_V: cute.CopyAtom,
+        pipeline_q,
+        pipeline_kv,
+        block_info: BlockInfo,
+        num_splits: Int32,
+        SeqlenInfoCls: Callable,
+        blocksparse_tensors: Optional[BlockSparseTensors],
+        tile_scheduler: TileSchedulerProtocol,
+    ):
+        warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+        issue_kv_for_this_warp = (
+            const_expr(not self.use_tma_KV or len(self.load_warp_ids) == 1)
+            or warp_idx == self.load_warp_ids[0]
+        )
+        issue_q_for_this_warp = (
+            const_expr(not self.use_tma_Q or len(self.load_warp_ids) == 1)
+            or warp_idx == self.load_warp_ids[0]
+        )
+        cta_layout_vmnk = cute.tiled_divide(
+            cute.make_layout(self.cluster_shape_mnk), (thr_mma_qk.thr_id.shape,)
+        )
+        cta_rank_in_cluster = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster())
+        block_in_cluster_coord_vmnk = cta_layout_vmnk.get_flat_coord(cta_rank_in_cluster)
+        bidx, _, _ = cute.arch.block_idx()
+        if const_expr(cute.size(thr_mma_qk.thr_id.shape) == 1):
+            mma_tile_coord_v = 0
+        else:
+            mma_tile_coord_v = bidx % cute.size(thr_mma_qk.thr_id.shape)
+
+        q_producer_phase = Int32(1)
+        kv_producer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Producer, self.kv_stage
+        )
+        work_tile = tile_scheduler.initial_work_tile_info()
+        while work_tile.is_valid_tile:
+            m_block, head_idx, batch_idx, split_idx = work_tile.tile_idx
+            head_idx_kv = self._kv_head_idx(head_idx)
+            seqlen = SeqlenInfoCls(batch_idx)
+            mQ_cur = seqlen.offset_batch_Q(mQ, batch_idx, dim=3)[None, None, head_idx]
+            if const_expr(mPageTable is not None):
+                # Preserve the physical-page mode for page_idx-based TMA.
+                mK_cur, mV_cur = [t[None, None, head_idx_kv, None] for t in (mK, mV)]
+            elif const_expr(not seqlen.has_cu_seqlens_k):
+                mK_cur, mV_cur = [t[None, None, head_idx_kv, batch_idx] for t in (mK, mV)]
+            else:
+                mK_cur = cute.domain_offset(
+                    (seqlen.offset_k, Int32(0)), mK[None, None, head_idx_kv]
+                )
+                mV_cur = cute.domain_offset(
+                    (Int32(0), seqlen.offset_k), mV[None, None, head_idx_kv]
+                )
+            if const_expr(mPageTable is None):
+                gK = cute.local_tile(
+                    mK_cur, cute.select(self.mma_tiler_qk, mode=[1, 2]), (None, None)
+                )
+                gV = cute.local_tile(
+                    mV_cur, cute.select(self.mma_tiler_pv, mode=[1, 2]), (None, None)
+                )
+            else:
+                gK = cute.local_tile(
+                    mK_cur, cute.select(self.mma_tiler_qk, mode=[1, 2]), (None, None, None)
+                )
+                gV = cute.local_tile(
+                    mV_cur, cute.select(self.mma_tiler_pv, mode=[1, 2]), (None, None, None)
+                )
+            tSgK = thr_mma_qk.partition_B(gK)
+            tOgV = thr_mma_pv.partition_B(gV)
+
+            q_cta_layout = cute.make_layout(cute.slice_(cta_layout_vmnk, (0, 0, None, 0)).shape)
+            # (bM, bK, loopM, loopK, loopL)
+            gQ = cute.local_tile(
+                mQ_cur, cute.select(self.mma_tiler_qk, mode=[0, 2]), (m_block, None)
+            )
+            tSgQ = thr_mma_qk.partition_A(gQ)
+            load_Q_fn, _, _ = copy_utils.tma_get_copy_fn(
+                tma_atom_Q,
+                block_in_cluster_coord_vmnk[2],
+                q_cta_layout,
+                tSgQ,
+                sQ,
+            )
+            kv_cta_layout = cute.make_layout(cute.slice_(cta_layout_vmnk, (0, None, 0, 0)).shape)
+            tKsK, tKgK = cpasync.tma_partition(
+                tma_atom_K,
+                block_in_cluster_coord_vmnk[1],
+                kv_cta_layout,
+                cute.group_modes(sK, 0, 3),
+                cute.group_modes(tSgK, 0, 3),
+            )
+            tVsV, tVgV = cpasync.tma_partition(
+                tma_atom_V,
+                block_in_cluster_coord_vmnk[1],
+                kv_cta_layout,
+                cute.group_modes(sV, 0, 3),
+                cute.group_modes(tOgV, 0, 3),
+            )
+            # Paged TMA carries an additional physical-page mode.
+            if const_expr(mPageTable is None):
+                tKgK = tKgK[None, None, None]
+                tVgV = tVgV[None, None, None]
+            else:
+                tKgK = tKgK[None, None, None, None]
+                tVgV = tVgV[None, None, None, None]
+            load_Q = partial(
+                self.load_Q,
+                load_Q_fn,
+                pipeline_q=pipeline_q,
+                phase=q_producer_phase,
+            )
+            load_K = partial(
+                self.load_KV,
+                tma_atom_K,
+                tKgK,
+                tKsK,
+                K_or_V="K",
+                pipeline_kv=pipeline_kv,
+                hdim_stage_count=self.qk_hdim_stage,
+            )
+            load_V = partial(
+                self.load_KV,
+                tma_atom_V,
+                tVgV,
+                tVsV,
+                K_or_V="V",
+                pipeline_kv=pipeline_kv,
+                hdim_stage_count=self.pv_hdim_stage,
+            )
+
+            if const_expr(not self.use_block_sparsity):
+                n_block_min, n_block_max = block_info.get_n_block_min_max(
+                    seqlen, m_block, split_idx, num_splits
+                )
+                if const_expr(not self.is_split_kv) or n_block_min < n_block_max:
+                    # Q tile, split across the head-dim stages.
+                    if issue_q_for_this_warp:
+                        for iter in cutlass.range(self.qk_hdim_stage, unroll=1):
+                            load_Q(block=iter, stage=iter)
+                    q_producer_phase ^= 1
+
+                    # First logical KV block: n_block_max - 1.
+                    kv_coord = n_block_max - 1
+                    page_idx = (
+                        mPageTable[batch_idx, kv_coord]
+                        if const_expr(mPageTable is not None)
+                        else None
+                    )
+                    v_page_idx = page_idx
+                    if issue_kv_for_this_warp:
+                        load_K(
+                            block=kv_coord,
+                            producer_state=kv_producer_state,
+                            page_idx=page_idx,
                         )
-                        tTMEM_LOADrS_ex2[k + 1, j] = cute.math.exp2(
-                            tTMEM_LOADrS_ex2[k + 1, j], fastmath=True
+                        kv_producer_state.advance()
+
+                    for i in cutlass.range(n_block_max - 1 - n_block_min, unroll=1):
+                        n_block = n_block_max - 2 - i
+                        page_idx = (
+                            mPageTable[batch_idx, n_block]
+                            if const_expr(mPageTable is not None)
+                            else None
+                        )
+                        # QK-ahead issue order: load next K before the previous V.
+                        if issue_kv_for_this_warp:
+                            load_K(
+                                block=n_block,
+                                producer_state=kv_producer_state,
+                                page_idx=page_idx,
+                            )
+                            kv_producer_state.advance()
+                            # V for the previously produced score tile.
+                            load_V(
+                                block=n_block + 1,
+                                producer_state=kv_producer_state,
+                                page_idx=v_page_idx,
+                            )
+                            kv_producer_state.advance()
+                        v_page_idx = page_idx
+                    # Final V tile for n_block_min.
+                    if issue_kv_for_this_warp:
+                        load_V(
+                            block=n_block_min,
+                            producer_state=kv_producer_state,
+                            page_idx=v_page_idx,
+                        )
+                        kv_producer_state.advance()
+            else:
+                if issue_kv_for_this_warp or issue_q_for_this_warp:
+                    kv_producer_state, q_producer_phase = produce_block_sparse_loads_sm100_qk_ahead(
+                        blocksparse_tensors,
+                        batch_idx,
+                        head_idx,
+                        m_block,
+                        seqlen,
+                        kv_producer_state,
+                        load_Q,
+                        load_K,
+                        load_V,
+                        pipeline_kv,
+                        self.q_load_stage,
+                        q_producer_phase,
+                        self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
+                        self.q_subtile_factor if self.q_subtile_factor is not None else 1,
+                    )
+
+            work_tile = tile_scheduler.advance_to_next_work()
+            # End of persistent scheduler loop
+        if issue_kv_for_this_warp:
+            _producer_tail_with_cutlass_state(pipeline_kv, kv_producer_state)
+        # This is equivalent to pipeline_q.producer_tail for the TMA-Q producer warp.
+        if issue_q_for_this_warp:
+            pipeline_q.producer_acquire_w_index_phase(self.q_load_stage - 1, q_producer_phase)
+
+    @cute.jit
+    def mma(
+        self,
+        tiled_mma_qk,
+        tiled_mma_pv,
+        sQ: cute.Tensor,
+        sK: cute.Tensor,
+        sV: cute.Tensor,
+        tStS: cute.Tensor,
+        tOtO: cute.Tensor,
+        tOrP: cute.Tensor,
+        pipeline_q: pipeline.PipelineAsync,
+        pipeline_kv: pipeline.PipelineAsync,
+        pipeline_s_p_o: pipeline.PipelineAsync,
+        pipeline_p_lastsplit: pipeline.PipelineAsync,
+        pipeline_o_acc: pipeline.PipelineAsync,
+        block_info: BlockInfo,
+        num_splits: Int32,
+        SeqlenInfoCls: Callable,
+        blocksparse_tensors: Optional[BlockSparseTensors],
+        tile_scheduler=None,
+    ):
+        bidx, _, _ = cute.arch.block_idx()
+        if const_expr(cute.size(tiled_mma_qk.thr_id.shape) == 1):
+            mma_tile_coord_v = 0
+        else:
+            mma_tile_coord_v = bidx % cute.size(tiled_mma_qk.thr_id.shape)
+        is_leader_cta = mma_tile_coord_v == 0
+
+        thr_mma_qk = tiled_mma_qk.get_slice(mma_tile_coord_v)
+        thr_mma_pv = tiled_mma_pv.get_slice(mma_tile_coord_v)
+        tSrQ = tiled_mma_qk.make_fragment_A(sQ)
+        tSrK = tiled_mma_qk.make_fragment_B(sK)
+        tOrV = tiled_mma_pv.make_fragment_B(sV)
+        if const_expr(self.q_load_stage == 2):
+            tSrQs = (tSrQ[None, None, None, 0], tSrQ[None, None, None, 1])
+        else:
+            tSrQs = (tSrQ[None, None, None, 0],)
+
+        qk_mma_op, pv_mma_op = tiled_mma_qk.op, tiled_mma_pv.op
+        qk_mma_idesc, pv_mma_idesc = (
+            sm100_desc.mma_op_to_idesc(qk_mma_op),
+            sm100_desc.mma_op_to_idesc(pv_mma_op),
+        )
+        qk_mma_kind = sm100_utils._tcgen05_mma_kind(qk_mma_op)
+        q_smem_base = sm100_desc.smem_desc_base_from_tensor(sQ, sm100_desc.Major.K)
+        k_smem_base = sm100_desc.smem_desc_base_from_tensor(sK, sm100_desc.Major.K)
+        v_smem_base = sm100_desc.smem_desc_base_from_tensor(sV, sm100_desc.Major.MN)
+        q_smem_start = [
+            sm100_desc.make_smem_desc_start_addr(sQ[None, None, None, stage].iterator)
+            for stage in range(self.q_load_stage)
+        ]
+        sm100_utils.declare_ptx_smem_desc(
+            q_smem_start[self.q_load_stage - 1],
+            q_smem_base,
+            tSrQ[None, None, None, 0].layout,
+            var_name_prefix="fa_fwd_q_smem_desc",
+        )
+        sm100_utils.declare_ptx_idesc(qk_mma_op, var_name="fa_fwd_qk_mma_idesc")
+        sm100_utils.declare_ptx_idesc(pv_mma_op, var_name="fa_fwd_pv_mma_idesc")
+        sQ_stage_stride = (sQ.layout.stride[-1] * sQ.element_type.width // 8) >> 4
+        if const_expr(self.q_load_stage == 1):
+            sQ_stage_stride = 0
+        gemm_Si = [
+            partial(
+                sm100_utils.gemm_ptx_precomputed_varname,
+                smem_desc_base_b=k_smem_base,
+                tCrB_layout=tSrK[None, None, None, 0].layout,
+                smem_var_name_prefix="fa_fwd_q_smem_desc",
+                idesc_var_name="fa_fwd_qk_mma_idesc",
+                kind=qk_mma_kind,
+                smem_offset=-sQ_stage_stride if stage == 0 else sQ_stage_stride,
+                cta_group=self.cta_group_size,
+            )
+            for stage in range(self.q_load_stage)
+        ]
+        gemm_Pi = [
+            partial(
+                sm100_utils.gemm_ptx_partial,
+                pv_mma_op,
+                tOtO[None, None, None, stage].iterator.toint(),
+                sA=None,
+                cta_group=self.cta_group_size,
+            )
+            for stage in range(self.pv_hdim_stage)
+        ]
+        mma_q_consumer_phase = Int32(0)
+        mma_kv_consumer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer, self.kv_stage
+        )
+        s_p_o_producer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Producer, self.s_stage
+        )
+        p_lastsplit_consumer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer, self.s_stage
+        )
+        o_acc_producer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Producer, self.o_stage
+        )
+        work_tile = tile_scheduler.initial_work_tile_info()
+        while work_tile.is_valid_tile:
+            m_block, head_idx, batch_idx, split_idx = work_tile.tile_idx
+            seqlen = SeqlenInfoCls(batch_idx)
+            n_block_min, n_block_max = block_info.get_n_block_min_max(
+                seqlen, m_block, split_idx, num_splits
+            )
+            if const_expr(self.use_block_sparsity):
+                block_iter_count = get_total_block_count(
+                    blocksparse_tensors,
+                    batch_idx,
+                    head_idx,
+                    m_block,
+                    split_idx,
+                    num_splits,
+                    self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
+                    self.q_subtile_factor if self.q_subtile_factor is not None else 1,
+                    seqlen_info=seqlen,
+                )
+                process_tile = block_iter_count > Int32(0)
+            else:
+                block_iter_count = n_block_max - n_block_min
+                if const_expr(not self.is_split_kv):
+                    process_tile = True
+                else:
+                    process_tile = n_block_min < n_block_max
+
+            if process_tile:
+                O_should_accumulate = False
+                if block_iter_count > 1:
+                    # First QK for logical n_block_max - 1.
+                    if is_leader_cta:
+                        pipeline_s_p_o.producer_acquire(s_p_o_producer_state)
+                        s_stage = s_p_o_producer_state.index
+                        tSAcc = tStS[None, None, None, s_stage]
+                        tiled_mma_qk.set(tcgen05.Field.ACCUMULATE, False)
+                        for iter in cutlass.range_constexpr(self.qk_hdim_stage):
+                            pipeline_q.consumer_wait_w_index_phase(iter, mma_q_consumer_phase)
+                            pipeline_kv.consumer_wait(mma_kv_consumer_state)
+                            Ki_index = mma_kv_consumer_state.index
+                            sK_cur = sK[None, None, None, Ki_index]
+                            gemm_Si[iter](
+                                acc_tmem_addr=tSAcc.iterator.toint(),
+                                smem_desc_start_b=sm100_desc.make_smem_desc_start_addr(
+                                    sK_cur.iterator
+                                ),
+                                zero_init=iter == 0,
+                            )
+                            tiled_mma_qk.set(tcgen05.Field.ACCUMULATE, True)
+                            pipeline_kv.consumer_release(mma_kv_consumer_state)
+                            mma_kv_consumer_state.advance()
+                        pipeline_s_p_o.producer_commit(s_p_o_producer_state)
+                        s_p_o_producer_state.advance()
+                    for i in cutlass.range(1, block_iter_count - 1, 1, unroll=1):
+                        # Next QK in reverse logical n_block order.
+                        if is_leader_cta:
+                            pipeline_s_p_o.producer_acquire(s_p_o_producer_state)
+                            s_stage = s_p_o_producer_state.index
+                            tSAcc = tStS[None, None, None, s_stage]
+                            tiled_mma_qk.set(tcgen05.Field.ACCUMULATE, False)
+                            for iter in cutlass.range_constexpr(self.qk_hdim_stage):
+                                pipeline_kv.consumer_wait(mma_kv_consumer_state)
+                                Ki_index = mma_kv_consumer_state.index
+                                sK_cur = sK[None, None, None, Ki_index]
+                                gemm_Si[iter](
+                                    acc_tmem_addr=tSAcc.iterator.toint(),
+                                    smem_desc_start_b=sm100_desc.make_smem_desc_start_addr(
+                                        sK_cur.iterator
+                                    ),
+                                    zero_init=iter == 0,
+                                )
+                                tiled_mma_qk.set(tcgen05.Field.ACCUMULATE, True)
+                                pipeline_kv.consumer_release(mma_kv_consumer_state)
+                                mma_kv_consumer_state.advance()
+                            pipeline_s_p_o.producer_commit(s_p_o_producer_state)
+                            s_p_o_producer_state.advance()
+
+                            # PV for the previous softmax tile.
+                            pipeline_p_lastsplit.consumer_wait(p_lastsplit_consumer_state)
+                            p_stage = p_lastsplit_consumer_state.index
+                            pipeline_o_acc.producer_acquire(o_acc_producer_state)
+                            for iter in cutlass.range_constexpr(self.pv_hdim_stage):
+                                pipeline_kv.consumer_wait(mma_kv_consumer_state)
+                                Vi_index = mma_kv_consumer_state.index
+                                sV_cur = sV[None, None, None, Vi_index]
+                                gemm_Pi[iter](
+                                    tOrP[None, None, None, p_stage],
+                                    tOrV[None, None, None, Vi_index],
+                                    sB=sV_cur,
+                                    zero_init=not O_should_accumulate,
+                                )
+                                pipeline_kv.consumer_release(mma_kv_consumer_state)
+                                mma_kv_consumer_state.advance()
+                            O_should_accumulate = True
+                            pipeline_o_acc.producer_commit(o_acc_producer_state)
+                            o_acc_producer_state.advance()
+                            pipeline_p_lastsplit.consumer_release(p_lastsplit_consumer_state)
+                            p_lastsplit_consumer_state.advance()
+                    if is_leader_cta:
+                        # Last QK in this work tile.
+                        pipeline_s_p_o.producer_acquire(s_p_o_producer_state)
+                        s_stage = s_p_o_producer_state.index
+                        tSAcc = tStS[None, None, None, s_stage]
+                        tiled_mma_qk.set(tcgen05.Field.ACCUMULATE, False)
+                        for iter in cutlass.range_constexpr(self.qk_hdim_stage):
+                            pipeline_kv.consumer_wait(mma_kv_consumer_state)
+                            Ki_index = mma_kv_consumer_state.index
+                            sK_cur = sK[None, None, None, Ki_index]
+                            gemm_Si[iter](
+                                acc_tmem_addr=tSAcc.iterator.toint(),
+                                smem_desc_start_b=sm100_desc.make_smem_desc_start_addr(
+                                    sK_cur.iterator
+                                ),
+                                zero_init=iter == 0,
+                            )
+                            tiled_mma_qk.set(tcgen05.Field.ACCUMULATE, True)
+                            pipeline_kv.consumer_release(mma_kv_consumer_state)
+                            mma_kv_consumer_state.advance()
+                            pipeline_q.consumer_release_w_index(iter)
+                        mma_q_consumer_phase ^= 1
+                        pipeline_s_p_o.producer_commit(s_p_o_producer_state)
+                        s_p_o_producer_state.advance()
+
+                        # PV for the penultimate produced P tile.
+                        pipeline_p_lastsplit.consumer_wait(p_lastsplit_consumer_state)
+                        p_stage = p_lastsplit_consumer_state.index
+                        pipeline_o_acc.producer_acquire(o_acc_producer_state)
+                        for iter in cutlass.range_constexpr(self.pv_hdim_stage):
+                            pipeline_kv.consumer_wait(mma_kv_consumer_state)
+                            Vi_index = mma_kv_consumer_state.index
+                            sV_cur = sV[None, None, None, Vi_index]
+                            gemm_Pi[iter](
+                                tOrP[None, None, None, p_stage],
+                                tOrV[None, None, None, Vi_index],
+                                sB=sV_cur,
+                                zero_init=not O_should_accumulate,
+                            )
+                            pipeline_kv.consumer_release(mma_kv_consumer_state)
+                            mma_kv_consumer_state.advance()
+                        O_should_accumulate = True
+                        pipeline_o_acc.producer_commit(o_acc_producer_state)
+                        o_acc_producer_state.advance()
+                        pipeline_p_lastsplit.consumer_release(p_lastsplit_consumer_state)
+                        p_lastsplit_consumer_state.advance()
+                else:
+                    if is_leader_cta:
+                        # Only QK for this work tile.
+                        pipeline_s_p_o.producer_acquire(s_p_o_producer_state)
+                        s_stage = s_p_o_producer_state.index
+                        tSAcc = tStS[None, None, None, s_stage]
+                        tiled_mma_qk.set(tcgen05.Field.ACCUMULATE, False)
+                        for iter in cutlass.range_constexpr(self.qk_hdim_stage):
+                            pipeline_q.consumer_wait_w_index_phase(iter, mma_q_consumer_phase)
+                            pipeline_kv.consumer_wait(mma_kv_consumer_state)
+                            Ki_index = mma_kv_consumer_state.index
+                            sK_cur = sK[None, None, None, Ki_index]
+                            gemm_Si[iter](
+                                acc_tmem_addr=tSAcc.iterator.toint(),
+                                smem_desc_start_b=sm100_desc.make_smem_desc_start_addr(
+                                    sK_cur.iterator
+                                ),
+                                zero_init=iter == 0,
+                            )
+                            tiled_mma_qk.set(tcgen05.Field.ACCUMULATE, True)
+                            pipeline_kv.consumer_release(mma_kv_consumer_state)
+                            mma_kv_consumer_state.advance()
+                            pipeline_q.consumer_release_w_index(iter)
+                        mma_q_consumer_phase ^= 1
+                        pipeline_s_p_o.producer_commit(s_p_o_producer_state)
+                        s_p_o_producer_state.advance()
+
+                if is_leader_cta:
+                    # Final PV for the last produced P tile.
+                    pipeline_p_lastsplit.consumer_wait(p_lastsplit_consumer_state)
+                    p_stage = p_lastsplit_consumer_state.index
+                    pipeline_o_acc.producer_acquire(o_acc_producer_state)
+                    for iter in cutlass.range_constexpr(self.pv_hdim_stage):
+                        pipeline_kv.consumer_wait(mma_kv_consumer_state)
+                        Vi_index = mma_kv_consumer_state.index
+                        sV_cur = sV[None, None, None, Vi_index]
+                        gemm_Pi[iter](
+                            tOrP[None, None, None, p_stage],
+                            tOrV[None, None, None, Vi_index],
+                            sB=sV_cur,
+                            zero_init=not O_should_accumulate,
+                        )
+                        pipeline_kv.consumer_release(mma_kv_consumer_state)
+                        mma_kv_consumer_state.advance()
+                    O_should_accumulate = True
+                    pipeline_o_acc.producer_commit(o_acc_producer_state)
+                    o_acc_producer_state.advance()
+                    pipeline_p_lastsplit.consumer_release(p_lastsplit_consumer_state)
+                    p_lastsplit_consumer_state.advance()
+            work_tile = tile_scheduler.advance_to_next_work()
+        # End of persistent scheduler loop
+
+    @cute.jit
+    def softmax_step_block_sparse(
+        self,
+        mma_si_consumer_phase: Int32,
+        sm_stats_producer_phase: Int32,
+        softmax_step_state: Int32,
+        n_block: Int32,
+        softmax_step: Callable,
+        mask_fn: Optional[Callable] = None,
+        is_first: bool = False,
+    ) -> Tuple[cute.Int32, cute.Int32, cute.Int32]:
+        p_lastsplit_producer_phase = softmax_step_state % Int32(2)
+        stage = softmax_step_state // Int32(2)
+        (
+            mma_si_consumer_phase,
+            sm_stats_producer_phase,
+            p_lastsplit_producer_phase,
+        ) = softmax_step(
+            mma_si_consumer_phase,
+            sm_stats_producer_phase,
+            p_lastsplit_producer_phase,
+            n_block,
+            mask_fn=mask_fn,
+            is_first=is_first,
+            stage=stage,
+        )
+        stage ^= 1
+        return (
+            mma_si_consumer_phase,
+            sm_stats_producer_phase,
+            p_lastsplit_producer_phase + stage * Int32(2),
+        )
+
+    @cute.jit
+    def softmax_loop(
+        self,
+        stage: int | Int32,
+        softmax_scale_log2: Float32,
+        softmax_scale: Float32 | None,
+        descale_tensors: Optional[DescaleTensors],
+        thr_mma_qk,
+        tStS: cute.Tensor,  # ((TILE_M, TILE_N), 1, 1, q_stage)
+        sScale: cute.Tensor,
+        mLSE: Optional[cute.Tensor],
+        pipeline_s_p_o: pipeline.PipelineAsync,
+        pipeline_p_lastsplit: pipeline.PipelineAsync,
+        pipeline_sm_stats: pipeline.PipelineAsync,
+        sm_stats_barrier: pipeline.NamedBarrier,
+        pipeline_s0_s1_sequence: Optional[pipeline.PipelineAsync],
+        learnable_sink: Optional[cute.Tensor],
+        block_info: BlockInfo,
+        num_splits: Int32,
+        SeqlenInfoCls: Callable,
+        AttentionMaskCls: Callable,
+        aux_data: AuxData = AuxData(),
+        fastdiv_mods=(None, None),
+        head_divmod=None,
+        blocksparse_tensors: Optional[BlockSparseTensors] = None,
+        tile_scheduler=None,
+    ):
+        tidx = cute.arch.thread_idx()[0] % (cute.arch.WARP_SIZE * len(self.softmax_warp_ids))
+        warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx()) % 4
+        aux_tensors = aux_data.tensors
+
+        cta_qk_tiler = (self.mma_tiler_qk[0] // thr_mma_qk.thr_id.shape, self.mma_tiler_qk[1])
+        tScS = thr_mma_qk.partition_C(cute.make_identity_tensor(self.mma_tiler_qk[:2]))
+        tScS = tScS[(None, None), 0, 0]
+
+        mma_si_consumer_phase = Int32(0)
+        sm_stats_producer_phase = Int32(1)
+        sm_stats_stage = Int32(0)
+        p_lastsplit_producer_phase = Int32(1)
+
+        work_tile = tile_scheduler.initial_work_tile_info()
+        while work_tile.is_valid_tile:
+            m_block, head_idx, batch_idx, split_idx = work_tile.tile_idx
+            seqlen = SeqlenInfoCls(batch_idx)
+            n_block_min, n_block_max = block_info.get_n_block_min_max(
+                seqlen, m_block, split_idx, num_splits
+            )
+
+            mask = AttentionMaskCls(seqlen)
+            shared_mask_kwargs = dict(
+                m_block=m_block * self.cta_group_size,
+                thr_mma=thr_mma_qk,
+                mask_causal=self.is_causal,
+                mask_local=self.is_local,
+                batch_idx=batch_idx,
+                head_idx=head_idx,
+                aux_data=aux_data,
+                vec_size=self.mask_vec_size,
+            )
+
+            # Recompute fastdiv_mods if necessary
+            recompute_fastdiv_mods_q = cutlass.const_expr(
+                aux_tensors is not None and (seqlen.has_cu_seqlens_q or seqlen.has_seqused_q)
+            )
+            recompute_fastdiv_mods_k = cutlass.const_expr(
+                aux_tensors is not None and (seqlen.has_cu_seqlens_k or seqlen.has_seqused_k)
+            )
+
+            if cutlass.const_expr(fastdiv_mods is not None):
+                seqlen_q_divmod, seqlen_k_divmod = fastdiv_mods
+                fastdiv_mods = (
+                    seqlen_q_divmod
+                    if not recompute_fastdiv_mods_q
+                    else FastDivmodDivisor(seqlen.seqlen_q),
+                    seqlen_k_divmod
+                    if not recompute_fastdiv_mods_k
+                    else FastDivmodDivisor(seqlen.seqlen_k),
+                )
+
+            mask_mod = self.mask_mod if const_expr(self.mask_mod is not None) else None
+            mask_fn = partial(
+                mask.apply_mask_sm100,
+                mask_mod=mask_mod,
+                fastdiv_mods=fastdiv_mods,
+                head_divmod=head_divmod,
+                **shared_mask_kwargs,
+            )
+            if const_expr(self.use_block_sparsity):
+                # Full blocks don't need mask_mod.
+                mask_fn_none = partial(
+                    mask.apply_mask_sm100,
+                    mask_mod=None,
+                    fastdiv_mods=fastdiv_mods,
+                    head_divmod=head_divmod,
+                    **shared_mask_kwargs,
+                )
+            else:
+                mask_fn_none = None
+
+            max_offset = 8 if cutlass.const_expr(self.q_dtype.width == 8) else 0
+            if const_expr(self.score_mod is None):
+                softmax_scale_log2_eff = softmax_scale_log2
+                softmax_scale_eff = None
+            else:
+                softmax_scale_log2_eff = softmax_scale_log2
+                softmax_scale_eff = softmax_scale
+            rescale_threshold = 0.0
+            softmax = SoftmaxSm100.create(
+                softmax_scale_log2_eff,
+                rescale_threshold=rescale_threshold,
+                softmax_scale=softmax_scale_eff,
+                max_offset=max_offset,
+            )
+            softmax.reset()
+            if const_expr(self.use_block_sparsity):
+                tile_block_count = get_total_block_count(
+                    blocksparse_tensors,
+                    batch_idx,
+                    head_idx,
+                    m_block,
+                    split_idx,
+                    num_splits,
+                    self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
+                    self.q_subtile_factor if self.q_subtile_factor is not None else 1,
+                    seqlen_info=seqlen,
+                )
+                has_work = tile_block_count > Int32(0)
+            else:
+                tile_block_count = n_block_max - n_block_min
+                has_work = const_expr(not self.is_split_kv) or tile_block_count > Int32(0)
+            softmax_step = partial(
+                self.softmax_step,
+                softmax=softmax,
+                thr_mma_qk=thr_mma_qk,
+                pipeline_s_p_o=pipeline_s_p_o,
+                pipeline_p_lastsplit=pipeline_p_lastsplit,
+                pipeline_sm_stats=pipeline_sm_stats,
+                sm_stats_barrier=sm_stats_barrier,
+                pipeline_s0_s1_sequence=pipeline_s0_s1_sequence,
+                sm_stats_stage=sm_stats_stage,
+                tStS=tStS,
+                tScS=tScS,
+                sScale=sScale,
+                batch_idx=batch_idx,
+                head_idx=head_idx,
+                m_block=m_block * self.cta_group_size,
+                seqlen=seqlen,
+                aux_data=aux_data,
+                fastdiv_mods=fastdiv_mods,
+                head_divmod=head_divmod,
+            )
+
+            if const_expr(self.use_block_sparsity) or has_work:
+                pipeline_sm_stats.producer_acquire_w_index_phase(
+                    sm_stats_stage, sm_stats_producer_phase
+                )
+                sm_stats_producer_phase ^= 1
+
+            if const_expr(self.use_block_sparsity):
+                if const_expr(aux_tensors is not None):
+                    m_tile_end = (m_block + 1) * self.cta_group_size * self.m_block_size
+                    check_m_boundary = m_tile_end > seqlen.seqlen_q
+                else:
+                    check_m_boundary = False
+                softmax_step_state = p_lastsplit_producer_phase + stage * Int32(2)
+                (
+                    mma_si_consumer_phase,
+                    sm_stats_producer_phase,
+                    softmax_step_state,
+                    empty_tile,
+                ) = softmax_block_sparse_sm100(
+                    blocksparse_tensors,
+                    batch_idx,
+                    head_idx,
+                    m_block,
+                    seqlen,
+                    split_idx,
+                    num_splits,
+                    partial(self.softmax_step_block_sparse, softmax_step=softmax_step),
+                    mask_fn,
+                    mask_fn_none,
+                    mma_si_consumer_phase,
+                    sm_stats_producer_phase,
+                    softmax_step_state,
+                    pipeline_sm_stats,
+                    sm_stats_barrier,
+                    1,
+                    sm_stats_stage,
+                    check_m_boundary,
+                    self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
+                    self.q_subtile_factor if self.q_subtile_factor is not None else 1,
+                )
+                p_lastsplit_producer_phase = softmax_step_state % Int32(2)
+                stage = softmax_step_state // Int32(2)
+                if not empty_tile:
+                    sScale[tidx + self.m_block_size] = softmax.row_sum[0]
+                    if const_expr(mLSE is not None or learnable_sink is not None):
+                        sScale[tidx + self.m_block_size * 2] = softmax.row_max[0]
+                    sm_stats_barrier.arrive_w_index(index=sm_stats_stage * 4 + warp_idx)
+
+            if has_work and const_expr(not self.use_block_sparsity):
+                mma_si_consumer_phase, sm_stats_producer_phase, p_lastsplit_producer_phase = (
+                    softmax_step(
+                        mma_si_consumer_phase,
+                        sm_stats_producer_phase,
+                        p_lastsplit_producer_phase,
+                        n_block_max - 1,
+                        is_first=True,
+                        mask_fn=partial(mask_fn, mask_seqlen=True),
+                        stage=stage,
+                    )
+                )
+                stage ^= 1
+                n_block_max -= 1
+                # Next couple of iterations with causal masking
+                if const_expr(self.is_causal or self.is_local):
+                    n_block_min_causal_local_mask = block_info.get_n_block_min_causal_local_mask(
+                        seqlen, m_block, n_block_min
+                    )
+                    for n_tile in cutlass.range(
+                        n_block_max - n_block_min_causal_local_mask, unroll=1
+                    ):
+                        n_block = n_block_max - 1 - n_tile
+                        (
+                            mma_si_consumer_phase,
+                            sm_stats_producer_phase,
+                            p_lastsplit_producer_phase,
+                        ) = softmax_step(
+                            mma_si_consumer_phase,
+                            sm_stats_producer_phase,
+                            p_lastsplit_producer_phase,
+                            n_block,
+                            mask_fn=partial(mask_fn, mask_seqlen=False),
+                            stage=stage,
+                        )
+                        stage ^= 1
+                    n_block_max = cutlass.min(n_block_max, n_block_min_causal_local_mask)
+                # The remaining iterations have no masking (but may still need mask_mod)
+                n_block_min_before_local_mask = block_info.get_n_block_min_before_local_mask(
+                    seqlen, m_block, n_block_min
+                )
+                for n_tile in cutlass.range(n_block_max - n_block_min_before_local_mask, unroll=1):
+                    n_block = n_block_max - n_tile - 1
+                    if const_expr(self.mask_mod is not None):
+                        (
+                            mma_si_consumer_phase,
+                            sm_stats_producer_phase,
+                            p_lastsplit_producer_phase,
+                        ) = softmax_step(
+                            mma_si_consumer_phase,
+                            sm_stats_producer_phase,
+                            p_lastsplit_producer_phase,
+                            n_block,
+                            mask_fn=partial(mask_fn, mask_seqlen=False),
+                            stage=stage,
                         )
                     else:
-                        tTMEM_LOADrS_ex2[k, j], tTMEM_LOADrS_ex2[k + 1, j] = ex2_emulation_2(
-                            tTMEM_LOADrS_ex2[k, j], tTMEM_LOADrS_ex2[k + 1, j]
+                        (
+                            mma_si_consumer_phase,
+                            sm_stats_producer_phase,
+                            p_lastsplit_producer_phase,
+                        ) = softmax_step(
+                            mma_si_consumer_phase,
+                            sm_stats_producer_phase,
+                            p_lastsplit_producer_phase,
+                            n_block,
+                            stage=stage,
                         )
-            tTMEM_STORErP_ex2[None, j].store(tTMEM_LOADrS_ex2[None, j].load().to(self.q_dtype))
-        tmem_store_atom = cute.make_copy_atom(
-            tcgen05.St32x32bOp(tcgen05.Repetition(32)), self.qk_acc_dtype
-        )
-        tilePlikeFP32 = tStS_slice.shape[1] // Float32.width * self.q_dtype.width
-        tStS_P_layout = cute.composition(
-            tStS_slice.layout, cute.make_layout((tStS_slice.shape[0], tilePlikeFP32))
-        )
-        tStS_P = cute.make_tensor(tStS_slice.iterator, tStS_P_layout)
-        tScS_P_layout = cute.composition(
-            tScS_slice.layout, cute.make_layout((tScS_slice.shape[0], tilePlikeFP32))
-        )
-        tScS_P = cute.make_tensor(tScS_slice.iterator, tScS_P_layout)
-        tmem_tiled_store = tcgen05.make_tmem_copy(tmem_store_atom, tStS_P)
-        thr_store = tmem_tiled_store.get_slice(thread_idx)
-        tTMEM_STOREtP = thr_store.partition_D(tStS_P)
-        tTMEM_STOREcS = thr_store.partition_S(tScS_P)
-        tTMEM_STORErP_ = cute.make_tensor(
-            cute.recast_ptr(tTMEM_STORErP.iterator, dtype=self.qk_acc_dtype),
-            tTMEM_STOREcS.shape,
-        )
-        cute.copy(tmem_tiled_store, tTMEM_STORErP_, tTMEM_STOREtP)
-        cute.arch.fence_view_async_tmem_store()
+                    stage ^= 1
+                # Separate iterations with local masking on the left
+                if const_expr(self.is_local and block_info.window_size_left is not None):
+                    n_block_max = cutlass.min(n_block_max, n_block_min_before_local_mask)
+                    for n_tile in cutlass.range(0, n_block_max - n_block_min, unroll=1):
+                        n_block = n_block_max - 1 - n_tile
+                        (
+                            mma_si_consumer_phase,
+                            sm_stats_producer_phase,
+                            p_lastsplit_producer_phase,
+                        ) = softmax_step(
+                            mma_si_consumer_phase,
+                            sm_stats_producer_phase,
+                            p_lastsplit_producer_phase,
+                            n_block,
+                            mask_fn=partial(mask_fn, mask_seqlen=False),
+                            stage=stage,
+                        )
+                        # Now that we no longer already have the 1st iteration, need mask_seqlen=True here
+                        stage ^= 1
+                # Dense path always writes scale / signals
+                sScale[tidx + self.m_block_size] = softmax.row_sum[0]
+                if const_expr(mLSE is not None or learnable_sink is not None):
+                    sScale[tidx + self.m_block_size * 2] = softmax.row_max[0]
+                sm_stats_barrier.arrive_w_index(index=sm_stats_stage * 4 + warp_idx)
+            work_tile = tile_scheduler.advance_to_next_work()
+        # This is equivalent to pipeline_sm_stats.producer_tail
+        pipeline_sm_stats.producer_acquire_w_index_phase(sm_stats_stage, sm_stats_producer_phase)
 
-        p_handle.commit()
-        acc_scale_ = scale * (old_row_max - row_max_safe)
-        acc_scale = cute.math.exp2(acc_scale_, fastmath=True) * 0.5
-        # TODO: calc row sum with TensorSSA
-        row_sum *= acc_scale
-        local_row_sum_0 = (row_sum, row_sum)
-        local_row_sum_1 = (0.0, 0.0)
-        local_row_sum_2 = (0.0, 0.0)
-        local_row_sum_3 = (0.0, 0.0)
-        reduction_unroll = 4
-        frg_tile = cute.size(tTMEM_LOADrS) // reduction_unroll
-        tTMEM_LOADrS_frg = cute.logical_divide(tTMEM_LOADrS, cute.make_layout(frg_tile))
-        for j in cutlass.range_constexpr(0, cute.size(tTMEM_LOADrS_frg, mode=[0]), 2):
-            local_row_sum_0 = cute.arch.add_packed_f32x2(
-                local_row_sum_0, (tTMEM_LOADrS_frg[j, 0], tTMEM_LOADrS_frg[j + 1, 0])
+    @cute.jit
+    def correction_loop(
+        self,
+        thr_mma_qk,
+        thr_mma_pv,
+        tStS: cute.Tensor,
+        tOtO: cute.Tensor,
+        sScale: cute.Tensor,
+        mO: cute.Tensor,
+        mLSE: Optional[cute.Tensor],
+        sO: cute.Tensor,
+        gmem_tiled_copy_O: Optional[cute.TiledCopy],
+        pipeline_o_acc: pipeline.PipelineAsync,
+        pipeline_sm_stats,
+        sm_stats_barrier,
+        pipeline_o_epi: Optional[pipeline.PipelineAsync],
+        learnable_sink: Optional[cute.Tensor],
+        softmax_scale_log2: Float32,
+        block_info: BlockInfo,
+        num_splits: Int32,
+        SeqlenInfoCls,
+        blocksparse_tensors: Optional[BlockSparseTensors] = None,
+        tile_scheduler=None,
+    ):
+        tidx = cute.arch.thread_idx()[0] % (cute.arch.WARP_SIZE * len(self.correction_warp_ids))
+        warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx()) % 4
+
+        mma_tile_coord_v = thr_mma_qk.thr_idx
+
+        sm_stats_consumer_phase = Int32(0)
+        o_corr_consumer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer, self.o_stage
+        )
+        o_epi_producer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Producer, self.o_stage
+        )
+
+        work_tile = tile_scheduler.initial_work_tile_info()
+        while work_tile.is_valid_tile:
+            m_block, head_idx, batch_idx, split_idx = work_tile.tile_idx
+            seqlen = SeqlenInfoCls(batch_idx)
+            n_block_min, n_block_max = block_info.get_n_block_min_max(
+                seqlen, m_block, split_idx, num_splits
             )
-            local_row_sum_1 = cute.arch.add_packed_f32x2(
-                local_row_sum_1, (tTMEM_LOADrS_frg[j, 1], tTMEM_LOADrS_frg[j + 1, 1])
+            m_tile_idx = m_block * self.cta_group_size + mma_tile_coord_v
+            mO_cur = seqlen.offset_batch_Q(mO, batch_idx, dim=3)[None, None, head_idx]
+            gO = cute.local_tile(
+                mO_cur,
+                self.epi_tile,
+                (m_tile_idx, 0),
             )
-            local_row_sum_2 = cute.arch.add_packed_f32x2(
-                local_row_sum_2, (tTMEM_LOADrS_frg[j, 2], tTMEM_LOADrS_frg[j + 1, 2])
+            stats = (
+                Float32(0.0),
+                -Float32.inf
+                if const_expr(mLSE is not None or learnable_sink is not None)
+                else None,
+                True,
             )
-            local_row_sum_3 = cute.arch.add_packed_f32x2(
-                local_row_sum_3, (tTMEM_LOADrS_frg[j, 3], tTMEM_LOADrS_frg[j + 1, 3])
+            softmax_scale_log2_eff = softmax_scale_log2
+            max_offset = (
+                Float32(8.0) if cutlass.const_expr(self.q_dtype.width == 8) else Float32(0.0)
             )
-        local_row_sum_0 = cute.arch.add_packed_f32x2(local_row_sum_0, local_row_sum_1)
-        local_row_sum_2 = cute.arch.add_packed_f32x2(local_row_sum_2, local_row_sum_3)
-        local_row_sum_0 = cute.arch.add_packed_f32x2(local_row_sum_0, local_row_sum_2)
-        row_sum = local_row_sum_0[0] + local_row_sum_0[1]
-        return row_max, row_sum, mma_s_consumer, p_mma_producer, s_corr_producer
+            max_offset_scale = (
+                Float32(256.0) if cutlass.const_expr(self.q_dtype.width == 8) else Float32(1.0)
+            )
+
+            if const_expr(self.use_block_sparsity):
+                total_block_count = get_total_block_count(
+                    blocksparse_tensors,
+                    batch_idx,
+                    head_idx,
+                    m_block,
+                    split_idx,
+                    num_splits,
+                    self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
+                    self.q_subtile_factor if self.q_subtile_factor is not None else 1,
+                    seqlen_info=seqlen,
+                )
+                has_work = total_block_count > Int32(0)
+            else:
+                total_block_count = n_block_max - n_block_min
+                has_work = const_expr(not self.is_split_kv) or total_block_count > Int32(0)
+
+            if has_work:
+                # The first accumulated O tile has no previous scale correction.
+                sm_stats_barrier.arrive_and_wait_w_index(index=0 * 4 + warp_idx)
+                pipeline_sm_stats.consumer_release_w_index(0)
+                sm_stats_consumer_phase ^= 1
+                for i in cutlass.range(total_block_count - 1, unroll=1):
+                    # Rescale O(i-1) before accumulating O(i).
+                    sm_stats_barrier.arrive_and_wait_w_index(index=0 * 4 + warp_idx)
+                    scale = sScale[tidx]
+                    pipeline_o_acc.consumer_wait(o_corr_consumer_state)
+                    for stage in cutlass.range_constexpr(self.pv_hdim_stage):
+                        self.correction_rescale(
+                            thr_mma_pv,
+                            tOtO[None, None, None, stage],
+                            tidx,
+                            scale,
+                        )
+                    pipeline_o_acc.consumer_release(o_corr_consumer_state)
+                    o_corr_consumer_state.advance()
+                    pipeline_sm_stats.consumer_release_w_index(0)
+                    sm_stats_consumer_phase ^= 1
+                # Normalize and store the final accumulated O tile.
+                sm_stats_barrier.arrive_and_wait_w_index(index=0 * 4 + warp_idx)
+                row_sum = sScale[tidx + self.m_block_size]
+                row_max = (
+                    sScale[tidx + self.m_block_size * 2]
+                    if const_expr(mLSE is not None or learnable_sink is not None)
+                    else None
+                )
+                pipeline_sm_stats.consumer_release_w_index(0)
+                if const_expr(learnable_sink is not None):
+                    LOG2_E = math.log2(math.e)
+                    sink_val = Float32(learnable_sink[head_idx])
+                    if row_max == -Float32.inf:
+                        row_max = sink_val * (LOG2_E / softmax_scale_log2_eff)
+                        row_sum = max_offset_scale
+                    else:
+                        row_sum += cute.math.exp2(
+                            sink_val * LOG2_E - row_max * softmax_scale_log2_eff + max_offset,
+                            fastmath=True,
+                        )
+                acc_O_mn_row_is_zero_or_nan = row_sum == 0.0 or row_sum != row_sum
+                stats = (row_sum, row_max, acc_O_mn_row_is_zero_or_nan)
+                scale = (
+                    cute.arch.rcp_approx(row_sum)
+                    if not acc_O_mn_row_is_zero_or_nan
+                    else Float32(0.0)
+                )
+                pipeline_o_acc.consumer_wait(o_corr_consumer_state)
+                if const_expr(not self.use_correction_warps_for_epi):
+                    pipeline_o_epi.producer_acquire(o_epi_producer_state)
+                self.correction_epilogue(
+                    thr_mma_pv,
+                    tOtO,
+                    tidx,
+                    m_tile_idx,
+                    seqlen.seqlen_q,
+                    scale,
+                    sO[None, None, 0],
+                    mO_cur,
+                    gO,
+                    gmem_tiled_copy_O,
+                )
+                pipeline_o_acc.consumer_release(o_corr_consumer_state)
+                if const_expr(not self.use_correction_warps_for_epi):
+                    pipeline_o_epi.producer_commit(o_epi_producer_state)
+                    o_epi_producer_state.advance()
+                o_corr_consumer_state.advance()
+                sm_stats_consumer_phase ^= 1
+            elif const_expr(self.use_block_sparsity):
+                sm_stats_barrier.arrive_and_wait_w_index(index=0 * 4 + warp_idx)
+                pipeline_sm_stats.consumer_release_w_index(0)
+                sm_stats_consumer_phase ^= 1
+                row_sum = Float32(1.0)
+                row_max = (
+                    -Float32.inf
+                    if const_expr(mLSE is not None or learnable_sink is not None)
+                    else None
+                )
+                if const_expr(learnable_sink is not None):
+                    LOG2_E = math.log2(math.e)
+                    sink_val = Float32(learnable_sink[head_idx])
+                    if row_max == -Float32.inf:
+                        row_max = sink_val * (LOG2_E / softmax_scale_log2_eff)
+                        row_sum = max_offset_scale
+                    else:
+                        row_sum += cute.math.exp2(
+                            sink_val * LOG2_E - row_max * softmax_scale_log2_eff + max_offset,
+                            fastmath=True,
+                        )
+                acc_O_mn_row_is_zero_or_nan = row_sum == 0.0 or row_sum != row_sum
+                stats = (row_sum, row_max, acc_O_mn_row_is_zero_or_nan)
+                if const_expr(not self.use_correction_warps_for_epi):
+                    pipeline_o_epi.producer_acquire(o_epi_producer_state)
+                self.correction_epilogue(
+                    thr_mma_pv,
+                    tOtO,
+                    tidx,
+                    m_tile_idx,
+                    seqlen.seqlen_q,
+                    Float32(0.0),
+                    sO[None, None, 0],
+                    mO_cur,
+                    gO,
+                    gmem_tiled_copy_O,
+                )
+                if const_expr(not self.use_correction_warps_for_epi):
+                    pipeline_o_epi.producer_commit(o_epi_producer_state)
+                    o_epi_producer_state.advance()
+
+            if const_expr(mLSE is not None):
+                if const_expr(not seqlen.has_cu_seqlens_q):
+                    mLSE_cur = mLSE[None, head_idx, batch_idx]
+                else:
+                    mLSE_cur = cute.domain_offset((seqlen.offset_q,), mLSE[None, head_idx])
+                row_sum, row_max, acc_O_mn_row_is_zero_or_nan = stats
+                LN2 = math.log(2.0)
+                lse = (
+                    (
+                        row_max * softmax_scale_log2_eff
+                        + (cute.math.log2(row_sum, fastmath=True) - max_offset)
+                    )
+                    * LN2
+                    if not acc_O_mn_row_is_zero_or_nan
+                    else -Float32.inf
+                )
+                gLSE = cute.local_tile(mLSE_cur, (self.m_block_size,), (m_tile_idx,))
+                if tidx < seqlen.seqlen_q - m_tile_idx * self.m_block_size:
+                    gLSE[tidx] = lse
+            work_tile = tile_scheduler.advance_to_next_work()
+        # TMEM free is owned by the MMA warp after softmax/correction arrive.
+        if const_expr(not self.use_correction_warps_for_epi):
+            _producer_tail_with_cutlass_state(pipeline_o_epi, o_epi_producer_state)
+
+    @cute.jit
+    def epilogue_s2g(
+        self,
+        mO: cute.Tensor,
+        sO: cute.Tensor,
+        gmem_tiled_copy_O: Optional[cute.TiledCopy],
+        tma_atom_O: Optional[cute.CopyAtom],
+        pipeline_o_epi: pipeline.PipelineAsync,
+        block_info: BlockInfo,
+        num_splits: Int32,
+        SeqlenInfoCls: Callable,
+        mma_tile_coord_v: Int32 = 0,
+        tile_scheduler=None,
+    ):
+        o_epi_consumer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer, self.o_stage
+        )
+        work_tile = tile_scheduler.initial_work_tile_info()
+        while work_tile.is_valid_tile:
+            m_block, head_idx, batch_idx, split_idx = work_tile.tile_idx
+            seqlen = SeqlenInfoCls(batch_idx)
+            m_tile_idx = m_block * self.cta_group_size + mma_tile_coord_v
+            mO_cur = seqlen.offset_batch_Q(mO, batch_idx, dim=3)[None, None, head_idx]
+
+            gO = cute.local_tile(
+                mO_cur,
+                self.epi_tile,
+                (m_tile_idx, 0),
+            )
+
+            pipeline_o_epi.consumer_wait(o_epi_consumer_state)
+            if const_expr(self.use_tma_O):
+                store_O, _, _ = copy_utils.tma_get_copy_fn(
+                    tma_atom_O,
+                    0,
+                    cute.make_layout(1),
+                    sO[None, None, 0],
+                    gO,
+                    single_stage=True,
+                )
+                store_O()
+                cute.arch.cp_async_bulk_commit_group()
+                cute.arch.cp_async_bulk_wait_group(0, read=True)
+            else:
+                tidx = cute.arch.thread_idx()[0] % (
+                    cute.arch.WARP_SIZE * len(self.epilogue_warp_ids)
+                )
+                self._store_O_to_gmem(
+                    sO[None, None, 0],
+                    gO,
+                    mO_cur,
+                    gmem_tiled_copy_O,
+                    tidx,
+                    seqlen.seqlen_q,
+                    m_tile_idx,
+                )
+            pipeline_o_epi.consumer_release(o_epi_consumer_state)
+            o_epi_consumer_state.advance()
+
+            work_tile = tile_scheduler.advance_to_next_work()
+
+    @cute.jit
+    def softmax_step(
+        self,
+        mma_si_consumer_phase: Int32,
+        sm_stats_producer_phase: Int32,
+        p_lastsplit_producer_phase: Int32,
+        n_block: Int32,
+        softmax: SoftmaxSm100,
+        thr_mma_qk,
+        pipeline_s_p_o: pipeline.PipelineAsync,
+        pipeline_p_lastsplit: pipeline.PipelineAsync,
+        pipeline_sm_stats: pipeline.PipelineAsync,
+        sm_stats_barrier: pipeline.NamedBarrier,
+        pipeline_s0_s1_sequence: Optional[pipeline.PipelineAsync],
+        sm_stats_stage: Int32,
+        tStS: cute.Tensor,
+        tScS: cute.Tensor,
+        sScale: cute.Tensor,
+        stage: int | Int32,
+        batch_idx: Int32,
+        head_idx: Int32,
+        m_block: Int32,
+        seqlen,
+        aux_data: AuxData = AuxData(),
+        fastdiv_mods=(None, None),
+        head_divmod=None,
+        mask_fn: Optional[Callable] = None,
+        is_first: bool = False,
+    ) -> Tuple[cute.Int32, cute.Int32, cute.Int32]:
+        """Perform a single step of the softmax computation on a block of attention scores.
+
+        This method processes one block of the attention matrix, computing numerically stable
+        softmax by first finding the row maximum, subtracting it from all elements, applying
+        exponential function, and then normalizing by the sum of exponentials. It also handles
+        optional masking of attention scores.
+
+        The method involves several key operations:
+        1. Loading attention scores from tensor memory
+        2. Applying optional masking based on position
+        3. Computing row-wise maximum values for numerical stability
+        4. Transforming scores using exp2(x*scale - max*scale)
+        5. Computing row sums for normalization
+        6. Coordinating pipeline synchronization between different processing stages
+        """
+        tidx = cute.arch.thread_idx()[0] % (cute.arch.WARP_SIZE * len(self.softmax_warp_ids))
+        warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx()) % 4
+        # Wait for Si
+        pipeline_s_p_o.consumer_wait_w_index_phase(stage, mma_si_consumer_phase)
+        tSAcc = tStS[(None, None), 0, 0, stage]
+        tmem_load_atom = cute.make_copy_atom(
+            tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(32)), self.qk_acc_dtype
+        )
+        thr_tmem_load = tcgen05.make_tmem_copy(tmem_load_atom, tSAcc).get_slice(tidx)
+        tStS_t2r = thr_tmem_load.partition_S(tSAcc)
+        tScS_t2r = thr_tmem_load.partition_D(tScS)
+        tSrS_t2r = cute.make_rmem_tensor(tScS_t2r.shape, self.qk_acc_dtype)
+        cute.copy(thr_tmem_load, tStS_t2r, tSrS_t2r)
+        cute.arch.fence_view_async_tmem_load()
+        if cutlass.const_expr(self.score_mod is not None):
+            self.apply_score_mod(
+                tSrS_t2r,
+                thr_tmem_load,
+                thr_mma_qk,
+                batch_idx,
+                head_idx,
+                m_block,
+                n_block,
+                softmax,
+                seqlen,
+                aux_data,
+                fastdiv_mods,
+                head_divmod,
+            )
+        if const_expr(mask_fn is not None):
+            mask_fn(tSrS_t2r, n_block=n_block, thr_tmem_load=thr_tmem_load)
+        row_max, acc_scale = softmax.update_row_max(tSrS_t2r.load(), is_first)
+
+        if const_expr(not is_first):
+            sScale[tidx] = acc_scale
+        sm_stats_barrier.arrive_w_index(index=sm_stats_stage * 4 + warp_idx)
+
+        tSrP_r2t = cute.make_rmem_tensor(tSrS_t2r.shape, self.q_dtype)
+        softmax.scale_subtract_rowmax(tSrS_t2r, row_max)
+        softmax.apply_exp2_convert(
+            tSrS_t2r,
+            tSrP_r2t,
+            ex2_emu_freq=self.ex2_emu_freq if const_expr(mask_fn is None) else 0,
+            ex2_emu_res=self.ex2_emu_res,
+            ex2_emu_start_frg=self.ex2_emu_start_frg,
+        )
+
+        pipeline_p_lastsplit.producer_acquire_w_index_phase(stage, p_lastsplit_producer_phase)
+        tmem_store_atom = cute.make_copy_atom(
+            tcgen05.copy.St32x32bOp(tcgen05.copy.Repetition(32)), self.qk_acc_dtype
+        )
+        tilePlikeFP32 = tSAcc.shape[1] // Float32.width * self.v_dtype.width
+        tStP_layout = cute.composition(
+            tSAcc.layout, cute.make_layout((tSAcc.shape[0], tilePlikeFP32))
+        )
+        tStP = cute.make_tensor(tSAcc.iterator, tStP_layout)
+        tScP_layout = cute.composition(
+            tScS.layout, cute.make_layout((tScS.shape[0], tilePlikeFP32))
+        )
+        tScP = cute.make_tensor(tScS.iterator, tScP_layout)
+        thr_tmem_store = tcgen05.make_tmem_copy(tmem_store_atom, tStP).get_slice(tidx)
+        tStP_r2t = thr_tmem_store.partition_D(tStP)
+        tScP_r2t = thr_tmem_store.partition_S(tScP)
+        tSrP_r2t_f32 = cute.make_tensor(
+            cute.recast_ptr(tSrP_r2t.iterator, dtype=self.qk_acc_dtype),
+            tScP_r2t.shape,
+        )
+        cute.copy(thr_tmem_store, tSrP_r2t_f32, tStP_r2t)
+        cute.arch.fence_view_async_tmem_store()
+        pipeline_p_lastsplit.producer_commit_w_index(stage)
+        pipeline_s_p_o.consumer_release_w_index(stage)
+        pipeline_sm_stats.producer_acquire_w_index_phase(sm_stats_stage, sm_stats_producer_phase)
+        softmax.update_row_sum(tSrS_t2r.load(), acc_scale, is_first)
+        phase_advance = stage
+        return (
+            mma_si_consumer_phase ^ phase_advance,
+            sm_stats_producer_phase ^ 1,
+            p_lastsplit_producer_phase ^ phase_advance,
+        )
+
+    @cute.jit
+    def apply_score_mod(
+        self,
+        tSrS_t2r,
+        thr_tmem_load,
+        thr_mma_qk,
+        batch_idx,
+        head_idx,
+        m_block,
+        n_block,
+        softmax,
+        seqlen: SeqlenInfoQK,
+        aux_data: AuxData = AuxData(),
+        fastdiv_mods=(None, None),
+        head_divmod=None,
+    ):
+        """Apply score modification for SM100 (constant q_idx)."""
+        # Prepare index tensor with extra partition
+        cS = cute.make_identity_tensor((self.mma_tiler_qk[0], self.mma_tiler_qk[1]))
+        cS = cute.domain_offset((m_block * self.m_block_size, n_block * self.n_block_size), cS)
+        tScS = thr_mma_qk.partition_C(cS)
+        tScS = tScS[(None, None), 0, 0]
+        tScS_t2r = thr_tmem_load.partition_D(tScS)
+
+        # Shared q_idx for all scores
+        q_idx_logical = tScS_t2r[0][0]
+
+        # For Pack-GQA, compute the logical head index for this tile
+        if cutlass.const_expr(self.pack_gqa):
+            assert head_divmod is not None
+            # Building up the logical q_head idx: final_q_head = kv_head * qhead_per_kvhead + (q_physical % qhead_per_kvhead)
+            q_physical = q_idx_logical
+            q_idx_logical, head_offset = divmod(q_physical, head_divmod)
+            head_idx = head_idx * self.qhead_per_kvhead + head_offset
+
+        if cutlass.const_expr(aux_data.tensors is not None):
+            seqlen_q_divmod, _ = fastdiv_mods
+            _, q_idx_logical = divmod(q_idx_logical, seqlen_q_divmod)
+
+        apply_score_mod_inner(
+            tSrS_t2r,
+            tScS_t2r,
+            self.score_mod,
+            batch_idx,
+            head_idx,
+            softmax.softmax_scale,
+            self.score_vec_size,
+            self.qk_acc_dtype,
+            aux_data,
+            fastdiv_mods,
+            seqlen_info=seqlen,
+            constant_q_idx=q_idx_logical,
+            qhead_per_kvhead=self.qhead_per_kvhead if cutlass.const_expr(self.pack_gqa) else 1,
+        )
 
     @cute.jit
     def correction_rescale(
         self,
-        scale_softmax_log2: Float32,
-        stats_args: tuple,
-        o_args: tuple,
-        epi_tile: cute.Tile,
-    ) -> pipeline.PipelineConsumer:
-        (s_corr_consumer, tStS, tScS) = stats_args
-        (mma_o_consumer, tOtO_staged, cO_staged) = o_args
-        tidx, _, _ = cute.arch.thread_idx()
-        thread_idx = tidx % (self.threads_per_warp * len(self.softmax_warp_ids))
-
-        stats_handle = s_corr_consumer.wait_and_advance()
-        tStS_slice = tStS[(None, None), 0, 0, stats_handle.index]
-        tScS_slice = tScS[(None, None), 0, 0]
-        stats_layout = cute.composition(
-            tStS_slice.layout, cute.make_layout((tStS_slice.shape[0], 2))
-        )
-        stats_c_layout = cute.composition(
-            tScS_slice.layout, cute.make_layout((tScS_slice.shape[0], 2))
-        )
-        tOtStats = cute.make_tensor(tStS_slice.iterator + self.tilePlikeFP32, stats_layout)
-        tOcStats = cute.make_tensor(tScS_slice.iterator, stats_c_layout)
-        tmem_load_stats_atom = cute.make_copy_atom(
-            tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(2)),
-            self.qk_acc_dtype,
-        )
-        tiled_tmem_load_stats = tcgen05.make_tmem_copy(tmem_load_stats_atom, tOtStats)
-        thr_tmem_load_stats = tiled_tmem_load_stats.get_slice(thread_idx)
-        tTMEM_LOADtStats = thr_tmem_load_stats.partition_S(tOtStats)
-        tTMEM_LOADcStats = thr_tmem_load_stats.partition_D(tOcStats)
-        tTMEM_LOADrStats = cute.make_rmem_tensor(tTMEM_LOADcStats.shape, self.qk_acc_dtype)
-        cute.copy(tiled_tmem_load_stats, tTMEM_LOADtStats, tTMEM_LOADrStats)
-
-        scale = scale_softmax_log2 * (tTMEM_LOADrStats[0] - tTMEM_LOADrStats[1])
-        scale = cute.math.exp2(scale, fastmath=True)
-        stats_handle.release()
-        o_handle = mma_o_consumer.wait_and_advance()
-        for iter in cutlass.range(self.iterations_pv, unroll_full=True):
-            tOtO = tOtO_staged[(None, None), 0, 0, iter]
-            cO = cO_staged[None, None, iter]
-            tOtO_epi = cute.zipped_divide(tOtO, epi_tile)
-            cO_epi = cute.zipped_divide(cO, epi_tile)
-            tmem_load_atom = cute.make_copy_atom(
-                tcgen05.Ld32x32bOp(tcgen05.Repetition(16)),
-                self.pv_acc_dtype,
-            )
-            tmem_tiled_load = tcgen05.make_tmem_copy(tmem_load_atom, tOtO_epi)
-            thr_load = tmem_tiled_load.get_slice(thread_idx)
-            tmem_store_atom = cute.make_copy_atom(
-                tcgen05.St32x32bOp(tcgen05.Repetition(16)),
-                self.pv_acc_dtype,
-            )
-            tmem_store_atom = tcgen05.make_tmem_copy(tmem_store_atom, tOtO_epi)
-            thr_store = tmem_store_atom.get_slice(thread_idx)
-            tTMEM_LOADtO = thr_load.partition_S(tOtO_epi)
-            tTMEM_LOADcO = thr_load.partition_D(cO_epi)
-            tTMEM_STOREtO = thr_store.partition_D(tOtO_epi)
-            tTMrO = cute.make_rmem_tensor_like(
-                cute.append(
-                    cute.make_layout(tTMEM_LOADcO[None, 0, 0].shape),
-                    cute.make_layout(2, stride=cute.size(tTMEM_LOADcO[None, 0, 0].shape)),
-                ),
-                self.pv_acc_dtype,
-            )
-            tTMEM_LOADtO_0 = tTMEM_LOADtO[None, 0, 0]
-            cute.copy(tmem_tiled_load, tTMEM_LOADtO_0, tTMrO[None, 0])
-            iter_num = cute.size(tTMEM_LOADtO, mode=[1])
-            for i in cutlass.range(1, iter_num, unroll_full=True):
-                tTMEM_LOADtO_i = tTMEM_LOADtO[None, i, 0]
-                cute.copy(tmem_tiled_load, tTMEM_LOADtO_i, tTMrO[None, i % 2])
-                for j in cutlass.range(0, cute.size(tTMrO, mode=[0]), 2, unroll_full=True):
-                    tTMrO[j, (i - 1) % 2], tTMrO[j + 1, (i - 1) % 2] = cute.arch.mul_packed_f32x2(
-                        (tTMrO[j, (i - 1) % 2], tTMrO[j + 1, (i - 1) % 2]),
-                        (scale, scale),
-                    )
-                tTMEM_STOREtO_prev_i = tTMEM_STOREtO[None, i - 1, 0]
-                cute.copy(tmem_store_atom, tTMrO[None, (i - 1) % 2], tTMEM_STOREtO_prev_i)
-
-            for j in cutlass.range(0, cute.size(tTMrO, mode=[0]), 2, unroll_full=True):
-                tTMrO[j, (iter_num - 1) % 2], tTMrO[j + 1, (iter_num - 1) % 2] = (
-                    cute.arch.mul_packed_f32x2(
-                        (
-                            tTMrO[j, (iter_num - 1) % 2],
-                            tTMrO[j + 1, (iter_num - 1) % 2],
-                        ),
-                        (scale, scale),
-                    )
-                )
-            cute.copy(
-                tmem_store_atom,
-                tTMrO[None, (iter_num - 1) % 2],
-                tTMEM_STOREtO[None, iter_num - 1, 0],
-            )
-        cute.arch.fence_view_async_tmem_store()
-        o_handle.release()
-        return mma_o_consumer, s_corr_consumer
-
-    @cute.jit
-    def correction_epilog(
-        self,
-        value_args: Tuple,
-        sum_args: Tuple,
-        o_args: Tuple,
-        epi_tile: cute.Tile,
-    ) -> Tuple[pipeline.PipelineConsumer, pipeline.PipelineProducer]:
-        (seqlen_q, scale_output) = value_args
-        (sum_consumer, sSum) = sum_args
-        (mma_o_consumer, gO_staged, cO_staged, tOtO_staged) = o_args
-        tidx, _, _ = cute.arch.thread_idx()
-        thread_idx = tidx % (self.threads_per_warp * len(self.softmax_warp_ids))
-        sum_handle = sum_consumer.wait_and_advance()
-        row_sum = sSum[thread_idx]
-        cute.arch.fence_view_async_shared()
-        sum_handle.release()
-        row_sum_is_zero_or_nan = row_sum == 0.0 or row_sum != row_sum
-        scale = scale_output / row_sum if not row_sum_is_zero_or_nan else 0.0
-        o_handle = mma_o_consumer.wait_and_advance()
-        for iter in cutlass.range(self.iterations_pv):
-            gO = gO_staged[None, None, iter]
-            cO = cO_staged[None, None, iter]
-            tOtO = tOtO_staged[(None, None), 0, 0, iter]
-            tOtO_epi = cute.zipped_divide(tOtO, epi_tile)
-            cO_epi = cute.zipped_divide(cO, epi_tile)
-            gO_epi = cute.zipped_divide(gO, epi_tile)
-            tidx, _, _ = cute.arch.thread_idx()
-            thread_idx = tidx % (self.threads_per_warp * len(self.softmax_warp_ids))
-            tmem_copy_atom = cute.make_copy_atom(
-                tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(32)), self.pv_acc_dtype
-            )
-            tiled_tmem_load = tcgen05.make_tmem_copy(tmem_copy_atom, tOtO_epi)
-            thr_tmem_load = tiled_tmem_load.get_slice(thread_idx)
-            tTMEM_LOADtO = thr_tmem_load.partition_S(tOtO_epi)
-            tTMEM_LOADgO = thr_tmem_load.partition_D(gO_epi)
-            tTMEM_LOADcO = thr_tmem_load.partition_D(cO_epi)
-            for i in cutlass.range(cute.size(tTMEM_LOADtO, mode=[1]), unroll_full=True):
-                tTMEM_LOADtO_i = tTMEM_LOADtO[None, i, 0]
-                tTMEM_LOADgO_i = tTMEM_LOADgO[None, i, 0]
-                tTMEM_LOADcO_i = tTMEM_LOADcO[None, i, 0]
-                tTMrO = cute.make_rmem_tensor(tTMEM_LOADcO[None, 0, i].shape, self.pv_acc_dtype)
-                cute.copy(tiled_tmem_load, tTMEM_LOADtO_i, tTMrO)
-                for j in cutlass.range(0, cute.size(tTMrO), 2, unroll_full=True):
-                    tTMrO[j], tTMrO[j + 1] = cute.arch.mul_packed_f32x2(
-                        (tTMrO[j], tTMrO[j + 1]),
-                        (scale, scale),
-                    )
-                tSMrO = cute.make_rmem_tensor(tTMrO.shape, self.o_dtype)
-                o_vec = tTMrO.load()
-                tSMrO.store(o_vec.to(self.o_dtype))
-                if cute.elem_less(tTMEM_LOADcO_i[0][0], seqlen_q):
-                    cute.autovec_copy(tSMrO, tTMEM_LOADgO_i)
-        o_handle.release()
-        return mma_o_consumer, sum_consumer
-
-    @cute.jit
-    def store_sum_max(
-        self,
-        row_max,
-        mLSE,
-        row_sum,
-        sSum,
-        sum_producer,
-        current_block_coord,
-        seqlen_q,
-        cum_seqlen_q,
-        cuseqlen_q,
-        scale_softmax,
+        thr_mma,
+        tOtO: cute.Tensor,
+        tidx: Int32,
+        scale: Float32,
     ):
-        tidx, _, _ = cute.arch.thread_idx()
-        thread_idx = tidx % (self.threads_per_warp * len(self.softmax_warp_ids))
-        sum_handle = sum_producer.acquire_and_advance()
-        sSum[thread_idx] = row_sum
-        cute.arch.fence_view_async_shared()
-        sum_handle.commit()
-        row_sum_is_zero_or_nan = row_sum == 0.0 or row_sum != row_sum
+        """Rescale intermediate attention results based on softmax normalization factor.
 
-        if cutlass.const_expr(mLSE is not None):
-            q_idx = current_block_coord[0] * self.cta_tiler[0] + tidx
-            hb_idx = (
-                (current_block_coord[2][0], Int32(0))
-                if cutlass.const_expr(cum_seqlen_q is not None)
-                else current_block_coord[2]
-            )
-            lse_value = (
-                scale_softmax * row_max + cute.math.log(row_sum, fastmath=True)
-                if not row_sum_is_zero_or_nan
-                else -Float32.inf
-            )
-            if cute.elem_less(q_idx, seqlen_q):
-                global_q_idx = (
-                    q_idx + cuseqlen_q if cutlass.const_expr(cum_seqlen_q is not None) else q_idx
+        This method performs a crucial correction step in the attention computation pipeline.
+        When processing attention in blocks, the softmax normalization factors may change
+        as new blocks are processed. This method rescales previously computed partial
+        output values to account for updated normalization factors.
+
+        The implementation uses efficient tensor memory operations to:
+        1. Load existing partial attention output from tensor memory
+        2. Apply the scaling factor to all elements
+        3. Store the rescaled results back to tensor memory
+        """
+        tOcO = thr_mma.partition_C(cute.make_identity_tensor(self.mma_tiler_pv[:2]))
+        corr_tile_size = 16  # tuneable parameter
+        tmem_load_atom = cute.make_copy_atom(
+            tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(corr_tile_size)), self.pv_acc_dtype
+        )
+        tmem_store_atom = cute.make_copy_atom(
+            tcgen05.copy.St32x32bOp(tcgen05.copy.Repetition(corr_tile_size)),
+            self.pv_acc_dtype,
+        )
+        tOtO_i = cute.composition(tOtO, cute.make_layout((self.m_block_size, corr_tile_size)))
+        tOcO_i = cute.composition(tOcO, cute.make_layout((self.m_block_size, corr_tile_size)))
+        thr_tmem_load = tcgen05.make_tmem_copy(tmem_load_atom, tOtO_i).get_slice(tidx)
+        thr_tmem_store = tcgen05.make_tmem_copy(tmem_store_atom, tOtO_i).get_slice(tidx)
+        tOtO_t2r = thr_tmem_load.partition_S(tOtO_i)
+        tOrO_t2r_shape = thr_tmem_load.partition_D(tOcO_i).shape
+        tOtO_r2t = thr_tmem_store.partition_D(tOtO_i)
+
+        frg_count = self.mma_tiler_pv[1] // corr_tile_size
+        tOrO_frg = cute.make_rmem_tensor((tOrO_t2r_shape, frg_count), self.pv_acc_dtype)
+        for i in cutlass.range_constexpr(frg_count):
+            tOrO_frg = cute.make_rmem_tensor(tOrO_t2r_shape, self.pv_acc_dtype)
+            tOtO_t2r_i = cute.make_tensor(tOtO_t2r.iterator + i * corr_tile_size, tOtO_t2r.layout)
+            cute.copy(thr_tmem_load, tOtO_t2r_i, tOrO_frg)
+            for j in cutlass.range(0, cute.size(tOrO_frg), 2, unroll_full=True):
+                tOrO_frg[j], tOrO_frg[j + 1] = cute.arch.mul_packed_f32x2(
+                    (tOrO_frg[j], tOrO_frg[j + 1]), (scale, scale)
                 )
-                mLSE[global_q_idx, hb_idx] = lse_value
-        return sum_producer
+            tOtO_r2t_i = cute.make_tensor(tOtO_r2t.iterator + i * corr_tile_size, tOtO_r2t.layout)
+            cute.copy(thr_tmem_store, tOrO_frg, tOtO_r2t_i)
+        cute.arch.fence_view_async_tmem_store()
+
+    @cute.jit
+    def correction_epilogue(
+        self,
+        thr_mma,
+        tOtO: cute.Tensor,
+        tidx: Int32,
+        m_tile_idx: Int32,
+        seqlen_q: Int32,
+        scale: Float32,
+        sO: cute.Tensor,
+        mO_cur: Optional[cute.Tensor] = None,
+        gO: Optional[cute.Tensor] = None,
+        gmem_tiled_copy_O: Optional[cute.TiledCopy] = None,
+    ):
+        """Apply final scaling and stage the attention output in shared memory."""
+        corr_tile_size = 8 * 32 // self.o_dtype.width
+        epi_subtile = (self.m_block_size, corr_tile_size)
+        tmem_copy_atom = sm100_utils_basic.get_tmem_load_op(
+            self.mma_tiler_pv,
+            self.o_layout,
+            self.o_dtype,
+            self.pv_acc_dtype,
+            epi_subtile,
+            use_2cta_instrs=self.use_2cta_instrs,
+        )
+
+        for hdim_stage in cutlass.range_constexpr(self.pv_hdim_stage):
+            tOtO_stage = tOtO[(None, None), 0, 0, hdim_stage]
+            sO_stage = cute.local_tile(
+                sO,
+                cute.select(self.block_tiler_pv, mode=[0, 1]),
+                (0, hdim_stage),
+            )
+
+            # Use CTA 0 mapping for smem partitioning since sO is per-CTA sized.
+            tOsO = thr_mma.get_slice(0).partition_C(sO_stage)
+            tOcO = thr_mma.partition_C(cute.make_identity_tensor(self.mma_tiler_pv[:2]))
+
+            tOtO_i = cute.logical_divide(
+                tOtO_stage, cute.make_layout((self.m_block_size, corr_tile_size))
+            )
+            tOcO_i = cute.logical_divide(
+                tOcO, cute.make_layout((self.m_block_size, corr_tile_size))
+            )
+            tOsO_i = cute.logical_divide(
+                tOsO, cute.make_layout((self.m_block_size, corr_tile_size))
+            )
+
+            tiled_tmem_load = tcgen05.make_tmem_copy(tmem_copy_atom, tOtO_i[(None, None), 0])
+            thr_tmem_load = tiled_tmem_load.get_slice(tidx)
+            smem_copy_atom = sm100_utils_basic.get_smem_store_op(
+                self.o_layout,
+                self.o_dtype,
+                self.pv_acc_dtype,
+                tiled_tmem_load,
+            )
+            tiled_smem_store = cute.make_tiled_copy_D(smem_copy_atom, tiled_tmem_load)
+
+            tOtO_t2r = thr_tmem_load.partition_S(tOtO_i[(None, None), None])
+            tOsO_s2r = copy_utils.partition_D_position_independent(
+                thr_tmem_load, tOsO_i[(None, None), None]
+            )
+            tOcO_t2r = thr_tmem_load.partition_D(tOcO_i[(None, None), None])
+            for i in cutlass.range(self.mma_tiler_pv[1] // corr_tile_size, unroll_full=True):
+                tOtO_t2r_i = tOtO_t2r[None, 0, 0, i]
+                tOsO_r2s_i = tOsO_s2r[None, 0, 0, i]
+                tOrO_frg = cute.make_rmem_tensor(tOcO_t2r[None, 0, 0, i].shape, self.pv_acc_dtype)
+                cute.copy(tiled_tmem_load, tOtO_t2r_i, tOrO_frg)
+                for j in cutlass.range(0, cute.size(tOrO_frg), 2, unroll_full=True):
+                    tOrO_frg[j], tOrO_frg[j + 1] = cute.arch.mul_packed_f32x2(
+                        (tOrO_frg[j], tOrO_frg[j + 1]),
+                        (scale, scale),
+                    )
+                copy_utils.cvt_copy(tiled_smem_store, tOrO_frg, tOsO_r2s_i)
+        cute.arch.fence_view_async_shared()
+
+        if const_expr(self.use_correction_warps_for_epi):
+            assert not self.use_tma_O
+            assert gmem_tiled_copy_O is not None
+            cute.arch.barrier(
+                barrier_id=int(NamedBarrierFwdSm100.Epilogue),
+                number_of_threads=len(self.epilogue_warp_ids) * cute.arch.WARP_SIZE,
+            )
+            self._store_O_to_gmem(
+                sO,
+                gO,
+                mO_cur,
+                gmem_tiled_copy_O,
+                tidx,
+                seqlen_q,
+                m_tile_idx,
+            )
+
+    @cute.jit
+    def _store_O_to_gmem(
+        self,
+        sO_stage: cute.Tensor,
+        gO: cute.Tensor,
+        mO_cur: cute.Tensor,
+        gmem_tiled_copy_O: cute.TiledCopy,
+        tidx: Int32,
+        seqlen_q: Int32,
+        m_tile_idx: Int32,
+    ):
+        """Copy O from smem to gmem via registers."""
+        gmem_thr_copy_O = gmem_tiled_copy_O.get_slice(tidx)
+        tOsO = gmem_thr_copy_O.partition_S(sO_stage)
+        cO = cute.make_identity_tensor((self.m_block_size, self.head_dim_v_padded))
+        tOcO = gmem_thr_copy_O.partition_S(cO)
+        t0OcO = gmem_tiled_copy_O.get_slice(0).partition_S(cO)
+        tOpO = copy_utils.predicate_k(tOcO, limit=mO_cur.shape[1])
+
+        tOrO = cute.make_fragment_like(tOsO, self.o_dtype)
+        cute.autovec_copy(tOsO, tOrO)
+        tOgO = gmem_thr_copy_O.partition_D(gO)
+        for rest_m in cutlass.range_constexpr(cute.size(tOrO.shape[1])):
+            if t0OcO[0, rest_m, 0][0] < seqlen_q - m_tile_idx * self.m_block_size - tOcO[0][0]:
+                cute.copy(
+                    gmem_tiled_copy_O,
+                    tOrO[None, rest_m, None],
+                    tOgO[None, rest_m, None],
+                    pred=tOpO[None, rest_m, None] if const_expr(self.check_hdim_v_oob) else None,
+                )

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -75,6 +75,7 @@ def check_tensor_vs_ref(name, actual, ref, pt, rtol=2, atol=None):
     diff_pt_max = (pt - ref).abs().max().item()
     assert diff_max <= rtol * diff_pt_max + atol, f"{name}: {diff_max=} too large compared to {diff_pt_max=} for {rtol=}, {atol=}"
 
+
 # torch FakeTensorMode would enable fast cutedsl kernel compilation without allocating the actual GPU memory or running the kernel
 # When operating fake tensors, we cannot perform data-dependent operations (e.g., `tensor.max()`).
 USE_FAKE_TENSOR = int(os.getenv("FLASH_ATTENTION_FAKE_TENSOR", 0)) == 1
@@ -178,17 +179,6 @@ def test_flash_attn_output(
         pytest.xfail("has_qv: local not supported yet")
     if has_qv and has_learnable_sink:
         pytest.xfail("has_qv: learnable sink not supported yet")
-    # TODO(wangsiyu): SM100 head_dim=256 2CTA kernel currently does not support the following features.
-    # Remove these skips when support is added.
-    if d == 256 and IS_SM100:
-        if has_learnable_sink:
-            pytest.skip("SM100 head_dim=256 2CTA kernel does not support learnable_sink yet")
-        if local:
-            pytest.skip("SM100 head_dim=256 2CTA kernel does not support local attention yet")
-        if softcap > 0.0:
-            pytest.skip("SM100 head_dim=256 2CTA kernel does not support softcap yet")
-        if deterministic:
-            pytest.skip("SM100 head_dim=256 2CTA kernel does not support deterministic mode yet")
     device = "cuda"
     # set seed
     seed = 0
@@ -545,8 +535,8 @@ def test_flash_attn_hd256_sm100_noncontiguous_transpose():
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 @pytest.mark.parametrize("mha_type", ["mha", "mqa", "gqa"])
 # @pytest.mark.parametrize("mha_type", ["mha"])
-# @pytest.mark.parametrize("has_learnable_sink", [False, True])
-@pytest.mark.parametrize("has_learnable_sink", [False])
+@pytest.mark.parametrize("has_learnable_sink", [False, True])
+# @pytest.mark.parametrize("has_learnable_sink", [False])
 # @pytest.mark.parametrize("has_qv", [False, True])
 @pytest.mark.parametrize("has_qv", [False])
 @pytest.mark.parametrize("deterministic", [False, True])
@@ -641,19 +631,6 @@ def test_flash_attn_varlen_output(
     local = local_enum > 0
     if local and causal:
         pytest.skip()
-    # TODO(wangsiyu): SM100 head_dim=256 2CTA kernel currently does not support the following features.
-    # Remove these skips when support is added.
-    if d == 256 and IS_SM100:
-        if has_learnable_sink:
-            pytest.skip("SM100 head_dim=256 2CTA kernel does not support learnable_sink yet")
-        if local:
-            pytest.skip("SM100 head_dim=256 2CTA kernel does not support local attention yet")
-        if softcap > 0.0:
-            pytest.skip("SM100 head_dim=256 2CTA kernel does not support softcap yet")
-        if deterministic:
-            pytest.skip("SM100 head_dim=256 2CTA kernel does not support deterministic mode yet")
-        if not unpad_q or not unpad_kv:
-            pytest.skip("SM100 head_dim=256 2CTA kernel does not support seqused_q/seqused_k mode yet (requires unpad_q=True and unpad_kv=True)")
     if (
         causal or local
     ):  # Right now reference only supports causal attention with seqlen_k == seqlen_q
@@ -936,9 +913,10 @@ def test_flash_attn_varlen_output(
             and (
                 (dv == d and d <= 128)
                 or (d == 192 and dv == 128)
-                or (IS_SM100 and d == 256 and dv == 256 and softcap == 0.0)
+                or (IS_SM100 and d == 256 and dv == 256)
             )
             and not has_learnable_sink
+            and (softcap == 0.0 or (IS_SM100 and d == 256 and dv == 256))
             # and False
         ):
             if d > 192 and IS_SM90:
@@ -1631,7 +1609,7 @@ def test_flash_attn_kvcache(
 
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 @pytest.mark.parametrize("causal", [False, True])
-@pytest.mark.parametrize("d", [64, 128])
+@pytest.mark.parametrize("d", [64, 128, 256])
 @pytest.mark.parametrize("seqlen_q,seqlen_k", [(128, 128), (256, 256)])
 @maybe_fake_tensor_mode(USE_FAKE_TENSOR)
 def test_flash_attn_bwd_preallocated_outputs(seqlen_q, seqlen_k, d, causal, dtype):
@@ -1670,7 +1648,7 @@ def test_flash_attn_bwd_preallocated_outputs(seqlen_q, seqlen_k, d, causal, dtyp
 
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 @pytest.mark.parametrize("causal", [False, True])
-@pytest.mark.parametrize("d", [64, 128])
+@pytest.mark.parametrize("d", [64, 128, 256])
 @pytest.mark.parametrize("seqlen_q,seqlen_k", [(128, 128), (256, 256)])
 @maybe_fake_tensor_mode(USE_FAKE_TENSOR)
 def test_flash_attn_lse_grad(seqlen_q, seqlen_k, d, causal, dtype):
@@ -1750,7 +1728,7 @@ def test_flash_attn_lse_grad(seqlen_q, seqlen_k, d, causal, dtype):
 
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 @pytest.mark.parametrize("causal", [False, True])
-@pytest.mark.parametrize("d", [128])
+@pytest.mark.parametrize("d", [128, 256])
 @pytest.mark.parametrize("seqlen_q,seqlen_k", [(128, 128)])
 @maybe_fake_tensor_mode(USE_FAKE_TENSOR)
 def test_flash_attn_lse_grad_unused(seqlen_q, seqlen_k, d, causal, dtype):
@@ -2904,7 +2882,7 @@ def test_flash_attn_mla_paged(dtype, seqlen_q, seqlen_k, page_size, causal, has_
 # ---------------------------------------------------------------------------
 
 @pytest.mark.parametrize("causal", [False, True])
-@pytest.mark.parametrize("d", [128, 192])
+@pytest.mark.parametrize("d", [128, 192, 256])
 @pytest.mark.parametrize("seqlen_q", [1, 64, 128, 256])
 @maybe_fake_tensor_mode(USE_FAKE_TENSOR)
 def test_flash_attn_seqlen_k_zero(seqlen_q, d, causal):
@@ -2974,8 +2952,9 @@ def test_flash_attn_seqlen_k_zero(seqlen_q, d, causal):
     ],
 )
 @pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("d", [128, 256])
 @maybe_fake_tensor_mode(USE_FAKE_TENSOR)
-def test_flash_attn_empty_q_dense(shape, causal):
+def test_flash_attn_empty_q_dense(shape, causal, d):
     """Dense (non-varlen) path must not raise ZeroDivisionError when Q is empty.
 
     num_splits_heuristic divides num_SMs by total_mblocks = batch_size * num_head_kv
@@ -2987,7 +2966,6 @@ def test_flash_attn_empty_q_dense(shape, causal):
     batch_size, seqlen_q = shape
     device = "cuda"
     dtype = torch.bfloat16
-    d = 128
     nheads = 16
     nheads_kv = 16
     # Pick seqlen_k large enough that num_n_blocks > 4 so the heuristic's own
@@ -3015,8 +2993,9 @@ def test_flash_attn_empty_q_dense(shape, causal):
 
 
 @pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("d", [128, 256])
 @maybe_fake_tensor_mode(USE_FAKE_TENSOR)
-def test_flash_attn_empty_q_varlen(causal):
+def test_flash_attn_empty_q_varlen(causal, d):
     """Varlen path must not raise ZeroDivisionError when total_q == 0.
 
     Parallels test_flash_attn_empty_q_dense for the cu_seqlens_q path, where
@@ -3025,7 +3004,6 @@ def test_flash_attn_empty_q_varlen(causal):
     """
     device = "cuda"
     dtype = torch.bfloat16
-    d = 128
     nheads = 16
     nheads_kv = 16
     batch_size = 2

--- a/tests/cute/test_flash_attn_varlen.py
+++ b/tests/cute/test_flash_attn_varlen.py
@@ -5,6 +5,7 @@ import torch
 import torch.nn.functional as F
 from flash_attn.cute import flash_attn_varlen_func
 
+
 @pytest.mark.parametrize("B", [1, 7, 20])
 @pytest.mark.parametrize("H", [1, 4, 6])
 @pytest.mark.parametrize("D", [64, 128, 256])
@@ -35,21 +36,28 @@ def test_varlen(
         min_len=min_seq_len,
         max_len=max_seq_len,
         mha_type=mha_type,
-        dtype=dtype
+        dtype=dtype,
     )
 
     ok = check_varlen_vs_torch_flash(
-        q, k, v,
-        cu_seqlens_q, cu_seqlens_k,
-        total_q=total_q, total_k=total_k,
+        q,
+        k,
+        v,
+        cu_seqlens_q,
+        cu_seqlens_k,
+        total_q=total_q,
+        total_k=total_k,
         softmax_scale=softmax_scale,
         causal=causal,
         mha_type=mha_type,
     )
     assert ok
 
+
 def check_varlen_vs_torch_flash(
-    q, k, v,
+    q,
+    k,
+    v,
     cu_seqlens_q=None,
     cu_seqlens_k=None,
     seqused_q=None,
@@ -58,19 +66,25 @@ def check_varlen_vs_torch_flash(
     total_k=None,
     softmax_scale=None,
     causal=True,
-    mha_type='mha',
+    mha_type="mha",
     softcap=0.0,
     atol=3e-2,
     rtol=3e-2,
+    error_ratio=2.0,
 ):
-    assert q.requires_grad and k.requires_grad and v.requires_grad, "Set requires_grad=True on inputs"
+    assert q.requires_grad and k.requires_grad and v.requires_grad, (
+        "Set requires_grad=True on inputs"
+    )
 
     def clone_like(t):
         c = t.clone().detach().requires_grad_(True)
         return c
 
     q_fa, k_fa, v_fa = map(clone_like, (q, k, v))
-    q_t,  k_t,  v_t  = map(clone_like, (q, k, v))
+    q_t, k_t, v_t = map(clone_like, (q, k, v))
+    q_ref, k_ref, v_ref = [
+        tensor.detach().float().requires_grad_(True) for tensor in (q, k, v)
+    ]
 
     if cu_seqlens_q is not None:
         cu_seqlens_q_fa = cu_seqlens_q.clone()
@@ -86,13 +100,17 @@ def check_varlen_vs_torch_flash(
         cu_seqlens_k_fa = None
         cu_seqlens_k_t = None
 
-    out_fa, lse_fa = flash_attn_varlen_func(
-        q_fa, k_fa, v_fa,
+    out_fa, _ = flash_attn_varlen_func(
+        q_fa,
+        k_fa,
+        v_fa,
         cu_seqlens_q=cu_seqlens_q_fa,
         cu_seqlens_k=cu_seqlens_k_fa,
         seqused_q=seqused_q,
         seqused_k=seqused_k,
-        softmax_scale=(1.0 / q.shape[-1]**0.5) if softmax_scale is None else softmax_scale,
+        softmax_scale=(1.0 / q.shape[-1] ** 0.5)
+        if softmax_scale is None
+        else softmax_scale,
         causal=causal,
         window_size=(None, None),
         learnable_sink=None,
@@ -101,7 +119,9 @@ def check_varlen_vs_torch_flash(
     )
 
     out_t = torch_flash_ref(
-        q_t, k_t, v_t,
+        q_t,
+        k_t,
+        v_t,
         cu_seqlens_q=cu_seqlens_q_t,
         cu_seqlens_k=cu_seqlens_k_t,
         seqused_q=seqused_q,
@@ -113,8 +133,30 @@ def check_varlen_vs_torch_flash(
         mha_type=mha_type,
     )
 
+    out_ref = torch_flash_ref(
+        q_ref,
+        k_ref,
+        v_ref,
+        cu_seqlens_q=cu_seqlens_q_t,
+        cu_seqlens_k=cu_seqlens_k_t,
+        seqused_q=seqused_q,
+        seqused_k=seqused_k,
+        total_q=total_q,
+        total_k=total_k,
+        softmax_scale=softmax_scale,
+        causal=causal,
+        mha_type=mha_type,
+    )
 
-    ok_fwd = torch.allclose(out_fa.float(), out_t.float(), atol=atol, rtol=rtol)
+    def within_reference_error(actual, baseline, reference):
+        if torch.allclose(actual.float(), baseline.float(), atol=atol, rtol=rtol):
+            return True
+        rounding_atol = 2 * (reference + 0.3 - 0.3 - reference).abs().max().item()
+        actual_error = (actual.float() - reference).abs().max().item()
+        baseline_error = (baseline.float() - reference).abs().max().item()
+        return actual_error <= error_ratio * baseline_error + rounding_atol
+
+    ok_fwd = within_reference_error(out_fa, out_t, out_ref)
     if not ok_fwd:
         return False
 
@@ -131,18 +173,14 @@ def check_varlen_vs_torch_flash(
     # Ref bwd
     out_t.backward(grad_t, retain_graph=False)
     dq_t, dk_t, dv_t = q_t.grad, k_t.grad, v_t.grad
+    out_ref.backward(grad_out.float(), retain_graph=False)
+    dq_ref, dk_ref, dv_ref = q_ref.grad, k_ref.grad, v_ref.grad
 
-    # mean_ok_q = _stats("dQ", dq_fa, dq_t, atol=atol, rtol=rtol)
-    # mean_ok_k = _stats("dK", dk_fa, dk_t, atol=atol, rtol=rtol)
-    # mean_ok_v = _stats("dV", dv_fa, dv_t, atol=atol, rtol=rtol)
-
-    # return mean_ok_q and mean_ok_k and mean_ok_v
-
-    ok_q = torch.allclose(dq_fa.float(), dq_t.float(), atol=atol, rtol=rtol)
-    ok_k = torch.allclose(dk_fa.float(), dk_t.float(), atol=atol, rtol=rtol)
-    ok_v = torch.allclose(dv_fa.float(), dv_t.float(), atol=atol, rtol=rtol)
-    # print(f"Close? dQ={ok_q}, dK={ok_k}, dV={ok_v}")
+    ok_q = within_reference_error(dq_fa, dq_t, dq_ref)
+    ok_k = within_reference_error(dk_fa, dk_t, dk_ref)
+    ok_v = within_reference_error(dv_fa, dv_t, dv_ref)
     return ok_q and ok_k and ok_v
+
 
 def generate_varlen_args(
     batch_size=8,
@@ -151,7 +189,7 @@ def generate_varlen_args(
     min_len=32,
     max_len=64,
     mha_type="mha",
-    dtype = torch.bfloat16,
+    dtype=torch.bfloat16,
 ):
 
     torch.manual_seed(0)
@@ -176,32 +214,36 @@ def generate_varlen_args(
         H_kv = n_heads
     elif mha_type == "mha":
         H = H_kv = n_heads
-    else: # MQA
+    else:  # MQA
         H = n_heads
         H_kv = 1
 
     d_head_v = d_head
 
     q = torch.randn(total_q, H, d_head, device=device, dtype=dtype, requires_grad=True)
-    k = torch.randn(total_k, H_kv, d_head, device=device, dtype=dtype, requires_grad=True)
-    v = torch.randn(total_k, H_kv, d_head_v, device=device, dtype=dtype, requires_grad=True)
+    k = torch.randn(
+        total_k, H_kv, d_head, device=device, dtype=dtype, requires_grad=True
+    )
+    v = torch.randn(
+        total_k, H_kv, d_head_v, device=device, dtype=dtype, requires_grad=True
+    )
 
     return q, k, v, cu_seqlens_q, cu_seqlens_k, total_q, total_k
 
+
 # Simple for loop over batch dim implementation
 def torch_flash_ref(
-        q: torch.Tensor,
-        k: torch.Tensor,
-        v: torch.Tensor,
-        cu_seqlens_q: torch.Tensor = None,
-        cu_seqlens_k: torch.Tensor = None,
-        total_q: int = 0,
-        total_k: int = 0,
-        softmax_scale: Optional[float] = None,
-        causal: bool = False,
-        **kwargs
-    ):
-
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cu_seqlens_q: torch.Tensor = None,
+    cu_seqlens_k: torch.Tensor = None,
+    total_q: int = 0,
+    total_k: int = 0,
+    softmax_scale: Optional[float] = None,
+    causal: bool = False,
+    **kwargs,
+):
     """
     q: (total_q, H, d) if cu_seqlens_q is not None, otherwise (B, L, H, d)
     k: (total_k, H_kv, d) if cu_seqlens_k is not None, otherwise (B, L, H_kv, d)
@@ -239,8 +281,6 @@ def torch_flash_ref(
         B_kv = k.shape[0]
 
     d = q.shape[-1]
-    d_v = v.shape[-1]
-
     assert H_kv == v.shape[-2]
     assert d == k.shape[-1]
     assert B == B_kv
@@ -251,19 +291,19 @@ def torch_flash_ref(
     device = q.device
     dtype = q.dtype
 
-    hcseq_q = cu_seqlens_q.to(device='cpu')
-    hcseq_k = cu_seqlens_k.to(device='cpu')
+    hcseq_q = cu_seqlens_q.to(device="cpu")
+    hcseq_k = cu_seqlens_k.to(device="cpu")
 
     outs = []
     for b in range(B):
         if hcseq_q is not None:
-            q_start, q_end = int(hcseq_q[b]), int(hcseq_q[b+1])
+            q_start, q_end = int(hcseq_q[b]), int(hcseq_q[b + 1])
             qb = q[q_start:q_end]
         else:
             qb = q[b]
 
         if hcseq_k is not None:
-            k_start, k_end = int(hcseq_k[b]), int(hcseq_k[b+1])
+            k_start, k_end = int(hcseq_k[b]), int(hcseq_k[b + 1])
             kb = k[k_start:k_end]
             vb = v[k_start:k_end]
         else:
@@ -275,12 +315,14 @@ def torch_flash_ref(
         vb = vb.permute(1, 0, 2).unsqueeze(0)
 
         ob = F.scaled_dot_product_attention(
-            qb, kb, vb,
+            qb,
+            kb,
+            vb,
             attn_mask=None,
             dropout_p=0.0,
             is_causal=causal,
             scale=softmax_scale,
-            enable_gqa=H_kv!=H
+            enable_gqa=H_kv != H,
         )
 
         ob = ob.squeeze(0).permute(1, 0, 2).contiguous()
@@ -292,10 +334,13 @@ def torch_flash_ref(
         out = torch.stack(outs, dim=0).to(device=device, dtype=dtype)
     return out
 
+
 @torch.no_grad()
 def _stats(name, a, b, atol, rtol):
     diff = (a - b).float()
     mean_abs = diff.abs().mean().item()
-    mean_rel = (diff.abs().mean() / b.abs().clamp_min(1e-6).mean().item())
-    print(f"{name}: mean_abs={mean_abs:.4e}, mean_rel={mean_rel:.4e}, sum_fa={a.sum()}, sum_ref={b.sum()}")
+    mean_rel = diff.abs().mean() / b.abs().clamp_min(1e-6).mean().item()
+    print(
+        f"{name}: mean_abs={mean_abs:.4e}, mean_rel={mean_rel:.4e}, sum_fa={a.sum()}, sum_ref={b.sum()}"
+    )
     return mean_abs < atol and mean_rel < rtol

--- a/tests/cute/test_mask_mod.py
+++ b/tests/cute/test_mask_mod.py
@@ -604,7 +604,10 @@ Q_BOUNDARY_SEQLEN_PAIRS = [
 
 @pytest.mark.parametrize("seqlen_q,seqlen_k", Q_BOUNDARY_SEQLEN_PAIRS)
 @pytest.mark.parametrize("mask_name", ["block_diagonal", "document"])
-def test_q_boundary_masking_block_sparse_bwd(seqlen_q, seqlen_k, mask_name):
+@pytest.mark.parametrize("headdim", [128, 256])
+def test_q_boundary_masking_block_sparse_bwd(
+    seqlen_q, seqlen_k, mask_name, headdim
+):
     """Test Q boundary masking for block-sparse backward pass.
 
     This test specifically exercises the fix for the bug where Q rows beyond seqlen_q
@@ -625,7 +628,7 @@ def test_q_boundary_masking_block_sparse_bwd(seqlen_q, seqlen_k, mask_name):
         seqlen_k=seqlen_k,
         nheads=4,
         kv_mode="mha",
-        headdim=128,
+        headdim=headdim,
         dtype=torch.bfloat16,
         mask_name=mask_name,
         window_size=None,
@@ -763,7 +766,7 @@ def test_single_doc_bwd_minimal():
 @pytest.mark.parametrize("seqlen_q,seqlen_k", SEQLEN_PAIRS_COMPREHENSIVE)
 @pytest.mark.parametrize("nheads", [16])
 @pytest.mark.parametrize("kv_mode", ["mha", "gqa", "mqa"])
-@pytest.mark.parametrize("headdim", [128])
+@pytest.mark.parametrize("headdim", [128, 256])
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 @pytest.mark.parametrize("use_block_sparsity", [True, False])
 @pytest.mark.parametrize(
@@ -804,7 +807,7 @@ def test_static_masks(
 @pytest.mark.parametrize("seqlen_q,seqlen_k", SEQLEN_PAIRS_SMOKE)
 @pytest.mark.parametrize("nheads", [16])
 @pytest.mark.parametrize("kv_mode", ["mha", "gqa"])
-@pytest.mark.parametrize("headdim", [128])
+@pytest.mark.parametrize("headdim", [128, 256])
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 @pytest.mark.parametrize("use_block_sparsity", [True, False])
 @pytest.mark.parametrize(
@@ -913,8 +916,15 @@ def _run_mask_mod_only(q, k, v, mask_mod, aux_tensors, pack_gqa):
 @pytest.mark.parametrize("qhead_per_kvhead,num_kv_heads", [(1, 4), (4, 2)])
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
 @pytest.mark.parametrize("mask_case", VEC_MASK_TEST_CASES)
+@pytest.mark.parametrize("head_dim", [128, 256])
 def test_cute_mask_mod_vectorized(
-    seqlen_q, seqlen_k, qhead_per_kvhead, num_kv_heads, dtype, mask_case
+    seqlen_q,
+    seqlen_k,
+    qhead_per_kvhead,
+    num_kv_heads,
+    dtype,
+    mask_case,
+    head_dim,
 ):
     """Tests equality between scalar and vectorized versions of mask mods."""
     if COMPUTE_CAPABILITY not in (10, 11):
@@ -924,7 +934,6 @@ def test_cute_mask_mod_vectorized(
 
     num_heads = num_kv_heads * qhead_per_kvhead
     pack_gqa = qhead_per_kvhead > 1
-    head_dim = 128
     batch_size = 2
 
     q = torch.randn(
@@ -970,7 +979,8 @@ def test_cute_mask_mod_vectorized(
         )
 
 
-def test_sm100_block_sparse_sink_all_masked():
+@pytest.mark.parametrize("headdim", [128, 256])
+def test_sm100_block_sparse_sink_all_masked(headdim):
     """Block-sparse regression for the sink path"""
     if torch.cuda.get_device_capability()[0] != 10:
         pytest.skip("SM100-only test")
@@ -980,7 +990,6 @@ def test_sm100_block_sparse_sink_all_masked():
     seqlen_q = 256
     seqlen_k = 128
     nheads = 8
-    headdim = 128
     q = torch.randn(batch_size, seqlen_q, nheads, headdim, dtype=dtype, device=device)
     k = torch.randn(batch_size, seqlen_k, nheads, headdim, dtype=dtype, device=device)
     v = torch.randn(batch_size, seqlen_k, nheads, headdim, dtype=dtype, device=device)
@@ -1262,12 +1271,12 @@ def test_sm100_block_sparse_q_stage1():
 
 
 @pytest.mark.skipif(COMPUTE_CAPABILITY != 10, reason="SM100-only test")
-def test_sm100_block_sparse_coarse_blocks():
+@pytest.mark.parametrize("headdim", [128, 256])
+def test_sm100_block_sparse_coarse_blocks(headdim):
     torch.manual_seed(42)
     seqlen_q = 512
     seqlen_k = 512
     nheads = 4
-    headdim = 128
     dtype = torch.bfloat16
     tile_m = 128
     tile_n = 128
@@ -1434,12 +1443,12 @@ def test_sm100_block_sparse_coarse_kv_masks_tail_subtiles(headdim):
 
 
 @pytest.mark.skipif(COMPUTE_CAPABILITY != 10, reason="SM100-only test")
-def test_sm100_block_sparse_coarse_blocks_mismatch():
+@pytest.mark.parametrize("headdim", [128, 256])
+def test_sm100_block_sparse_coarse_blocks_mismatch(headdim):
     torch.manual_seed(0)
     seqlen_q = 1024
     seqlen_k = 512
     nheads = 2
-    headdim = 128
     dtype = torch.bfloat16
     tile_m = 128
     tile_n = 128
@@ -2378,7 +2387,10 @@ def _build_block_sparse_masks_for_bwd(
 )
 @pytest.mark.parametrize("spt", [False, True])
 @pytest.mark.parametrize("kv_mode", ["mha", "gqa"])
-def test_block_sparse_bwd_deterministic(seqlen_q, seqlen_k, mask_name, window_size, spt, kv_mode):
+@pytest.mark.parametrize("headdim", [128, 256])
+def test_block_sparse_bwd_deterministic(
+    seqlen_q, seqlen_k, mask_name, window_size, spt, kv_mode, headdim
+):
     torch.manual_seed(42)
     if mask_name == "sliding_window" and seqlen_q > seqlen_k:
         pytest.skip("sliding_window requires seqlen_q <= seqlen_k")
@@ -2389,7 +2401,6 @@ def test_block_sparse_bwd_deterministic(seqlen_q, seqlen_k, mask_name, window_si
     nheads = 4
     nheads_kv = 1 if kv_mode == "gqa" else nheads
     pack_gqa = nheads != nheads_kv
-    headdim = 128
     tile_m = 128
     tile_n = 128
     dtype = torch.bfloat16

--- a/tests/cute/test_mask_mod_varlen.py
+++ b/tests/cute/test_mask_mod_varlen.py
@@ -439,7 +439,10 @@ PARAMETERIZED_MASK_CONFIGS = [
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 @pytest.mark.parametrize("kv_mode", ["mha", "gqa"])
 @pytest.mark.parametrize("mask_name", STATIC_MASK_NAMES)
-def test_varlen_static_masks(seqlens_q, seqlens_k, dtype, kv_mode, mask_name):
+@pytest.mark.parametrize("head_dim", [128, 256])
+def test_varlen_static_masks(
+    seqlens_q, seqlens_k, dtype, kv_mode, mask_name, head_dim
+):
     """Test static mask_mods with varlen (packed) attention."""
     num_heads = 8
     if kv_mode == "gqa":
@@ -454,7 +457,7 @@ def test_varlen_static_masks(seqlens_q, seqlens_k, dtype, kv_mode, mask_name):
         seqlens_k=seqlens_k,
         num_heads=num_heads,
         num_kv_heads=num_kv_heads,
-        head_dim=128,
+        head_dim=head_dim,
         dtype=dtype,
         mask_name=mask_name,
     )
@@ -464,8 +467,9 @@ def test_varlen_static_masks(seqlens_q, seqlens_k, dtype, kv_mode, mask_name):
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 @pytest.mark.parametrize("kv_mode", ["mha", "gqa"])
 @pytest.mark.parametrize("mask_name,window_size", PARAMETERIZED_MASK_CONFIGS)
+@pytest.mark.parametrize("head_dim", [128, 256])
 def test_varlen_parameterized_masks(
-    seqlens_q, seqlens_k, dtype, kv_mode, mask_name, window_size
+    seqlens_q, seqlens_k, dtype, kv_mode, mask_name, window_size, head_dim
 ):
     """Test parameterized mask_mods with varlen (packed) attention.
 
@@ -484,7 +488,7 @@ def test_varlen_parameterized_masks(
         seqlens_k=seqlens_k,
         num_heads=num_heads,
         num_kv_heads=num_kv_heads,
-        head_dim=128,
+        head_dim=head_dim,
         dtype=dtype,
         mask_name=mask_name,
         window_size=window_size,
@@ -609,10 +613,17 @@ GLOBAL_MASK_NAMES = ["global_packed_doc", "global_ima", "global_causal_window"]
 
 @pytest.mark.parametrize("seqlens_q,seqlens_k", SEQLEN_CONFIGS)
 @pytest.mark.parametrize("mask_name", GLOBAL_MASK_NAMES)
-def test_varlen_global_masks(seqlens_q, seqlens_k, mask_name):
+@pytest.mark.parametrize("head_dim", [128, 256])
+def test_varlen_global_masks(seqlens_q, seqlens_k, mask_name, head_dim):
     """Test global-index mask_mods (aux-tensor-driven) with varlen packed attention."""
     _run_varlen_global_mask_test(
-        seqlens_q, seqlens_k, 8, 8, 128, torch.bfloat16, mask_name
+        seqlens_q,
+        seqlens_k,
+        8,
+        8,
+        head_dim,
+        torch.bfloat16,
+        mask_name,
     )
 
 
@@ -674,7 +685,10 @@ def _run_varlen_mask_only(
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 @pytest.mark.parametrize("kv_mode", ["mha", "gqa"])
 @pytest.mark.parametrize("mask_case", VEC_MASK_TEST_CASES)
-def test_varlen_mask_mod_vectorized(seqlens_q, seqlens_k, dtype, kv_mode, mask_case):
+@pytest.mark.parametrize("head_dim", [128, 256])
+def test_varlen_mask_mod_vectorized(
+    seqlens_q, seqlens_k, dtype, kv_mode, mask_case, head_dim
+):
     """Tests equality between scalar and vectorized mask mods on varlen inputs."""
     if COMPUTE_CAPABILITY not in (10, 11):
         pytest.skip("vectorized mask_mod application is SM100/SM110-only")
@@ -703,8 +717,6 @@ def test_varlen_mask_mod_vectorized(seqlens_q, seqlens_k, dtype, kv_mode, mask_c
     else:
         num_kv_heads = num_heads
     pack_gqa = num_heads != num_kv_heads
-    head_dim = 128
-
     q, k, v, cu_seqlens_q, cu_seqlens_k = setup_varlen_tensors(
         seqlens_q, seqlens_k, num_heads, num_kv_heads, head_dim, dtype
     )
@@ -900,8 +912,15 @@ BLOCK_SPARSE_SEQLEN_CONFIGS = [
 @pytest.mark.parametrize("varlen_k", [False, True])
 @pytest.mark.parametrize("use_seqused_k", [False, True])
 @pytest.mark.parametrize("head_broadcast", [False, True])
+@pytest.mark.parametrize("head_dim", [128, 256])
 def test_varlen_block_sparse(
-    varlen_q, varlen_k, use_seqused_k, head_broadcast, mask_name, seqlens
+    varlen_q,
+    varlen_k,
+    use_seqused_k,
+    head_broadcast,
+    mask_name,
+    seqlens,
+    head_dim,
 ):
     """Block sparsity + mask_mod should produce identical output to mask_mod alone."""
     if varlen_k and use_seqused_k:
@@ -915,7 +934,6 @@ def test_varlen_block_sparse(
     random.seed(42)
     device = "cuda"
     num_heads = 4
-    head_dim = 128
     dtype = torch.bfloat16
     # On Blackwell (SM100) q_stage=2 → effective tile is 256; elsewhere 128.
     tile_m = 256 if COMPUTE_CAPABILITY >= 10 else 128

--- a/tests/cute/test_score_mod.py
+++ b/tests/cute/test_score_mod.py
@@ -201,10 +201,11 @@ def run_flex_reference(q, k, v, eager_score_mod, dtype=None) -> torch.Tensor:
 
 @pytest.mark.parametrize("seqlen_q,seqlen_kv", SEQLEN_CONFIGS)
 @pytest.mark.parametrize("qhead_per_kvhead,num_kv_heads", [(1, 2), (4, 2)])
+@pytest.mark.parametrize("dim", [128, 256])
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
 @pytest.mark.parametrize("score_mod_pair", TEST_PAIRS)
 def test_cute_vs_flex_attention(
-    seqlen_q, seqlen_kv, qhead_per_kvhead, num_kv_heads, dtype, score_mod_pair
+    seqlen_q, seqlen_kv, qhead_per_kvhead, num_kv_heads, dim, dtype, score_mod_pair
 ):
     torch.random.manual_seed(42)
     cute_score_mod, eager_score_mod = score_mod_pair
@@ -212,7 +213,11 @@ def test_cute_vs_flex_attention(
     num_q_heads = num_kv_heads * qhead_per_kvhead
     pack_gqa = qhead_per_kvhead > 1
     q, k, v = create_tensors(
-        seqlen_q=seqlen_q, seqlen_kv=seqlen_kv, num_heads=num_q_heads, dtype=dtype
+        seqlen_q=seqlen_q,
+        seqlen_kv=seqlen_kv,
+        num_heads=num_q_heads,
+        dim=dim,
+        dtype=dtype,
     )
     if pack_gqa:
         k = k[:, :num_kv_heads, :, :].clone()
@@ -254,6 +259,7 @@ def test_cute_vs_flex_attention(
 
 @pytest.mark.parametrize("seqlen_q,seqlen_kv", SEQLEN_CONFIGS)
 @pytest.mark.parametrize("qhead_per_kvhead,num_kv_heads", [(1, 1), (4, 2)])
+@pytest.mark.parametrize("dim", [128, 256])
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
 @pytest.mark.parametrize("score_mod_vec_pair", TEST_PAIRS_VECTORIZED)
 def test_cute_score_mod_vectorized(
@@ -261,6 +267,7 @@ def test_cute_score_mod_vectorized(
     seqlen_kv,
     qhead_per_kvhead,
     num_kv_heads,
+    dim,
     dtype,
     score_mod_vec_pair,
 ):
@@ -271,7 +278,11 @@ def test_cute_score_mod_vectorized(
     num_q_heads = num_kv_heads * qhead_per_kvhead
     pack_gqa = qhead_per_kvhead > 1
     q, k, v = create_tensors(
-        seqlen_q=seqlen_q, seqlen_kv=seqlen_kv, num_heads=num_q_heads, dtype=dtype
+        seqlen_q=seqlen_q,
+        seqlen_kv=seqlen_kv,
+        num_heads=num_q_heads,
+        dim=dim,
+        dtype=dtype,
     )
     if pack_gqa:
         k = k[:, :num_kv_heads, :, :].clone()
@@ -290,10 +301,11 @@ def test_cute_score_mod_vectorized(
 
 @pytest.mark.parametrize("seqlen_q,seqlen_kv", SEQLEN_CONFIGS)
 @pytest.mark.parametrize("qhead_per_kvhead,num_kv_heads", [(1, 1), (4, 2)])
+@pytest.mark.parametrize("dim", [128, 256])
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
 @pytest.mark.parametrize("score_mod_pair", TEST_PAIRS_WITH_AUX_TENSORS)
 def test_cute_vs_flex_attention_with_aux_tensors(
-    seqlen_q, seqlen_kv, qhead_per_kvhead, num_kv_heads, dtype, score_mod_pair
+    seqlen_q, seqlen_kv, qhead_per_kvhead, num_kv_heads, dim, dtype, score_mod_pair
 ):
     torch.random.manual_seed(42)
     cute_score_mod, eager_score_mod_factory = score_mod_pair
@@ -306,6 +318,7 @@ def test_cute_vs_flex_attention_with_aux_tensors(
         seqlen_q=seqlen_q,
         seqlen_kv=seqlen_kv,
         num_heads=num_q_heads,
+        dim=dim,
         dtype=dtype,
     )
     if pack_gqa:
@@ -361,6 +374,7 @@ def test_cute_vs_flex_attention_with_aux_tensors(
 
 @pytest.mark.parametrize("seqlen_q,seqlen_kv", SEQLEN_CONFIGS)
 @pytest.mark.parametrize("qhead_per_kvhead,num_kv_heads", [(1, 1), (4, 2)])
+@pytest.mark.parametrize("dim", [128, 256])
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
 @pytest.mark.parametrize("score_mod_vec_pair", TEST_PAIRS_WITH_AUX_TENSORS_VECTORIZED)
 def test_cute_score_mod_with_aux_tensors_vectorized(
@@ -368,6 +382,7 @@ def test_cute_score_mod_with_aux_tensors_vectorized(
     seqlen_kv,
     qhead_per_kvhead,
     num_kv_heads,
+    dim,
     dtype,
     score_mod_vec_pair,
 ):
@@ -379,7 +394,11 @@ def test_cute_score_mod_with_aux_tensors_vectorized(
     num_q_heads = num_kv_heads * qhead_per_kvhead
     pack_gqa = qhead_per_kvhead > 1
     q, k, v = create_tensors(
-        seqlen_q=seqlen_q, seqlen_kv=seqlen_kv, num_heads=num_q_heads, dtype=dtype
+        seqlen_q=seqlen_q,
+        seqlen_kv=seqlen_kv,
+        num_heads=num_q_heads,
+        dim=dim,
+        dtype=dtype,
     )
     if pack_gqa:
         k = k[:, :num_kv_heads, :, :].clone()
@@ -847,7 +866,24 @@ def run_flex_reference_bwd(q, k, v, eager_score_mod, grad_out, dtype=None):
         v = v.requires_grad_(True)
 
     compiled_flex = torch.compile(flex_attention)
-    out = compiled_flex(q, k, v, score_mod=eager_score_mod, enable_gqa=q.shape[1] != k.shape[1])
+    kernel_options = (
+        {
+            "bwd_BLOCK_M1": 32,
+            "bwd_BLOCK_N1": 32,
+            "bwd_BLOCK_M2": 32,
+            "bwd_BLOCK_N2": 32,
+        }
+        if q.dtype != torch.float32 and q.shape[-1] == 256
+        else None
+    )
+    out = compiled_flex(
+        q,
+        k,
+        v,
+        score_mod=eager_score_mod,
+        enable_gqa=q.shape[1] != k.shape[1],
+        kernel_options=kernel_options,
+    )
     dq, dk, dv = torch.autograd.grad(out, (q, k, v), grad_out)
 
     return out, dq, dk, dv
@@ -1019,7 +1055,7 @@ def test_sm90_block_sparse_score_mod_backward_with_dq_swapab():
         (113, 203),
     ],
 )
-@pytest.mark.parametrize("dim", [64, 128])
+@pytest.mark.parametrize("dim", [64, 128, 256])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
 @pytest.mark.parametrize("score_mod_triple", BWD_TEST_PAIRS)
 @pytest.mark.parametrize("use_autograd", [True, False])
@@ -1089,7 +1125,7 @@ def make_aux_tensors_for_bwd(cute_score_mod, eager_factory, seqlen_q, num_heads,
         (256, 128),
     ],
 )
-@pytest.mark.parametrize("dim", [64, 128])
+@pytest.mark.parametrize("dim", [64, 128, 256])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
 @pytest.mark.parametrize("score_mod_triple", BWD_TEST_PAIRS_WITH_AUX)
 def test_cute_vs_flex_attention_backward_with_aux(
@@ -1149,7 +1185,7 @@ def test_cute_vs_flex_attention_backward_with_aux(
 
 
 @pytest.mark.parametrize("seqlen_q,seqlen_kv", [(128, 128), (128, 256)])
-@pytest.mark.parametrize("dim", [64, 128])
+@pytest.mark.parametrize("dim", [64, 128, 256])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
 @pytest.mark.parametrize("qhead_per_kvhead,num_kv_heads", [(4, 2)])
 @pytest.mark.parametrize("score_mod_triple", BWD_TEST_PAIRS_PACK_GQA)
@@ -1259,14 +1295,15 @@ def test_cute_score_mod_aux_tensors_and_scalars_match_flex():
 
 
 @pytest.mark.parametrize("use_autograd", [True, False])
-def test_cute_score_mod_bwd_aux_scalars_matches_flex(use_autograd):
+@pytest.mark.parametrize("dim", [128, 256])
+def test_cute_score_mod_bwd_aux_scalars_matches_flex(use_autograd, dim):
     torch.manual_seed(0)
     q, k, v = create_tensors(
         batch_size=1,
         num_heads=4,
         seqlen_q=128,
         seqlen_kv=128,
-        dim=128,
+        dim=dim,
         dtype=torch.bfloat16,
     )
     score_scale = 2


### PR DESCRIPTION
Refactor the dedicated HD256 kernels onto the current generic HD128/main contracts while preserving the HD256 2CTA QK iteration order.

- Support dense and varlen MHA/MQA/GQA forward and backward, causal and local attention, seqused inputs, zero-length inputs, and Q-longer-than-K shapes.
- Add softcap, learnable sink, dLSE, deterministic backward, FlexAttention score/mask modifiers, block-sparse forward and fixed-length backward, and paged-KV forward.
- Align GQA dK/dV accumulation and postprocessing, q-head parallel reduction, preallocated gradients, and LSE-gradient handling with current main.
- Fix empty-Q and K=1 synchronization, warp participation, and bulk dK/dV reduction behavior in the HD256 path.
- Enable the existing main correctness suites for HD256 without changing their public test structure.

Validation:
- 204429 correctness cases passed with zero failures or errors.
- 24 forward/backward benchmark points stayed within the 2% regression gate.
- 120000 forward/backward stress calls per rank completed without a watchdog stall.

Please review this PR, thanks ! @tridao @Johnsonms  @drisspg  @jayhshah 