### PR TITLE
[Build] Fix CUDA gencode selection for older toolkits

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,3 +10,5 @@ recursive-include flash_attn *.h
 recursive-include flash_attn *.cuh
 recursive-include flash_attn *.cpp
 recursive-include flash_attn *.hpp
+
+include setup_helpers.py

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,8 @@ import urllib.request
 import urllib.error
 from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
 
+from setup_helpers import add_cuda_gencodes, get_cuda_supported_archs
+
 import torch
 from torch.utils.cpp_extension import (
     BuildExtension,
@@ -96,59 +98,6 @@ def get_cuda_bare_metal_version(cuda_dir):
     bare_metal_version = parse(output[release_idx].split(",")[0])
 
     return raw_output, bare_metal_version
-
-
-def add_cuda_gencodes(cc_flag, archs, bare_metal_version):
-    """
-    Adds -gencode flags based on nvcc capabilities:
-      - sm_80/90 (regular)
-      - sm_100/120 on CUDA >= 12.8
-      - Use 100f on CUDA >= 12.9 (Blackwell family-specific)
-      - Map requested 110 -> 101 if CUDA < 13.0 (Thor rename)
-      - Embed PTX for newest arch for forward compatibility
-    """
-    # Always-regular 80
-    if "80" in archs:
-        cc_flag += ["-gencode", "arch=compute_80,code=sm_80"]
-
-    # Hopper 9.0 needs >= 11.8
-    if bare_metal_version >= Version("11.8") and "90" in archs:
-        cc_flag += ["-gencode", "arch=compute_90,code=sm_90"]
-
-    # Blackwell 10.x requires >= 12.8
-    if bare_metal_version >= Version("12.8"):
-        if "100" in archs:
-            # CUDA 12.9 introduced "family-specific" for Blackwell (100f)
-            if bare_metal_version >= Version("12.9"):
-                cc_flag += ["-gencode", "arch=compute_100f,code=sm_100"]
-            else:
-                cc_flag += ["-gencode", "arch=compute_100,code=sm_100"]
-
-        if "120" in archs:
-            # sm_120 is supported in CUDA 12.8/12.9+ toolkits
-            if bare_metal_version >= Version("12.9"):
-                cc_flag += ["-gencode", "arch=compute_120f,code=sm_120"]
-            else:
-                cc_flag += ["-gencode", "arch=compute_120,code=sm_120"]
-
-
-        # Thor rename: 12.9 uses sm_101; 13.0+ uses sm_110
-        if "110" in archs:
-            if bare_metal_version >= Version("13.0"):
-                cc_flag += ["-gencode", "arch=compute_110f,code=sm_110"]
-            else:
-                # Provide Thor support for CUDA 12.9 via sm_101
-                if bare_metal_version >= Version("12.8"):
-                    cc_flag += ["-gencode", "arch=compute_101,code=sm_101"]
-                # else: no Thor support in older toolkits
-
-    # PTX for newest requested arch (forward-compat)
-    numeric = [a for a in archs if a.isdigit()]
-    if numeric:
-        newest = max(numeric, key=int)
-        cc_flag += ["-gencode", f"arch=compute_{newest},code=compute_{newest}"]
-
-    return cc_flag
 
 
 def get_hip_version():
@@ -298,7 +247,12 @@ if not SKIP_CUDA_BUILD and not IS_ROCM:
                 "Note: make sure nvcc has a supported version by running nvcc -V."
             )
         # Build -gencode (regular + PTX + family-specific 'f' when available)
-        add_cuda_gencodes(cc_flag, set(cuda_archs()), bare_metal_version)
+        add_cuda_gencodes(
+            cc_flag,
+            set(cuda_archs()),
+            bare_metal_version,
+            get_cuda_supported_archs(CUDA_HOME),
+        )
     else:
         # No nvcc present; warnings already emitted above
         pass

