### PR TITLE
[CuTe, Fwd] Fix PackGQA predication for padded head dimensions

### DIFF
--- a/flash_attn/cute/pack_gqa.py
+++ b/flash_attn/cute/pack_gqa.py
@@ -176,11 +176,17 @@ class PackGQA:
                 mQ_cur_copy = cute.tiled_divide(mQ_cur, (elems_per_load,))
                 for k in cutlass.range_constexpr(cute.size(tQsQ.shape[2])):
                     ki = tQcQ[0, 0, k][1] // elems_per_load
+                    pred = None
+                    if cutlass.const_expr(self.check_hdim_oob):
+                        # Slicing one K group drops tiled-copy predicate broadcasting,
+                        # so expand its transaction predicate to the copy operand.
+                        pred = cute.make_fragment_like(tQsQ[None, m, k], cutlass.Boolean)
+                        pred.fill(tQpQ[0, m, k])
                     cute.copy(
                         gmem_thr_copy,
                         mQ_cur_copy[None, ki],
                         tQsQ[None, m, k],
-                        pred=tQpQ[None, m, k] if cutlass.const_expr(self.check_hdim_oob) else None,
+                        pred=pred,
                     )
             # We don't need to clear the sQ smem tiles since we'll only write out the valid outputs
 
@@ -255,9 +261,15 @@ class PackGQA:
                 mO_cur_copy = cute.tiled_divide(mO_cur, (elems_per_load,))
                 for k in cutlass.range_constexpr(cute.size(tOrO.shape[2])):
                     ki = tOcO[0, 0, k][1] // elems_per_load
+                    pred = None
+                    if cutlass.const_expr(self.check_hdim_oob):
+                        # Slicing one K group drops tiled-copy predicate broadcasting,
+                        # so expand its transaction predicate to the copy operand.
+                        pred = cute.make_fragment_like(tOrO[None, m, k], cutlass.Boolean)
+                        pred.fill(tOpO[0, m, k])
                     cute.copy(
                         gmem_thr_copy,
                         tOrO[None, m, k],
                         mO_cur_copy[None, ki],
-                        pred=tOpO[None, m, k] if cutlass.const_expr(self.check_hdim_oob) else None,
+                        pred=pred,
                     )

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -815,6 +815,74 @@ def test_flash_attn_small_head_dim(seqlen_q, seqlen_k, d, causal, dtype):
     ).abs().max().item() + fwd_atol
 
 
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("head_dim,head_dim_v", [(72, 64), (64, 72)])
+@maybe_fake_tensor_mode(USE_FAKE_TENSOR)
+def test_flash_attn_pack_gqa_padded_head_dim(head_dim, head_dim_v, causal):
+    torch.manual_seed(0)
+    batch_size, seqlen_q, seqlen_k = 1, 64, 64
+    num_heads, num_heads_kv = 5, 1
+    dtype = torch.bfloat16
+    q = torch.randn(
+        batch_size, seqlen_q, num_heads, head_dim, device="cuda", dtype=dtype
+    )
+    k = torch.randn(
+        batch_size, seqlen_k, num_heads_kv, head_dim, device="cuda", dtype=dtype
+    )
+    v = torch.randn(
+        batch_size, seqlen_k, num_heads_kv, head_dim_v, device="cuda", dtype=dtype
+    )
+
+    out, _ = flash_attn_func(q, k, v, causal=causal, pack_gqa=True)
+    if is_fake_mode():
+        return
+
+    out_ref, _ = attention_ref(q, k, v, causal=causal)
+    out_pt, _ = attention_ref(q, k, v, causal=causal, upcast=False, reorder_ops=True)
+    check_tensor_vs_ref("out", out, out_ref, out_pt)
+
+
+def test_flash_attn_varlen_pack_gqa_padded_head_dim():
+    torch.manual_seed(0)
+    q_lengths, k_lengths = (33, 64), (65, 64)
+    num_heads, num_heads_kv = 5, 1
+    head_dim, head_dim_v = 72, 72
+    dtype = torch.bfloat16
+    q = torch.randn(sum(q_lengths), num_heads, head_dim, device="cuda", dtype=dtype)
+    k = torch.randn(sum(k_lengths), num_heads_kv, head_dim, device="cuda", dtype=dtype)
+    v = torch.randn(sum(k_lengths), num_heads_kv, head_dim_v, device="cuda", dtype=dtype)
+    cu_seqlens_q = torch.tensor(
+        [0, q_lengths[0], sum(q_lengths)], device="cuda", dtype=torch.int32
+    )
+    cu_seqlens_k = torch.tensor(
+        [0, k_lengths[0], sum(k_lengths)], device="cuda", dtype=torch.int32
+    )
+
+    out, _ = flash_attn_varlen_func(
+        q,
+        k,
+        v,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        max_seqlen_q=max(q_lengths),
+        max_seqlen_k=max(k_lengths),
+        pack_gqa=True,
+    )
+
+    references = []
+    q_start = k_start = 0
+    for q_length, k_length in zip(q_lengths, k_lengths):
+        q_batch = q[q_start : q_start + q_length].unsqueeze(0)
+        k_batch = k[k_start : k_start + k_length].unsqueeze(0)
+        v_batch = v[k_start : k_start + k_length].unsqueeze(0)
+        references.append(attention_ref(q_batch, k_batch, v_batch)[0].squeeze(0))
+        q_start += q_length
+        k_start += k_length
+    reference = torch.cat(references)
+
+    torch.testing.assert_close(out, reference, atol=0.025, rtol=0.025)
+
+
 @maybe_fake_tensor_mode(USE_FAKE_TENSOR)
 def test_flash_attn_hd256_sm100_noncontiguous_transpose():
     if not IS_SM100:

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -816,13 +816,16 @@ def test_flash_attn_small_head_dim(seqlen_q, seqlen_k, d, causal, dtype):
 
 
 @pytest.mark.parametrize("causal", [False, True])
