### PR TITLE
Enable SM100 hd256 causal-left local attention

### DIFF
--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -605,6 +605,12 @@ def _flash_attn_fwd(
     # hd=256 2CTA forward uses dedicated kernel (Blackwell family)
     use_dedicated_hd256_kernel = arch // 10 in [10, 11] and head_dim == 256 and head_dim_v == 256
     use_2cta_instrs = use_2cta_instrs or use_dedicated_hd256_kernel
+    if use_dedicated_hd256_kernel and local:
+        assert (
+            window_size_left is not None and window_size_left >= 0 and window_size_right == 0
+        ), (
+            "SM100/SM110 dedicated head_dim=256 forward only supports causal-left local attention"
+        )
 
     if softcap is not None:
         assert score_mod is None, "softcap and score_mod cannot be used together"
@@ -1458,6 +1464,12 @@ def _flash_attn_bwd(
 
     use_dedicated_hd256_kernel = arch // 10 in [10, 11] and head_dim == 256 and head_dim_v == 256
     use_2cta_instrs = use_2cta_instrs or use_dedicated_hd256_kernel
+    if use_dedicated_hd256_kernel and local:
+        assert (
+            window_size_left is not None and window_size_left >= 0 and window_size_right == 0
+        ), (
+            "SM100/SM110 dedicated head_dim=256 backward only supports causal-left local attention"
+        )
 
     q, k, v, out, dout, lse, cu_seqlens_q, cu_seqlens_k, seqused_q, seqused_k = [
         maybe_contiguous(t)
@@ -1791,8 +1803,8 @@ def _flash_attn_bwd(
             head_dim_v,
             qhead_per_kvhead,
             causal,
-            window_size_left is not None,
-            window_size_right is not None,
+            window_size_left if use_dedicated_hd256_kernel else window_size_left is not None,
+            window_size_right if use_dedicated_hd256_kernel else window_size_right is not None,
             m_block_size,
             n_block_size,
             num_threads,
@@ -1928,6 +1940,8 @@ def _flash_attn_bwd(
                     tile_n_dq=dq_tile_mn[1],
                     tile_m_dkdv=dkdv_tile_mn[0],
                     tile_n_dkdv=dkdv_tile_mn[1],
+                    window_size_left=window_size_left,
+                    window_size_right=window_size_right,
                 )
             else:
                 fa_bwd_obj = FlashAttentionBackwardSm100(
@@ -1973,8 +1987,8 @@ def _flash_attn_bwd(
             cu_seqlens_k_tensor,
             seqused_q_tensor,
             seqused_k_tensor,
-            window_size_left,
-            window_size_right,
+            None if use_dedicated_hd256_kernel else window_size_left,
+            None if use_dedicated_hd256_kernel else window_size_right,
             dQ_semaphore_tensor,
             dK_semaphore_tensor,
             dV_semaphore_tensor,
@@ -2000,8 +2014,8 @@ def _flash_attn_bwd(
             cu_seqlens_k,
             seqused_q,
             seqused_k,
-            window_size_left,
-            window_size_right,
+            None if use_dedicated_hd256_kernel else window_size_left,
+            None if use_dedicated_hd256_kernel else window_size_right,
             dQ_semaphore,
             dK_semaphore,
             dV_semaphore,

--- a/flash_attn/cute/sm100_hd256_2cta_fmha_backward.py
+++ b/flash_attn/cute/sm100_hd256_2cta_fmha_backward.py
@@ -57,7 +57,6 @@ class BlackwellFusedMultiHeadAttentionBackward:
         assert head_dim == 256 and head_dim_v == 256, (
             "SM100 dedicated backward kernel only supports (head_dim, head_dim_v) = (256, 256)"
         )
-        assert not is_local, "SM100 backward with head_dim=256 does not support local attention"
         assert tile_m_dq == 128 and tile_n_dq == 128, (
             "SM100 dedicated backward kernel only supports tile_m_dq=128 and tile_n_dq=128"
         )

--- a/flash_attn/cute/sm100_hd256_2cta_fmha_forward.py
+++ b/flash_attn/cute/sm100_hd256_2cta_fmha_forward.py
@@ -203,12 +203,6 @@ class BlackwellFusedMultiHeadAttentionForward:
         assert aux_data.scalars is None, (
             "SM100 forward with head_dim=256 does not support aux_scalars"
         )
-        assert not self.is_local, (
-            "SM100 forward with head_dim=256 does not support local attention yet"
-        )
-        assert window_size_left is None and window_size_right is None, (
-            "SM100 forward with head_dim=256 does not support runtime window_size overrides"
-        )
         assert descale_tensors is None, (
             "SM100 forward with head_dim=256 does not support descale_tensors"
         )

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -96,6 +96,47 @@ def test_flash_attn_sm120_rejects_splitkv():
         flash_attn_func(q, k, v, num_splits=3)
 
 
+@pytest.mark.skipif(not IS_SM100, reason="requires the SM100 head_dim=256 kernel")
+def test_flash_attn_hd256_gemma4_sliding_window():
+    """Exercise the causal-left local path used by Gemma 4."""
+    torch.manual_seed(1234)
+    device = "cuda"
+    batch, seqlen, nheads, nheads_kv, head_dim = 1, 2048, 8, 4, 256
+    window_size = (1023, 0)
+
+    q, k, v = [
+        torch.randn(shape, device=device, dtype=torch.bfloat16, requires_grad=True)
+        for shape in (
+            (batch, seqlen, nheads, head_dim),
+            (batch, seqlen, nheads_kv, head_dim),
+            (batch, seqlen, nheads_kv, head_dim),
+        )
+    ]
+    q_ref, k_ref, v_ref = [tensor.detach().float().requires_grad_(True) for tensor in (q, k, v)]
+    dout = torch.randn_like(q)
+
+    out_ref, _ = attention_ref(q_ref, k_ref, v_ref, None, None, window_size=window_size)
+    out, _ = flash_attn_func(q, k, v, window_size=window_size)
+    out_ref.backward(dout.float())
+    out.backward(dout)
+
+    for name, actual, reference in (
+        ("out", out, out_ref),
+        ("dq", q.grad, q_ref.grad),
+        ("dk", k.grad, k_ref.grad),
+        ("dv", v.grad, v_ref.grad),
+    ):
+        actual_float = actual.detach().float().flatten()
+        reference_float = reference.detach().float().flatten()
+        cosine = torch.nn.functional.cosine_similarity(actual_float, reference_float, dim=0).item()
+        relative_l2 = (
+            torch.linalg.vector_norm(actual_float - reference_float)
+            / torch.linalg.vector_norm(reference_float)
+        ).item()
+        assert cosine >= 0.9999, f"{name}: cosine={cosine:.8f}"
+        assert relative_l2 <= 1e-2, f"{name}: relative_l2={relative_l2:.8f}"
+
+
 # @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float8_e4m3fn])
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 @pytest.mark.parametrize("mha_type", ["mha", "mqa", "gqa"])


### PR DESCRIPTION
## Summary

Enable the existing SM100/SM110 dedicated head-dim 256 2CTA kernel for causal-left local attention (`window_size_left >= 0`, `window_size_right == 0`). This is the sliding-window shape used by Gemma 4.

The forward kernel already contains local semantic trip-range and mask handling. The backward dQ and dK/dV kernels likewise already accept constructor-specialized window sizes; this change wires those values through the interface and includes the exact values in the compile-cache key.

Arbitrary bilateral local attention remains rejected by the interface.

## Performance

B300, BF16, `B=1, Hq=8, Hkv=4, S=65536, D=256`, window `(1023, 0)`:

| path | FA2 | FA4 | speedup |
|---|---:|---:|---:|
| forward | 1.62 ms | 2.30 ms | 0.70x |
| backward | 13.98 ms | 4.04 ms | 3.46x |
| forward + backward | 15.60 ms | 6.34 ms | 2.46x |

## Correctness

- Added a D256 GQA causal-left test against an FP32 attention reference.
- Exact downstream production topology also passes: CP4, packed varlen with two 1536-token documents, post-Ulysses `Hq=8/Hkv=4`, window `(1023,0)`.
- FA4 vs FA2 downstream metrics:
  - output: cosine `0.99999982`, relative L2 `0.00068479`
  - dQ: cosine `0.99999535`, relative L2 `0.00305870`
  - dK: cosine `0.99999255`, relative L2 `0.00389192`
  - dV: cosine `0.99999613`, relative L2 `0.00278712`

No existing tolerance is changed.
