### PR TITLE
[Generation] Track EOS per sequence in batched decoding

### DIFF
--- a/flash_attn/utils/generation.py
+++ b/flash_attn/utils/generation.py
@@ -109,6 +109,7 @@ def decode(
     tensor_parallel=1,
     cg=False,
     enable_timing=False,
+    pad_token_id=None,
 ):
     """Decoding, either greedy or with top-k or top-p sampling.
     If top-k = 0, don't limit the number of candidates (pure sampling).
@@ -119,13 +120,33 @@ def decode(
     Arguments:
         input_ids: (batch, seq_len)
         max_length: int
+        eos_token_id (optional): int or sequence of ints that mark a completed sequence.
         teacher_outputs (optional): (batch, seq_len). If provided, instead of sampling from the
             logits, the next token is taken from the teacher_outputs. Useful for testing.
+        pad_token_id (optional): Token emitted for sequences that have already completed. Defaults
+            to the first eos_token_id.
     Returns: GreedySearchDecoderOnlyOutput or SampleDecoderOnlyOutput, with the following fields:
-        sequences: (batch, max_length)
+        sequences: (batch, decoded length), where decoded length is at most max_length
         scores: tuples of (batch, vocab_size)
     """
     batch_size, seqlen_og = input_ids.shape
+    eos_token_ids = None
+    pad_token = None
+    unfinished_sequences = None
+    if eos_token_id is not None:
+        eos_token_ids = torch.as_tensor(
+            eos_token_id, dtype=input_ids.dtype, device=input_ids.device
+        ).reshape(-1)
+        if eos_token_ids.numel() == 0:
+            raise ValueError("eos_token_id must contain at least one token ID")
+        pad_token = (
+            eos_token_ids[0]
+            if pad_token_id is None
+            else torch.as_tensor(
+                pad_token_id, dtype=input_ids.dtype, device=input_ids.device
+            ).reshape(())
+        )
+        unfinished_sequences = torch.ones(batch_size, dtype=torch.bool, device=input_ids.device)
     teacher_output_len = teacher_outputs.shape[1] if teacher_outputs is not None else 0
     if cg:
         if not hasattr(model, "_decoding_cache"):
