### PR TITLE
[CuTe, SM80/SM120] Support learnable_sink (attention sinks) on Ampere/Ada/consumer-Blackwell

### DIFF
--- a/flash_attn/cute/flash_fwd.py
+++ b/flash_attn/cute/flash_fwd.py
@@ -645,8 +645,11 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
 
         mQ/mK/mV/mO has same data types(supports fp16 and bf16) and same layout:
         (batch_size, seqlen_q, num_head, head_dim):(_, _, _, 1)
+
+        learnable_sink: optional per-head fp32 attention-sink logit (shape (num_head,)),
+        folded into the softmax denominator as an extra column, i.e.
+        row_sum += exp(sink[head] - row_max). None reproduces the previous behavior exactly.
         """
-        assert learnable_sink is None, "Learnable sink is not supported in this kernel"
         self._check_type(
             *(t.element_type if t is not None else None for t in (mQ, mK, mV, mO, mLSE, mCuSeqlensQ, mCuSeqlensK, mSeqUsedQ, mSeqUsedK))
         )
@@ -724,6 +727,7 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
             softmax_scale,
             window_size_left,
             window_size_right,
+            learnable_sink,
             self.sQ_layout,
             self.sK_layout,
             self.sV_layout,
@@ -763,6 +767,7 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
         softmax_scale: Optional[Float32],
         window_size_left: Optional[Int32],
         window_size_right: Optional[Int32],
+        learnable_sink: Optional[cute.Tensor],
         sQ_layout: cute.ComposedLayout,
         sK_layout: cute.ComposedLayout,
         sV_layout: cute.ComposedLayout,
@@ -1064,7 +1069,21 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
         # TODO: local
 
         # normalize acc_O by row_sum and calculate the lse
-        row_scale = softmax.finalize()
+        sink_val = None
+        if const_expr(learnable_sink is not None):
+            if const_expr(not self.pack_gqa):
+                # Every row in this CTA shares the same Q-head (num_head), so a single
+                # scalar sink value broadcasts to all rows in Softmax.finalize.
+                sink_val = Float32(learnable_sink[num_head])
+            else:  # Each thread might have a different sink value due to different q_head
+                sink_val = cute.make_rmem_tensor_like(softmax.row_max, Float32)
+                cS = cute.make_identity_tensor((self.tile_m, self.tile_n))
+                tScS_mn = layout_utils.reshape_acc_to_mn(thr_mma_qk.partition_C(cS))
+                for r in cutlass.range(cute.size(sink_val), unroll_full=True):
+                    row = m_block * self.tile_m + tScS_mn[r][0]
+                    q_head_idx = row % self.qhead_per_kvhead + num_head * self.qhead_per_kvhead
+                    sink_val[r] = Float32(learnable_sink[q_head_idx])
+        row_scale = softmax.finalize(sink_val=sink_val)
         softmax.rescale_O(acc_O, row_scale)
 
         # ///////////////////////////////////////////////////////////////////////////////

--- a/tests/cute/test_sm80_learnable_sink.py
+++ b/tests/cute/test_sm80_learnable_sink.py
@@ -1,0 +1,82 @@
+"""Regression tests for learnable_sink (attention-sink) support on the SM80/Ampere/Ada
+CuTeDSL forward kernel (flash_attn.cute.flash_fwd.FlashAttentionForwardSm80).
+
+Before this fix, FlashAttentionForwardSm80.__call__ hardcoded
+`assert learnable_sink is None`, so sink-attention models (e.g. gpt-oss, StreamingLLM-style
+architectures) had no FA4 CuTeDSL forward path on Ampere/Ada (A100, RTX 3090/4090) or
+consumer-Blackwell (RTX 50-series, which shares this base kernel via FlashAttentionForwardSm120).
+`tests/cute/test_flash_attn.py::test_flash_attn_output` already parametrizes
+`has_learnable_sink=[False, True]` with no SM80-specific skip, so it exercises this path too;
+this file adds a few focused, fast cases at the shapes most relevant to the fix (GQA with
+pack_gqa, plain MHA, and a multi-n-block causal case) so the sink path has direct regression
+coverage independent of the full parametrized matrix.
+"""
+
+import pytest
+import torch
+
+from flash_attn.cute.interface import flash_attn_func
+from flash_attn.cute.testing import attention_ref
+
+IS_SM80_FAMILY = torch.cuda.is_available() and torch.cuda.get_device_capability()[0] in (8, 12)
+
+
+@pytest.mark.skipif(
+    not IS_SM80_FAMILY, reason="Targets the SM80-family (Ampere/Ada/SM120) forward kernel"
+)
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize(
+    "seqlen_q,seqlen_k,nheads,nheads_kv,d",
+    [
+        # gpt-oss-20b production shape: D=64, GQA 8:1, single-tile prefill (pack_gqa path).
+        (64, 64, 64, 8, 64),
+        # Same GQA ratio but long enough seqlen_k to exercise the multi-n-block mainloop.
+        (64, 512, 64, 8, 64),
+        # Plain MHA (no pack_gqa), larger head_dim, for generality.
+        (128, 256, 16, 16, 128),
+    ],
+)
+def test_sm80_learnable_sink_matches_reference(seqlen_q, seqlen_k, nheads, nheads_kv, d, causal):
+    device = "cuda"
+    dtype = torch.bfloat16
+    torch.random.manual_seed(0)
+    batch_size = 2
+
+    q = torch.randn(batch_size, seqlen_q, nheads, d, device=device, dtype=dtype, requires_grad=False) * 0.1
+    k = torch.randn(batch_size, seqlen_k, nheads_kv, d, device=device, dtype=dtype, requires_grad=False) * 0.1
+    v = torch.randn(batch_size, seqlen_k, nheads_kv, d, device=device, dtype=dtype, requires_grad=False) * 0.1
+    learnable_sink = torch.randn(nheads, dtype=torch.bfloat16, device=device) * 2.0
+
+    out, lse, *_ = flash_attn_func(
+        q, k, v, causal=causal, learnable_sink=learnable_sink, return_lse=True
+    )
+    out_ref, _, lse_ref = attention_ref(
+        q, k, v, causal=causal, learnable_sink=learnable_sink, return_lse=True
+    )
+
+    out_f, ref_f = out.float(), out_ref.float()
+    cos_sim = torch.nn.functional.cosine_similarity(out_f.flatten(), ref_f.flatten(), dim=0)
+    assert cos_sim.item() > 0.999, f"cosine similarity too low: {cos_sim.item()}"
+    assert (out_f - ref_f).abs().max().item() < 0.05
+    assert torch.allclose(lse.float(), lse_ref.float(), atol=0.05, rtol=0.05)
+
+
+@pytest.mark.skipif(
+    not IS_SM80_FAMILY, reason="Targets the SM80-family (Ampere/Ada/SM120) forward kernel"
+)
+def test_sm80_no_sink_regression():
+    """learnable_sink=None must reproduce pre-existing (no-sink) behavior exactly."""
+    device = "cuda"
+    dtype = torch.bfloat16
+    torch.random.manual_seed(0)
+    q = torch.randn(2, 64, 16, 64, device=device, dtype=dtype) * 0.1
+    k = torch.randn(2, 64, 16, 64, device=device, dtype=dtype) * 0.1
+    v = torch.randn(2, 64, 16, 64, device=device, dtype=dtype) * 0.1
+
+    out, *_ = flash_attn_func(q, k, v, causal=True)
+    assert not torch.isnan(out).any()
+    out_ref, _ = attention_ref(q, k, v, causal=True)
+    cos_sim = torch.nn.functional.cosine_similarity(
+        out.float().flatten(), out_ref.float().flatten(), dim=0
+    )
+    assert cos_sim.item() > 0.999


### PR DESCRIPTION
## Summary

`FlashAttentionForwardSm80.__call__` in `flash_attn/cute/flash_fwd.py` (the SM80/Ampere/Ada
forward kernel — A100, RTX 3090/4090, and other non-datacenter GPUs) hardcoded:

```python
assert learnable_sink is None, "Learnable sink is not supported in this kernel"
```

So any model using attention sinks (e.g. gpt-oss, StreamingLLM-style architectures) had
no FA4 CuTeDSL forward path on Ampere/Ada, and — since `FlashAttentionForwardSm120`
(`flash_attn/cute/flash_fwd_sm120.py`) subclasses `FlashAttentionForwardSm80` without
overriding `__call__`/`kernel` — on consumer-Blackwell (RTX 50-series) either. Only
Hopper (`flash_fwd_sm90.py`) and datacenter-Blackwell (`flash_fwd_sm100.py`) had a real
sink implementation. That means most people self-hosting sink-attention models on
consumer/prosumer hardware (no H100/B200) had no FA4 path at all for this.

`flash_attn/cute/softmax.py`'s `Softmax.finalize(sink_val=...)` is already arch-agnostic
and folds a sink logit into the softmax denominator (`row_sum += exp(sink - row_max)`);
SM90/SM100 already call it that way. It just was never wired up on SM80.

### Changes (`flash_attn/cute/flash_fwd.py`)

- Removed the `assert learnable_sink is None`.
- Threaded `learnable_sink` from `__call__` through to `kernel()` (it was accepted as a
  parameter but silently dropped before reaching the device kernel).
- At the point where the mainloop finalizes the softmax (previously `row_scale =
  softmax.finalize()`), compute `sink_val` and pass it through, mirroring
  `flash_fwd_sm90.py`'s existing pattern exactly:
  - Non-`pack_gqa`: every row in the CTA shares one Q-head, so a single scalar
    `Float32(learnable_sink[num_head])` broadcasts to all rows.
  - `pack_gqa`: different rows within the same CTA can belong to different Q-heads
    (multiple Q-heads packed per KV-head), so each row's sink value is looked up via an
    identity-tensor partition of `thr_mma_qk` (the same `cS = cute.make_identity_tensor(...)`
    + `reshape_acc_to_mn` pattern already used elsewhere in this file for `score_mod`/mask
    row indexing), giving a per-row `learnable_sink[q_head_idx]`.

`interface.py`'s `_flash_attn_fwd` dispatch already threads `learnable_sink` generically
through `compile_args`/`call_args` for every architecture (SM80 included) — that plumbing
was already correct, so no changes were needed there. The only actual blocker was the
flat assert inside the SM80 kernel itself.

### Tests

Adds `tests/cute/test_sm80_learnable_sink.py`: focused regression coverage at the
gpt-oss-20b production shape (D=64, GQA 8:1, exercising the `pack_gqa` per-row path) and a
plain-MHA D=128 shape (exercising the scalar-broadcast path), both causal and non-causal,
plus a `learnable_sink=None` regression check, comparing against `attention_ref`'s existing
sink-aware reference. The existing `tests/cute/test_flash_attn.py::test_flash_attn_output`
already parametrizes `has_learnable_sink=[False, True]` with no SM80-specific skip, so those
cases exercise this path too — they would previously fail with the assert above on any
Ampere/Ada GPU.

## Test plan

- Confirmed pre-fix: reverting just `flash_fwd.py` reproduces
  `AssertionError: Learnable sink is not supported in this kernel` on real hardware.
- Ran the new test file, `pytest tests/cute/test_sm80_learnable_sink.py`, on 2x RTX 4090
  (sm_89) — 7/7 passed.
- Additionally wrote a standalone script comparing `flash_attn.cute.flash_attn_func(...,
  learnable_sink=...)` against a plain PyTorch SDPA-with-sink reference (softmax with an
  extra sink logit column) across 5 shapes/configs on the same RTX 4090s:
  - gpt-oss-20b shape (D=64, GQA 8:1, causal): cos_sim = 0.99999821
  - same shape, non-causal: cos_sim = 0.99999774
  - GQA 8:1, longer seqlen_k (multi n-block mainloop): cos_sim = 0.99999785
  - MHA D=128, causal: cos_sim = 0.99999797
  - MHA D=128, non-causal: cos_sim = 0.99999785
- Confirmed `learnable_sink=None` still produces identical (regression-free) output.
- `FlashAttentionForwardSm120` inherits this fix structurally (no override of
  `__call__`/`kernel`), which would also close the SM120/RTX-50-series side of #1810, but
  I don't have SM120 hardware and could not verify it directly — flagging this for a
  maintainer/reviewer with access to that hardware. Related: #1895 (gpt-oss learnable-sink
  backward support) is a separate, larger scope (training/backward) not addressed here —
  this PR is forward-only, matching the existing SM90/SM100 forward-only sink support.
