### PR TITLE
[CuTe] Include callable defaults in JIT cache hashes

### DIFF
--- a/flash_attn/cute/utils.py
+++ b/flash_attn/cute/utils.py
@@ -100,7 +100,7 @@ def _get_disable_2cta_default(is_fwd: bool = False) -> bool:
 
 
 def _compute_base_hash(func: Callable) -> str:
-    """Compute hash from source code or bytecode and closure values."""
+    """Compute a hash from callable code and captured compile-time values."""
     try:
         data = inspect.getsource(func).encode()
     except (OSError, TypeError):
@@ -115,13 +115,22 @@ def _compute_base_hash(func: Callable) -> str:
         for cell in func.__closure__:
             hasher.update(repr(cell.cell_contents).encode())
 
+    # Factory-generated score/mask modifiers often capture specialization values
+    # as defaults instead of closure cells. Those values affect generated code and
+    # therefore must distinguish entries in the compile cache as well.
+    for attr in ("__defaults__", "__kwdefaults__"):
+        values = getattr(func, attr, None)
+        if values is not None:
+            hasher.update(attr.encode())
+            hasher.update(repr(values).encode())
+
     return hasher.hexdigest()
 
 
 def hash_callable(
     func: Callable, mixer_attrs: Tuple[str] = _MIXER_ATTRS, set_cute_hash: bool = True
 ) -> str:
-    """Hash a callable based on the source code or bytecode and closure values.
+    """Hash a callable based on its code and captured compile-time values.
     Fast-path: if the callable (or its __wrapped__ base) has a ``__cute_hash__``
     attribute, that value is returned immediately as the base hash, then
     metadata dunders are mixed in to produce the final dict-key hash.

--- a/tests/cute/test_score_mod.py
+++ b/tests/cute/test_score_mod.py
@@ -168,6 +168,23 @@ def tensor_bias_and_scalar_scale_score_eager(batch_bias, scale: int):
     return score_mod
 
 
+def default_scale_score_mod(scale):
+    @cute.jit
+    def score_mod(
+        score,
+        b_idx,
+        h_idx,
+        q_idx,
+        kv_idx,
+        seqlen_info,
+        aux_tensors,
+        scale=scale,
+    ):
+        return score * cutlass.Float32(scale)
+
+    return score_mod
+
+
 def create_tensors(
     batch_size=2, num_heads=4, seqlen_q=64, seqlen_kv=64, dim=128, dtype=torch.bfloat16
 ):
@@ -229,6 +246,37 @@ def test_score_mod_aux_cache_separates_dtype_and_layout(monkeypatch):
         ).transpose(1, 2)
         torch.testing.assert_close(out.float(), reference, atol=0.04, rtol=0.04)
     assert len(cache.cache) == 3
+
+
+def test_score_mod_defaults_separate_compile_cache(monkeypatch):
+    torch.manual_seed(0)
+    head_dim = 64
+    q, k, v = create_tensors(
+        batch_size=1,
+        num_heads=2,
+        seqlen_q=64,
+        seqlen_kv=64,
+        dim=head_dim,
+        dtype=torch.bfloat16,
+    )
+    scales = (1.0, 2.0)
+    cache = JITCache()
+    monkeypatch.setattr(_flash_attn_fwd, "compile_cache", cache)
+
+    outputs = [
+        run_cute_flash(q, k, v, default_scale_score_mod(scale)) for scale in scales
+    ]
+
+    scores = q.float() @ k.float().transpose(-1, -2) / math.sqrt(head_dim)
+    references = [
+        (torch.softmax(scores * scale, dim=-1) @ v.float()).to(q.dtype)
+        for scale in scales
+    ]
+    for out, reference in zip(outputs, references):
+        torch.testing.assert_close(out, reference, atol=0.025, rtol=0.025)
+
+    assert len(cache.cache) == 2
+    assert not torch.equal(outputs[0], outputs[1])
 
 
 @pytest.mark.parametrize("seqlen_q,seqlen_kv", SEQLEN_CONFIGS)

