### PR TITLE
[CuTe, SM100] Fix deadlock in varlen + block-sparse + SplitKV forward

### DIFF
--- a/flash_attn/cute/flash_fwd_sm100.py
+++ b/flash_attn/cute/flash_fwd_sm100.py
@@ -1650,6 +1650,12 @@ class FlashAttentionForwardSm100:
                             kv_producer_state.advance()
 
             else:
+                # Match the dense path (get_n_block_min_max): the scheduler packs the
+                # per-batch dynamic num_splits into the top 16 bits of split_idx.
+                num_splits_dyn = num_splits
+                if const_expr(self.is_split_kv and block_info.pack_split_idx):
+                    num_splits_dyn = split_idx >> 16
+                    split_idx = split_idx & 0xFFFF
                 kv_producer_state, q_producer_phase = produce_block_sparse_loads_sm100(
                     blocksparse_tensors,
                     batch_idx,
@@ -1657,7 +1663,7 @@ class FlashAttentionForwardSm100:
                     m_block,
                     seqlen,
                     split_idx,
-                    num_splits,
+                    num_splits_dyn,
                     kv_producer_state,
                     load_Q,
                     load_K,
@@ -1804,13 +1810,18 @@ class FlashAttentionForwardSm100:
             process_tile = False
 
             if const_expr(self.use_block_sparsity):
+                # See the load warp: unpack dynamic num_splits packed by the scheduler.
+                num_splits_dyn = num_splits
+                if const_expr(self.is_split_kv and block_info.pack_split_idx):
+                    num_splits_dyn = split_idx >> 16
+                    split_idx = split_idx & 0xFFFF
                 block_iter_count = get_total_block_count(
                     blocksparse_tensors,
                     batch_idx,
                     head_idx,
                     m_block,
                     split_idx,
-                    num_splits,
+                    num_splits_dyn,
                     self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
                     self.q_subtile_factor,
                     seqlen_info=seqlen,
@@ -2106,7 +2117,10 @@ class FlashAttentionForwardSm100:
             n_block_min, n_block_max = block_info.get_n_block_min_max(
                 seqlen, m_block, split_idx=split_idx, num_splits=num_splits,
             )
+            # Keep the dynamic num_splits for the block-sparse helpers below.
+            num_splits_dyn = num_splits
             if const_expr(self.is_split_kv and block_info.pack_split_idx):
+                num_splits_dyn = split_idx >> 16
                 split_idx = split_idx & 0xFFFF
 
             mask = AttentionMaskCls(seqlen)
@@ -2193,7 +2207,7 @@ class FlashAttentionForwardSm100:
                     head_idx,
                     m_block,
                     split_idx,
-                    num_splits,
+                    num_splits_dyn,
                     self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
                     self.q_subtile_factor,
                     seqlen_info=seqlen,
@@ -2255,7 +2269,7 @@ class FlashAttentionForwardSm100:
                     m_block,
                     seqlen,
                     split_idx,
-                    num_splits,
+                    num_splits_dyn,
                     softmax_step,
                     mask_fn,
                     mask_fn_none,
@@ -2610,7 +2624,10 @@ class FlashAttentionForwardSm100:
             n_block_min, n_block_max = block_info.get_n_block_min_max(
                 seqlen, m_block, split_idx=split_idx, num_splits=num_splits,
             )
+            # Keep the dynamic num_splits for the block-sparse helper below.
+            num_splits_dyn = num_splits
             if const_expr(self.is_split_kv and block_info.pack_split_idx):
+                num_splits_dyn = split_idx >> 16
                 split_idx = split_idx & 0xFFFF
 
             if const_expr(self.is_split_kv):
@@ -2636,7 +2653,7 @@ class FlashAttentionForwardSm100:
                     head_idx,
                     m_block,
                     split_idx,
-                    num_splits,
+                    num_splits_dyn,
                     self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
                     self.q_subtile_factor,
                     seqlen_info=seqlen,


### PR DESCRIPTION
https://github.com/Dao-AILab/flash-attention/issues/2760

When scheduler metadata provides per-batch dynamic num_splits, the varlen tile schedulers pack num_splits into the top 16 bits of split_idx. The dense path unpacks it inside BlockInfo.get_n_block_min_max, but the SM100 block-sparse paths pass split_idx to the block-sparse helpers as is: the load and MMA warps passed the packed value, for which split_block_range yields an empty block range, while the softmax and correction warps passed the unpacked value, yielding a non-empty range. The warps then disagree on whether a tile has work, the softmax/correction/MMA mbarrier handshake never completes, and the kernel spins forever. Every varlen + block-sparse
+ SplitKV forward hangs this way.

Also pass the dynamic per-batch num_splits (instead of the static maximum) to the block-sparse helpers so the split ranges cover the whole block list, matching the dense path.