### PR TITLE
[CuTe] Prevent partial persistent JIT cache artifacts

### DIFF
--- a/flash_attn/cute/cache_utils.py
+++ b/flash_attn/cute/cache_utils.py
@@ -3,6 +3,7 @@ import fcntl
 import hashlib
 import os
 import pickle
+import secrets
 import sys
 import tempfile
 import time
@@ -203,8 +204,9 @@ class JITPersistentCache(JITCache):
     def _try_load_from_storage(self, key: CompileKeyType) -> bool:
         """
         Try to load a function from persistent storage into in-memory cache.
-        Returns True if loaded successfully, False if not found on disk.
-        Holds a shared lock during loading to prevent concurrent writes.
+        Returns True if loaded successfully, False if missing or invalid on disk.
+        Loads under a shared lock, then revalidates failures under an exclusive
+        lock before removing an invalid artifact.
         """
         sha256_hex = self._key_to_hash(key)
         obj_path = self.cache_path / f"{sha256_hex}.o"
@@ -214,15 +216,44 @@ class JITPersistentCache(JITCache):
             timeout=self.LOCK_TIMEOUT_SECONDS,
             label=sha256_hex,
         ):
-            if obj_path.exists():
-                fa_log(1, f"Loading compiled function from disk: {obj_path}")
-                m = cute.runtime.load_module(str(obj_path), enable_tvm_ffi=True)
-                fn = getattr(m, self.EXPORT_FUNCTION_PREFIX)
-                JITCache.__setitem__(self, key, fn)
+            try:
+                return self._load_from_storage_unlocked(key, obj_path)
+            except Exception as exc:
+                load_error = exc
+
+        fa_log(
+            1,
+            f"Failed to load cached function from {obj_path}; "
+            f"revalidating under exclusive lock: {load_error}",
+        )
+        with FileLock(
+            self._lock_path(sha256_hex),
+            exclusive=True,
+            timeout=self.LOCK_TIMEOUT_SECONDS,
+            label=sha256_hex,
+        ):
+            if JITCache.__contains__(self, key):
                 return True
-            else:
-                fa_log(1, f"Cache miss on disk for key hash {sha256_hex}")
-        return False
+            if not obj_path.exists():
+                return False
+            try:
+                return self._load_from_storage_unlocked(key, obj_path)
+            except Exception as exc:
+                fa_log(1, f"Removing invalid cached function {obj_path}: {exc}")
+                obj_path.unlink(missing_ok=True)
+                return False
+
+    def _load_from_storage_unlocked(self, key: CompileKeyType, obj_path: Path) -> bool:
+        """Load one object while the caller holds its shared or exclusive lock."""
+        if not obj_path.exists():
+            fa_log(1, f"Cache miss on disk for key hash {obj_path.stem}")
+            return False
+
+        fa_log(1, f"Loading compiled function from disk: {obj_path}")
+        module = cute.runtime.load_module(str(obj_path), enable_tvm_ffi=True)
+        fn = getattr(module, self.EXPORT_FUNCTION_PREFIX)
+        JITCache.__setitem__(self, key, fn)
+        return True
 
     def _try_export_to_storage(self, key: CompileKeyType, fn: JitCompiledFunction) -> None:
         """Export a compiled function to persistent storage under exclusive lock."""
@@ -239,10 +270,26 @@ class JITPersistentCache(JITCache):
                 fa_log(1, f"Skipping export, already on disk: {obj_path}")
                 return
             fa_log(1, f"Exporting compiled function to disk: {obj_path}")
-            fn.export_to_c(
-                object_file_path=str(obj_path),
-                function_name=self.EXPORT_FUNCTION_PREFIX,
-            )
+            while True:
+                temp_path = self.cache_path / (f".{sha256_hex}.{secrets.token_hex(8)}.tmp.o")
+                try:
+                    fd = os.open(
+                        temp_path,
+                        os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                        0o666,
+                    )
+                    break
+                except FileExistsError:
+                    continue
+            try:
+                os.close(fd)
+                fn.export_to_c(
+                    object_file_path=str(temp_path),
+                    function_name=self.EXPORT_FUNCTION_PREFIX,
+                )
+                temp_path.replace(obj_path)
+            finally:
+                temp_path.unlink(missing_ok=True)
             fa_log(1, f"Successfully exported compiled function to disk: {obj_path}")
 
     def _key_to_hash(self, key: CompileKeyType) -> str:

--- a/tests/cute/test_cache_utils.py
+++ b/tests/cute/test_cache_utils.py
@@ -1,5 +1,8 @@
 import logging
+from pathlib import Path
 from types import SimpleNamespace
+
+import pytest
 
 import flash_attn.cute.cache_utils as cache_utils
 from flash_attn.cute import fa_logging
