### PR TITLE
[CuTe, SM120] Support automatic num_splits

### DIFF
--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -367,7 +367,8 @@ def _get_fwd_config(
         132 if is_fake_mode() else torch.cuda.get_device_properties(device).multi_processor_count
     )
     if arch // 10 == 12:
-        assert num_splits == 1, "SM120 forward only supports num_splits=1"
+        assert num_splits <= 1, "SM120 forward only supports num_splits=1"
+        num_splits = 1
     elif num_splits < 1:
         num_splits = num_splits_heuristic(total_mblocks, num_SMs, num_n_blocks, 128)
 

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -365,7 +365,8 @@ def _get_fwd_config(
     num_n_blocks = (seqlen_k_loaded + tile_n - 1) // tile_n
     num_SMs = None
     if arch // 10 == 12:
-        assert num_splits == 1, "SM120 forward only supports num_splits=1"
+        assert num_splits <= 1, "SM120 forward only supports num_splits=1"
+        num_splits = 1
     elif num_splits < 1:
         num_SMs = get_num_sms_for_selection(device.index, arch)
         num_splits = num_splits_heuristic(total_mblocks, num_SMs, num_n_blocks, 128)

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -98,10 +98,13 @@ VERBOSE = True
 
 
 @pytest.mark.skipif(not IS_SM120, reason="SM120-only SplitKV unsupported behavior")
-def test_flash_attn_sm120_rejects_splitkv():
+def test_flash_attn_sm120_num_splits():
     q = torch.randn(1, 16, 4, 64, device="cuda", dtype=torch.bfloat16)
     k = torch.randn(1, 16, 1, 64, device="cuda", dtype=torch.bfloat16)
     v = torch.randn(1, 16, 1, 64, device="cuda", dtype=torch.bfloat16)
+    out = flash_attn_func(q, k, v)
+    out_auto = flash_attn_func(q, k, v, num_splits=0)
+    torch.testing.assert_close(out_auto, out)
     with pytest.raises(AssertionError, match="SM120 forward only supports num_splits=1"):
         flash_attn_func(q, k, v, num_splits=3)
 

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -97,10 +97,13 @@ VERBOSE = True
 
 
 @pytest.mark.skipif(not IS_SM120, reason="SM120-only SplitKV unsupported behavior")
-def test_flash_attn_sm120_rejects_splitkv():
+def test_flash_attn_sm120_num_splits():
     q = torch.randn(1, 16, 4, 64, device="cuda", dtype=torch.bfloat16)
     k = torch.randn(1, 16, 1, 64, device="cuda", dtype=torch.bfloat16)
     v = torch.randn(1, 16, 1, 64, device="cuda", dtype=torch.bfloat16)
+    out = flash_attn_func(q, k, v)
+    out_auto = flash_attn_func(q, k, v, num_splits=0)
+    torch.testing.assert_close(out_auto, out)
     with pytest.raises(AssertionError, match="SM120 forward only supports num_splits=1"):
         flash_attn_func(q, k, v, num_splits=3)
 


### PR DESCRIPTION
## Summary

SM120 does not support SplitKV, so `num_splits=1` is its only executable configuration. Automatic selection (`num_splits <= 0`) currently asserts instead of choosing that configuration. This surfaced because `benchmarks/benchmark_attn.py` uses `num_splits=0` by default.

- resolve automatic values to `1` on SM120
- keep rejecting SplitKV requests greater than `1`
- cover default, automatic, and unsupported values in the existing SM120 test

## Testing

```bash
PYTHONPATH=$PWD FLASH_ATTENTION_CUTE_DSL_CACHE_ENABLED=1 \
  pytest -q tests/cute/test_flash_attn.py -k sm120_num_splits
```

Result on RTX 5070 Ti (SM120), rebased onto `main` at `145b101`: `1 passed, 415817 deselected`.

```bash
PYTHONPATH=$PWD FLASH_ATTENTION_CUTE_DSL_CACHE_ENABLED=1 \
  python benchmarks/benchmark_attn.py --backend fa2,fa4 --fwd \
  --headdim 128 --seqlen 1k --causal false --warmup 5 --rep 20
```

Stock benchmark completes without the `--num-splits 1` workaround.
