### PR TITLE
[CuTe, SM100] Sparse MLA bwd: don't scatter dK/dV at -1 sentinel indices

### DIFF
--- a/flash_attn/cute/flash_bwd_mla_dk_sm100.py
+++ b/flash_attn/cute/flash_bwd_mla_dk_sm100.py
@@ -1117,13 +1117,15 @@ class dKGemmKernel:
                 else:
                     seqlen_k_idx = (batch, seqlen_k_idx_in_batch)
                 cute.copy(tiled_copy_c, tCsC[(None, None, topk_idx, c_buffer)], tCrC)
-                for j in cutlass.range_constexpr(cute.size(tCrC, mode=[1])):
-                    for i in cutlass.range_constexpr(cute.size(tCrC, mode=[0])):
-                        ptr = elem_pointer(tCgC, (i, j, subtile_idx, seqlen_k_idx))
-                        cute.arch.atomic_add(
-                            ptr=ptr,
-                            val=tCrC[i, j],
-                        )
+                # Skip -1 sentinel slots (invalid top-k entries)
+                if seqlen_k_idx_in_batch >= 0:
+                    for j in cutlass.range_constexpr(cute.size(tCrC, mode=[1])):
+                        for i in cutlass.range_constexpr(cute.size(tCrC, mode=[0])):
+                            ptr = elem_pointer(tCgC, (i, j, subtile_idx, seqlen_k_idx))
+                            cute.arch.atomic_add(
+                                ptr=ptr,
+                                val=tCrC[i, j],
+                            )
             epilog_sync_barrier.arrive_and_wait()
 
         epilog_sync_barrier.arrive_and_wait()

--- a/flash_attn/cute/flash_bwd_mla_sm100.py
+++ b/flash_attn/cute/flash_bwd_mla_sm100.py
@@ -2103,21 +2103,23 @@ class FlashAttentionSparseMLABackwardSm100:
 
                         for j in cutlass.range_constexpr(gmem_rows_per_thread):
                             gmem_n_idx = rIdxTopK[j]
