### PR TITLE
fix: mark FA2 auxiliary outputs non-differentiable

### DIFF
--- a/flash_attn/flash_attn_interface.py
+++ b/flash_attn/flash_attn_interface.py
@@ -505,7 +505,10 @@ class FlashAttnQKVPackedFunc(torch.autograd.Function):
             ctx.alibi_slopes = alibi_slopes
             ctx.deterministic = deterministic
         out = out_padded[..., :head_size_og]
-        return out if not return_softmax else (out, softmax_lse, S_dmask)
+        if not return_softmax:
+            return out
+        ctx.mark_non_differentiable(softmax_lse, S_dmask)
+        return out, softmax_lse, S_dmask
 
     @staticmethod
     def backward(ctx, dout, *args):
@@ -595,7 +598,10 @@ class FlashAttnVarlenQKVPackedFunc(torch.autograd.Function):
             ctx.alibi_slopes = alibi_slopes
             ctx.deterministic = deterministic
         out = out_padded[..., :head_size_og]
-        return out if not return_softmax else (out, softmax_lse, S_dmask)
+        if not return_softmax:
+            return out
+        ctx.mark_non_differentiable(softmax_lse, S_dmask)
+        return out, softmax_lse, S_dmask
 
     @staticmethod
     def backward(ctx, dout, *args):
@@ -684,7 +690,10 @@ class FlashAttnKVPackedFunc(torch.autograd.Function):
             ctx.alibi_slopes = alibi_slopes
             ctx.deterministic = deterministic
         out = out_padded[..., :head_size_og]
-        return out if not return_softmax else (out, softmax_lse, S_dmask)
+        if not return_softmax:
+            return out
+        ctx.mark_non_differentiable(softmax_lse, S_dmask)
+        return out, softmax_lse, S_dmask
 
     @staticmethod
     def backward(ctx, dout, *args):
@@ -784,7 +793,10 @@ class FlashAttnVarlenKVPackedFunc(torch.autograd.Function):
             ctx.alibi_slopes = alibi_slopes
             ctx.deterministic = deterministic
         out = out_padded[..., :head_size_og]
-        return out if not return_softmax else (out, softmax_lse, S_dmask)
+        if not return_softmax:
+            return out
+        ctx.mark_non_differentiable(softmax_lse, S_dmask)
+        return out, softmax_lse, S_dmask
 
     @staticmethod
     def backward(ctx, dout, *args):
@@ -875,7 +887,10 @@ class FlashAttnFunc(torch.autograd.Function):
             ctx.alibi_slopes = alibi_slopes
             ctx.deterministic = deterministic
         out = out_padded[..., :head_size_og]
-        return out if not return_softmax else (out, softmax_lse, S_dmask)
+        if not return_softmax:
+            return out
+        ctx.mark_non_differentiable(softmax_lse, S_dmask)
+        return out, softmax_lse, S_dmask
 
     @staticmethod
     def backward(ctx, dout, *args):
@@ -976,7 +991,10 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
             ctx.deterministic = deterministic
 
         out = out_padded[..., :head_size_og]
-        return out if not return_softmax else (out, softmax_lse, S_dmask)
+        if not return_softmax:
+            return out
+        ctx.mark_non_differentiable(softmax_lse, S_dmask)
+        return out, softmax_lse, S_dmask
 
     @staticmethod
     def backward(ctx, dout, *args):