-@pytest.mark.parametrize("head_dim,head_dim_v", [(72, 64), (64, 72)])
+@pytest.mark.parametrize(
+    "head_dim,head_dim_v",
+    [(72, 64), (64, 72), (88, 88), (104, 104), (120, 120), (136, 136)],
+)
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
 @maybe_fake_tensor_mode(USE_FAKE_TENSOR)
-def test_flash_attn_pack_gqa_padded_head_dim(head_dim, head_dim_v, causal):
+def test_flash_attn_pack_gqa_padded_head_dim(head_dim, head_dim_v, causal, dtype):
     torch.manual_seed(0)
     batch_size, seqlen_q, seqlen_k = 1, 64, 64
     num_heads, num_heads_kv = 5, 1
-    dtype = torch.bfloat16
     q = torch.randn(
         batch_size, seqlen_q, num_heads, head_dim, device="cuda", dtype=dtype
     )
@@ -833,7 +836,8 @@ def test_flash_attn_pack_gqa_padded_head_dim(head_dim, head_dim_v, causal):
         batch_size, seqlen_k, num_heads_kv, head_dim_v, device="cuda", dtype=dtype
     )
 
-    out, _ = flash_attn_func(q, k, v, causal=causal, pack_gqa=True)
+    # GQA selects PackGQA by default, so cover the public default dispatch.
+    out, _ = flash_attn_func(q, k, v, causal=causal)
     if is_fake_mode():
         return
 
@@ -866,7 +870,6 @@ def test_flash_attn_varlen_pack_gqa_padded_head_dim():
         cu_seqlens_k=cu_seqlens_k,
         max_seqlen_q=max(q_lengths),
         max_seqlen_k=max(k_lengths),
-        pack_gqa=True,
     )
 
     references = []


### PR DESCRIPTION
## Summary

Fix the CuTe PackGQA load/store predicates for head dimensions that are 8-byte-vector aligned but not multiples of 16 elements, such as 72, 88, 104, 120, and 136.

PackGQA slices Q loads and O stores into one K group. The sliced copy operand retains its vector layout, while the old predicate contains only one Boolean transaction value. CuTe IR verification therefore rejects the default GQA path.

Representative main failures:

- `D=72, Dv=64`: expected predicate shape `((8),(1))`, got `(1,(1))`;
- `D=64, Dv=72`: expected predicate shape `((8,1),(1))`, got `(1,(1))`.

The patch materializes a Boolean fragment matching the sliced operand and fills it with the existing transaction predicate. The branch is compile-time eliminated when no head-dimension predicate is needed.

## Correctness coverage

RTX 5090 / SM120:

- unmodified main: the first three representative dense cases fail during IR verification;
- patch: 25 focused real-GPU cases pass;
- patch: 24 dense FakeTensor compile cases pass;
- BF16 and FP16;
- causal and non-causal;
- `D/Dv` combinations `(72,64)`, `(64,72)`, `(88,88)`, `(104,104)`, `(120,120)`, and `(136,136)`;
- varlen coverage and FP32-reference numerical checks;
- tests exercise the public default dispatch, where GQA automatically selects PackGQA.

## RTX 5090 performance

BF16/FP16, batch 1, 8 Q heads / 1 KV head, D=72. Each cell uses seven alternating unpacked/PackGQA timing blocks with 50 launches per block. Values are `pack_gqa=False latency / PackGQA latency`; greater than 1 means PackGQA is faster.

| dtype | sequence | non-causal | causal |
|---|---:|---:|---:|
| BF16 | 512 | 1.052x | 0.997x |
| BF16 | 2048 | 1.003x | 0.967x |
| BF16 | 8192 | 1.002x | 1.125x |
| FP16 | 512 | 1.064x | 0.998x |
| FP16 | 2048 | 1.004x | 0.967x |
| FP16 | 8192 | 1.001x | 1.168x |

The 12-cell geometric mean is 1.027x. The optimization is shape-dependent: causal S2048 is about 3.3% slower, while causal S8192 is 12.5%-16.8% faster. This PR's primary capability is making the already-selected default PackGQA path compile and run for these dimensions; it does not claim a universal speedup.

## Related work and scope

#2634 introduced related full-fragment predicates in partial-row PackGQA branches. Its current tile-aligned generic path still retains the compressed predicate and reproduces this padded-dimension failure, so the focused fix remains independently useful.

The global predicate helper, TMA paths, pointer/layout mapping, and backward kernels are intentionally unchanged.