-                            for w in cutlass.range_constexpr(2):
-                                dv_offset = (
-                                    self.hdimv // self.num_hdimv_splits * split  # 256 * split
-                                    + (self.hdimv // self.num_hdimv_splits // 2) * w  # 128 * w
-                                    + 32 * i
-                                )
-                                dv_offset += tdVcdV[0, j, 0][1]
-                                gmem_coord = (gmem_n_idx, dv_offset)
-                                dV_gmem_ptr = elem_pointer(mdV_cur, gmem_coord)
+                            # Skip -1 sentinel slots (invalid top-k entries)
+                            if gmem_n_idx >= 0:
+                                for w in cutlass.range_constexpr(2):
+                                    dv_offset = (
+                                        self.hdimv // self.num_hdimv_splits * split  # 256 * split
+                                        + (self.hdimv // self.num_hdimv_splits // 2) * w  # 128 * w
+                                        + 32 * i
+                                    )
+                                    dv_offset += tdVcdV[0, j, 0][1]
+                                    gmem_coord = (gmem_n_idx, dv_offset)
+                                    dV_gmem_ptr = elem_pointer(mdV_cur, gmem_coord)
 
-                                a = tSR_rdV[0, j, 0, w]
-                                b = tSR_rdV[1, j, 0, w]
-                                c = tSR_rdV[2, j, 0, w]
-                                d = tSR_rdV[3, j, 0, w]
-                                atomic_add_fp32x4(a, b, c, d, dV_gmem_ptr)
+                                    a = tSR_rdV[0, j, 0, w]
+                                    b = tSR_rdV[1, j, 0, w]
+                                    c = tSR_rdV[2, j, 0, w]
+                                    d = tSR_rdV[3, j, 0, w]
+                                    atomic_add_fp32x4(a, b, c, d, dV_gmem_ptr)
 
                     cute.arch.fence_view_async_tmem_load()
                     self.epi_barrier.arrive_and_wait()

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -2604,7 +2604,6 @@ def _flash_attn_bwd_sparse_mla(
     prealloc_dk = dk is not None
     prealloc_dqv = dqv is not None
     prealloc_dv = dv is not None
-    dq = dk = None
     if not prealloc_dq and q is not None:
         dq = torch.empty_like(q)
     if not prealloc_dk and k is not None:

--- a/flash_attn/cute/testing.py
+++ b/flash_attn/cute/testing.py
@@ -417,12 +417,15 @@ def attention_ref(
         )
     if gather_kv_indices is not None:
         batch = q_shape[0]
-        topk_len = gather_kv_indices.shape[2]
-        if topk_len < seqlen_k:
-            topk_index_mask = torch.full(
-                (batch, seqlen_q, seqlen_k), False, device="cuda"
-            ).scatter_(-1, gather_kv_indices, True)
-            scores.masked_fill_(rearrange(~topk_index_mask, "b t s -> b 1 t s"), float("-inf"))
+        # -1 is a sentinel for invalid top-k slots; route sentinels (and any
+        # out-of-range index) to a dummy extra column so they never unmask a
+        # real key
+        gather_idx = gather_kv_indices.long()
+        gather_idx = gather_idx.masked_fill((gather_idx < 0) | (gather_idx >= seqlen_k), seqlen_k)
+        topk_index_mask = torch.full(
+            (batch, seqlen_q, seqlen_k + 1), False, device="cuda"
+        ).scatter_(-1, gather_idx, True)[..., :seqlen_k]
+        scores.masked_fill_(rearrange(~topk_index_mask, "b t s -> b 1 t s"), float("-inf"))
     if local_mask is not None:
         scores.masked_fill_(local_mask, float("-inf"))
     if attn_bias is not None:

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -33,6 +33,7 @@ from flash_attn.cute.interface import (
     get_scheduler_metadata,
     _flash_attn_fwd,
     _flash_attn_bwd,
+    _flash_attn_bwd_sparse_mla,
 )
 
 def retry_on_oom(func):
@@ -2579,6 +2580,295 @@ def test_flash_attn_mla_absorbed(
             check_tensor_vs_ref("dK", dk, dk_ref, dk_pt)
             check_tensor_vs_ref("dV", dv, dv_ref, dv_pt)
             check_tensor_vs_ref("dQv", dqv, dqv_ref, dqv_pt)
+
+
+def causal_topk_indices(batch_size, seqlen_q, seqlen_k, topk_len, device):
+    """Top-k indices as produced by a causal sparse-attention selector: query t
+    gets min(t+1, seqlen_k, topk_len) valid keys drawn from [0, t], with
+    trailing -1 sentinel padding (the documented marker for invalid slots)."""
+    n_keys = max(seqlen_k, topk_len)
+    scores = torch.rand(batch_size, seqlen_q, n_keys, device=device)
+    key_idx = torch.arange(n_keys, device=device)
+    query_idx = torch.arange(seqlen_q, device=device)
+    invalid = (key_idx[None, None, :] > query_idx[None, :, None]) | (key_idx >= seqlen_k)[None, None, :]
+    scores.masked_fill_(invalid, float("-inf"))
+    val, idx = scores.topk(topk_len, dim=-1)
+    idx = idx.masked_fill(torch.isinf(val), -1)
+    return idx.to(torch.int32).contiguous()
+
+
+def plant_canary(shape, pad_words, device):
+    """Allocate a float32 buffer of `shape` with `pad_words` extra words on
+    each side holding int32 patterns 1..pad_words. Every pattern value is a
+    subnormal fp32 bit pattern, so a single misdirected red.add.f32 (even of
+    +0.0) flushes it to zero."""
+    numel = math.prod(shape)
+    parent = torch.zeros(pad_words + numel + pad_words, dtype=torch.float32, device=device)
+    pattern = torch.arange(1, pad_words + 1, dtype=torch.int32, device=device)
+    parent[:pad_words].view(torch.int32).copy_(pattern)
+    parent[-pad_words:].view(torch.int32).copy_(pattern)
+    return parent, parent[pad_words:-pad_words].view(shape)
+
+
+def check_canary(name, parent, pad_words):
+    expected = torch.arange(1, pad_words + 1, dtype=torch.int32)
+    for side, sl in (("before", slice(None, pad_words)), ("after", slice(-pad_words, None))):
+        got = parent[sl].view(torch.int32).cpu()
+        n_bad = (got != expected).sum().item()
+        assert n_bad == 0, (
+            f"{name}: {n_bad}/{pad_words} canary words {side} the buffer were "
+            f"corrupted by an out-of-bounds scatter"
+        )
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("shared_kv", [False, True])
+@pytest.mark.parametrize("seqlen_q,seqlen_k", [(512, 512), (1024, 1024)])
+@maybe_fake_tensor_mode(USE_FAKE_TENSOR)
+def test_flash_attn_mla_sparse_bwd_sentinel(seqlen_q, seqlen_k, shared_kv, causal, dtype):
+    """Sparse-MLA backward with -1-padded gather_kv_indices, the padding any
+    causal top-k selector produces for early queries.
+
+    Regression test for unguarded sentinel scatters: the dV/dK backward
+    epilogues used to atomically accumulate at row -1 — out of bounds of the
+    (batch-sliced) buffer — corrupting adjacent memory even though the addend
+    is exactly 0.0, because red.add.f32 flushes subnormal destinations to zero
+    and canonicalizes NaN payloads. Checks that
+      1. grads match the reference through the public autograd path, and
+      2. int32 canaries planted directly before/after preallocated dk/dv
+         buffers are untouched by the scatter epilogues.
+    """
+    if not IS_SM100:
+        pytest.skip()
+    device = "cuda"
+    torch.random.manual_seed(0)
+    batch_size = 2
+    nheads, nheads_kv, hdim, hdimv = 128, 1, 64, 512
+    topk_len = 256
+
+    q_ref = torch.randn(batch_size, seqlen_q, nheads, hdim, device=device, dtype=dtype).requires_grad_()
+    k_ref = torch.randn(batch_size, seqlen_k, nheads_kv, hdim, device=device, dtype=dtype).requires_grad_()
+    v_ref = torch.randn(batch_size, seqlen_k, nheads_kv, hdimv, device=device, dtype=dtype).requires_grad_()
+    qv_ref = torch.randn(batch_size, seqlen_q, nheads, hdimv, device=device, dtype=dtype).requires_grad_()
+    gather_kv_indices = causal_topk_indices(batch_size, seqlen_q, seqlen_k, topk_len, device)
+
+    q, k, v, qv = [x.detach().clone().requires_grad_() for x in (q_ref, k_ref, v_ref, qv_ref)]
+    if shared_kv:
+        q, k, qv = qv, v, None
+        q_ref, k_ref, qv_ref = qv_ref, v_ref, None
+
+    out_ref, _ = attention_ref(
+        q_ref, k_ref, v_ref, causal=causal, qv=qv_ref, gather_kv_indices=gather_kv_indices
+    )
+    out_pt, _ = attention_ref(
+        q_ref, k_ref, v_ref, causal=causal, qv=qv_ref, gather_kv_indices=gather_kv_indices,
+        upcast=False, reorder_ops=True,
+    )
+
+    out, lse = flash_attn_func(
+        q, k, v, qv=qv, gather_kv_indices=gather_kv_indices, causal=causal, pack_gqa=True
+    )
+
+    g = torch.randn_like(out)
+    if shared_kv:
+        dq, dk = torch.autograd.grad(out, (q, k), g)
+        dv = dqv = None
+    else:
+        dq, dk, dv, dqv = torch.autograd.grad(out, (q, k, v, qv), g)
+
+    # Rerun the backward with preallocated dk/dv surrounded by canaries. The
+    # scatter epilogues write rows of hdim/hdimv fp32 words, so an unguarded
+    # -1 sentinel lands exactly in the pad before the buffer.
+    dv_parent, dv_buf = plant_canary((batch_size, seqlen_k, nheads_kv, hdimv), hdimv, device)
+    if shared_kv:
+        dk_parent = dk_buf = None
+    else:
+        dk_parent, dk_buf = plant_canary((batch_size, seqlen_k, nheads_kv, hdim), hdim, device)
+    with torch.no_grad():
+        fq, fk, fqv = (None, None, q) if shared_kv else (q, k, qv)
+        out2, lse2, p2, row_max2 = _flash_attn_fwd(
+            fq, fk, v, qv=fqv, causal=causal, gather_kv_indices=gather_kv_indices, pack_gqa=True
+        )
+        dq2, dk2, dv2, dqv2 = _flash_attn_bwd_sparse_mla(
+            fq, fk, v, fqv, out2, g, lse2, p2, row_max2, gather_kv_indices,
+            causal=causal, dk=dk_buf, dv=dv_buf,
+        )
+
+    if is_fake_mode():
+        # no more flash_attn cutedsl calls; skip data-dependent checks
+        return
+
+    assert (gather_kv_indices == -1).any(), "test must exercise sentinel slots"
+
+    fwd_atol = 2 * (out_ref + 0.3 - 0.3 - out_ref).abs().max().item()
+    assert (out - out_ref).abs().max().item() <= 2 * (out_pt - out_ref).abs().max().item() + fwd_atol
+    assert not torch.isnan(lse).any(), "LSE contains NaN"
+
+    if shared_kv:
+        dq_ref, dk_ref = torch.autograd.grad(out_ref, (q_ref, k_ref), g)
+        dq_pt, dk_pt = torch.autograd.grad(out_pt, (q_ref, k_ref), g)
+        dv_ref = dqv_ref = dv_pt = dqv_pt = None
+    else:
+        dq_ref, dk_ref, dv_ref, dqv_ref = torch.autograd.grad(out_ref, (q_ref, k_ref, v_ref, qv_ref), g)
+        dq_pt, dk_pt, dv_pt, dqv_pt = torch.autograd.grad(out_pt, (q_ref, k_ref, v_ref, qv_ref), g)
+
+    print_diff_stats("dQ", dq, dq_ref, dq_pt)
+    print_diff_stats("dK", dk, dk_ref, dk_pt)
+    print_diff_stats("dV", dv, dv_ref, dv_pt)
+    print_diff_stats("dQv", dqv, dqv_ref, dqv_pt)
+
+    check_tensor_vs_ref("dQ", dq, dq_ref, dq_pt)
+    check_tensor_vs_ref("dK", dk, dk_ref, dk_pt)
+    check_tensor_vs_ref("dV", dv, dv_ref, dv_pt)
+    check_tensor_vs_ref("dQv", dqv, dqv_ref, dqv_pt)
+
+    check_canary("dV", dv_parent, hdimv)
+    if not shared_kv:
+        check_canary("dK", dk_parent, hdim)
+    # preallocated buffers must produce the same grads as internal allocation
+    if shared_kv:
+        check_tensor_vs_ref("dV(prealloc)", dv2, dk_ref, dk_pt)
+        check_tensor_vs_ref("dQv(prealloc)", dqv2, dq_ref, dq_pt)
+    else:
+        check_tensor_vs_ref("dQ(prealloc)", dq2, dq_ref, dq_pt)
+        check_tensor_vs_ref("dK(prealloc)", dk2, dk_ref, dk_pt)
+        check_tensor_vs_ref("dV(prealloc)", dv2, dv_ref, dv_pt)
+        check_tensor_vs_ref("dQv(prealloc)", dqv2, dqv_ref, dqv_pt)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("shared_kv", [False, True])
+@maybe_fake_tensor_mode(USE_FAKE_TENSOR)
+def test_flash_attn_mla_sparse_bwd_sentinel_varlen(shared_kv, causal, dtype):
+    """Varlen counterpart of test_flash_attn_mla_sparse_bwd_sentinel.
+
+    The varlen kernels are separate compile-time specializations, and the dK
+    epilogue applies the sentinel guard to the doc-relative index before
+    adding seqlen_k_offset — a -1 that slipped past the guard would land in
+    the previous doc's last row (in bounds, so only doc 0's row -1 is
+    canary-visible, same as batch 0 in the non-varlen test). Includes a doc
+    shorter than topk_len whose index rows are almost entirely sentinels.
+    """
+    if not IS_SM100:
+        pytest.skip()
+    device = "cuda"
+    torch.random.manual_seed(0)
+    nheads, nheads_kv, hdim, hdimv = 128, 1, 64, 512
+    topk_len = 256
+    seqlens = [512, 4, 1024]
+    total = sum(seqlens)
+    cu_bounds = [0] + list(itertools.accumulate(seqlens))
+    cu_seqlens = torch.tensor(cu_bounds, dtype=torch.int32, device=device)
+    max_seqlen = max(seqlens)
+
+    q_ref = torch.randn(total, nheads, hdim, device=device, dtype=dtype).requires_grad_()
+    k_ref = torch.randn(total, nheads_kv, hdim, device=device, dtype=dtype).requires_grad_()
+    v_ref = torch.randn(total, nheads_kv, hdimv, device=device, dtype=dtype).requires_grad_()
+    qv_ref = torch.randn(total, nheads, hdimv, device=device, dtype=dtype).requires_grad_()
+    # doc-relative key indices with -1 tail padding, packed along the token dim
+    gather_kv_indices = torch.cat(
+        [causal_topk_indices(1, L, L, topk_len, device)[0] for L in seqlens], dim=0
+    ).contiguous()
+
+    q, k, v, qv = [x.detach().clone().requires_grad_() for x in (q_ref, k_ref, v_ref, qv_ref)]
+    if shared_kv:
+        q, k, qv = qv, v, None
+        q_ref, k_ref, qv_ref = qv_ref, v_ref, None
+
+    # reference per doc (each doc is an independent attention problem)
+    outs_ref, outs_pt = [], []
+    for i in range(len(seqlens)):
+        s, e = cu_bounds[i], cu_bounds[i + 1]
+        doc = dict(causal=causal, gather_kv_indices=gather_kv_indices[s:e].unsqueeze(0))
+        o_ref, _ = attention_ref(
+            q_ref[s:e].unsqueeze(0), k_ref[s:e].unsqueeze(0), v_ref[s:e].unsqueeze(0),
+            qv=qv_ref[s:e].unsqueeze(0) if qv_ref is not None else None, **doc,
+        )
+        o_pt, _ = attention_ref(
+            q_ref[s:e].unsqueeze(0), k_ref[s:e].unsqueeze(0), v_ref[s:e].unsqueeze(0),
+            qv=qv_ref[s:e].unsqueeze(0) if qv_ref is not None else None,
+            upcast=False, reorder_ops=True, **doc,
+        )
+        outs_ref.append(o_ref[0])
+        outs_pt.append(o_pt[0])
+    out_ref = torch.cat(outs_ref, dim=0)
+    out_pt = torch.cat(outs_pt, dim=0)
+
+    out, lse = flash_attn_varlen_func(
+        q, k, v, qv=qv, cu_seqlens_q=cu_seqlens, cu_seqlens_k=cu_seqlens,
+        max_seqlen_q=max_seqlen, max_seqlen_k=max_seqlen,
+        gather_kv_indices=gather_kv_indices, causal=causal, pack_gqa=True,
+    )
+
+    g = torch.randn_like(out)
+    if shared_kv:
+        dq, dk = torch.autograd.grad(out, (q, k), g)
+        dv = dqv = None
+    else:
+        dq, dk, dv, dqv = torch.autograd.grad(out, (q, k, v, qv), g)
+
+    # canary rerun with preallocated dk/dv (see non-varlen test)
+    dv_parent, dv_buf = plant_canary((total, nheads_kv, hdimv), hdimv, device)
+    if shared_kv:
+        dk_parent = dk_buf = None
+    else:
+        dk_parent, dk_buf = plant_canary((total, nheads_kv, hdim), hdim, device)
+    with torch.no_grad():
+        fq, fk, fqv = (None, None, q) if shared_kv else (q, k, qv)
+        out2, lse2, p2, row_max2 = _flash_attn_fwd(
+            fq, fk, v, qv=fqv, cu_seqlens_q=cu_seqlens, cu_seqlens_k=cu_seqlens,
+            max_seqlen_q=max_seqlen, max_seqlen_k=max_seqlen,
+            causal=causal, gather_kv_indices=gather_kv_indices, pack_gqa=True,
+        )
+        dq2, dk2, dv2, dqv2 = _flash_attn_bwd_sparse_mla(
+            fq, fk, v, fqv, out2, g, lse2, p2, row_max2, gather_kv_indices,
+            causal=causal,
+            cu_seqlens_q=cu_seqlens, cu_seqlens_k=cu_seqlens,
+            max_seqlen_q=max_seqlen, max_seqlen_k=max_seqlen,
+            dk=dk_buf, dv=dv_buf,
+        )
+
+    if is_fake_mode():
+        # no more flash_attn cutedsl calls; skip data-dependent checks
+        return
+
+    assert (gather_kv_indices == -1).any(), "test must exercise sentinel slots"
+
+    fwd_atol = 2 * (out_ref + 0.3 - 0.3 - out_ref).abs().max().item()
+    assert (out - out_ref).abs().max().item() <= 2 * (out_pt - out_ref).abs().max().item() + fwd_atol
+    assert not torch.isnan(lse).any(), "LSE contains NaN"
+
+    if shared_kv:
+        dq_ref, dk_ref = torch.autograd.grad(out_ref, (q_ref, k_ref), g)
+        dq_pt, dk_pt = torch.autograd.grad(out_pt, (q_ref, k_ref), g)
+        dv_ref = dqv_ref = dv_pt = dqv_pt = None
+    else:
+        dq_ref, dk_ref, dv_ref, dqv_ref = torch.autograd.grad(out_ref, (q_ref, k_ref, v_ref, qv_ref), g)
+        dq_pt, dk_pt, dv_pt, dqv_pt = torch.autograd.grad(out_pt, (q_ref, k_ref, v_ref, qv_ref), g)
+
+    print_diff_stats("dQ", dq, dq_ref, dq_pt)
+    print_diff_stats("dK", dk, dk_ref, dk_pt)
+    print_diff_stats("dV", dv, dv_ref, dv_pt)
+    print_diff_stats("dQv", dqv, dqv_ref, dqv_pt)
+
+    check_tensor_vs_ref("dQ", dq, dq_ref, dq_pt)
+    check_tensor_vs_ref("dK", dk, dk_ref, dk_pt)
+    check_tensor_vs_ref("dV", dv, dv_ref, dv_pt)
+    check_tensor_vs_ref("dQv", dqv, dqv_ref, dqv_pt)
+
+    check_canary("dV", dv_parent, hdimv)
+    if not shared_kv:
+        check_canary("dK", dk_parent, hdim)
+    if shared_kv:
+        check_tensor_vs_ref("dV(prealloc)", dv2, dk_ref, dk_pt)
+        check_tensor_vs_ref("dQv(prealloc)", dqv2, dq_ref, dq_pt)
+    else:
+        check_tensor_vs_ref("dQ(prealloc)", dq2, dq_ref, dq_pt)
+        check_tensor_vs_ref("dK(prealloc)", dk2, dk_ref, dk_pt)
+        check_tensor_vs_ref("dV(prealloc)", dv2, dv_ref, dv_pt)
+        check_tensor_vs_ref("dQv(prealloc)", dqv2, dqv_ref, dqv_pt)
 
 
 # @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])


### PR DESCRIPTION
In the sparse-MLA (`gather_kv_indices` / DSA top-k) backward on SM100, both scatter-reduce epilogues atomically accumulate at row indices read straight from `gather_kv_indices` with no validity guard, while every load path treats `-1` as invalid and predicates the gather (`topk_gather_kv.py`: `row_valid = topk_idx >= 0 and topk_idx < self.seqlen_k_limit`):

- `flash_bwd_mla_sm100.py` (dV epilogue): `gmem_n_idx = rIdxTopK[j]` used directly in `elem_pointer(mdV_cur, (gmem_n_idx, dv_offset))` + `atomic_add_fp32x4`.
- `flash_bwd_mla_dk_sm100.py` (dK epilogue): `seqlen_k_idx_in_batch = sI_tile[topk_idx]` used directly in `elem_pointer` + `cute.arch.atomic_add`.

`-1` is the documented sentinel for invalid top-k slots (the forward handles it via the kv bitmask — `interface.py`: "always use kv bitmask by default (handles -1 sentinel)"), and any causal top-k index tensor necessarily contains `-1` padding for early tokens, so any causal DSA workload hits this on every backward call.

### Why the damage is hard to attribute

The masked math is correct — `p` and `ds` are exactly 0.0 at sentinel slots — so the scattered *value* is 0.0. But:

1. Index `-1` computes an address one row before the (batch-sliced) buffer base: for batch 0 that is out of bounds into whatever tensor the allocator placed there; for later batches it is the previous batch's last dk/dv row.
2. PTX `red.add.f32` flushes subnormal destinations to (sign-preserving) zero and canonicalizes NaN payloads **even when the addend is 0.0**. If the adjacent tensor holds int32 data reinterpreted as fp32 — e.g. another top-k index tensor, whose small positive values are all subnormal bit patterns — those values are silently zeroed, and `-1` (0xFFFFFFFF, a NaN bit pattern) is canonicalized to 0x7FC00000, a huge positive int.
3. Whether anything visibly breaks depends purely on CUDA caching-allocator block adjacency, so the symptom is deterministic per layout but appears/disappears with unrelated allocation changes — it mimics a stale-cache or race bug and survives clearing every DSL compile cache. Observed symptoms range from bitwise-correct results, to silently wrong grads, to IMA inside `_sparse_mla_dk` (when the corrupted victim is the index tensor of the same call).

### Demonstration

Plant an int32 canary (values 1..N — all subnormal fp32 bit patterns) immediately before a dv/dk buffer and run one sparse fwd+bwd with causal `-1`-padded indices on GB200:

- unpatched: every canary word covered by row `-1` is flushed to 0x0 while `p`/`ds` at all sentinel slots are bitwise 0.0 and all grads still match an fp32 reference (the OOB landed in the canary, i.e. in dead memory);
- in a second layout, the internally allocated `dk` landed right after an unrelated int32 tensor, and the dK epilogue zeroed that tensor's last 256 bytes — the allocator-adjacency lottery described above;
- patched: canaries intact, valid-slot grads unchanged: max abs err vs the fp32 reference matches the unpatched run's, with residual differences <=2e-5 that also appear between reruns of the same binary (atomic fp32 reduction-order noise).

### Fix

Skip the atomic when the index is negative, mirroring the load-side guard. The skipped contribution is mathematically 0.0, so numerics for valid slots are unchanged (verified: max abs err vs an fp32 reference is the same before/after, up to <=2e-5 run-to-run atomic reduction-order noise).

Also fixes `_flash_attn_bwd_sparse_mla` discarding caller-supplied `dq=`/`dk=` buffers (`dq = dk = None` immediately after recording `prealloc_dq/dk`, then the re-allocation is skipped because `prealloc_*` is True → crash). The new test uses preallocated `dk`/`dv` to plant canaries.

### Tests

`tests/cute/test_flash_attn.py::test_flash_attn_mla_sparse_bwd_sentinel` (parametrized over causal × shared_kv × seqlen 512/1024) and a varlen counterpart `..._sentinel_varlen` (causal × shared_kv, packed docs [512, 4, 1024] including one shorter than topk_len, whose index rows are almost entirely sentinels):

1. builds causal top-k indices with `-1` tail padding (what any causal selector produces for early queries),
2. checks out/lse/grads against `attention_ref` through the public autograd path,
3. reruns the backward with preallocated `dk`/`dv` surrounded by int32 canaries and asserts the canaries are untouched.

The varlen kernels are separate compile-time specializations, and the dK epilogue guard must apply to the doc-relative index *before* `seqlen_k_offset` is added — the varlen test pins that down (doc 0's row `-1` is the canary-visible case; later docs' row `-1` would land in the previous doc's last row).

```bash
# fails on main, passes on this branch
pytest tests/cute/test_flash_attn.py -k "mla_sparse_bwd_sentinel"
# unchanged
pytest tests/cute/test_flash_attn.py -k "mla_absorbed"
```

Fails deterministically on `main` (canary check; grads can also go garbage / IMA depending on allocation layout), passes with the fix. Also made `attention_ref`'s top-k mask sentinel-aware (its `scatter_` routed `-1` into key 0 and tripped scatter's bounds check; out-of-range indices now also map to a dummy column).

Existing `test_flash_attn_mla_absorbed` subset (kv_sparsity, both causal, both shared_kv, seqlen 256/1024) passes unchanged with the guard.

### Notes / not addressed here

- Indices `>= seqlen_k` are treated as invalid by the load-side guard but are not guarded in the scatter (only `-1` is the documented sentinel). If such indices are considered legal input, the scatter guard should become `0 <= idx < seqlen_k`.
- Two related issues observed while debugging, left for separate PRs: non-contiguous (`.split()`-view) k/v are accepted by the sparse path and produce wrong results (`maybe_contiguous` only fixes `stride(-1) != 1`); and for invalid rows the gathered `sK`/`sV` smem tiles are left unwritten by the predicated `cp.async` yet still consumed by the MMA — correctness relies on `dS == 0`, so a leftover Inf/NaN in smem would produce NaN (zero-fill or predicating the MMA would make this robust).

Environment: GB200 (SM100), torch 2.13.0+cu130, nvidia-cutlass-dsl 4.6.0.dev0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
