### PR TITLE
[CuTe,Bwd,Sm90] Fix: wait for bwd_preprocess on the block-sparse path, matching the dense path

### DIFF
--- a/flash_attn/cute/block_sparse_utils.py
+++ b/flash_attn/cute/block_sparse_utils.py
@@ -1636,6 +1636,13 @@ def _load_q_do_block_sm90(
     else:
         pipeline_Q.producer_acquire(producer_state_Q)
     load_Q(m_block, producer_state=producer_state_Q)
+    if load_kv:
+        # Wait for bwd preprocess to finish writing LSE and dPsum, and zeroing dQaccum. Same
+        # point in the load order as the dense arm's wait in flash_bwd_sm90.load(): after this
+        # block's K/Q loads, before the first load that reads preprocess output.
+        # load_kv is the tile's first-block marker -- the caller flips kv_loaded in the same
+        # branch that loads a block -- so this runs once per tile, like the dense arm's.
+        cute.arch.griddepcontrol_wait()
     load_LSE(m_block, producer_state=producer_state_Q)
 
     producer_state_dO_cur = (

--- a/flash_attn/cute/flash_bwd_sm90.py
+++ b/flash_attn/cute/flash_bwd_sm90.py
@@ -994,6 +994,8 @@ class FlashAttentionBackwardSm90:
                             producer_state_Q.advance()
                             producer_state_dO.advance()
                     else:
+                        # The wait for bwd preprocess that the dense arm above does inline sits
+                        # in _load_q_do_block_sm90, at the same point in the load order.
                         producer_state_Q, producer_state_dO = produce_block_sparse_q_loads_bwd_sm90(
                             blocksparse_tensors,
                             batch_idx,


### PR DESCRIPTION
I recently hit the same bug as #2643, and I think this is a better fix. It affects anyone running backward with PyTorch's `flex_attention` flash-attention backend (`backend="FLASH"`) and a `mask_mod`. The kernel reads preprocess's outputs before they have been written, so gradients can come out garbage, sometimes NaN (rarely, 0.1% to 1% of backward launches in my runs).

Credit to @codecaution for the diagnosis in #2643. This differs only in where the wait is: I put it in `_load_q_do_block_sm90` after `load_Q` and before `load_LSE`, matching the dense path's order (`load_K; load_Q; wait; load_LSE`). #2643 waits ahead of all loads, which gives up the first block's K/Q TMA overlap: arounds +1.2% in my local measurements on long-sequence shapes with a sparse mask, about a third of what PDL buys for this shape. Happy to close this and fold the placement change into #2643 instead if that's preferred.

CC @drisspg (block-sparse backward / flex_attention `backend="FLASH"`).