@@ -172,14 +193,18 @@ def decode(
             token = sample(logits, top_k=top_k, top_p=top_p, temperature=temperature)
         else:
             token = teacher_outputs[:, inference_params.seqlen_offset]
+        if unfinished_sequences is not None:
+            token = torch.where(unfinished_sequences, token, pad_token)
         # return rearrange(token, "b -> b 1")
         return token.unsqueeze(1)
 
     def should_stop(current_token, inference_params):
         if inference_params.seqlen_offset == 0:
             return False
-        if eos_token_id is not None and (current_token == eos_token_id).all():
-            return True
+        if unfinished_sequences is not None:
+            unfinished_sequences.logical_and_((current_token != eos_token_ids).all(dim=-1))
+            if not unfinished_sequences.any():
+                return True
         if inference_params.seqlen_offset >= max_length - 1:
             return True
         return False

--- a/tests/test_generation_eos.py
+++ b/tests/test_generation_eos.py
@@ -1,0 +1,222 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from flash_attn.utils.generation import decode
+
+
+class FakeGenerationModel:
+    def __init__(self, sampled_tokens=None):
+        self.sampled_tokens = iter(sampled_tokens) if sampled_tokens is not None else None
+
+    def __call__(self, input_ids, **kwargs):
+        batch_size = input_ids.shape[0]
+        logits = torch.zeros(batch_size, 1, 16, device=input_ids.device)
+        if self.sampled_tokens is not None:
+            token_ids = torch.as_tensor(next(self.sampled_tokens), device=input_ids.device)
+            logits.fill_(-torch.inf)
+            logits[torch.arange(batch_size, device=input_ids.device), 0, token_ids] = 0
+        return SimpleNamespace(logits=logits)
+
+
+def test_decode_tracks_finished_batch_rows():
+    input_ids = torch.tensor([[1, 2], [1, 2], [1, 2]])
+    teacher_outputs = torch.tensor(
+        [
+            [1, 2, 9, 4, 5, 6, 7],
+            [1, 2, 3, 4, 9, 6, 7],
+            [1, 2, 3, 9, 5, 6, 7],
+        ]
+    )
+
+    output = decode(
+        input_ids,
+        FakeGenerationModel(),
+        max_length=7,
+        eos_token_id=9,
+        teacher_outputs=teacher_outputs,
+        pad_token_id=0,
+    )
+
+    expected = torch.tensor(
+        [
+            [1, 2, 9, 0, 0],
+            [1, 2, 3, 4, 9],
+            [1, 2, 3, 9, 0],
+        ]
+    )
+    assert torch.equal(output.sequences, expected)
+    assert len(output.scores) == 3
+
+
+def test_decode_defaults_padding_to_eos_token():
+    input_ids = torch.tensor([[1, 2], [1, 2]])
+    teacher_outputs = torch.tensor(
+        [
+            [1, 2, 9, 4, 5, 6, 7],
+            [1, 2, 3, 4, 9, 6, 7],
+        ]
+    )
+
+    output = decode(
+        input_ids,
+        FakeGenerationModel(),
+        max_length=7,
+        eos_token_id=9,
+        teacher_outputs=teacher_outputs,
+    )
+
+    expected = torch.tensor(
+        [
+            [1, 2, 9, 9, 9],
+            [1, 2, 3, 4, 9],
+        ]
+    )
+    assert torch.equal(output.sequences, expected)
+    assert len(output.scores) == 3
+
+
+def test_decode_accepts_multiple_eos_token_ids():
+    input_ids = torch.tensor([[1, 2], [1, 2]])
+    teacher_outputs = torch.tensor(
+        [
+            [1, 2, 8, 4, 5],
+            [1, 2, 3, 9, 5],
+        ]
+    )
+
+    output = decode(
+        input_ids,
+        FakeGenerationModel(),
+        max_length=5,
+        eos_token_id=[8, 9],
+        teacher_outputs=teacher_outputs,
+        pad_token_id=0,
+    )
+
+    expected = torch.tensor(
+        [
+            [1, 2, 8, 0],
+            [1, 2, 3, 9],
+        ]
+    )
+    assert torch.equal(output.sequences, expected)
+    assert len(output.scores) == 2
+
+
+def test_decode_tracks_finished_batch_rows_when_sampling():
+    input_ids = torch.tensor([[1, 2], [1, 2], [1, 2]])
+    model = FakeGenerationModel(sampled_tokens=[[9, 3, 3], [4, 3, 9], [5, 9, 5]])
+
+    output = decode(
+        input_ids,
+        model,
+        max_length=7,
+        eos_token_id=9,
+        pad_token_id=0,
+    )
+
+    expected = torch.tensor(
+        [
+            [1, 2, 9, 0, 0],
+            [1, 2, 3, 3, 9],
+            [1, 2, 3, 9, 0],
+        ]
+    )
+    assert torch.equal(output.sequences, expected)
+    assert len(output.scores) == 3
+
+
+@pytest.mark.parametrize("eos_token_id", [None, 9])
+def test_decode_runs_to_max_length_when_no_eos_is_generated(eos_token_id):
+    input_ids = torch.tensor([[1, 2], [1, 2]])
+    teacher_outputs = torch.tensor([[1, 2, 3, 4, 5], [1, 2, 4, 5, 6]])
+
+    output = decode(
+        input_ids,
+        FakeGenerationModel(),
+        max_length=5,
+        eos_token_id=eos_token_id,
+        teacher_outputs=teacher_outputs,
+    )
+
+    assert torch.equal(output.sequences, teacher_outputs)
+    assert len(output.scores) == 3
+
+
+def test_decode_stops_when_batch_rows_finish_together():
+    input_ids = torch.tensor([[1, 2], [1, 2]])
+    teacher_outputs = torch.tensor([[1, 2, 9, 3], [1, 2, 9, 4]])
+
+    output = decode(
+        input_ids,
+        FakeGenerationModel(),
+        max_length=4,
+        eos_token_id=9,
+        teacher_outputs=teacher_outputs,
+        pad_token_id=0,
+    )
+
+    assert torch.equal(output.sequences, teacher_outputs[:, :3])
+    assert len(output.scores) == 1
+
+
+def test_decode_rejects_empty_eos_token_ids():
+    with pytest.raises(ValueError, match="at least one token ID"):
+        decode(
+            torch.tensor([[1, 2]]),
+            FakeGenerationModel(),
+            max_length=3,
+            eos_token_id=[],
+        )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA graph requires a CUDA device")
+def test_decode_finished_batch_rows_match_with_cuda_graph():
+    class TransitionModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            logits = torch.full((16, 16), -torch.inf, device="cuda")
+            for token_id, next_token_id in {
+                0: 1,
+                2: 9,
+                3: 5,
+                4: 6,
+                5: 9,
+                6: 7,
+                7: 9,
+                9: 1,
+            }.items():
+                logits[token_id, next_token_id] = 0
+            self.logits = torch.nn.Parameter(logits, requires_grad=False)
+
+        def allocate_inference_cache(self, *args):
+            return {}
+
+        def forward(self, input_ids, **kwargs):
+            return SimpleNamespace(logits=self.logits[input_ids[:, -1:]])
+
+    input_ids = torch.tensor([[1, 2], [1, 3], [1, 4]], device="cuda")
+    outputs = [
+        decode(
+            input_ids,
+            TransitionModel(),
+            max_length=8,
+            eos_token_id=9,
+            pad_token_id=0,
+            cg=cg,
+        )
+        for cg in (False, True)
+    ]
+
+    expected = torch.tensor(
+        [
+            [1, 2, 9, 0, 0],
+            [1, 3, 5, 9, 0],
+            [1, 4, 6, 7, 9],
+        ],
+        device="cuda",
+    )
+    assert all(torch.equal(output.sequences, expected) for output in outputs)
+    assert all(len(output.scores) == 3 for output in outputs)


### PR DESCRIPTION
## Summary

- track EOS completion independently for every row in batched `decode`;
- pad rows that have already finished while unfinished rows continue;
- stop as soon as the last active row finishes;
- accept either one EOS token ID or multiple IDs, with an optional `pad_token_id`.

## Problem

The existing stop condition checks whether every row emits the same scalar EOS on the same decoding step:

```python
(current_token == eos_token_id).all()
```

That does not model normal batched generation. If one row finishes earlier, it continues to receive ordinary sampled tokens until all other rows happen to finish together or `max_length` is reached. Passing multiple EOS IDs also fails because Python list comparison does not produce the tensor expected by `.all()`.

This makes batched output semantically incorrect for mixed-length responses and wastes decoding steps after all rows have actually completed.

## Implementation

`decode` now maintains a device-side boolean unfinished mask. On each step it:

1. replaces tokens for already-finished rows with `pad_token_id`;
2. marks rows finished if the new token matches any EOS ID;
3. exits when no unfinished row remains.

`pad_token_id` is appended to the public signature for positional compatibility. When omitted, it defaults to the first EOS ID. The no-EOS path keeps its existing behavior.

## Validation

Focused tests cover teacher forcing and real logit sampling, staggered and simultaneous completion, scalar and multiple EOS IDs, custom and default padding, no-EOS/no-hit max-length behavior, empty-EOS validation, and real eager/CUDA-graph parity.

- RTX 5090: 9 passed;
- CPU-only: 8 passed, 1 CUDA-graph test skipped;
- Ruff and `git diff --check`: passed;
- unmodified main fails the staggered-EOS cases and crashes on multiple EOS IDs.

## Scope

This changes the regular `decode` utility only. `decode_speculative` still explicitly rejects EOS and is intentionally unchanged; compacting finished rows out of the model/KV-cache batch is also out of scope.