### PR TITLE
[CuTe, SM120] Optimize backward on consumer Blackwell

### DIFF
--- a/flash_attn/cute/flash_bwd.py
+++ b/flash_attn/cute/flash_bwd.py
@@ -17,6 +17,7 @@ import cutlass.utils as utils_basic
 from quack import layout_utils
 from flash_attn.cute import ampere_helpers as sm80_utils
 from flash_attn.cute.cute_dsl_utils import assume_tensor_aligned
+from flash_attn.cute import copy_utils
 from flash_attn.cute import utils
 from flash_attn.cute.mask import AttentionMask
 from flash_attn.cute.softmax import call_score_mod, call_score_mod_bwd
@@ -52,6 +53,7 @@ class FlashAttentionBackwardSm80:
         V_in_regs: bool = False,
         score_mod: cutlass.Constexpr | None = None,
         score_mod_bwd: cutlass.Constexpr | None = None,
+        skip_full_causal_mask: bool = False,
     ):
         """Initializes the configuration for a flash attention v2 kernel.
 
@@ -100,6 +102,7 @@ class FlashAttentionBackwardSm80:
         self.share_QV_smem = V_in_regs
         self.score_mod = score_mod
         self.score_mod_bwd = score_mod_bwd
+        self.skip_full_causal_mask = skip_full_causal_mask
 
     @staticmethod
     def can_implement(
@@ -211,10 +214,23 @@ class FlashAttentionBackwardSm80:
             sdO_layout_atom, (self.m_block_size, self.head_dim_v_padded, self.num_stages_dO), (0, 1, 2),
         )
         # TODO: do we set swizzle to be 3 here explicitly?
-        sPdS_layout_atom = sm80_utils.get_smem_layout_atom(self.dtype, self.n_block_size)
-        self.sPdS_layout = cute.tile_to_shape(
-            sPdS_layout_atom, (self.m_block_size, self.n_block_size), (0, 1),
-        )
+        if cutlass.const_expr(not self.SdP_swapAB):
+            sPdS_layout_atom = sm80_utils.get_smem_layout_atom(self.dtype, self.n_block_size)
+            self.sPdS_layout = cute.tile_to_shape(
+                sPdS_layout_atom, (self.m_block_size, self.n_block_size), (0, 1),
+            )
+        else:
+            # SdP_swapAB: the SdP accumulator is (n, m)-shaped, so store P/dS
+            # TRANSPOSED in smem, i.e. physically (n_block, m_block) with rows
+            # contiguous along m. The r2s copy (tiled over the swapped
+            # tiled_mma_sdp C layout) then composes without any transposed
+            # store, the dK/dV gemms read their (n, k=m) A-operand directly
+            # (non-transposed ldmatrix), and the dQ gemm reads dS as (m, n)
+            # through a transpose_view with the transposed ldmatrix atom.
+            sPdS_layout_atom = sm80_utils.get_smem_layout_atom(self.dtype, self.m_block_size)
+            self.sPdS_layout = cute.tile_to_shape(
+                sPdS_layout_atom, (self.n_block_size, self.m_block_size), (0, 1),
+            )
         # We set stride to be multiple of 64 so that if ShuffleLSE, even if threads read from sLSE but out of bounds,
         # it's still a valid smem address.
         self.sLSE_layout = cute.make_layout(
@@ -296,12 +312,20 @@ class FlashAttentionBackwardSm80:
             cute.make_layout(self.num_threads),
             cute.make_layout(async_copy_elems_accum),
         )
+        # The 256-thread SM120 dQ MMA distributes each lane's C fragment as
+        # four contiguous fp32 values. Preserve that grouping in the global
+        # accumulator so the 128-thread postprocess can reconstruct it.
+        dQaccum_values_per_thread = (
+            4 if cutlass.const_expr(getattr(self, "arch", 80) == 120) else 1
+        )
         self.gmem_tiled_copy_dQaccum = cute.make_tiled_copy_tv(
             cute.make_copy_atom(
-                cute.nvgpu.CopyUniversalOp(), cutlass.Float32, num_bits_per_copy=cutlass.Float32.width
+                cute.nvgpu.CopyUniversalOp(),
+                cutlass.Float32,
+                num_bits_per_copy=dQaccum_values_per_thread * cutlass.Float32.width,
             ),
             cute.make_layout(self.num_threads),
-            cute.make_layout(1)
+            cute.make_layout(dQaccum_values_per_thread),
         )
         if cutlass.const_expr(self.qhead_per_kvhead > 1):
             self.gmem_tiled_copy_dK = self.gmem_tiled_copy_dQaccum
@@ -623,7 +647,17 @@ class FlashAttentionBackwardSm80:
             sdPsumMma = storage.sdPsum.get_tensor(sLSEMma_layout)
 
             # Transpose view of tensors for tiled mma
-            sQt, sdOt, sKt, sPt, sdSt = [layout_utils.transpose_view(t) for t in (sQ, sdO, sK, sP, sdS)]
+            sQt, sdOt, sKt = [layout_utils.transpose_view(t) for t in (sQ, sdO, sK)]
+            if cutlass.const_expr(not self.SdP_swapAB):
+                sPt, sdSt = [layout_utils.transpose_view(t) for t in (sP, sdS)]
+                sdS_dQ_view = sdS
+            else:
+                # P/dS are stored transposed in smem (physically (n, m)), so the
+                # (n, k=m) A-operand views for the dK/dV gemms are the tensors
+                # themselves, while the dQ gemm's (m, k=n) dS view is the
+                # transpose_view (read with the transposed ldmatrix atom).
+                sPt, sdSt = sP, sdS
+                sdS_dQ_view = layout_utils.transpose_view(sdS)
 
             gmem_thr_copy_QK = gmem_tiled_copy_QK.get_slice(tidx)
             gmem_thr_copy_VdO = gmem_tiled_copy_VdO.get_slice(tidx)
@@ -668,7 +702,7 @@ class FlashAttentionBackwardSm80:
             tdVrdO = utils.mma_make_fragment_B(sdOt[None, None, 0], thr_mma_dkv, swapAB=self.dKV_swapAB)
             tdKrdS = utils.mma_make_fragment_A(sdSt, thr_mma_dkv, swapAB=self.dKV_swapAB)
             tdKrQ = utils.mma_make_fragment_B(sQt[None, None, 0], thr_mma_dkv, swapAB=self.dKV_swapAB)
-            tdQrdS = utils.mma_make_fragment_A(sdS, thr_mma_dq, swapAB=self.dQ_swapAB)
+            tdQrdS = utils.mma_make_fragment_A(sdS_dQ_view, thr_mma_dq, swapAB=self.dQ_swapAB)
             tdQrK = utils.mma_make_fragment_B(sKt, thr_mma_dq, swapAB=self.dQ_swapAB)
 
             LSEslice = (None, 0, None) if cutlass.const_expr(not self.SdP_swapAB) else (0, None, None)
@@ -690,15 +724,20 @@ class FlashAttentionBackwardSm80:
             smem_thr_copy_KV = utils.make_tiled_copy_B(
                 smem_copy_atom, tiled_mma_sdp, swapAB=self.SdP_swapAB
             ).get_slice(tidx)
-            # TODO: should this be smem_copy_atom_transposed?
+            # When SdP_swapAB, P/dS live transposed in smem (physically (n, m),
+            # contiguous along m=k of the dK/dV gemms), so their A-operand reads
+            # use the NON-transposed ldmatrix atom; conversely the dQ gemm reads
+            # dS as (m, n) through a transpose_view, needing the transposed atom.
             smem_thr_copy_PdSt = utils.make_tiled_copy_A(
-                smem_copy_atom_transposed, tiled_mma_dkv, swapAB=self.dKV_swapAB
+                smem_copy_atom_transposed if cutlass.const_expr(not self.SdP_swapAB) else smem_copy_atom,
+                tiled_mma_dkv, swapAB=self.dKV_swapAB
             ).get_slice(tidx)
             smem_thr_copy_QdOt = utils.make_tiled_copy_B(
                 smem_copy_atom_transposed, tiled_mma_dkv, swapAB=self.dKV_swapAB
             ).get_slice(tidx)
             smem_thr_copy_dS = utils.make_tiled_copy_A(
-                smem_copy_atom, tiled_mma_dq, swapAB=self.dQ_swapAB
+                smem_copy_atom if cutlass.const_expr(not self.SdP_swapAB) else smem_copy_atom_transposed,
+                tiled_mma_dq, swapAB=self.dQ_swapAB
             ).get_slice(tidx)
             smem_thr_copy_Kt = utils.make_tiled_copy_B(
                 smem_copy_atom_transposed, tiled_mma_dq, swapAB=self.dQ_swapAB
@@ -719,7 +758,7 @@ class FlashAttentionBackwardSm80:
             tdKsdSt = smem_thr_copy_PdSt.partition_S(sdSt)
             tdVsdOt = smem_thr_copy_QdOt.partition_S(sdOt)
             tdKsQt = smem_thr_copy_QdOt.partition_S(sQt)
-            tdQsdS = smem_thr_copy_dS.partition_S(sdS)
+            tdQsdS = smem_thr_copy_dS.partition_S(sdS_dQ_view)
             tdQsKt = smem_thr_copy_Kt.partition_S(sKt)
             tPsP = r2s_thr_copy_PdS.partition_D(sP)
             tdSsdS = r2s_thr_copy_PdS.partition_D(sdS)
@@ -837,12 +876,24 @@ class FlashAttentionBackwardSm80:
                 # Mainloop
                 # ///////////////////////////////////////////////////////////////////////////////
                 # Start processing of the first n-block.
+                if cutlass.const_expr(getattr(self, "arch", 80) == 120):
+                    num_mma_warps_sdp = self.num_threads // cute.arch.WARP_SIZE
+                    n_warps_sdp = (
+                        num_mma_warps_sdp // self.AtomLayoutMSdP
+                        if not self.SdP_swapAB
+                        else self.AtomLayoutMSdP
+                    )
+                    r2p_compatible = cutlass.const_expr(n_warps_sdp == 1)
+                else:
+                    r2p_compatible = cutlass.const_expr(True)
                 mask = AttentionMask(
                     self.m_block_size,
                     self.n_block_size,
                     seqlen,
                     window_size_left,
                     window_size_right,
+                    swap_AB=self.SdP_swapAB,
+                    r2p_compatible=r2p_compatible,
                 )
                 mask_fn = partial(
                     mask.apply_mask, n_block=n_block, thr_mma=thr_mma_sdp,
@@ -853,7 +904,21 @@ class FlashAttentionBackwardSm80:
                 smem_pipe_read_do = cutlass.Int32(0)
                 smem_pipe_write_q = cutlass.Int32(self.num_stages_Q - 1)
                 smem_pipe_write_do = cutlass.Int32(0)
-                for m_tile in cutlass.range(m_block_min, m_block_max, unroll=1):
+                masked_m_block_max = m_block_max
+                if cutlass.const_expr(self.skip_full_causal_mask and self.is_causal):
+                    full_valid_m_block_min = cute.ceil_div(
+                        n_block * self.n_block_size
+                        + self.n_block_size
+                        - 1
+                        + seqlen.seqlen_q
+                        - seqlen.seqlen_k,
+                        self.m_block_size,
+                    )
+                    masked_m_block_max = min(
+                        max(full_valid_m_block_min, m_block_min), m_block_max
+                    )
+
+                for m_tile in cutlass.range(m_block_min, masked_m_block_max, unroll=1):
                     compute_one_m_block(
                         m_tile, smem_pipe_read_q, smem_pipe_read_do, smem_pipe_write_q, smem_pipe_write_do,
                         mask_fn=mask_fn,
@@ -862,6 +927,28 @@ class FlashAttentionBackwardSm80:
                     smem_pipe_read_do = self.advance_pipeline(smem_pipe_read_do, self.num_stages_dO)
                     smem_pipe_write_q = self.advance_pipeline(smem_pipe_write_q, self.num_stages_Q)
                     smem_pipe_write_do = self.advance_pipeline(smem_pipe_write_do, self.num_stages_dO)
+                if cutlass.const_expr(self.skip_full_causal_mask and self.is_causal):
+                    for m_tile in cutlass.range(masked_m_block_max, m_block_max, unroll=1):
+                        compute_one_m_block(
+                            m_tile,
+                            smem_pipe_read_q,
+                            smem_pipe_read_do,
+                            smem_pipe_write_q,
+                            smem_pipe_write_do,
+                            mask_fn=None,
+                        )
+                        smem_pipe_read_q = self.advance_pipeline(
+                            smem_pipe_read_q, self.num_stages_Q
+                        )
+                        smem_pipe_read_do = self.advance_pipeline(
+                            smem_pipe_read_do, self.num_stages_dO
+                        )
+                        smem_pipe_write_q = self.advance_pipeline(
+                            smem_pipe_write_q, self.num_stages_Q
+                        )
+                        smem_pipe_write_do = self.advance_pipeline(
+                            smem_pipe_write_do, self.num_stages_dO
+                        )
 
             # ///////////////////////////////////////////////////////////////////////////////
             # Epilogue
@@ -929,8 +1016,10 @@ class FlashAttentionBackwardSm80:
         cute.autovec_copy(
             smem_copy_params.tSsLSEMma[None, smem_pipe_read_q if cutlass.const_expr(self.num_stages_Q > 1) else 0], tLSErLSE
         )
-        acc_S_mn = layout_utils.reshape_acc_to_mn(acc_S)
-        acc_S_pre_mn = layout_utils.reshape_acc_to_mn(acc_S_pre)
+        # With SdP_swapAB the accumulator is (n, m)-shaped; transpose the mn view
+        # so mode 0 is always the query-row dim (LSE/dPsum are indexed per row).
+        acc_S_mn = layout_utils.reshape_acc_to_mn(acc_S, transpose=self.SdP_swapAB)
+        acc_S_pre_mn = layout_utils.reshape_acc_to_mn(acc_S_pre, transpose=self.SdP_swapAB)
         if cutlass.const_expr(self.score_mod is not None):
             for r in cutlass.range(cute.size(acc_S_mn, mode=[0]), unroll_full=True):
                 acc_S_mn[r, None].store(
@@ -966,13 +1055,14 @@ class FlashAttentionBackwardSm80:
             smem_copy_params.tdPsV,
             smem_copy_params.smem_thr_copy_QdO, smem_copy_params.smem_thr_copy_KV,
             hook_fn=load_Q_next if cutlass.const_expr(self.num_stages_Q > 1) else None,
+            B_in_regs=self.V_in_regs,
             swap_AB=self.SdP_swapAB,
         )
         tLSErdPsum = cute.make_fragment_like(smem_copy_params.tSsdPsumMma[None, 0])
         cute.autovec_copy(
             smem_copy_params.tSsdPsumMma[None, smem_pipe_read_do if cutlass.const_expr(self.num_stages_dO > 1) else 0], tLSErdPsum
         )
-        acc_dP_mn = layout_utils.reshape_acc_to_mn(acc_dP)
+        acc_dP_mn = layout_utils.reshape_acc_to_mn(acc_dP, transpose=self.SdP_swapAB)
         # if cute.arch.thread_idx()[0] == 0 and cute.arch.block_idx()[0] == bidx: cute.print_tensor(acc_dP_mn)
         assert cute.size(acc_dP_mn, mode=[0]) == cute.size(tLSErdPsum)
         for r in cutlass.range(cute.size(acc_dP_mn, mode=[0]), unroll_full=True):
@@ -1001,9 +1091,11 @@ class FlashAttentionBackwardSm80:
         if cutlass.const_expr(not self.Mma_dKV_is_RS):
             cute.arch.barrier()  # Make sure P is written
         # For hdim 64, It's faster to write to smem_dS first before the dV gemm
-        if cutlass.const_expr(not self.Mma_dKV_is_RS):
-            tdSrdS = smem_copy_params.r2s_thr_copy_PdS.retile(rdS)
-            cute.copy(smem_copy_params.r2s_thr_copy_PdS, tdSrdS, smem_copy_params.tdSsdS)
+        # NOTE: even in RS mode (dK/dV consume P/dS straight from registers),
+        # dS must still be staged to smem because the dQ gemm always reads its
+        # A operand from sdS. Only the sP write is skipped in RS mode.
+        tdSrdS = smem_copy_params.r2s_thr_copy_PdS.retile(rdS)
+        cute.copy(smem_copy_params.r2s_thr_copy_PdS, tdSrdS, smem_copy_params.tdSsdS)
         if cutlass.const_expr(self.Mma_dKV_is_RS):
             tdVrP = layout_utils.reshape_acc_to_frgA(rP)
         else:
@@ -1039,9 +1131,22 @@ class FlashAttentionBackwardSm80:
             acc_dQ_atomic = gmem_copy_params.gmem_thr_copy_dQaccum.retile(acc_dQ)
             tdQgdQaccum_atomic = gmem_copy_params.tdQgdQaccum[None, None, m_block]
             assert cute.size(acc_dQ_atomic) == cute.size(tdQgdQaccum_atomic)
-            for i in cutlass.range(cute.size(acc_dQ_atomic), unroll_full=True):
-                utils.atomic_add_fp32(acc_dQ_atomic[i], utils.elem_pointer(tdQgdQaccum_atomic, i))
-                # utils.atomic_add_fp32(acc_dQ[i], tdQgdQaccum_atomic.iterator + i * tdQgdQaccum_atomic.stride[1])
+            if cutlass.const_expr(getattr(self, "arch", 80) == 120):
+                num_atomic_values = cute.size(acc_dQ_atomic)
+                assert num_atomic_values % 4 == 0
+                for i in cutlass.range(0, num_atomic_values, 4, unroll_full=True):
+                    copy_utils.atomic_add_fp32x4(
+                        acc_dQ_atomic[i],
+                        acc_dQ_atomic[i + 1],
+                        acc_dQ_atomic[i + 2],
+                        acc_dQ_atomic[i + 3],
+                        utils.elem_pointer(tdQgdQaccum_atomic, i),
+                    )
+            else:
+                for i in cutlass.range(cute.size(acc_dQ_atomic), unroll_full=True):
+                    utils.atomic_add_fp32(
+                        acc_dQ_atomic[i], utils.elem_pointer(tdQgdQaccum_atomic, i)
+                    )
             # if cute.arch.thread_idx()[0] == 64 and cute.arch.block_idx()[0] == bidx: cute.print_tensor(acc_dQ)
 
         # If num_stages_Q == 1, we want to do Mma_dK first so we can start loading Q for the next iteration
@@ -1179,7 +1284,9 @@ class FlashAttentionBackwardSm80:
             if cutlass.const_expr(not seqlen.has_cu_seqlens_k):
                 mdK_cur, mdV_cur = [t[batch_idx, head_idx_kv, None] for t in (mdK, mdV)]
             else:
-                padded_offset_k = seqlen.offset_k + batch_idx * self.n_block_size
+                # Match the padded sequence base used by the dK/dV
+                # postprocess. Raw offset_k can start part-way through a tile.
+                padded_offset_k = seqlen.padded_offset_k
                 mdK_cur = cute.domain_offset((padded_offset_k * self.head_dim_padded,), mdK[head_idx_kv, None])
                 mdV_cur = cute.domain_offset((padded_offset_k * self.head_dim_v_padded,), mdV[head_idx_kv, None])
 
@@ -1191,10 +1298,35 @@ class FlashAttentionBackwardSm80:
             acc_dK_atomic = gmem_thr_copy_dK.retile(acc_dK)
             assert cute.size(acc_dV_atomic) == cute.size(tdVgdVaccum)
             assert cute.size(acc_dK_atomic) == cute.size(tdKgdKaccum)
-            for i in cutlass.range(cute.size(acc_dV_atomic), unroll_full=True):
-                utils.atomic_add_fp32(acc_dV_atomic[i], utils.elem_pointer(tdVgdVaccum, i))
-            for i in cutlass.range(cute.size(acc_dK_atomic), unroll_full=True):
-                utils.atomic_add_fp32(acc_dK_atomic[i], utils.elem_pointer(tdKgdKaccum, i))
+            if cutlass.const_expr(getattr(self, "arch", 80) == 120):
+                num_dv_values = cute.size(acc_dV_atomic)
+                num_dk_values = cute.size(acc_dK_atomic)
+                assert num_dv_values % 4 == 0 and num_dk_values % 4 == 0
+                for i in cutlass.range(0, num_dv_values, 4, unroll_full=True):
+                    copy_utils.atomic_add_fp32x4(
+                        acc_dV_atomic[i],
+                        acc_dV_atomic[i + 1],
+                        acc_dV_atomic[i + 2],
+                        acc_dV_atomic[i + 3],
+                        utils.elem_pointer(tdVgdVaccum, i),
+                    )
+                for i in cutlass.range(0, num_dk_values, 4, unroll_full=True):
+                    copy_utils.atomic_add_fp32x4(
+                        acc_dK_atomic[i],
+                        acc_dK_atomic[i + 1],
+                        acc_dK_atomic[i + 2],
+                        acc_dK_atomic[i + 3],
+                        utils.elem_pointer(tdKgdKaccum, i),
+                    )
+            else:
+                for i in cutlass.range(cute.size(acc_dV_atomic), unroll_full=True):
+                    utils.atomic_add_fp32(
+                        acc_dV_atomic[i], utils.elem_pointer(tdVgdVaccum, i)
+                    )
+                for i in cutlass.range(cute.size(acc_dK_atomic), unroll_full=True):
+                    utils.atomic_add_fp32(
+                        acc_dK_atomic[i], utils.elem_pointer(tdKgdKaccum, i)
+                    )
 
     @cute.jit
     def advance_pipeline(self, pipeline_index, num_stages: cutlass.Constexpr):

--- a/flash_attn/cute/flash_bwd_postprocess.py
+++ b/flash_attn/cute/flash_bwd_postprocess.py
@@ -159,7 +159,15 @@ class FlashAttentionBackwardPostprocess:
             cute.make_layout(self.num_threads),
             cute.make_layout(async_copy_elems_accum),
         )
-        num_s2r_copy_elems = 1 if const_expr(self.arch // 10 in [8, 12]) else 4
+        # SM120's 256-thread main kernel writes each lane's dQ accumulator as
+        # four contiguous fp32 values. Read the same four-value grouping back
+        # before reinterpreting it as the MMA accumulator fragment.
+        if const_expr(self.arch // 10 == 12):
+            num_s2r_copy_elems = 4
+        elif const_expr(self.arch // 10 == 8):
+            num_s2r_copy_elems = 1
+        else:
+            num_s2r_copy_elems = 4
         if const_expr(self.arch // 10 in [8, 12]):
             self.s2r_tiled_copy_dQaccum = copy_utils.tiled_copy_1d(
                 Float32, self.num_threads, num_s2r_copy_elems
@@ -630,8 +638,14 @@ class FlashAttentionBackwardPostprocess:
                 # Step 3: Copy dQ from register to smem
                 cute.arch.barrier()  # make sure all threads have finished loading dQaccum
                 if const_expr(self.arch // 10 in [8, 9, 12]):
+                    # SM120 uses the SM80 MMA register layout, so its R->S
+                    # mapping must use the universal SM80 copy rather than the
+                    # stmatrix path selected for native SM90 MMA fragments.
+                    store_atom_arch = (
+                        80 if const_expr(self.arch // 10 in [8, 12]) else self.arch
+                    )
                     copy_atom_r2s_dQ = utils.get_smem_store_atom(
-                        self.arch, self.dtype, transpose=self.dQ_swapAB
+                        store_atom_arch, self.dtype, transpose=self.dQ_swapAB
                     )
                     tiled_copy_r2s_dQ = cute.make_tiled_copy_C(copy_atom_r2s_dQ, tiled_mma)
                 else:

--- a/flash_attn/cute/flash_bwd_sm120.py
+++ b/flash_attn/cute/flash_bwd_sm120.py
@@ -12,6 +12,9 @@ from flash_attn.cute.flash_bwd import FlashAttentionBackwardSm80
 
 
 class FlashAttentionBackwardSm120(FlashAttentionBackwardSm80):
+    # Marker for SM120-only correctness paths shared with the SM80 kernel.
+    arch: int = 120
+
     @staticmethod
     def can_implement(
         dtype,

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -1888,27 +1888,89 @@ def _flash_attn_bwd(
         causal, window_size_left, window_size_right
     )
 
+    sm120_bwd_d128_long = False
     if arch // 10 == 12:
-        # SM120: uses SM80 MMA with 99 KB SMEM, 128 threads (4 warps).
+        # SM120: uses SM80 MMA with 99 KB SMEM, 256 threads (8 warps).
         m_block_size = 64
         n_block_size = 64
-        if head_dim <= 64:
+        if (
+            head_dim <= 64
+            and head_dim_v <= 64
+            and not local
+            and cu_seqlens_q is None
+            and cu_seqlens_k is None
+            and seqused_q is None
+            and seqused_k is None
+        ):
+            # A 64x128 tile halves the K/V grid and Q/dO rereads, and fits the
+            # 99 KB SMEM cap. Require two waves so small grids stay at 64x64.
+            _grid_n128 = ((k.shape[1] + 127) // 128) * q.shape[-2] * q.shape[0]
+            _sm_count = get_num_sms_for_selection(q.device.index, arch)
+            if _grid_n128 >= 2 * _sm_count:
+                n_block_size = 128
+        # For long D<=64 problems, keep P/dS in registers as direct dV/dK
+        # operands. Shorter problems do not amortize this RS configuration.
+        _sm120_bwd_rs = (
+            n_block_size == 128
+            and q.shape[1] >= 8192
+        )
+        # One Q/dO stage reduces SMEM pressure and pipeline overhead on SM120.
+        num_stages_Q = 1
+        num_stages_dO = 1
+        # Long D128 has room for a second Q stage, while a second dO stage would
+        # exceed the SMEM cap. Short sequences stay at one stage.
+        if (
+            head_dim <= 128
+            and head_dim_v <= 128
+            and cu_seqlens_q is None
+            and cu_seqlens_k is None
+            and seqused_q is None
+            and seqused_k is None
+            and q.shape[1] >= 8192
+            and not _sm120_bwd_rs
+        ):
             num_stages_Q = 2
-            num_stages_dO = 2
-        else:
-            num_stages_Q = 1
-            num_stages_dO = 1
         SdP_swapAB = False
         dKV_swapAB = False
         dQ_swapAB = False
         AtomLayoutMSdP = 4
         AtomLayoutNdKV = 4
         AtomLayoutMdQ = 4
+        if _sm120_bwd_rs:
+            # See comment above (_sm120_bwd_rs): RS register-resident dK/dV.
+            SdP_swapAB = True
+            AtomLayoutMSdP = 1
+            AtomLayoutNdKV = 8  # num_threads // 32; required by Mma_dKV_is_RS
+        if head_dim == 128 and head_dim_v == 128:
+            # Match the SM8x D128 geometry so dK/dV cover the full 64-wide
+            # head-dimension slab per atom iteration.
+            AtomLayoutNdKV = 2
         V_in_regs = False
+        sm120_bwd_d128_long = (
+            head_dim == 128
+            and head_dim_v == 128
+            and not local
+            and block_sparse_tensors is None
+            and cu_seqlens_q is None
+            and cu_seqlens_k is None
+            and seqused_q is None
+            and seqused_k is None
+            and q.shape[1] == k.shape[1]
+            and q.shape[1] >= 8192
+            and q.shape[-2] == k.shape[-2]
+        )
+        if sm120_bwd_d128_long:
+            # Match the SM8x D128 warp geometry and keep V in registers. The
+            # latter is safe because the dP GEMM explicitly consumes its
+            # register fragment instead of re-reading the Q/V smem alias.
+            AtomLayoutMdQ = 2
+            V_in_regs = True
+        # This flag only selects the SM90 single-WG postprocess; SM120 selects
+        # its postprocess thread count from AtomLayoutMdQ below.
         dQ_single_wg = False
         cluster_size = 1
         use_2cta_instrs = False
-        num_threads = 128
+        num_threads = 256
         assert not (block_sparse_tensors is not None), "Block sparsity backward not supported on SM 12.0"
         assert score_mod is None and score_mod_bwd is None, "score_mod backward not supported on SM 12.0"
         assert mask_mod is None, "mask_mod backward not supported on SM 12.0"
@@ -2102,6 +2164,22 @@ def _flash_attn_bwd(
         if arch // 10 == 8:
             raise NotImplementedError("Custom user-provided score_mod is not supported on SM8x architectures.")
 
+    sm120_skip_full_causal_mask = (
+        arch // 10 == 12
+        and sm120_bwd_d128_long
+        and causal
+        and qhead_per_kvhead == 1
+        and seqlen_q == seqlen_k
+        and seqlen_q % m_block_size == 0
+        and seqlen_k % n_block_size == 0
+        and softcap == 0.0
+        and score_mod is None
+        and score_mod_bwd is None
+        and mask_mod is None
+        and learnable_sink is None
+        and dlse is None
+    )
+
     device = q.device
     out_torch_dtype = q.dtype
 
@@ -2236,7 +2314,7 @@ def _flash_attn_bwd(
         cu_total_m_blocks=cu_total_m_blocks_q,
         fake_mode=fake_mode,
     )
-    # num_threads: SM90 derives from BwdConfig.num_wg, SM120 is set to 128 above,
+    # num_threads: SM90 derives from BwdConfig.num_wg, SM120 is set to 256 above,
     # SM100/SM110 uses default from function signature (384).
     if arch // 10 not in [9, 12]:
         num_threads = 384
@@ -2304,6 +2382,7 @@ def _flash_attn_bwd(
             n_block_size,
             num_threads,
             pack_gqa,
+            sm120_skip_full_causal_mask,
             num_stages_Q,
             num_stages_dO,
             SdP_swapAB,
@@ -2428,6 +2507,7 @@ def _flash_attn_bwd(
                 V_in_regs=V_in_regs,
                 score_mod=score_mod,
                 score_mod_bwd=score_mod_bwd,
+                skip_full_causal_mask=sm120_skip_full_causal_mask,
             )
         elif arch // 10 == 9:
             fa_bwd_obj = FlashAttentionBackwardSm90(
@@ -2595,6 +2675,13 @@ def _flash_attn_bwd(
             # dQ postprocess: match main kernel's MMA WG count, unless dQ_single_wg
             num_threads_post_dQ = 128 if dQ_single_wg else cfg.num_wg * 128
             num_threads_post_dKV = cfg.num_wg * 128
+        elif arch // 10 == 12:
+            # The long D128 AtomLayoutMdQ=2 path uses the full 256-thread
+            # accumulator partition. The default AtomLayoutMdQ=4 path keeps
+            # the validated 128-thread V4 bridge, which is faster for small
+            # problems. dK/dV always follow the 256-thread main partition.
+            num_threads_post_dQ = num_threads if AtomLayoutMdQ == 2 else 128
+            num_threads_post_dKV = num_threads
         else:
             num_threads_post_dQ = 128
             num_threads_post_dKV = 128

--- a/flash_attn/cute/mask.py
+++ b/flash_attn/cute/mask.py
@@ -164,6 +164,16 @@ class AttentionMask:
     window_size_right: Optional[Int32] = None
     qhead_per_kvhead_packgqa: cutlass.Constexpr[int] = 1  # only pass in if we're doing PackGQA
     swap_AB: cutlass.Constexpr[bool] = False
+    # When True, the R2P bitmask fast-path is used for non-causal seqlen-mask
+    # and causal masks (when not swap_AB). This path assumes the per-thread
+    # column indices in the MMA accumulator follow the standard SM80/SM90
+    # pattern (col_pair stride = 1 within a pair, 8 between pairs). When the
+    # tiled MMA has multiple N-warps (e.g. SM120 backward at 256 threads with
+    # AtomLayoutSdP = (4, 2, 1)), the per-thread column indices interleave
+    # differently and the R2P bitmask produces wrong results. Callers in that
+    # regime should pass r2p_compatible=False to force the general-purpose
+    # per-element comparison path.
+    r2p_compatible: cutlass.Constexpr[bool] = True
 
     @property
     def seqlen_q(self) -> Int32:
@@ -210,7 +220,7 @@ class AttentionMask:
         seqlenk_col_limit = self.seqlen_k - n_block * self.tile_n - thr_col_offset
         if const_expr(not mask_causal and not mask_local and mask_mod is None):
             if const_expr(mask_seqlen):
-                r2p = const_expr(not self.swap_AB)
+                r2p = const_expr(not self.swap_AB and self.r2p_compatible)
                 if const_expr(not r2p):
                     # traverse column index.
                     for c in cutlass.range(cute.size(tScS_mn.shape[1]), unroll_full=True):
@@ -301,7 +311,9 @@ class AttentionMask:
                     1 + self.seqlen_k - n_block * self.tile_n - self.seqlen_q - thr_col_offset
                 )
                 if const_expr(mask_causal):
-                    r2p = const_expr(not self.swap_AB)  # R2P trick, see apply_mask_sm100
+                    r2p = const_expr(
+                        not self.swap_AB and self.r2p_compatible
+                    )  # R2P trick, see apply_mask_sm100
                     for r in cutlass.range(cute.size(tScS_mn.shape[0]), unroll_full=True):
                         # get the column index limit based on current row. Only consider the row index, so the column index sets to 0.
                         if const_expr(self.qhead_per_kvhead_packgqa == 1):
@@ -339,7 +351,7 @@ class AttentionMask:
                         if const_expr(self.window_size_left is not None)
                         else None
                     )
-                    r2p_local = const_expr(not self.swap_AB)
+                    r2p_local = const_expr(not self.swap_AB and self.r2p_compatible)
                     for r in cutlass.range(cute.size(tScS_mn.shape[0]), unroll_full=True):
                         if const_expr(self.qhead_per_kvhead_packgqa == 1):
                             row_idx = tScS_mn[r, 0][0] + m_block * self.tile_m

--- a/tests/cute/test_flash_attn_fast.py
+++ b/tests/cute/test_flash_attn_fast.py
@@ -11,6 +11,7 @@ from einops import rearrange
 
 from flash_attn.cute.cache_utils import JITCache
 from flash_attn.cute.interface import (
+    _flash_attn_bwd,
     _flash_attn_fwd,
     flash_attn_combine,
     flash_attn_func,
@@ -105,14 +106,116 @@ def test_flash_attn_output(seqlen_q, seqlen_k, d, causal, num_splits, mha_type, 
     assert (dv - dv_ref).abs().max().item() <= 2 * (dv_pt - dv_ref).abs().max().item() + dv_atol
 
 
+@pytest.mark.skipif(not IS_SM120, reason="SM120-specific long-sequence backward paths")
+@pytest.mark.parametrize("d,causal", [(64, False), (128, False), (128, True)])
+@maybe_fake_tensor_mode(USE_FAKE_TENSOR)
+def test_flash_attn_sm120_long_backward_paths(d, causal, monkeypatch):
+    """Cover the D64 RS path and the D128 V-in-register/mask-skip path."""
+    device = "cuda"
+    dtype = torch.bfloat16
+    seqlen = 8192
+    shape = (1, seqlen, 1, d)
+
+    # With one reported SM, the small B1/H1 D64 case still selects the 64x128
+    # tile and register-resident P/dS path, without allocating a multi-wave
+    # reference problem. D128 ignores this selector and exercises its separate
+    # long-sequence V-in-register path (plus mask skip for the causal case).
+    if d == 64:
+        monkeypatch.setenv("FLASH_ATTENTION_NUM_SMS", "1")
+    torch.manual_seed(8192 + d + int(causal))
+    base = [torch.randn(shape, device=device, dtype=dtype) for _ in range(3)]
+    q, k, v = [tensor.detach().requires_grad_() for tensor in base]
+    out, lse = flash_attn_func(q, k, v, causal=causal, num_splits=1)
+    dout = torch.randn_like(out)
+
+    original_bwd_cache = _flash_attn_bwd.compile_cache
+    test_bwd_cache = JITCache()
+    _flash_attn_bwd.compile_cache = test_bwd_cache
+    try:
+        grads = _flash_attn_bwd(q, k, v, out, dout, lse, causal=causal)
+        assert len(test_bwd_cache.cache) == 1
+        key = next(iter(test_bwd_cache.cache))
+        # Keep these indices synchronized with the SM80/SM90/SM120 compile key
+        # in interface._flash_attn_bwd.
+        selected = {
+            "m_block_size": key[8],
+            "n_block_size": key[9],
+            "num_threads": key[10],
+            "skip_full_causal_mask": key[12],
+            "num_stages_Q": key[13],
+            "num_stages_dO": key[14],
+            "SdP_swapAB": key[15],
+            "AtomLayoutMSdP": key[18],
+            "AtomLayoutNdKV": key[19],
+            "AtomLayoutMdQ": key[20],
+            "V_in_regs": key[21],
+        }
+        expected = (
+            {
+                "m_block_size": 64,
+                "n_block_size": 128,
+                "num_threads": 256,
+                "skip_full_causal_mask": False,
+                "num_stages_Q": 1,
+                "num_stages_dO": 1,
+                "SdP_swapAB": True,
+                "AtomLayoutMSdP": 1,
+                "AtomLayoutNdKV": 8,
+                "AtomLayoutMdQ": 4,
+                "V_in_regs": False,
+            }
+            if d == 64
+            else {
+                "m_block_size": 64,
+                "n_block_size": 64,
+                "num_threads": 256,
+                "skip_full_causal_mask": causal,
+                "num_stages_Q": 2,
+                "num_stages_dO": 1,
+                "SdP_swapAB": False,
+                "AtomLayoutMSdP": 4,
+                "AtomLayoutNdKV": 2,
+                "AtomLayoutMdQ": 2,
+                "V_in_regs": True,
+            }
+        )
+        assert selected == expected
+        if not is_fake_mode():
+            torch.cuda.synchronize()
+    finally:
+        test_bwd_cache.clear()
+        _flash_attn_bwd.compile_cache = original_bwd_cache
+
+    if is_fake_mode():
+        return
+
+    q_ref, k_ref, v_ref = [tensor.detach().requires_grad_() for tensor in base]
+    q_pt, k_pt, v_pt = [tensor.detach().requires_grad_() for tensor in base]
+    out_ref, _ = attention_ref(q_ref, k_ref, v_ref, causal=causal)
+    out_pt, _ = attention_ref(
+        q_pt, k_pt, v_pt, causal=causal, upcast=False, reorder_ops=True
+    )
+    grads_ref = torch.autograd.grad(out_ref, (q_ref, k_ref, v_ref), dout)
+    grads_pt = torch.autograd.grad(out_pt, (q_pt, k_pt, v_pt), dout)
+
+    for actual, reference, pytorch in (
+        (out, out_ref, out_pt),
+        *zip(grads, grads_ref, grads_pt),
+    ):
+        atol = 2 * (reference + 0.3 - 0.3 - reference).abs().max().item()
+        assert (actual - reference).abs().max().item() <= (
+            2 * (pytorch - reference).abs().max().item() + atol
+        )
+
+
 # ---------------------------------------------------------------------------
 # Forward + backward (varlen with cu_seqlens)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.skipif(USE_FAKE_TENSOR, reason="requires a data-dependent CUDA max")
-def test_flash_attn_varlen_tensor_max_seqlen_reuses_fwd_cache():
-    """A fresh CUDA scalar max_seqlen must not create a new compile key."""
+def test_flash_attn_varlen_tensor_max_seqlen_reuses_fwd_bwd_cache():
+    """A fresh CUDA scalar max_seqlen must not create new compile keys."""
     device = "cuda"
     dtype = torch.bfloat16
     seqlens = torch.tensor([384, 320], dtype=torch.int32, device=device)
@@ -123,17 +226,25 @@ def test_flash_attn_varlen_tensor_max_seqlen_reuses_fwd_cache():
         ]
     )
     total = int(cu_seqlens[-1].item())
-    q = torch.randn(total, 2, 64, device=device, dtype=dtype)
-    k = torch.randn_like(q)
-    v = torch.randn_like(q)
+    q = torch.randn(total, 2, 64, device=device, dtype=dtype, requires_grad=True)
+    k = torch.randn_like(q, requires_grad=True)
+    v = torch.randn_like(q, requires_grad=True)
+    dout = torch.randn_like(q)
 
-    original_cache = _flash_attn_fwd.compile_cache
-    test_cache = JITCache()
-    _flash_attn_fwd.compile_cache = test_cache
+    original_fwd_cache = _flash_attn_fwd.compile_cache
+    original_bwd_cache = _flash_attn_bwd.compile_cache
+    test_fwd_cache = JITCache()
+    test_bwd_cache = JITCache()
+    _flash_attn_fwd.compile_cache = test_fwd_cache
+    _flash_attn_bwd.compile_cache = test_bwd_cache
     try:
         outputs = []
-        for _ in range(2):
-            max_seqlen = (cu_seqlens[1:] - cu_seqlens[:-1]).max()
+        grads = []
+        for max_seqlen in (
+            (cu_seqlens[1:] - cu_seqlens[:-1]).max(),
+            (cu_seqlens[1:] - cu_seqlens[:-1]).max(),
+            int(seqlens.max().item()),
+        ):
             out, _ = flash_attn_varlen_func(
                 q,
                 k,
@@ -144,17 +255,28 @@ def test_flash_attn_varlen_tensor_max_seqlen_reuses_fwd_cache():
                 max_seqlen_k=max_seqlen,
             )
             outputs.append(out)
+            grads.append(torch.autograd.grad(out, (q, k, v), dout))
 
-        assert torch.equal(outputs[0], outputs[1])
-        assert len(test_cache.cache) == 1
-        assert all(
-            not torch.is_tensor(value)
-            for key in test_cache.cache
-            for value in key
-        )
+        for output in outputs[1:]:
+            assert torch.equal(outputs[0], output)
+        for current_grads in grads[1:]:
+            for expected, actual in zip(grads[0], current_grads):
+                # SM120 dQ/dK/dV use atomics, so repeated launches need not be
+                # bitwise deterministic even when they reuse the same kernel.
+                torch.testing.assert_close(actual, expected, atol=1e-2, rtol=1e-2)
+        assert len(test_fwd_cache.cache) == 1
+        assert len(test_bwd_cache.cache) == 1
+        for test_cache in (test_fwd_cache, test_bwd_cache):
+            assert all(
+                not torch.is_tensor(value)
+                for key in test_cache.cache
+                for value in key
+            )
     finally:
-        test_cache.clear()
-        _flash_attn_fwd.compile_cache = original_cache
+        test_fwd_cache.clear()
+        test_bwd_cache.clear()
+        _flash_attn_fwd.compile_cache = original_fwd_cache
+        _flash_attn_bwd.compile_cache = original_bwd_cache
 
 
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
@@ -320,22 +442,33 @@ def test_flash_attn_varlen_unpad_output(seqlen, d, causal, mha_type, unpad_q, un
         return
 
     g = torch.randn_like(out_unpad)
+    if not unpad_q:
+        g = g.masked_fill(~q_mask, 0.0)
     dq_in, dk_in, dv_in = torch.autograd.grad(out_unpad, (q_in, k_in, v_in), g)
+
+    g_padded = output_pad_fn(g) if unpad_q else g
+    grads_ref = torch.autograd.grad(out_ref, (q_ref, k_ref, v_ref), g_padded)
+    grads_pt = torch.autograd.grad(out_pt, (q_ref, k_ref, v_ref), g_padded)
+
+    dq = dq_pad_fn(dq_in) if unpad_q else dq_in
+    dk = dk_pad_fn(dk_in) if unpad_kv else dk_in
+    dv = dk_pad_fn(dv_in) if unpad_kv else dv_in
 
     # Mask out padding positions again
     k_mask = rearrange(key_padding_mask, "b s -> b s 1 1")
-    if not unpad_q:
-        dq_in = dq_in.clone().masked_fill_(~q_mask, 0.0)
-    if not unpad_kv:
-        dk_in = dk_in.clone().masked_fill_(~k_mask, 0.0)
-        dv_in = dv_in.clone().masked_fill_(~k_mask, 0.0)
+    dq = dq.masked_fill(~q_mask, 0.0)
+    dk = dk.masked_fill(~k_mask, 0.0)
+    dv = dv.masked_fill(~k_mask, 0.0)
 
-    assert dq_in.isfinite().all(), "dq contains non-finite values"
-    assert dk_in.isfinite().all(), "dk contains non-finite values"
-    assert dv_in.isfinite().all(), "dv contains non-finite values"
-    assert dq_in.abs().max().item() > 0, "dq is all zeros"
-    assert dk_in.abs().max().item() > 0, "dk is all zeros"
-    assert dv_in.abs().max().item() > 0, "dv is all zeros"
+    for name, actual, reference, pytorch in zip(
+        ("dq", "dk", "dv"), (dq, dk, dv), grads_ref, grads_pt
+    ):
+        assert actual.isfinite().all(), f"{name} contains non-finite values"
+        assert actual.abs().max().item() > 0, f"{name} is all zeros"
+        atol = 2 * (reference + 0.3 - 0.3 - reference).abs().max().item()
+        assert (actual - reference).abs().max().item() <= (
+            2 * (pytorch - reference).abs().max().item() + atol
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This adds a current-main SM120 CuTe DSL backward path for consumer Blackwell, validated on RTX 5090, without changing the public `flash_attn.cute` API.

- dispatch tuned SM120 backward kernels with matching dQ/dK/dV accumulator and postprocess mappings;
- select dense D64 and D128 configurations, including the D64 64x128 register-resident P/dS path and the long-D128 V-in-register path;
- repair the dP GEMM V-register operand, variable-length dK/dV addressing, and vector atomic stores;
- gate R2P and causal full-mask optimizations to layouts where they are valid;
- add real-GPU and FakeTensor coverage for long sequence, varlen, and CUDA-tensor `max_seqlen` backward paths.

## Mainline performance delta

BF16, 32K total tokens, model width 2048. The run order was patch / unmodified main / patch, with five timing blocks per run. Values are `main latency / median(two patch runs)`; greater than 1 means this PR is faster.

| D | sequence | non-causal | causal |
|---:|---:|---:|---:|
| 64 | 512 | 1.095x | 1.034x |
| 64 | 2048 | 1.136x | 1.098x |
| 64 | 8192 | 1.154x | 1.132x |
| 128 | 512 | 1.091x | 1.048x |
| 128 | 2048 | 1.112x | 1.080x |
| 128 | 8192 | 1.103x | 1.100x |

All twelve cells improve. The geometric-mean speedup over current main is 1.098x, with a range of 1.034x to 1.154x.

## FA2 parity on RTX 5090

The same 32K-token BF16 matrix compares native FA2 with the patched FA4 path. Values are `FA2 latency / FA4 latency`.

| D | sequence | non-causal | causal |
|---:|---:|---:|---:|
| 64 | 512 | 1.033x | 1.058x |
| 64 | 2048 | 1.016x | 1.028x |
| 64 | 8192 | 1.009x | 1.024x |
| 128 | 512 | 1.019x | 1.018x |
| 128 | 2048 | 1.013x | 1.003x |
| 128 | 8192 | 0.995x | 0.996x |

FA4 wins ten of twelve cells and is within 0.5% of FA2 in the remaining two. FP16 D128 S8192 measures 0.994x non-causal and 0.993x causal.

## Correctness

Environment: RTX 5090 (SM120), PyTorch 2.11.0+cu128, CuTe DSL 4.6.0.dev0.

- `tests/cute/test_flash_attn_fast.py`: 196 passed, 48 expected skips on real GPU;
- FakeTensor compilation: 195 passed, 49 expected skips;
- BF16/FP16 dense D64/D128 output and dQ/dK/dV pass the FP32-reference error criterion for causal and non-causal attention;
- random-padding varlen MHA/GQA/MQA gradients, CUDA-tensor `max_seqlen` cache reuse, and zero-Q dK/dV behavior pass;
- dedicated S8192 tests assert the actual JIT compile-key selections;
- `git diff --check`, `py_compile`, and Ruff pass.

## Scope and overlap

The import surface remains:

```python
from flash_attn.cute import flash_attn_func
```

The patch is limited to SM120 backward dispatch/kernel plumbing and tests. It does not add forward TMA, SplitKV, paged KV, D256, FP8, or FA3 support.

#2634 is a broader SM120 effort and contains overlapping backward work. This PR is intentionally a focused current-main extraction with isolated correctness and performance evidence; if #2634 lands first, this draft should be re-evaluated or closed rather than merged redundantly.

## Implementation note

The long-D128 `AtomLayoutMdQ=2` writer requires a 256-thread dQ postprocess; the default 128-thread bridge produces large dQ errors. The default `AtomLayoutMdQ=4` path intentionally retains its correct, faster 128-thread postprocess. SM120 uses the SM80 universal register-to-shared mapping rather than the SM90 `stmatrix` mapping.