### PR TITLE
[Generation] Fix speculative sampling axis indexing

### DIFF
--- a/flash_attn/utils/generation.py
+++ b/flash_attn/utils/generation.py
@@ -61,7 +61,7 @@ def modify_logits_for_top_p_filtering(logits, top_p):
     sorted_indices_to_remove = cumulative_probs <= (1 - top_p)
     # scatter sorted tensors to original indexing
     indices_to_remove = sorted_indices_to_remove.scatter(
-        1, sorted_indices, sorted_indices_to_remove
+        -1, sorted_indices, sorted_indices_to_remove
     )
     logits.masked_fill_(indices_to_remove, float("-inf"))
 
@@ -261,7 +261,7 @@ def sample_speculative(logits, logits_draft, tokens_draft, top_k=1, top_p=0.0, t
     )
     resample = torch.multinomial(resample_probs, num_samples=1).squeeze(dim=-1)  # (batch,)
     tokens = F.pad(tokens_draft, (0, 1))
-    tokens[:, first_rejected_idx] = resample
+    tokens[torch.arange(batch, device=tokens.device), first_rejected_idx] = resample
     return tokens, first_rejected_idx + 1
 
 

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -1,0 +1,45 @@
+import torch
+
+from flash_attn.utils.generation import (
+    modify_logits_for_top_p_filtering,
+    sample_speculative,
+)
+
+
+def test_top_p_filtering_supports_multiple_leading_dimensions():
+    logits = torch.tensor(
+        [
+            [[4.0, 3.0, 2.0, 1.0], [1.0, 3.0, 2.0, 4.0]],
+            [[2.0, 1.0, 4.0, 3.0], [3.0, 4.0, 1.0, 2.0]],
+        ]
+    )
+    expected = logits.flatten(0, -2).clone()
+    modify_logits_for_top_p_filtering(expected, top_p=0.75)
+
+    actual = logits.clone()
+    modify_logits_for_top_p_filtering(actual, top_p=0.75)
+
+    assert torch.isneginf(expected).any()
+    assert torch.equal(actual.flatten(0, -2), expected)
+
+
+def test_speculative_sampling_keeps_batch_rows_independent():
+    def peaked_logits(token_ids, vocab_size=4):
+        logits = torch.full((*token_ids.shape, vocab_size), -torch.inf)
+        return logits.scatter_(-1, token_ids.unsqueeze(-1), 0.0)
+
+    tokens_draft = torch.tensor([[0, 0], [2, 2]])
+    logits_draft = peaked_logits(tokens_draft)
+    logits = peaked_logits(torch.tensor([[1, 1, 1], [2, 2, 3]]))
+
+    with torch.random.fork_rng(devices=[]):
+        torch.manual_seed(0)
+        tokens, num_generated_tokens = sample_speculative(
+            logits,
+            logits_draft,
+            tokens_draft,
+            top_k=1,
+        )
+
+    assert torch.equal(num_generated_tokens, torch.tensor([1, 3]))
+    assert torch.equal(tokens, torch.tensor([[1, 0, 0], [2, 2, 3]]))


### PR DESCRIPTION
## Summary

- scatter top-p filtering masks along the vocabulary dimension so speculative logits with multiple leading dimensions work
- use paired batch/position indexing when writing resampled tokens so rows with different rejection positions cannot overwrite each other
- add deterministic CPU regressions for 3D top-p filtering and batched speculative sampling

## Problem

`sample_speculative` passes logits shaped `[batch, sequence, vocabulary]` into the top-p helper, but the helper scattered along dimension 1. Vocabulary indices can therefore be out of range for the sequence dimension, making speculative decoding with top-p fail.

The rejection path also indexed `tokens[:, first_rejected_idx]`. With a different rejection position per row, PyTorch interprets this as a Cartesian selection, so each row writes every selected column. This silently corrupts accepted draft tokens and can copy one sample's resampled token into another sample.

The patch keeps `decode_speculative`'s existing batch-size limitation unchanged; it corrects the documented batched contract of the lower-level `sample_speculative` helper.

## Validation

On `origin/main`, the regressions reproduce:

- `RuntimeError: index ... is out of bounds for dimension 1` for 3D top-p logits
- cross-row output `[[1, 0, 3], [1, 2, 3]]` instead of `[[1, 0, 0], [2, 2, 3]]`

Patched checks:

```text
CUDA_VISIBLE_DEVICES='' PYTHONPATH=. python -m pytest -q tests/test_generation.py
2 passed

ruff check tests/test_generation.py
All checks passed!

black --check --config /dev/null --line-length 100 --target-version py39 tests/test_generation.py
1 file would be left unchanged.

git show --check HEAD
# clean
```
