### PR TITLE
[Pretrained] Load safetensors-only models from the Hub

### DIFF
--- a/flash_attn/utils/pretrained.py
+++ b/flash_attn/utils/pretrained.py
@@ -44,14 +44,29 @@ def state_dict_from_pretrained(model_name, device=None, dtype=None):
         )
         is_sharded = True
         load_safe = True
-    else:  # Try loading from HF hub instead of from local files
-        resolved_archive_file = cached_file(model_name, WEIGHTS_NAME,
-                                            _raise_exceptions_for_missing_entries=False)
+    else:  # Try the HF Hub in the same format order as local checkpoints.
+        resolved_archive_file = cached_file(
+            model_name, WEIGHTS_NAME, _raise_exceptions_for_missing_entries=False
+        )
         if resolved_archive_file is None:
-            resolved_archive_file = cached_file(model_name, WEIGHTS_INDEX_NAME,
-                                                _raise_exceptions_for_missing_entries=False)
+            resolved_archive_file = cached_file(
+                model_name, WEIGHTS_INDEX_NAME, _raise_exceptions_for_missing_entries=False
+            )
             if resolved_archive_file is not None:
                 is_sharded = True
+        if resolved_archive_file is None:
+            resolved_archive_file = cached_file(
+                model_name, SAFE_WEIGHTS_NAME, _raise_exceptions_for_missing_entries=False
+            )
+            if resolved_archive_file is not None:
+                load_safe = True
+        if resolved_archive_file is None:
+            resolved_archive_file = cached_file(
+                model_name, SAFE_WEIGHTS_INDEX_NAME, _raise_exceptions_for_missing_entries=False
+            )
+            if resolved_archive_file is not None:
+                is_sharded = True
+                load_safe = True
 
     if resolved_archive_file is None:
         raise EnvironmentError(f"Model name {model_name} was not found.")

--- a/tests/test_pretrained.py
+++ b/tests/test_pretrained.py
@@ -1,0 +1,93 @@
+import torch
+from safetensors.torch import save_file as safe_save_file
+from transformers.utils import (
+    SAFE_WEIGHTS_INDEX_NAME,
+    SAFE_WEIGHTS_NAME,
+    WEIGHTS_INDEX_NAME,
+    WEIGHTS_NAME,
+)
+
+from flash_attn.utils import pretrained
+
+
+def mock_remote_files(monkeypatch, files):
+    calls = []
+
+    def mock_cached_file(model_name, filename, **kwargs):
+        assert model_name == "org/model"
+        assert kwargs == {"_raise_exceptions_for_missing_entries": False}
+        calls.append(filename)
+        return files.get(filename)
+
+    monkeypatch.setattr(pretrained, "cached_file", mock_cached_file)
+    return calls
+
+
+def test_remote_safetensors_fallback_and_dtype(tmp_path, monkeypatch):
+    weights_path = tmp_path / SAFE_WEIGHTS_NAME
+    weights = {"weight": torch.arange(6, dtype=torch.float32).reshape(2, 3)}
+    safe_save_file(weights, weights_path)
+    calls = mock_remote_files(monkeypatch, {SAFE_WEIGHTS_NAME: str(weights_path)})
+
+    state_dict = pretrained.state_dict_from_pretrained("org/model", dtype=torch.bfloat16)
+
+    assert calls == [WEIGHTS_NAME, WEIGHTS_INDEX_NAME, SAFE_WEIGHTS_NAME]
+    assert state_dict.keys() == weights.keys()
+    assert state_dict["weight"].dtype == torch.bfloat16
+    torch.testing.assert_close(state_dict["weight"].float(), weights["weight"])
+
+
+def test_remote_sharded_safetensors_fallback(tmp_path, monkeypatch):
+    index_path = tmp_path / SAFE_WEIGHTS_INDEX_NAME
+    index_path.write_text("{}")
+    shard_paths = [
+        tmp_path / "model-00001-of-00002.safetensors",
+        tmp_path / "model-00002-of-00002.safetensors",
+    ]
+    weights = {
+        "weight": torch.arange(4, dtype=torch.float32),
+        "bias": torch.tensor([1.5, -2.0], dtype=torch.float32),
+    }
+    safe_save_file({"weight": weights["weight"]}, shard_paths[0])
+    safe_save_file({"bias": weights["bias"]}, shard_paths[1])
+    calls = mock_remote_files(monkeypatch, {SAFE_WEIGHTS_INDEX_NAME: str(index_path)})
+    shard_calls = []
+
+    def mock_get_checkpoint_shard_files(model_name, resolved_index_path):
+        shard_calls.append((model_name, resolved_index_path))
+        return [str(path) for path in shard_paths], {}
+
+    monkeypatch.setattr(pretrained, "get_checkpoint_shard_files", mock_get_checkpoint_shard_files)
+
+    state_dict = pretrained.state_dict_from_pretrained("org/model")
+
+    assert calls == [
+        WEIGHTS_NAME,
+        WEIGHTS_INDEX_NAME,
+        SAFE_WEIGHTS_NAME,
+        SAFE_WEIGHTS_INDEX_NAME,
+    ]
+    assert shard_calls == [("org/model", str(index_path))]
+    assert state_dict.keys() == weights.keys()
+    for name, expected in weights.items():
+        torch.testing.assert_close(state_dict[name], expected)
+
+
+def test_remote_pytorch_weights_keep_priority(tmp_path, monkeypatch):
+    weights_path = tmp_path / WEIGHTS_NAME
+    safe_weights_path = tmp_path / SAFE_WEIGHTS_NAME
+    weights = {"format": torch.tensor([1])}
+    torch.save(weights, weights_path)
+    safe_save_file({"format": torch.tensor([2])}, safe_weights_path)
+    calls = mock_remote_files(
+        monkeypatch,
+        {
+            WEIGHTS_NAME: str(weights_path),
+            SAFE_WEIGHTS_NAME: str(safe_weights_path),
+        },
+    )
+
+    state_dict = pretrained.state_dict_from_pretrained("org/model")
+
+    assert calls == [WEIGHTS_NAME]
+    torch.testing.assert_close(state_dict["format"], weights["format"])


