### PR TITLE
[CuTe, Bwd, SM100] Fix dV epilogue for asymmetric head dims

### DIFF
--- a/flash_attn/cute/flash_bwd_sm100.py
+++ b/flash_attn/cute/flash_bwd_sm100.py
@@ -259,8 +259,10 @@ class FlashAttentionBackwardSm100:
         self.dQaccum_reduce_stage = self.tile_hdim // self.dQ_reduce_ncol
         self.dQaccum_reduce_stage_t2r = self.tile_hdim // self.dQ_reduce_ncol_t2r
         self.cluster_reduce_dQ = False and cute.size(self.cluster_shape_mn) > 1
-        # number of tma reduce adds for dKacc and dVacc epilogue (must divide hdim_per_wg)
+        # Column widths for TMA reduce-add in the dKacc and dVacc epilogues. Each
+        # width must divide its own head dimension per warpgroup.
         self.dK_reduce_ncol = math.gcd(32, self.tile_hdim // 2)
+        self.dV_reduce_ncol = math.gcd(32, self.tile_hdimv // 2)
         # CTA group for MMA operations
         self.cta_group = tcgen05.CtaGroup.TWO if self.use_2cta_instrs else tcgen05.CtaGroup.ONE
 
@@ -437,8 +439,7 @@ class FlashAttentionBackwardSm100:
             )
         else:
             self.sdK_layout = cute.make_layout((self.tile_n * self.dK_reduce_ncol, 2))
-            # self.dK_reduce_ncol same for dV
-            self.sdV_layout = cute.make_layout((self.tile_n * self.dK_reduce_ncol, 2))
+            self.sdV_layout = cute.make_layout((self.tile_n * self.dV_reduce_ncol, 2))
 
     @cute.jit
     def __call__(
@@ -699,6 +700,7 @@ class FlashAttentionBackwardSm100:
         self.tma_copy_bytes["dPsum"] = self.tile_m * Float32.width // 8
         self.tma_copy_bytes["dQ"] = self.tile_m * self.dQ_reduce_ncol * Float32.width // 8
         self.tma_copy_bytes["dKacc"] = self.tile_n * self.dK_reduce_ncol * Float32.width // 8
+        self.tma_copy_bytes["dVacc"] = self.tile_n * self.dV_reduce_ncol * Float32.width // 8
         self.tma_copy_bytes["dS"] = cute.size_in_bytes(self.ds_dtype, self.sdS_layout)
         self.tma_copy_bytes["sdS_xchg"] = self.tma_copy_bytes["dS"] // 2  # Half of dS for exchange
 
@@ -4010,6 +4012,12 @@ class FlashAttentionBackwardSm100:
         flat_epi_tile = (
             self.sdK_flat_epi_tile if const_expr(K_or_V == "K") else self.sdV_flat_epi_tile
         )
+        reduce_ncol = self.dK_reduce_ncol if const_expr(K_or_V == "K") else self.dV_reduce_ncol
+        reduce_copy_bytes = (
+            self.tma_copy_bytes["dKacc"]
+            if const_expr(K_or_V == "K")
+            else self.tma_copy_bytes["dVacc"]
+        )
         num_compute_threads = cute.arch.WARP_SIZE * len(self.compute_warp_ids)
         wg_idx = (cute.arch.thread_idx()[0] % num_compute_threads) // 128
         num_wg = num_compute_threads // 128
@@ -4080,7 +4088,7 @@ class FlashAttentionBackwardSm100:
             )
 
         tmem_load_atom = cute.make_copy_atom(
-            tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(self.dK_reduce_ncol)), Float32
+            tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(reduce_ncol)), Float32
         )
 
         read_flag = const_expr(not deterministic_KV)
@@ -4143,7 +4151,7 @@ class FlashAttentionBackwardSm100:
                         copy_utils.cpasync_reduce_bulk_add_f32(
                             sdKV.iterator,
                             gdKV_epi[None, epi_stage].iterator,
-                            self.tma_copy_bytes["dKacc"],
+                            reduce_copy_bytes,
                         )
                 if const_expr(epi_stage < num_epi_stages - 1):
                     cute.arch.cp_async_bulk_commit_group()