--- a/setup_helpers.py
+++ b/setup_helpers.py
@@ -1,0 +1,91 @@
+"""CUDA build helpers used by ``setup.py`` and its tests."""
+
+import os
+import subprocess
+from collections.abc import Iterable, MutableSequence
+from pathlib import Path
+from typing import Union
+
+from packaging.version import Version
+
+
+def get_cuda_supported_archs(
+    cuda_dir: Union[str, os.PathLike[str]],
+) -> set[str]:
+    """Return the virtual GPU architectures accepted by this nvcc."""
+    nvcc = Path(cuda_dir) / "bin" / "nvcc"
+    output = subprocess.check_output(
+        [str(nvcc), "--list-gpu-arch"], universal_newlines=True
+    )
+    supported_archs = {
+        target.removeprefix("compute_")
+        for target in output.split()
+        if target.startswith("compute_")
+    }
+    if not supported_archs:
+        raise RuntimeError(f"{nvcc} did not report any supported GPU architectures")
+    return supported_archs
+
+
+def add_cuda_gencodes(
+    cc_flag: MutableSequence[str],
+    archs: Iterable[str],
+    bare_metal_version: Version,
+    supported_archs: Iterable[str],
+) -> MutableSequence[str]:
+    """Append only the SASS and PTX targets supported by the detected nvcc.
+
+    ``FLASH_ATTN_CUDA_ARCHS`` describes desired architectures, but an older
+    toolkit cannot compile every requested target.  The PTX target must
+    therefore be selected from the architectures that nvcc can actually
+    emit, rather than directly from the requested set.
+    """
+    archs = set(archs)
+    supported_archs = set(supported_archs)
+    # Preserve custom numeric targets such as ``86`` that the old helper
+    # emitted as PTX-only, provided the detected nvcc actually accepts them.
+    ptx_archs = {arch for arch in archs if arch.isdigit() and arch in supported_archs}
+
+    def add_sass(virtual_arch: str, real_arch: str, ptx_arch: str) -> None:
+        cc_flag.extend(["-gencode", f"arch=compute_{virtual_arch},code=sm_{real_arch}"])
+        ptx_archs.add(ptx_arch)
+
+    if "80" in archs and "80" in supported_archs:
+        add_sass("80", "80", "80")
+
+    if "90" in archs and "90" in supported_archs:
+        add_sass("90", "90", "90")
+
+    if bare_metal_version >= Version("12.8"):
+        if "100" in archs and "100" in supported_archs:
+            add_sass(
+                "100f" if bare_metal_version >= Version("12.9") else "100",
+                "100",
+                "100",
+            )
+
+        if "120" in archs and "120" in supported_archs:
+            add_sass(
+                "120f" if bare_metal_version >= Version("12.9") else "120",
+                "120",
+                "120",
+            )
+
+        if "110" in archs:
+            if "110" in supported_archs:
+                add_sass("110f", "110", "110")
+            elif "101" in supported_archs:
+                # CUDA 12.8/12.9 still uses the pre-release Thor name.
+                add_sass("101", "101", "101")
+
+    if ptx_archs:
+        newest = max(ptx_archs, key=int)
+        cc_flag.extend(["-gencode", f"arch=compute_{newest},code=compute_{newest}"])
+    elif archs:
+        requested = ", ".join(sorted(archs))
+        raise RuntimeError(
+            f"CUDA {bare_metal_version} cannot compile any requested "
+            f"FLASH_ATTN_CUDA_ARCHS target ({requested})"
+        )
+
+    return cc_flag