### PR DESCRIPTION
## Summary

- discover single-file safetensors checkpoints for remote Hugging Face model IDs
- discover and assemble sharded safetensors checkpoints from their index
- preserve the existing PyTorch .bin preference and dtype/device conversion behavior

## Problem

state_dict_from_pretrained already supports local model.safetensors and model.safetensors.index.json files, but its Hugging Face Hub fallback probes only pytorch_model.bin and pytorch_model.bin.index.json.

As a result, a valid safetensors-only repository is reported as missing. On current main:

    state_dict_from_pretrained("hf-internal-testing/tiny-random-LlamaForCausalLM")
    OSError: Model name hf-internal-testing/tiny-random-LlamaForCausalLM was not found.

That public test repository contains model.safetensors and loads successfully once the missing discovery paths are included.

Local safetensors support originated in #446; this completes the equivalent remote discovery behavior.

## Fix

The Hub lookup now mirrors the established local priority:

1. pytorch_model.bin
2. pytorch_model.bin.index.json
3. model.safetensors
4. model.safetensors.index.json

A safetensors match selects safe_load_file, and an index match additionally uses the existing shard resolver. The downstream merge, CPU-before-GPU dtype conversion, and device movement remain unchanged.

## Tests

CPU tests use real temporary checkpoint files and mock only Hub discovery:

- single-file safetensors fallback, contents, and BF16 conversion
- sharded safetensors index discovery and two-shard assembly
- .bin short-circuit priority when both formats are available
- exact four-name lookup order

Post-rebase results:

- 3 focused tests passed
- Ruff checks passed
- Black checks passed with the repository's 100-column settings
- git diff --check passed
- real Hub integration loaded 21 tensors / 1,032,272 parameters and converted all tensors to BF16

The imported ALL_CAPS names remain external Hugging Face checkpoint protocol constants; no new production helper or module is introduced.
