### PR TITLE
[CuTe, SM90] Support KV128 block-sparse backward for hdim192

### DIFF
--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -185,7 +185,14 @@ class BwdConfig:
     dQ_single_wg: bool = False
 
 
-def _tile_size_bwd_sm90(head_dim, head_dim_v, causal, local, sparse_block_size_q=None):
+def _tile_size_bwd_sm90(
+    head_dim,
+    head_dim_v,
+    causal,
+    local,
+    sparse_block_size_q=None,
+    sparse_block_size_kv=None,
+):
     """Return BwdConfig for SM90.
 
     Configs based on C++ FA3 hopper/flash_bwd_launch_template.h,
@@ -225,9 +232,14 @@ def _tile_size_bwd_sm90(head_dim, head_dim_v, causal, local, sparse_block_size_q
     elif head_dim <= 192:
         hdimv128 = head_dim_v <= 128
         if hdimv128:
+            # Match 128-wide sparse metadata and reduce dO staging when needed to keep
+            # the wider tile under Hopper's shared-memory limit.
+            n_block_size = 128 if (head_dim == 192 and sparse_block_size_kv == 128) else 96
             return BwdConfig(
-                m_block_size=64, n_block_size=96,
-                num_stages_Q=2, num_stages_dO=2, num_stages_PdS=1,
+                m_block_size=64, n_block_size=n_block_size,
+                num_stages_Q=2,
+                num_stages_dO=1 if n_block_size == 128 and head_dim_v > 96 else 2,
+                num_stages_PdS=1,
                 SdP_swapAB=False, dKV_swapAB=True, dQ_swapAB=False,
                 AtomLayoutMSdP=1, AtomLayoutNdKV=2, AtomLayoutMdQ=1,
                 num_wg=2,
@@ -1827,11 +1839,11 @@ def _flash_attn_bwd(
                 else torch.zeros_like(learnable_sink)
             )
             return dq, dk, dv, dsink
-    sparse_q = None
+    sparse_q = sparse_kv = None
     kv_subtile_factor = 1
     if block_sparse_tensors is not None:
         if block_sparse_tensors.block_size is not None:
-            sparse_q = block_sparse_tensors.block_size[0]
+            sparse_q, sparse_kv = block_sparse_tensors.block_size
         elif arch // 10 == 9:
             sparse_q = 128
 
@@ -1875,6 +1887,7 @@ def _flash_attn_bwd(
             causal,
             local,
             sparse_block_size_q=sparse_q,
+            sparse_block_size_kv=sparse_kv,
         )
         m_block_size = cfg.m_block_size
         n_block_size = cfg.n_block_size

--- a/tests/cute/test_mask_mod.py
+++ b/tests/cute/test_mask_mod.py
@@ -282,6 +282,7 @@ def _run_mask_test(
     use_block_sparsity,
     needs_backward=False,
     use_autograd=False,
+    headdim_v=None,
 ):
     torch.manual_seed(42)
 
@@ -310,7 +311,7 @@ def _run_mask_test(
         raise ValueError(f"Unknown kv_mode: {kv_mode}")
 
     batch_size = 1
-    headdim_v = headdim
+    headdim_v = headdim if headdim_v is None else headdim_v
 
     aux_tensors_arg = None
     mask_mod_cute, mask_mod_flex = get_mask_pair(
@@ -1609,6 +1610,28 @@ def run_flex_reference_bwd(q, k, v, block_mask, grad_out, dtype=None):
         dq_ref.transpose(1, 2),
         dk_ref.transpose(1, 2),
         dv_ref.transpose(1, 2),
+    )
+
+
+@pytest.mark.skipif(COMPUTE_CAPABILITY != 9, reason="SM90-only test")
+def test_sm90_block_sparse_bwd_hdim192_hdimv128():
+    _run_mask_test(
+        seqlen_q=257,
+        seqlen_k=257,
+        nheads=2,
+        kv_mode="mha",
+        headdim=192,
+        headdim_v=128,
+        dtype=torch.bfloat16,
+        mask_name="causal",
+        window_size=None,
+        window_left=None,
+        window_right=None,
+        tile_m=128,
+        tile_n=128,
+        use_block_sparsity=True,
+        needs_backward=True,
+        use_autograd=True,
     )
 
 


### PR DESCRIPTION
Human Note
righ tnow we currently fail for blocksparse deepseek shape on hopper this is not perf optimal but it enables it to work and if we wnat to explore more perfomrnat options we can do it in a follow

Agent note
Fixes #2429.

FlexAttention's default BlockMask supplies 128-wide KV metadata, while the Hopper backward selector
always chose a 96-wide tile for head dimension 192. The mismatch made backward fail during metadata
normalization before the kernel could compile.

Select the 128-wide backward tile only for head dimension 192 with matching sparse metadata. Reduce
dO staging when its head dimension would otherwise exceed Hopper's shared-memory limit; the original
96-wide tuned configuration remains unchanged for dense calls and callers supplying 96-wide metadata.

This is a compatibility path, not a performance replacement for N96. On H100 with bf16, fixed warm
tensors, and five interleaved full-backward rounds, the measurements were:

| Workload | N96 with 96-wide metadata | N128 compatibility path |
| --- | ---: | ---: |
| B2/H4/S512/D192/Dv128 | 34.5 us | 49.1 us |
| B1/H8/S4096/D192/Dv128 | 353.1 us | 482.3 us |

The regression test uses the public autograd wrapper, ragged sequence length 257, 128x128 sparse
metadata, and fp32 FlexAttention reference gradients. It fails before this change with the issue's
exact block-size ValueError. Additional exact compiled `backend="FLASH"` checks covered bf16/fp16,
sequence lengths 257/384/512, and value head dimensions 64/128.

Test Plan:

```bash
gpu-run 4 -- env FLASH_ATTENTION_CUTE_DSL_CACHE_ENABLED=1 ~/.venvs/nightly/bin/pytest -q tests/cute/test_mask_mod.py::test_sm90_block_sparse_bwd_hdim192_hdimv128 tests/cute/test_mask_mod.py::test_sm90_block_sparse_bwd_mismatched_q_block_granularity_error_message tests/cute/test_mask_mod.py::test_sm90_block_sparse_infers_block_size tests/cute/test_mask_mod.py::test_sm90_block_sparse_explicit_192_block_size tests/cute/test_score_mod.py::test_sm90_block_sparse_score_mod_backward_with_dq_swapab 'tests/cute/test_flash_attn.py::test_flash_attn_output[128-128-192-False-0-0.0-False-False-False-mha-dtype0]'
~/.venvs/nightly/bin/python -m py_compile flash_attn/cute/interface.py tests/cute/test_mask_mod.py
~/.venvs/nightly/bin/ruff check --select E9,F63,F7,F82 flash_attn/cute/interface.py tests/cute/test_mask_mod.py
git diff --check
```