--- a/tests/test_setup_helpers.py
+++ b/tests/test_setup_helpers.py
@@ -1,0 +1,171 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+from packaging.version import Version
+
+
+_spec = importlib.util.spec_from_file_location(
+    "setup_helpers", Path(__file__).parents[1] / "setup_helpers.py"
+)
+assert _spec is not None and _spec.loader is not None
+_setup_helpers = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_setup_helpers)
+add_cuda_gencodes = _setup_helpers.add_cuda_gencodes
+get_cuda_supported_archs = _setup_helpers.get_cuda_supported_archs
+
+
+DEFAULT_ARCHS = frozenset({"80", "90", "100", "110", "120"})
+SUPPORTED_ARCHS = {
+    "11.7": {"80", "86", "87"},
+    "11.8": {"80", "86", "87", "89", "90"},
+    "12.7": {"80", "86", "87", "89", "90"},
+    "12.8": {"80", "86", "87", "89", "90", "100", "101", "120"},
+    "12.9": {"80", "86", "87", "89", "90", "100", "101", "120"},
+    "13.0": {"80", "86", "87", "89", "90", "100", "110", "120"},
+}
+
+
+def gencode_specs(version, archs=DEFAULT_ARCHS, supported_archs=None):
+    supported_archs = (
+        SUPPORTED_ARCHS[version] if supported_archs is None else supported_archs
+    )
+    flags = add_cuda_gencodes([], archs, Version(version), supported_archs)
+    assert flags[::2] == ["-gencode"] * (len(flags) // 2)
+    return flags[1::2]
+
+
+@pytest.mark.parametrize(
+    "version,expected",
+    [
+        (
+            "11.7",
+            [
+                "arch=compute_80,code=sm_80",
+                "arch=compute_80,code=compute_80",
+            ],
+        ),
+        (
+            "11.8",
+            [
+                "arch=compute_80,code=sm_80",
+                "arch=compute_90,code=sm_90",
+                "arch=compute_90,code=compute_90",
+            ],
+        ),
+        (
+            "12.7",
+            [
+                "arch=compute_80,code=sm_80",
+                "arch=compute_90,code=sm_90",
+                "arch=compute_90,code=compute_90",
+            ],
+        ),
+        (
+            "12.8",
+            [
+                "arch=compute_80,code=sm_80",
+                "arch=compute_90,code=sm_90",
+                "arch=compute_100,code=sm_100",
+                "arch=compute_120,code=sm_120",
+                "arch=compute_101,code=sm_101",
+                "arch=compute_120,code=compute_120",
+            ],
+        ),
+        (
+            "12.9",
+            [
+                "arch=compute_80,code=sm_80",
+                "arch=compute_90,code=sm_90",
+                "arch=compute_100f,code=sm_100",
+                "arch=compute_120f,code=sm_120",
+                "arch=compute_101,code=sm_101",
+                "arch=compute_120,code=compute_120",
+            ],
+        ),
+        (
+            "13.0",
+            [
+                "arch=compute_80,code=sm_80",
+                "arch=compute_90,code=sm_90",
+                "arch=compute_100f,code=sm_100",
+                "arch=compute_120f,code=sm_120",
+                "arch=compute_110f,code=sm_110",
+                "arch=compute_120,code=compute_120",
+            ],
+        ),
+    ],
+)
+def test_default_gencodes_follow_nvcc_capabilities(version, expected):
+    assert gencode_specs(version) == expected
+
+
+@pytest.mark.parametrize(
+    "version,expected",
+    [
+        (
+            "12.8",
+            [
+                "arch=compute_101,code=sm_101",
+                "arch=compute_101,code=compute_101",
+            ],
+        ),
+        (
+            "13.0",
+            [
+                "arch=compute_110f,code=sm_110",
+                "arch=compute_110,code=compute_110",
+            ],
+        ),
+    ],
+)
+def test_thor_ptx_uses_the_toolkit_arch_name(version, expected):
+    assert gencode_specs(version, {"110"}) == expected
+
+
+def test_custom_supported_architecture_remains_available_as_ptx():
+    assert gencode_specs("12.7", {"86"}) == ["arch=compute_86,code=compute_86"]
+
+
+@pytest.mark.parametrize("version,arch", [("11.7", "90"), ("12.7", "120")])
+def test_unsupported_only_request_fails_clearly(version, arch):
+    with pytest.raises(RuntimeError, match="cannot compile any requested"):
+        gencode_specs(version, {arch})
+
+
+def test_appends_to_existing_flags_in_place():
+    flags = ["--use_fast_math"]
+
+    result = add_cuda_gencodes(flags, {"80"}, Version("12.1"), {"80", "90"})
+
+    assert result is flags
+    assert flags == [
+        "--use_fast_math",
+        "-gencode",
+        "arch=compute_80,code=sm_80",
+        "-gencode",
+        "arch=compute_80,code=compute_80",
+    ]
+
+
+def test_empty_request_leaves_flags_unchanged():
+    flags = ["--use_fast_math"]
+
+    assert add_cuda_gencodes(flags, set(), Version("12.1"), {"80", "90"}) == flags
+
+
+def test_queries_nvcc_for_supported_architectures(monkeypatch):
+    invocation = {}
+
+    def fake_check_output(command, universal_newlines):
+        invocation["command"] = command
+        invocation["universal_newlines"] = universal_newlines
+        return "compute_80\ncompute_90\ncompute_120\n"
+
+    monkeypatch.setattr(_setup_helpers.subprocess, "check_output", fake_check_output)
+
+    assert get_cuda_supported_archs("/opt/cuda") == {"80", "90", "120"}
+    assert invocation == {
+        "command": ["/opt/cuda/bin/nvcc", "--list-gpu-arch"],
+        "universal_newlines": True,
+    }


### PR DESCRIPTION
## Summary

- query the detected `nvcc` for the virtual GPU architectures it actually accepts;
- select SASS and forward-compatible PTX only from supported requested targets;
- preserve custom PTX-only targets such as `FLASH_ATTN_CUDA_ARCHS=86`;
- move the gencode policy into a build-only helper so the CUDA version matrix can be tested without executing `setup.py`.

## Root cause and impact

The default architecture list contains `80;90;100;110;120`. The existing helper correctly skips unsupported SASS targets for older CUDA toolkits, but it chooses the PTX target from the unfiltered request. As a result, CUDA 11.7 through 12.7 still receive `arch=compute_120,code=compute_120` and abort source builds with:

```text
nvcc fatal: Unsupported gpu architecture 'compute_120'
```

The new selection uses `nvcc --list-gpu-arch` as the capability boundary. CUDA 12.1/12.4 now retain SM80 and SM90 SASS and emit compute_90 PTX; CUDA 12.8+ retains the existing Blackwell and Thor mappings. An explicit request containing no supported target fails early with a focused error instead of reaching a cryptic compiler failure.

This addresses the `compute_120` source-build failure reported in #1916.

## Validation

- `pytest -q tests/test_setup_helpers.py`: 14 passed;
- real `nvcc` compile probes accepted the complete generated flag sets with CUDA 12.1, 12.4, 12.8, and 13.0;
- the pre-fix CUDA 12.1 flag set reproduces `Unsupported gpu architecture 'compute_120'`;
- a custom CUDA 12.1 `compute_86` PTX-only target compiles successfully;
- an sdist was built and extracted, `setup_helpers.py` was present, package metadata loaded, and the helper tests passed from the extracted tree;
- Python 3.9 syntax parsing, `py_compile`, Ruff, and `git diff --check` pass.

## Scope

This does not change FlashAttention kernel architecture support, wheel contents, or the ROCm build. `setup_helpers.py` is intentionally an sdist-only build boundary and is not installed into the runtime wheel.