--- a/tests/test_flash_attn.py
+++ b/tests/test_flash_attn.py
@@ -2646,6 +2646,106 @@ def test_flash_attn_kvcache_paged_block_table_bounds(append_knew, paged_kv_block
     assert not out.isnan().any()
 
 
+@pytest.mark.parametrize(
+    "api",
+    [
+        "qkvpacked",
+        "kvpacked",
+        "separate",
+        "varlen_qkvpacked",
+        "varlen_kvpacked",
+        "varlen_separate",
+    ],
+)
+def test_flash_attn_aux_outputs_are_non_differentiable(api):
+    """Auxiliary testing outputs must not silently accept gradients."""
+    batch_size, seqlen, nheads, d = 2, 16, 4, 32
+    device = "cuda"
+    dtype = torch.bfloat16
+    total = batch_size * seqlen
+    kwargs = {
+        "dropout_p": 0.1,
+        "causal": True,
+        "return_attn_probs": True,
+    }
+
+    if api == "qkvpacked":
+        qkv = torch.randn(
+            batch_size,
+            seqlen,
+            3,
+            nheads,
+            d,
+            device=device,
+            dtype=dtype,
+            requires_grad=True,
+        )
+        inputs = (qkv,)
+        result = flash_attn_qkvpacked_func(qkv, **kwargs)
+    elif api == "kvpacked":
+        q = torch.randn(
+            batch_size, seqlen, nheads, d, device=device, dtype=dtype, requires_grad=True
+        )
+        kv = torch.randn(
+            batch_size,
+            seqlen,
+            2,
+            nheads,
+            d,
+            device=device,
+            dtype=dtype,
+            requires_grad=True,
+        )
+        inputs = (q, kv)
+        result = flash_attn_kvpacked_func(q, kv, **kwargs)
+    elif api == "separate":
+        q = torch.randn(
+            batch_size, seqlen, nheads, d, device=device, dtype=dtype, requires_grad=True
+        )
+        k = torch.randn_like(q, requires_grad=True)
+        v = torch.randn_like(q, requires_grad=True)
+        inputs = (q, k, v)
+        result = flash_attn_func(q, k, v, **kwargs)
+    else:
+        cu_seqlens = torch.arange(
+            0, total + 1, seqlen, device=device, dtype=torch.int32
+        )
+        if api == "varlen_qkvpacked":
+            qkv = torch.randn(
+                total, 3, nheads, d, device=device, dtype=dtype, requires_grad=True
+            )
+            inputs = (qkv,)
+            result = flash_attn_varlen_qkvpacked_func(
+                qkv, cu_seqlens, seqlen, **kwargs
+            )
+        elif api == "varlen_kvpacked":
+            q = torch.randn(total, nheads, d, device=device, dtype=dtype, requires_grad=True)
+            kv = torch.randn(
+                total, 2, nheads, d, device=device, dtype=dtype, requires_grad=True
+            )
+            inputs = (q, kv)
+            result = flash_attn_varlen_kvpacked_func(
+                q, kv, cu_seqlens, cu_seqlens, seqlen, seqlen, **kwargs
+            )
+        else:
+            q = torch.randn(total, nheads, d, device=device, dtype=dtype, requires_grad=True)
+            k = torch.randn_like(q, requires_grad=True)
+            v = torch.randn_like(q, requires_grad=True)
+            inputs = (q, k, v)
+            result = flash_attn_varlen_func(
+                q, k, v, cu_seqlens, cu_seqlens, seqlen, seqlen, **kwargs
+            )
+
+    out, softmax_lse, s_dmask = result
+    assert out.requires_grad
+    assert not softmax_lse.requires_grad
+    assert not s_dmask.requires_grad
+    with pytest.raises(RuntimeError, match="does not require grad"):
+        softmax_lse.sum().backward()
+    out.sum().backward()
+    assert all(x.grad is not None and torch.isfinite(x.grad).all() for x in inputs)
+
+
 @pytest.mark.skipif(USE_TRITON_ROCM, reason="compat-slot assert is only in the CUDA extension")
 def test_flash_attn_generator_arg_must_be_none():
     """The optional RNG `generator` slot is retained only for backwards-compat arg


### PR DESCRIPTION
## Summary

- mark `softmax_lse` and `S_dmask` as non-differentiable in all six FA2 autograd wrappers when `return_attn_probs=True`
- preserve the existing gradient path through the primary `out` tensor
- cover fixed-length and varlen APIs in QKV-packed, KV-packed, and separate Q/K/V forms

Fixes #1817.

## Motivation

The auxiliary outputs are intended for testing and their gradients are not implemented. Previously, a loss built only from `softmax_lse` silently materialized zero gradients for Q, K, and V. Marking both auxiliary outputs as non-differentiable makes that unsupported use fail explicitly while leaving normal output backpropagation unchanged.

Related work: #2405 independently marks the auxiliary outputs in `FlashAttnFunc` while adding `setup_context` support. This change applies the #1817 behavior consistently to all six current FA2 wrappers.

## Testing

- source build: `FLASH_ATTENTION_FORCE_BUILD=TRUE FLASH_ATTN_CUDA_ARCHS=80 MAX_JOBS=16 NVCC_THREADS=2 python -m pip install -e . --no-build-isolation --no-deps`
- regression: `python -m pytest -q -s tests/test_flash_attn.py::test_flash_attn_aux_outputs_are_non_differentiable` (`6 passed`)
- upstream PyTorch-reference helpers: 7 forward/backward cases across fixed/varlen, FP16/BF16, causal/non-causal, dropout `0.0/0.17`, and head dimensions `32/64/128/192/256`
- syntax and whitespace: `python -m py_compile flash_attn/flash_attn_interface.py tests/test_flash_attn.py` and `git diff --check`

Validated on an NVIDIA GeForce RTX 3090 (SM86) with PyTorch `2.13.0+cu130` and CUDA 13.0. Only one GPU was used because the change has no distributed semantics.