--- a/tests/cute/test_utils.py
+++ b/tests/cute/test_utils.py
@@ -6,6 +6,20 @@ from flash_attn.cute import utils as cute_utils
 from flash_attn.cute.utils import hash_callable
 
 
+def with_positional_default(value):
+    def inner(arg=value):
+        return arg
+
+    return inner
+
+
+def with_keyword_default(value):
+    def inner(*, arg=value):
+        return arg
+
+    return inner
+
+
 class TestHashCallable:
     """Tests for hash_callable function."""
 
@@ -191,6 +205,33 @@ class TestHashCallable:
         hash2 = hash_callable(func2)
         assert hash1 != hash2
 
+    def test_positional_default_values_affect_hash(self):
+        """Defaults can specialize generated callables without creating a closure."""
+        func1 = with_positional_default(1)
+        func1_equivalent = with_positional_default(1)
+        func2 = with_positional_default(2)
+        assert func1.__closure__ is None
+
+        assert hash_callable(func1, set_cute_hash=False) == hash_callable(
+            func1_equivalent, set_cute_hash=False
+        )
+        assert hash_callable(func1, set_cute_hash=False) != hash_callable(
+            func2, set_cute_hash=False
+        )
+
+    def test_keyword_default_values_affect_hash(self):
+        func1 = with_keyword_default(1)
+        func1_equivalent = with_keyword_default(1)
+        func2 = with_keyword_default(2)
+        assert func1.__closure__ is None
+
+        assert hash_callable(func1, set_cute_hash=False) == hash_callable(
+            func1_equivalent, set_cute_hash=False
+        )
+        assert hash_callable(func1, set_cute_hash=False) != hash_callable(
+            func2, set_cute_hash=False
+        )
+
 
 class TestHashCallableIntegration:
     """Integration tests for hash_callable with flash attention."""
@@ -223,4 +264,3 @@ class TestHashCallableIntegration:
         # getsource should never be called because __cute_hash__ is set
         assert call_count[0] == 0, f"getsource was called {call_count[0]} times"
         assert hash1 == hash2 == hash3 == "inductor-generated-hash"
-


### PR DESCRIPTION
## Summary

CuTe injects Python positional and keyword-only defaults into generated code, but `hash_callable()` only included source/bytecode and closure cells. Factory-created score modifiers with the same source and different defaults therefore shared one compile-cache key and could silently execute the wrong specialization.

This focused change adds `__defaults__` and `__kwdefaults__` to the existing callable hash policy. It intentionally reuses the established `repr` treatment used for closure values instead of introducing a general serializer or a second object-identity system.

## RTX 5090 reproduction

Two `@cute.jit` score-mod factories use identical source but defaults `scale=1.0` and `scale=2.0`.

On unmodified main:

- both callables have the same hash;
- the forward cache contains one compiled kernel after both calls;
- the second call reuses the scale-1 specialization;
- 86.7% of output elements differ from its own reference, with maximum absolute error `1.40625`.

With this patch, the two callables produce distinct cache entries and both outputs match their corresponding PyTorch references.

## Validation

- unmodified main: the two focused default-hash unit tests fail;
- patch: `tests/cute/test_utils.py` reports 13 passed;
- unmodified main: the end-to-end score-mod cache test fails numerically;
- patch: the same RTX 5090 test passes and observes two cache entries;
- `py_compile` and `git diff --check` pass.

## Scope and design

The production delta is limited to hashing the two standard Python default-value attributes. Existing fast paths for explicit `__cute_hash__`, closure handling, and `__vec_size__` remain unchanged.

Mutable defaults after hash memoization, global-variable hashing, a bytecode fallback redesign, tensor captures, and persistent-cache protocol changes are intentionally out of scope. No new helper module, serialization taxonomy, or module-level constant table is introduced.