### PR TITLE
[CuTe, Bwd] Return zero gradients for empty Q/K workloads

### DIFF
--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -1862,16 +1862,18 @@ def _flash_attn_bwd(
     if learnable_sink is not None:
         assert arch // 10 in [9, 10, 11], "Learnable sink backward is supported on SM90 and SM100/SM110"
         assert lse is not None, "learnable_sink backward requires LSE"
-        if q.numel() == 0 or k.numel() == 0:
-            dq = torch.zeros_like(q) if dq is None else dq.zero_()
-            dk = torch.zeros_like(k) if dk is None else dk.zero_()
-            dv = torch.zeros_like(v) if dv is None else dv.zero_()
-            dsink = (
-                dlse.sum(dim=(0, 2) if dlse.ndim == 3 else 1).to(learnable_sink.dtype)
-                if dlse is not None
-                else torch.zeros_like(learnable_sink)
-            )
-            return dq, dk, dv, dsink
+    if q.numel() == 0 or k.numel() == 0:
+        dq = torch.zeros_like(q) if dq is None else dq.zero_()
+        dk = torch.zeros_like(k) if dk is None else dk.zero_()
+        dv = torch.zeros_like(v) if dv is None else dv.zero_()
+        if learnable_sink is None:
+            return dq, dk, dv
+        dsink = (
+            dlse.sum(dim=(0, 2) if dlse.ndim == 3 else 1).to(learnable_sink.dtype)
+            if dlse is not None
+            else torch.zeros_like(learnable_sink)
+        )
+        return dq, dk, dv, dsink
     sparse_q = None
     kv_subtile_factor = 1
     if block_sparse_tensors is not None:

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -3847,6 +3847,126 @@ def test_flash_attn_empty_q_varlen(causal):
         assert lse.numel() == 0
 
 
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize(
+    "batch_size,seqlen_q,seqlen_k",
+    [
+        (2, 0, 32),
+        (2, 32, 0),
+        (0, 32, 32),
+    ],
+)
+@maybe_fake_tensor_mode(USE_FAKE_TENSOR)
+def test_flash_attn_empty_backward_dense(batch_size, seqlen_q, seqlen_k, causal):
+    """Dense backward returns zero gradients when the attention workload is empty."""
+    device = "cuda"
+    dtype = torch.bfloat16
+    nheads = 4
+    d = 64
+
+    q = torch.randn(
+        batch_size, seqlen_q, nheads, d,
+        device=device, dtype=dtype, requires_grad=True,
+    )
+    k = torch.randn(
+        batch_size, seqlen_k, nheads, d,
+        device=device, dtype=dtype, requires_grad=True,
+    )
+    v = torch.randn(
+        batch_size, seqlen_k, nheads, d,
+        device=device, dtype=dtype, requires_grad=True,
+    )
+
+    out, lse = flash_attn_func(q, k, v, causal=causal, return_lse=True)
+    grads = torch.autograd.grad(
+        (out, lse),
+        (q, k, v),
+        (torch.randn_like(out), torch.randn_like(lse)),
+    )
+
+    if is_fake_mode():
+        return
+    for grad, tensor in zip(grads, (q, k, v)):
+        assert grad.shape == tensor.shape
+        assert torch.count_nonzero(grad).item() == 0
+
+
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("total_q,total_k", [(0, 64), (64, 0), (0, 0)])
+@maybe_fake_tensor_mode(USE_FAKE_TENSOR)
+def test_flash_attn_empty_backward_varlen(total_q, total_k, causal):
+    """Varlen backward returns zero gradients when all Q or K sequences are empty."""
+    device = "cuda"
+    dtype = torch.bfloat16
+    nheads = 4
+    d = 64
+    batch_size = 2
+
+    q = torch.randn(total_q, nheads, d, device=device, dtype=dtype, requires_grad=True)
+    k = torch.randn(total_k, nheads, d, device=device, dtype=dtype, requires_grad=True)
+    v = torch.randn(total_k, nheads, d, device=device, dtype=dtype, requires_grad=True)
+    cu_seqlens_q = torch.tensor(
+        [0, total_q // 2, total_q], device=device, dtype=torch.int32,
+    )
+    cu_seqlens_k = torch.tensor(
+        [0, total_k // 2, total_k], device=device, dtype=torch.int32,
+    )
+
+    out, lse = flash_attn_varlen_func(
+        q,
+        k,
+        v,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        max_seqlen_q=total_q // batch_size,
+        max_seqlen_k=total_k // batch_size,
+        causal=causal,
+        return_lse=True,
+    )
+    grads = torch.autograd.grad(
+        (out, lse),
+        (q, k, v),
+        (torch.randn_like(out), torch.randn_like(lse)),
+    )
+
+    if is_fake_mode():
+        return
+    for grad, tensor in zip(grads, (q, k, v)):
+        assert grad.shape == tensor.shape
+        assert torch.count_nonzero(grad).item() == 0
+
+
+@pytest.mark.parametrize("seqlen_q,seqlen_k", [(32, 0), (0, 32)])
+@maybe_fake_tensor_mode(USE_FAKE_TENSOR)
+def test_flash_attn_empty_backward_preallocated_outputs(seqlen_q, seqlen_k):
+    """The empty-workload shortcut zeros and reuses caller-provided gradient buffers."""
+    device = "cuda"
+    dtype = torch.bfloat16
+    batch_size = 2
+    nheads = 4
+    d = 64
+
+    q = torch.randn(batch_size, seqlen_q, nheads, d, device=device, dtype=dtype)
+    k = torch.randn(batch_size, seqlen_k, nheads, d, device=device, dtype=dtype)
+    v = torch.randn_like(k)
+    out, lse, *_ = _flash_attn_fwd(q, k, v, return_lse=True)
+    dq = torch.ones_like(q)
+    dk = torch.ones_like(k)
+    dv = torch.ones_like(v)
+
+    grads = _flash_attn_bwd(
+        q, k, v, out, torch.randn_like(out), lse, dq=dq, dk=dk, dv=dv,
+    )
+
+    assert grads[0] is dq
+    assert grads[1] is dk
+    assert grads[2] is dv
+    if is_fake_mode():
+        return
+    for grad in grads:
+        assert torch.count_nonzero(grad).item() == 0
+
+
 @pytest.mark.parametrize("seqlen_k", [512, 1024])
 @maybe_fake_tensor_mode(USE_FAKE_TENSOR)
 def test_flash_attn_ex2_emu_decode_prefill_consistency(seqlen_k):

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -32,6 +32,8 @@ from flash_attn.cute.interface import (
     flash_attn_func,
     flash_attn_varlen_func,
     get_scheduler_metadata,
+    _bwd_preprocess,
+    _bwd_postprocess_convert,
     _flash_attn_fwd,
     _flash_attn_bwd,
     _flash_attn_bwd_sparse_mla,
@@ -3938,8 +3940,10 @@ def test_flash_attn_empty_backward_varlen(total_q, total_k, causal):
 
 @pytest.mark.parametrize("seqlen_q,seqlen_k", [(32, 0), (0, 32)])
 @maybe_fake_tensor_mode(USE_FAKE_TENSOR)
-def test_flash_attn_empty_backward_preallocated_outputs(seqlen_q, seqlen_k):
-    """The empty-workload shortcut zeros and reuses caller-provided gradient buffers."""
+def test_flash_attn_empty_backward_preallocated_outputs(
+    seqlen_q, seqlen_k, monkeypatch
+):
+    """The shortcut reuses gradient buffers without compiling backward kernels."""
     device = "cuda"
     dtype = torch.bfloat16
     batch_size = 2
@@ -3954,10 +3958,16 @@ def test_flash_attn_empty_backward_preallocated_outputs(seqlen_q, seqlen_k):
     dk = torch.ones_like(k)
     dv = torch.ones_like(v)
 
+    backward_stages = (_bwd_preprocess, _flash_attn_bwd, _bwd_postprocess_convert)
+    test_caches = tuple(JITCache() for _ in backward_stages)
+    for stage, cache in zip(backward_stages, test_caches):
+        monkeypatch.setattr(stage, "compile_cache", cache)
+
     grads = _flash_attn_bwd(
         q, k, v, out, torch.randn_like(out), lse, dq=dq, dk=dk, dv=dv,
     )
 
+    assert all(not cache.cache for cache in test_caches)
     assert grads[0] is dq
     assert grads[1] is dk
     assert grads[2] is dv


### PR DESCRIPTION
## Summary

- extend the reviewed empty-workload backward shortcut from learnable-sink attention to standard Q/K/V attention;
- return mathematically correct zero `dQ/dK/dV` before scratch allocation, preprocessing, JIT selection, or attention-kernel launch;
- zero and reuse caller-provided gradient buffers;
- preserve the existing learnable-sink `dSink` behavior.

## Problem

CuTe forward already defines empty workloads: empty Q returns an empty output, while empty K returns zero output with `-inf` LSE. Standard backward did not share that contract.

On RTX 5090 / SM120 with BF16, unmodified main gives:

- dense `Sq=0`: backward preprocessing rejects an inferred empty-tensor stride;
- dense `Sk=0`: the main backward path reaches a zero-work CUDA launch and returns runtime error 9;
- `batch=0`: the same dense preprocessing/launch failures;
- focused baseline result: 8 failed, 6 passed.

The six passing baseline cases are the varlen combinations: their current autograd route already happens to return successfully. They remain regression coverage for the shared mathematical contract; this PR does not claim those six were broken.

## Why the early return is correct

When there are no query rows, no loss term contributes to K or V, so `dK=dV=0` and `dQ` is empty. When there are no K/V rows, the output is independent of Q, so `dQ=0` and `dK/dV` are empty.

The existing zero-gradient logic was incorrectly nested under `learnable_sink`. Hoisting it to the common Q/K/V dispatch boundary applies the same rule to ordinary attention before any backward implementation detail sees an empty tensor.

This is useful for ragged or distributed training where one microbatch, sequence, or rank can legitimately receive zero tokens.

## Validation

RTX 5090 / SM120:

- unmodified main: 8 failed, 6 passed;
- patch: all 14 dense, varlen, causal/non-causal, batch-empty, and preallocated-buffer cases pass;
- all 14 pass under CuTe FakeTensor mode;
- preallocated `dQ/dK/dV` buffers are returned by identity and zeroed;
- dedicated cache assertions prove preprocess, main backward, and postprocess compile caches remain empty;
- 22 existing empty-Q/empty-K forward regressions pass;
- `git diff --check` passes.

## Scope

`zeros_like` or in-place zeroing may still perform the device work required to materialize returned gradients; the claim is specifically that no attention scratch space is allocated and no backward attention/preprocess/postprocess kernel is compiled or launched. Sparse MLA/QV backward uses a separate implementation and remains out of scope.