--- a/tests/cute/test_flash_bwd_sm100_config.py
+++ b/tests/cute/test_flash_bwd_sm100_config.py
@@ -1,0 +1,36 @@
+import math
+
+import pytest
+
+from flash_attn.cute.flash_bwd_sm100 import FlashAttentionBackwardSm100
+
+
+@pytest.mark.parametrize("head_dim", [64, 96, 128])
+@pytest.mark.parametrize("head_dim_v", range(8, 129, 8))
+def test_dkv_reduce_widths_divide_their_head_dims(head_dim, head_dim_v):
+    use_2cta_instrs = head_dim >= 128
+    kernel = FlashAttentionBackwardSm100(
+        head_dim,
+        head_dim_v,
+        cluster_size=2 if use_2cta_instrs else 1,
+        use_2cta_instrs=use_2cta_instrs,
+    )
+    kernel._setup_attributes()
+
+    assert kernel.dK_reduce_ncol == math.gcd(32, kernel.tile_hdim // 2)
+    assert kernel.dV_reduce_ncol == math.gcd(32, kernel.tile_hdimv // 2)
+    assert (kernel.tile_hdim // 2) % kernel.dK_reduce_ncol == 0
+    assert (kernel.tile_hdimv // 2) % kernel.dV_reduce_ncol == 0
+
+
+def test_asymmetric_dv_uses_its_own_reduce_width():
+    kernel = FlashAttentionBackwardSm100(
+        128,
+        96,
+        cluster_size=2,
+        use_2cta_instrs=True,
+    )
+    kernel._setup_attributes()
+
+    assert kernel.dK_reduce_ncol == 32
+    assert kernel.dV_reduce_ncol == 16


### PR DESCRIPTION
## Summary

- derive independent TMEM reduction widths for dK and dV from their respective padded head dimensions
- use the dV width consistently in its FP32 staging layout, TMEM load atom, and reduce-add byte count
- preserve the existing dK transaction width instead of shrinking both paths to a common divisor
- add configuration regressions across asymmetric SM100 head dimensions

Fixes #2552.

## Problem

The shared SM100 dK/dV epilogue derives `dK_reduce_ncol` from the Q/K head dimension and previously reused it for dV. For `(head_dim, head_dim_v) = (128, 96)`, each dV warpgroup owns 48 columns, but the reused width is 32:

```text
(tile_hdimv / 2) % dK_reduce_ncol = 48 % 32 = 16
```

That width does not partition the dV tile evenly. Issue #2552 reports correct output/dQ/dK but corrupted dV on B200 for this configuration.

The patch specializes the existing shared epilogue at compile time: dK keeps its 32-column loads, while dV uses `gcd(32, tile_hdimv / 2)` (16 columns for the 128/96 case). Already-aligned shapes keep their existing widths.

## Validation

Configuration coverage on the patch:

```text
PYTHONPATH=.:tests/cute python -m pytest -q tests/cute/test_flash_bwd_sm100_config.py
49 passed
```

A fresh no-cache CuTe compile targeting `sm_100a` passed both affected storage paths for BF16 `(Dqk, Dv) = (128, 96)`:

```text
MHA [(1, 256, 8, 128), (1, 256, 8, 128), (1, 256, 8, 96)]
GQA [(1, 256, 8, 128), (1, 256, 4, 128), (1, 256, 4, 96)]
```

This covers direct dV storage and the GQA FP32 reduce-add path. The compile used:

```text
CUTE_DSL_NO_CACHE=1
FLASH_ATTENTION_ARCH=sm_100
CUTE_DSL_ARCH=sm_100a
FLASH_ATTENTION_NUM_SMS=148
```

Additional checks:

```text
ruff check flash_attn/cute/flash_bwd_sm100.py tests/cute/test_flash_bwd_sm100_config.py
All checks passed!

black --check --config tests/pyproject.toml tests/cute/test_flash_bwd_sm100_config.py
1 file would be left unchanged.

git show --check HEAD
# clean
```

I only have an RTX 5090 (SM120), so I could cross-compile but could not execute the SM100 numerical reproducer locally. The B200 numerical failure and expected error levels are documented in #2552; this remains a draft pending SM100 CI/runtime confirmation.