@@ -28,3 +31,94 @@ def test_persistent_cache_hit_logs_at_host_level_only(tmp_path, monkeypatch, cap
         assert "Loading compiled function from disk" in caplog.text
     finally:
         monkeypatch.setattr(fa_logging, "_fa_log_level", original_level)
+
+
+def test_failed_export_does_not_publish_partial_object(tmp_path):
+    key = ("failed-export",)
+    cache = cache_utils.JITPersistentCache(tmp_path)
+    obj_path = tmp_path / f"{cache._key_to_hash(key)}.o"
+    reference_path = tmp_path / "reference-mode"
+    reference_path.touch()
+    expected_mode = reference_path.stat().st_mode & 0o777
+    reference_path.unlink()
+
+    class FailingExporter:
+        def export_to_c(self, object_file_path, function_name):
+            assert function_name == cache.EXPORT_FUNCTION_PREFIX
+            path = Path(object_file_path)
+            assert path != obj_path
+            assert path.name.endswith(".o")
+            path.write_bytes(b"partial-object")
+            raise RuntimeError("export failed")
+
+    with pytest.raises(RuntimeError, match="export failed"):
+        cache._try_export_to_storage(key, FailingExporter())
+
+    assert not obj_path.exists()
+    assert not list(tmp_path.glob("*.tmp.o"))
+
+    exported_paths = []
+
+    class SuccessfulExporter:
+        def export_to_c(self, object_file_path, function_name):
+            assert function_name == cache.EXPORT_FUNCTION_PREFIX
+            exported_paths.append(Path(object_file_path))
+            Path(object_file_path).write_bytes(b"valid-object")
+
+    cache._try_export_to_storage(key, SuccessfulExporter())
+
+    assert len(exported_paths) == 1
+    assert exported_paths[0] != obj_path
+    assert obj_path.read_bytes() == b"valid-object"
+    assert obj_path.stat().st_mode & 0o777 == expected_mode
+    assert not list(tmp_path.glob("*.tmp.o"))
+
+
+def test_invalid_object_is_removed_and_can_be_reexported(tmp_path, monkeypatch):
+    key = ("invalid-object",)
+    cache = cache_utils.JITPersistentCache(tmp_path)
+    obj_path = tmp_path / f"{cache._key_to_hash(key)}.o"
+    obj_path.write_bytes(b"invalid-object")
+    load_calls = []
+
+    def fail_load(path, **_kwargs):
+        load_calls.append(path)
+        raise RuntimeError("invalid ELF")
+
+    monkeypatch.setattr(cache_utils.cute.runtime, "load_module", fail_load)
+
+    assert not cache._try_load_from_storage(key)
+    assert len(load_calls) == 2
+    assert key not in cache.cache
+    assert not obj_path.exists()
+
+    class SuccessfulExporter:
+        def export_to_c(self, object_file_path, function_name):
+            assert function_name == cache.EXPORT_FUNCTION_PREFIX
+            Path(object_file_path).write_bytes(b"recompiled-object")
+
+    cache._try_export_to_storage(key, SuccessfulExporter())
+    assert obj_path.read_bytes() == b"recompiled-object"
+
+
+def test_load_failure_is_retried_before_removing_object(tmp_path, monkeypatch):
+    key = ("revalidated-object",)
+    cache = cache_utils.JITPersistentCache(tmp_path)
+    obj_path = tmp_path / f"{cache._key_to_hash(key)}.o"
+    obj_path.write_bytes(b"valid-object")
+    loaded_fn = object()
+    load_calls = 0
+
+    def load_after_retry(*_args, **_kwargs):
+        nonlocal load_calls
+        load_calls += 1
+        if load_calls == 1:
+            raise RuntimeError("transient load failure")
+        return SimpleNamespace(func=loaded_fn)
+
+    monkeypatch.setattr(cache_utils.cute.runtime, "load_module", load_after_retry)
+
+    assert cache._try_load_from_storage(key)
+    assert load_calls == 2
+    assert obj_path.exists()
+    assert cache[key] is loaded_fn


### PR DESCRIPTION
## Summary

The persistent CuTe cache exported directly to its final `<hash>.o` path. If `export_to_c()` wrote any bytes and then failed, that partial file looked like a cache hit forever: retries skipped export and fresh processes attempted to load an invalid object.

This change:

- exports to a unique same-directory temporary `.o` created with `O_EXCL`;
- atomically publishes it with `Path.replace()` only after export succeeds;
- removes temporary artifacts on every ordinary failure path while preserving the original export exception;
- retries load failures after releasing the shared lock and acquiring the per-key exclusive lock;
- removes an object only if it still fails exclusive revalidation, allowing normal cache-miss recompilation;
- preserves the prior `0666 & umask` artifact permissions instead of narrowing shared custom caches to `0600`.

## Reproduction on current main

A deterministic exporter wrote `partial-object` and raised. On unpatched `main`:

- the final object still existed;
- the failed exporter was called once;
- a valid retry exporter was called zero times because the final path existed;
- a fresh cache failed with `BinaryExecutionEngine: Failed to add object file: The file was not recognized as a valid object file`.

With this patch, failed export leaves neither a final object nor a temporary artifact, and a retry publishes the complete object once. An actual CuTe load of arbitrary partial bytes is revalidated, removed, and returned as a cache miss.

## Validation

- `PYTHONPATH=. python -m pytest -q tests/cute/test_cache_utils.py` (`4 passed`)
- real RTX 5090 compile -> atomic export -> in-memory clear -> disk reload; one final object, zero temp objects, bitwise-identical output
- real invalid-object load recovery with CuTe runtime
- five-process failed-writer/contention probe; no deadlock or partial publication
- artifact mode comparison: unpatched `0664`, patched `0664`
- `ruff check`, `ruff format --check`, `python -m py_compile`, and `git diff --check`

## Scope

Cache-key/fingerprint changes, launch-time incompatibility such as #2566, cold-compile serialization, `clear()` concurrency redesign, stale temp cleanup after SIGKILL, and fsync/power-loss durability are intentionally out of scope.
