### PR TITLE
[CuTe, Fwd] Fix forward compile key churn when max_seqlen is a tensor

### DIFF
--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -1055,13 +1055,19 @@ def _flash_attn_fwd(
             cu_total_m_blocks.device,
         )
 
+    # Tensor max_seqlen values (e.g. HF varlen) must not leak into the compile key:
+    # tensor identity changes on every call and defeats the JIT cache.
     is_static_persistent = (
         not causal
         and not local
         and cu_seqlens_q is None
         and seqused_q is None
         and not is_split_kv
-    ) or (max_m_blocks_leq_one and not is_split_kv)
+    ) or (
+        not torch.is_tensor(max_m_blocks_leq_one)
+        and max_m_blocks_leq_one
+        and not is_split_kv
+    )
 
     compile_key = (
         dtype,

--- a/tests/cute/test_flash_attn_fast.py
+++ b/tests/cute/test_flash_attn_fast.py
@@ -7,20 +7,21 @@ import random
 
 import pytest
 import torch
-
 from einops import rearrange
 
-from flash_attn.cute.testing import (
-    attention_ref,
-    generate_random_padding_mask,
-    generate_qkv,
-    maybe_fake_tensor_mode,
-    is_fake_mode,
-)
+from flash_attn.cute.cache_utils import JITCache
 from flash_attn.cute.interface import (
+    _flash_attn_fwd,
+    flash_attn_combine,
     flash_attn_func,
     flash_attn_varlen_func,
-    flash_attn_combine,
+)
+from flash_attn.cute.testing import (
+    attention_ref,
+    generate_qkv,
+    generate_random_padding_mask,
+    is_fake_mode,
+    maybe_fake_tensor_mode,
 )
 
 USE_FAKE_TENSOR = int(os.getenv("FLASH_ATTENTION_FAKE_TENSOR", 0)) == 1
@@ -107,6 +108,54 @@ def test_flash_attn_output(seqlen_q, seqlen_k, d, causal, num_splits, mha_type, 
 # ---------------------------------------------------------------------------
 # Forward + backward (varlen with cu_seqlens)
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(USE_FAKE_TENSOR, reason="requires a data-dependent CUDA max")
+def test_flash_attn_varlen_tensor_max_seqlen_reuses_fwd_cache():
+    """A fresh CUDA scalar max_seqlen must not create a new compile key."""
+    device = "cuda"
+    dtype = torch.bfloat16
+    seqlens = torch.tensor([384, 320], dtype=torch.int32, device=device)
+    cu_seqlens = torch.cat(
+        [
+            torch.zeros(1, dtype=torch.int32, device=device),
+            seqlens.cumsum(0, dtype=torch.int32),
+        ]
+    )
+    total = int(cu_seqlens[-1].item())
+    q = torch.randn(total, 2, 64, device=device, dtype=dtype)
+    k = torch.randn_like(q)
+    v = torch.randn_like(q)
+
+    original_cache = _flash_attn_fwd.compile_cache
+    test_cache = JITCache()
+    _flash_attn_fwd.compile_cache = test_cache
+    try:
+        outputs = []
+        for _ in range(2):
+            max_seqlen = (cu_seqlens[1:] - cu_seqlens[:-1]).max()
+            out, _ = flash_attn_varlen_func(
+                q,
+                k,
+                v,
+                cu_seqlens_q=cu_seqlens,
+                cu_seqlens_k=cu_seqlens,
+                max_seqlen_q=max_seqlen,
+                max_seqlen_k=max_seqlen,
+            )
+            outputs.append(out)
+
+        assert torch.equal(outputs[0], outputs[1])
+        assert len(test_cache.cache) == 1
+        assert all(
+            not torch.is_tensor(value)
+            for key in test_cache.cache
+            for value in key
+        )
+    finally:
+        test_cache.clear()
+        _flash_attn_fwd.compile_cache = original_cache
+
 
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 @pytest.mark.parametrize("mha_type", ["mha", "gqa", "mqa"])


### PR DESCRIPTION
## Problem

When `max_seqlen_q` / `max_seqlen_k` are CUDA tensors, as in Hugging Face varlen and padding-free attention, `_flash_attn_fwd` can place a fresh 0-D tensor in its compile key. Identical forward calls then miss the JIT cache and recompile on every invocation, significantly slowing down training.

This is the forward counterpart of #2507.

### Root Cause
`max_m_blocks_leq_one` inherits the tensor type from `max_seqlen_q`:

```python
max_m_blocks_leq_one = seqlen_q_packgqa <= q_stage * tile_m
```

When this predicate is false, the Python boolean expression used to compute is_static_persistent can return the tensor itself instead of a Python bool. Since is_static_persistent is included in the forward compile key, each newly created tensor produces a different cache key.

## Fix

Only use the `max_m_blocks_leq_one` static-persistent shortcut when the predicate is not a tensor.

This keeps the compile key host-scalar-only and avoids calling `.item()`, so the fix does not introduce a CPU-GPU synchronization. Tensor-valued callers conservatively use the non-static-persistent path.

## Verification
Added a regression test that:

- computes a fresh CUDA tensor max_seqlen for each call;
- invokes varlen forward twice with identical inputs;
- verifies that both outputs are identical;
- verifies that the forward compile cache contains only one entry;
- verifies that no tensor is present in the compile key.

Tested on NVIDIA RTX PRO 6000 Blackwell (SM120):

```bash
CUDA_VISIBLE_DEVICES=0 \
FLASH_ATTENTION_CUTE_DSL_CACHE_ENABLED=1 \
pytest -q -s \
tests/cute/test_flash_attn_fast.py::test_flash_attn_varlen_tensor_max_seqlen_reuses_fwd_cache
```

Result:
1 passed

The full FakeTensor fast suite also passes:
192 passed, 49 skipped