### PR TITLE
[FA2] Fix backward for non-contiguous Q/K/V inputs

### DIFF
--- a/flash_attn/flash_attn_interface.py
+++ b/flash_attn/flash_attn_interface.py
@@ -28,6 +28,12 @@ def maybe_contiguous(x):
     return x.contiguous() if x is not None and x.stride(-1) != 1 else x
 
 
+def _empty_like_lastdim_contiguous(x):
+    # CUDA backward requires stride(-1) == 1, but supported outer strides should be preserved.
+    memory_format = torch.preserve_format if x.stride(-1) == 1 else torch.contiguous_format
+    return torch.empty_like(x, memory_format=memory_format)
+
+
 def _get_block_size_n(device, head_dim, is_dropout, is_causal):
     # This should match the block sizes in the CUDA kernel
     assert head_dim <= 256
@@ -689,7 +695,7 @@ class FlashAttnKVPackedFunc(torch.autograd.Function):
     @staticmethod
     def backward(ctx, dout, *args):
         q, k, v, out, softmax_lse, rng_state = ctx.saved_tensors
-        dq = torch.empty_like(q)
+        dq = _empty_like_lastdim_contiguous(q)
         kv_shape = k.shape[:-2] + (2, *k.shape[-2:])
         dkv = torch.empty(kv_shape, dtype=k.dtype, device=k.device)
         head_size_og = dout.size(3)
@@ -789,7 +795,7 @@ class FlashAttnVarlenKVPackedFunc(torch.autograd.Function):
     @staticmethod
     def backward(ctx, dout, *args):
         q, k, v, out, softmax_lse, cu_seqlens_q, cu_seqlens_k, rng_state = ctx.saved_tensors
-        dq = torch.empty_like(q)
+        dq = _empty_like_lastdim_contiguous(q)
         kv_shape = k.shape[:-2] + (2, *k.shape[-2:])
         dkv = torch.empty(kv_shape, dtype=k.dtype, device=k.device)
         head_size_og = dout.size(2)
@@ -880,7 +886,7 @@ class FlashAttnFunc(torch.autograd.Function):
     @staticmethod
     def backward(ctx, dout, *args):
         q, k, v, out, softmax_lse, rng_state = ctx.saved_tensors
-        dq, dk, dv = torch.empty_like(q), torch.empty_like(k), torch.empty_like(v)
+        dq, dk, dv = [_empty_like_lastdim_contiguous(x) for x in (q, k, v)]
         head_size_og = dout.size(3)
         dout_padded = dout
         if head_size_og % 8 != 0:
@@ -981,7 +987,7 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
     @staticmethod
     def backward(ctx, dout, *args):
         q, k, v, out, softmax_lse, cu_seqlens_q, cu_seqlens_k, rng_state = ctx.saved_tensors
-        dq, dk, dv = torch.empty_like(q), torch.empty_like(k), torch.empty_like(v)
+        dq, dk, dv = [_empty_like_lastdim_contiguous(x) for x in (q, k, v)]
         head_size_og = dout.size(2)
         dout_padded = dout
         if head_size_og % 8 != 0:

--- a/tests/test_flash_attn.py
+++ b/tests/test_flash_attn.py
@@ -2347,6 +2347,60 @@ def test_flash_attn_bwd_transpose(seqlen, d, causal, dtype):
     ).abs().max().item()
 
 
+@pytest.mark.parametrize("varlen", [False, True], ids=["dense", "varlen"])
+@pytest.mark.parametrize("kvpacked", [False, True], ids=["separate", "kvpacked"])
+def test_flash_attn_bwd_noncontiguous_lastdim_inputs(varlen, kvpacked):
+    """Backward accepts the same last-dimension-strided inputs as forward."""
+    device = "cuda"
+    dtype = torch.float16
+    nheads = 4
+    d = 64
+    batch_size = 2
+    seqlen = 64
+
+    def make_lastdim_strided(shape):
+        base_shape = (*shape[:-2], shape[-1], shape[-2])
+        tensor = torch.randn(base_shape, device=device, dtype=dtype).transpose(-1, -2)
+        assert tensor.shape == shape
+        assert tensor.stride(-1) != 1
+        return tensor.detach().requires_grad_()
+
+    shape_prefix = (96,) if varlen else (batch_size, seqlen)
+    q = make_lastdim_strided((*shape_prefix, nheads, d))
+    if kvpacked:
+        inputs = (q, make_lastdim_strided((*shape_prefix, 2, nheads, d)))
+    else:
+        inputs = (
+            q,
+            make_lastdim_strided((*shape_prefix, nheads, d)),
+            make_lastdim_strided((*shape_prefix, nheads, d)),
+        )
+    inputs_ref = tuple(x.detach().contiguous().requires_grad_() for x in inputs)
+
+    cu_seqlens = (
+        torch.tensor([0, 32, 96], dtype=torch.int32, device=device) if varlen else None
+    )
+
+    def run_attn(tensors):
+        if varlen:
+            func = (
+                flash_attn_varlen_kvpacked_func if kvpacked else flash_attn_varlen_func
+            )
+            return func(*tensors, cu_seqlens, cu_seqlens, 64, 64, deterministic=True)
+        func = flash_attn_kvpacked_func if kvpacked else flash_attn_func
+        return func(*tensors, deterministic=True)
+
+    out = run_attn(inputs)
+    out_ref = run_attn(inputs_ref)
+    dout = torch.randn_like(out)
+    grads = torch.autograd.grad(out, inputs, dout)
+    grads_ref = torch.autograd.grad(out_ref, inputs_ref, dout)
+
+    torch.testing.assert_close(out, out_ref, rtol=0, atol=0)
+    for grad, grad_ref in zip(grads, grads_ref):
+        torch.testing.assert_close(grad, grad_ref, rtol=0, atol=0)
+
+
 @pytest.mark.parametrize("dtype", [torch.float16])
 @pytest.mark.parametrize("causal", [False, True])
 # @pytest.mark.parametrize('causal', [False])


### PR DESCRIPTION
## Summary

- allocate FA2 backward output buffers with a contiguous last dimension when the saved Q/K/V layout requires it
- preserve the existing outer layout for inputs whose last dimension is already contiguous
- cover dense and varlen attention with both separate Q/K/V and KV-packed public APIs

## Problem

FA2 forward accepts Q/K/V tensors whose last dimension has stride greater than one because the CUDA wrapper normalizes them before launch. The high-level autograd Functions save the original inputs, however, and backward currently uses torch.empty_like for dQ/dK/dV.

For a non-overlapping-dense transposed input, empty_like preserves that input layout. The resulting gradient buffer is then passed as a mutable output to the C++ backward API, which requires stride(-1) == 1 and fails, for example:

    RuntimeError: dq must have contiguous last dimension

This affects dense and varlen separate-QKV APIs, plus dQ in both KV-packed APIs. The QKV-packed dQKV and KV-packed dKV buffers are already created from explicit contiguous shapes and remain unchanged.

The regression became visible after the custom-op refactor in #1139 stopped returning normalized Q/K/V tensors to the outer autograd context.

## Fix

A shared allocation helper centralizes the CUDA mutable-output invariant:

- if stride(-1) is already 1, use preserve_format exactly as empty_like did before
- otherwise, allocate contiguous_format so the CUDA backward ABI can write the result

This changes allocation layout only for inputs that previously failed; it adds no copy to supported inputs.

## Tests

RTX 5090:

- 4 new cases passed: dense/varlen x separate-QKV/KV-packed
- outputs and all input gradients are bitwise equal to contiguous-input references under deterministic backward
- 32 existing non-contiguous-dout backward cases passed
- eager and torch.compile non-contiguous forward/backward checks passed
- helper policy check confirms valid outer strides are preserved and invalid last-dimension layouts become contiguous
- combined post-rebase run: 36 passed
- git diff --check passed
