### PR TITLE
[CuTe] Add packed QKV and KV public APIs

### DIFF
--- a/flash_attn/cute/README.md
+++ b/flash_attn/cute/README.md
@@ -17,10 +17,27 @@ pip install "flash-attn-4[cu13]"
 ## Usage
 
 ```python
-from flash_attn.cute import flash_attn_func, flash_attn_varlen_func
+from flash_attn.cute import (
+    flash_attn_func,
+    flash_attn_kvpacked_func,
+    flash_attn_qkvpacked_func,
+    flash_attn_varlen_func,
+    flash_attn_varlen_kvpacked_func,
+    flash_attn_varlen_qkvpacked_func,
+)
 
-out = flash_attn_func(q, k, v, causal=True)
+out, _ = flash_attn_func(q, k, v, causal=True)
+
+# Packed projection outputs can be passed without manually splitting them.
+out_qkv, _ = flash_attn_qkvpacked_func(qkv, causal=True)
+out_kv, _ = flash_attn_kvpacked_func(q, kv, causal=True)
 ```
+
+Packed inputs use the same CuTe options and return the same ``(out, lse)`` tuple
+as their unpacked counterparts. The packed dimensions are
+``(batch, seqlen, 3, heads, dim)`` for QKV and
+``(batch, seqlen_k, 2, heads_k, dim)`` for KV; the varlen forms omit the batch
+dimension.
 
 ## Development
 

--- a/flash_attn/cute/__init__.py
+++ b/flash_attn/cute/__init__.py
@@ -9,10 +9,18 @@ except PackageNotFoundError:
 
 from .interface import (
     flash_attn_func,
+    flash_attn_kvpacked_func,
+    flash_attn_qkvpacked_func,
     flash_attn_varlen_func,
+    flash_attn_varlen_kvpacked_func,
+    flash_attn_varlen_qkvpacked_func,
 )
 
 __all__ = [
     "flash_attn_func",
+    "flash_attn_kvpacked_func",
+    "flash_attn_qkvpacked_func",
     "flash_attn_varlen_func",
+    "flash_attn_varlen_kvpacked_func",
+    "flash_attn_varlen_qkvpacked_func",
 ]

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -3368,6 +3368,127 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
             return dq, dk, dv, None, *((None,) * 12), dsink, *((None,) * 14)
 
 
+def _unpack_packed_tensor(
+    tensor: torch.Tensor,
+    *,
+    name: str,
+    num_components: int,
+    expected_ndim: int,
+) -> tuple[torch.Tensor, ...]:
+    """Validate and unpack the QKV/KV axis shared by the packed public APIs."""
+    if tensor.ndim != expected_ndim:
+        raise ValueError(f"{name} must have {expected_ndim} dimensions, got {tensor.ndim}")
+    if tensor.shape[-3] != num_components:
+        raise ValueError(
+            f"{name} must have size {num_components} in its packed dimension, "
+            f"got {tensor.shape[-3]}"
+        )
+    return tensor.unbind(dim=-3)
+
+
+def flash_attn_qkvpacked_func(
+    qkv: torch.Tensor,
+    softmax_scale: Optional[float] = None,
+    causal: bool = False,
+    window_size: Tuple[Optional[int], Optional[int]] = (None, None),
+    learnable_sink: Optional[torch.Tensor] = None,
+    softcap: float = 0.0,
+    num_splits: int = 1,
+    deterministic: bool = False,
+    score_mod: Optional[Callable] = None,
+    score_mod_bwd: Optional[Callable] = None,
+    mask_mod: Optional[Callable] = None,
+    aux_tensors: Optional[list] = None,
+    aux_scalars: Optional[tuple] = None,
+    block_sparse_tensors: Optional[BlockSparseTensorsTorch] = None,
+    block_sparse_tensors_bwd: Optional[BlockSparseTensorsTorch] = None,
+    return_lse: bool = False,
+):
+    """FlashAttention over ``qkv`` shaped ``(batch, seqlen, 3, heads, dim)``.
+
+    This is the packed-input counterpart of :func:`flash_attn_func`. It delegates
+    to the same kernels and returns the CuTe API's ``(out, lse)`` tuple. Autograd
+    joins the Q, K, and V view gradients back into one packed gradient.
+    """
+    q, k, v = _unpack_packed_tensor(
+        qkv, name="qkv", num_components=3, expected_ndim=5
+    )
+    return flash_attn_func(
+        q,
+        k,
+        v,
+        softmax_scale=softmax_scale,
+        causal=causal,
+        window_size=window_size,
+        learnable_sink=learnable_sink,
+        softcap=softcap,
+        num_splits=num_splits,
+        pack_gqa=False,
+        deterministic=deterministic,
+        score_mod=score_mod,
+        score_mod_bwd=score_mod_bwd,
+        mask_mod=mask_mod,
+        aux_tensors=aux_tensors,
+        aux_scalars=aux_scalars,
+        block_sparse_tensors=block_sparse_tensors,
+        block_sparse_tensors_bwd=block_sparse_tensors_bwd,
+        return_lse=return_lse,
+    )
+
+
+def flash_attn_kvpacked_func(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    qv: Optional[torch.Tensor] = None,
+    gather_kv_indices: Optional[torch.Tensor] = None,
+    softmax_scale: Optional[float] = None,
+    causal: bool = False,
+    window_size: Tuple[Optional[int], Optional[int]] = (None, None),
+    learnable_sink: Optional[torch.Tensor] = None,
+    softcap: float = 0.0,
+    num_splits: int = 1,
+    pack_gqa: Optional[bool] = None,
+    deterministic: bool = False,
+    score_mod: Optional[Callable] = None,
+    score_mod_bwd: Optional[Callable] = None,
+    mask_mod: Optional[Callable] = None,
+    aux_tensors: Optional[list] = None,
+    aux_scalars: Optional[tuple] = None,
+    block_sparse_tensors: Optional[BlockSparseTensorsTorch] = None,
+    block_sparse_tensors_bwd: Optional[BlockSparseTensorsTorch] = None,
+    return_lse: bool = False,
+):
+    """FlashAttention over ``kv`` shaped ``(batch, seqlen_k, 2, heads_k, dim)``.
+
+    K and V may have fewer heads than Q for MQA/GQA. The function otherwise has
+    the same behavior and ``(out, lse)`` return contract as :func:`flash_attn_func`.
+    """
+    k, v = _unpack_packed_tensor(kv, name="kv", num_components=2, expected_ndim=5)
+    return flash_attn_func(
+        q,
+        k,
+        v,
+        qv=qv,
+        gather_kv_indices=gather_kv_indices,
+        softmax_scale=softmax_scale,
+        causal=causal,
+        window_size=window_size,
+        learnable_sink=learnable_sink,
+        softcap=softcap,
+        num_splits=num_splits,
+        pack_gqa=pack_gqa,
+        deterministic=deterministic,
+        score_mod=score_mod,
+        score_mod_bwd=score_mod_bwd,
+        mask_mod=mask_mod,
+        aux_tensors=aux_tensors,
+        aux_scalars=aux_scalars,
+        block_sparse_tensors=block_sparse_tensors,
+        block_sparse_tensors_bwd=block_sparse_tensors_bwd,
+        return_lse=return_lse,
+    )
+
+
 def flash_attn_func(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -3413,6 +3534,146 @@ def flash_attn_func(
         block_sparse_tensors,
         block_sparse_tensors_bwd,
         return_lse,
+    )
+
+
+def flash_attn_varlen_qkvpacked_func(
+    qkv: torch.Tensor,
+    cu_seqlens: Optional[torch.Tensor] = None,
+    max_seqlen: Optional[int] = None,
+    seqused: Optional[torch.Tensor] = None,
+    softmax_scale: Optional[float] = None,
+    causal: bool = False,
+    window_size: Tuple[Optional[int], Optional[int]] = (None, None),
+    learnable_sink: Optional[torch.Tensor] = None,
+    softcap: float = 0.0,
+    num_splits: int = 1,
+    deterministic: bool = False,
+    score_mod: Optional[Callable] = None,
+    score_mod_bwd: Optional[Callable] = None,
+    mask_mod: Optional[Callable] = None,
+    block_sparse_tensors: Optional[BlockSparseTensorsTorch] = None,
+    aux_tensors: Optional[list] = None,
+    aux_scalars: Optional[tuple] = None,
+    return_lse: bool = False,
+    scheduler_metadata: Optional[SchedulerMetadataTensorsTorch] = None,
+    seqlen_k_per_split: Optional[int] = None,
+    disable_scheduler_metadata: bool = False,
+):
+    """Varlen FlashAttention over ``qkv`` shaped ``(total, 3, heads, dim)``.
+
+    Q, K, and V share cumulative and maximum sequence lengths. The function
+    delegates to :func:`flash_attn_varlen_func` and returns its ``(out, lse)``
+    tuple, while autograd produces one gradient matching the packed input.
+    """
+    q, k, v = _unpack_packed_tensor(
+        qkv, name="qkv", num_components=3, expected_ndim=4
+    )
+    return flash_attn_varlen_func(
+        q,
+        k,
+        v,
+        cu_seqlens_q=cu_seqlens,
+        cu_seqlens_k=cu_seqlens,
+        max_seqlen_q=max_seqlen,
+        max_seqlen_k=max_seqlen,
+        seqused_q=seqused,
+        seqused_k=seqused,
+        softmax_scale=softmax_scale,
+        causal=causal,
+        window_size=window_size,
+        learnable_sink=learnable_sink,
+        softcap=softcap,
+        num_splits=num_splits,
+        pack_gqa=False,
+        deterministic=deterministic,
+        score_mod=score_mod,
+        score_mod_bwd=score_mod_bwd,
+        mask_mod=mask_mod,
+        block_sparse_tensors=block_sparse_tensors,
+        aux_tensors=aux_tensors,
+        aux_scalars=aux_scalars,
+        return_lse=return_lse,
+        scheduler_metadata=scheduler_metadata,
+        seqlen_k_per_split=seqlen_k_per_split,
+        disable_scheduler_metadata=disable_scheduler_metadata,
+    )
+
+
+def flash_attn_varlen_kvpacked_func(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    cu_seqlens_q: Optional[torch.Tensor] = None,
+    cu_seqlens_k: Optional[torch.Tensor] = None,
+    max_seqlen_q: Optional[int] = None,
+    max_seqlen_k: Optional[int] = None,
+    qv: Optional[torch.Tensor] = None,
+    min_seqlen_k: Optional[int] = None,
+    seqused_q: Optional[torch.Tensor] = None,
+    seqused_k: Optional[torch.Tensor] = None,
+    gather_kv_indices: Optional[torch.Tensor] = None,
+    page_table: Optional[torch.Tensor] = None,
+    softmax_scale: Optional[float] = None,
+    causal: bool = False,
+    window_size: Tuple[Optional[int], Optional[int]] = (None, None),
+    learnable_sink: Optional[torch.Tensor] = None,
+    softcap: float = 0.0,
+    num_splits: int = 1,
+    pack_gqa: Optional[bool] = None,
+    deterministic: bool = False,
+    score_mod: Optional[Callable] = None,
+    score_mod_bwd: Optional[Callable] = None,
+    mask_mod: Optional[Callable] = None,
+    block_sparse_tensors: Optional[BlockSparseTensorsTorch] = None,
+    aux_tensors: Optional[list] = None,
+    aux_scalars: Optional[tuple] = None,
+    return_lse: bool = False,
+    scheduler_metadata: Optional[SchedulerMetadataTensorsTorch] = None,
+    seqlen_k_per_split: Optional[int] = None,
+    disable_scheduler_metadata: bool = False,
+):
+    """Varlen FlashAttention over ``kv`` shaped ``(total_k, 2, heads_k, dim)``.
+
+    K and V may have fewer heads than Q for MQA/GQA. On architectures where the
+    underlying CuTe path supports paged KV, ``kv`` may instead have shape
+    ``(num_pages, page_size, 2, heads_k, dim)`` when ``page_table`` is set.
+    """
+    expected_ndim = 5 if page_table is not None else 4
+    k, v = _unpack_packed_tensor(
+        kv, name="kv", num_components=2, expected_ndim=expected_ndim
+    )
+    return flash_attn_varlen_func(
+        q,
+        k,
+        v,
+        qv=qv,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        max_seqlen_q=max_seqlen_q,
+        max_seqlen_k=max_seqlen_k,
+        min_seqlen_k=min_seqlen_k,
+        seqused_q=seqused_q,
+        seqused_k=seqused_k,
+        gather_kv_indices=gather_kv_indices,
+        page_table=page_table,
+        softmax_scale=softmax_scale,
+        causal=causal,
+        window_size=window_size,
+        learnable_sink=learnable_sink,
+        softcap=softcap,
+        num_splits=num_splits,
+        pack_gqa=pack_gqa,
+        deterministic=deterministic,
+        score_mod=score_mod,
+        score_mod_bwd=score_mod_bwd,
+        mask_mod=mask_mod,
+        block_sparse_tensors=block_sparse_tensors,
+        aux_tensors=aux_tensors,
+        aux_scalars=aux_scalars,
+        return_lse=return_lse,
+        scheduler_metadata=scheduler_metadata,
+        seqlen_k_per_split=seqlen_k_per_split,
+        disable_scheduler_metadata=disable_scheduler_metadata,
     )
 
 

--- a/tests/cute/test_packed_api.py
+++ b/tests/cute/test_packed_api.py
@@ -1,0 +1,271 @@
+import pytest
+import torch
+from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
+
+from flash_attn.cute import (
+    flash_attn_func,
+    flash_attn_kvpacked_func,
+    flash_attn_qkvpacked_func,
+    flash_attn_varlen_func,
+    flash_attn_varlen_kvpacked_func,
+    flash_attn_varlen_qkvpacked_func,
+)
+
+
+def _leaf_copy(tensor):
+    return tensor.detach().clone().requires_grad_(True)
+
+
+def _assert_outputs_and_grads_match(packed_result, unpacked_result, packed, unpacked):
+    packed_out, packed_lse = packed_result
+    unpacked_out, unpacked_lse = unpacked_result
+    torch.testing.assert_close(packed_out, unpacked_out, atol=0, rtol=0)
+    torch.testing.assert_close(packed_lse, unpacked_lse, atol=0, rtol=0)
+
+    torch.manual_seed(1)
+    dout = torch.randn_like(packed_out)
+    dlse = torch.randn_like(packed_lse)
+    packed_grads = torch.autograd.grad(packed_result, packed, (dout, dlse))
+    unpacked_grads = torch.autograd.grad(unpacked_result, unpacked, (dout, dlse))
+    for packed_grad, unpacked_grad in zip(packed_grads, unpacked_grads):
+        torch.testing.assert_close(packed_grad, unpacked_grad, atol=0.02, rtol=0.02)
+        assert packed_grad.is_contiguous()
+
+
+@pytest.mark.parametrize("causal", [False, True])
+def test_flash_attn_qkvpacked_matches_unpacked(causal):
+    torch.manual_seed(0)
+    packed = torch.randn(2, 48, 3, 4, 64, device="cuda", dtype=torch.bfloat16)
+    packed_input = _leaf_copy(packed)
+    unpacked_input = _leaf_copy(packed)
+
+    packed_result = flash_attn_qkvpacked_func(
+        packed_input, causal=causal, return_lse=True
+    )
+    unpacked_result = flash_attn_func(
+        *unpacked_input.unbind(dim=-3), causal=causal, return_lse=True
+    )
+
+    _assert_outputs_and_grads_match(
+        packed_result, unpacked_result, (packed_input,), (unpacked_input,)
+    )
+
+
+@pytest.mark.parametrize("causal", [False, True])
+def test_flash_attn_kvpacked_gqa_matches_unpacked(causal):
+    torch.manual_seed(0)
+    q = torch.randn(2, 40, 4, 64, device="cuda", dtype=torch.bfloat16)
+    kv = torch.randn(2, 56, 2, 2, 64, device="cuda", dtype=torch.bfloat16)
+    packed_q, packed_kv = _leaf_copy(q), _leaf_copy(kv)
+    unpacked_q, unpacked_kv = _leaf_copy(q), _leaf_copy(kv)
+
+    packed_result = flash_attn_kvpacked_func(
+        packed_q, packed_kv, causal=causal, return_lse=True
+    )
+    unpacked_result = flash_attn_func(
+        unpacked_q,
+        *unpacked_kv.unbind(dim=-3),
+        causal=causal,
+        return_lse=True,
+    )
+
+    _assert_outputs_and_grads_match(
+        packed_result,
+        unpacked_result,
+        (packed_q, packed_kv),
+        (unpacked_q, unpacked_kv),
+    )
+
+
+@pytest.mark.parametrize("causal", [False, True])
+def test_flash_attn_varlen_qkvpacked_matches_unpacked(causal):
+    torch.manual_seed(0)
+    cu_seqlens = torch.tensor([0, 17, 48], device="cuda", dtype=torch.int32)
+    packed = torch.randn(48, 3, 4, 64, device="cuda", dtype=torch.bfloat16)
+    packed_input = _leaf_copy(packed)
+    unpacked_input = _leaf_copy(packed)
+
+    packed_result = flash_attn_varlen_qkvpacked_func(
+        packed_input,
+        cu_seqlens,
+        31,
+        causal=causal,
+        return_lse=True,
+    )
+    unpacked_result = flash_attn_varlen_func(
+        *unpacked_input.unbind(dim=-3),
+        cu_seqlens_q=cu_seqlens,
+        cu_seqlens_k=cu_seqlens,
+        max_seqlen_q=31,
+        max_seqlen_k=31,
+        causal=causal,
+        return_lse=True,
+    )
+
+    _assert_outputs_and_grads_match(
+        packed_result, unpacked_result, (packed_input,), (unpacked_input,)
+    )
+
+
+@pytest.mark.parametrize("causal", [False, True])
+def test_flash_attn_varlen_kvpacked_gqa_matches_unpacked(causal):
+    torch.manual_seed(0)
+    cu_seqlens_q = torch.tensor([0, 17, 48], device="cuda", dtype=torch.int32)
+    cu_seqlens_k = torch.tensor([0, 23, 60], device="cuda", dtype=torch.int32)
+    q = torch.randn(48, 4, 64, device="cuda", dtype=torch.bfloat16)
+    kv = torch.randn(60, 2, 2, 64, device="cuda", dtype=torch.bfloat16)
+    packed_q, packed_kv = _leaf_copy(q), _leaf_copy(kv)
+    unpacked_q, unpacked_kv = _leaf_copy(q), _leaf_copy(kv)
+
+    packed_result = flash_attn_varlen_kvpacked_func(
+        packed_q,
+        packed_kv,
+        cu_seqlens_q,
+        cu_seqlens_k,
+        31,
+        37,
+        causal=causal,
+        return_lse=True,
+    )
+    unpacked_result = flash_attn_varlen_func(
+        unpacked_q,
+        *unpacked_kv.unbind(dim=-3),
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        max_seqlen_q=31,
+        max_seqlen_k=37,
+        causal=causal,
+        return_lse=True,
+    )
+
+    _assert_outputs_and_grads_match(
+        packed_result,
+        unpacked_result,
+        (packed_q, packed_kv),
+        (unpacked_q, unpacked_kv),
+    )
+
+
+@pytest.mark.parametrize("api", ["qkv", "kv", "varlen_qkv", "varlen_kv"])
+def test_packed_apis_work_with_torch_compile(api):
+    torch.manual_seed(0)
+
+    if api == "qkv":
+        inputs = (torch.randn(1, 32, 3, 4, 64, device="cuda", dtype=torch.bfloat16),)
+
+        def fn(qkv):
+            return flash_attn_qkvpacked_func(qkv, causal=True)[0]
+
+    elif api == "kv":
+        inputs = (
+            torch.randn(1, 24, 4, 64, device="cuda", dtype=torch.bfloat16),
+            torch.randn(1, 32, 2, 2, 64, device="cuda", dtype=torch.bfloat16),
+        )
+
+        def fn(q, kv):
+            return flash_attn_kvpacked_func(q, kv, causal=True)[0]
+
+    elif api == "varlen_qkv":
+        inputs = (
+            torch.randn(48, 3, 4, 64, device="cuda", dtype=torch.bfloat16),
+            torch.tensor([0, 17, 48], device="cuda", dtype=torch.int32),
+        )
+
+        def fn(qkv, cu_seqlens):
+            return flash_attn_varlen_qkvpacked_func(qkv, cu_seqlens, 31, causal=True)[0]
+
+    else:
+        inputs = (
+            torch.randn(48, 4, 64, device="cuda", dtype=torch.bfloat16),
+            torch.randn(60, 2, 2, 64, device="cuda", dtype=torch.bfloat16),
+            torch.tensor([0, 17, 48], device="cuda", dtype=torch.int32),
+            torch.tensor([0, 23, 60], device="cuda", dtype=torch.int32),
+        )
+
+        def fn(q, kv, cu_seqlens_q, cu_seqlens_k):
+            return flash_attn_varlen_kvpacked_func(
+                q,
+                kv,
+                cu_seqlens_q,
+                cu_seqlens_k,
+                31,
+                37,
+                causal=True,
+            )[0]
+
+    expected = fn(*inputs)
+    compiled_fn = torch.compile(fn, backend="eager")
+    actual = compiled_fn(*inputs)
+    torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+
+
+def test_packed_apis_support_fake_tensor_forward_and_backward():
+    with FakeTensorMode():
+        qkv = torch.empty(
+            1, 32, 3, 4, 64, device="cuda", dtype=torch.bfloat16, requires_grad=True
+        )
+        out, lse = flash_attn_qkvpacked_func(qkv, return_lse=True)
+        (dqkv,) = torch.autograd.grad(out.sum(), qkv)
+        assert isinstance(out, FakeTensor)
+        assert out.shape == (1, 32, 4, 64)
+        assert lse.shape == (1, 4, 32)
+        assert dqkv.shape == qkv.shape
+
+        q = torch.empty(
+            1, 24, 4, 64, device="cuda", dtype=torch.bfloat16, requires_grad=True
+        )
+        kv = torch.empty(
+            1, 32, 2, 2, 64, device="cuda", dtype=torch.bfloat16, requires_grad=True
+        )
+        out, _ = flash_attn_kvpacked_func(q, kv)
+        dq, dkv = torch.autograd.grad(out.sum(), (q, kv))
+        assert out.shape == q.shape
+        assert dq.shape == q.shape
+        assert dkv.shape == kv.shape
+
+        cu_seqlens = torch.tensor([0, 17, 48], device="cuda", dtype=torch.int32)
+        qkv = torch.empty(
+            48, 3, 4, 64, device="cuda", dtype=torch.bfloat16, requires_grad=True
+        )
+        out, _ = flash_attn_varlen_qkvpacked_func(qkv, cu_seqlens, 31)
+        (dqkv,) = torch.autograd.grad(out.sum(), qkv)
+        assert out.shape == (48, 4, 64)
+        assert dqkv.shape == qkv.shape
+
+        q = torch.empty(
+            48, 4, 64, device="cuda", dtype=torch.bfloat16, requires_grad=True
+        )
+        kv = torch.empty(
+            48, 2, 2, 64, device="cuda", dtype=torch.bfloat16, requires_grad=True
+        )
+        out, _ = flash_attn_varlen_kvpacked_func(q, kv, cu_seqlens, cu_seqlens, 31, 31)
+        dq, dkv = torch.autograd.grad(out.sum(), (q, kv))
+        assert out.shape == q.shape
+        assert dq.shape == q.shape
+        assert dkv.shape == kv.shape
+
+
+@pytest.mark.parametrize(
+    "function,args,match",
+    [
+        (flash_attn_qkvpacked_func, (torch.empty(1, 2, 4, 3, 8),), "size 3"),
+        (
+            flash_attn_kvpacked_func,
+            (torch.empty(1, 2, 3, 8), torch.empty(1, 2, 3, 3, 8)),
+            "size 2",
+        ),
+        (
+            flash_attn_varlen_qkvpacked_func,
+            (torch.empty(1, 2, 3, 4, 8),),
+            "4 dimensions",
+        ),
+        (
+            flash_attn_varlen_kvpacked_func,
+            (torch.empty(1, 3, 8), torch.empty(1, 2, 3, 4, 8)),
+            "4 dimensions",
+        ),
+    ],
+)
+def test_packed_apis_reject_invalid_layouts(function, args, match):
+    with pytest.raises(ValueError, match=match):
+        function(*args)


### PR DESCRIPTION
## Summary

Add the four packed-input public facades that users of the FA2 API expect:

- `flash_attn_qkvpacked_func`
- `flash_attn_kvpacked_func`
- `flash_attn_varlen_qkvpacked_func`
- `flash_attn_varlen_kvpacked_func`

They are exported from `flash_attn.cute` and documented alongside the existing unpacked APIs.

## Motivation

CuTe currently exports only `flash_attn_func` and `flash_attn_varlen_func`. Models whose projection already produces packed QKV or KV tensors must manually split those tensors and lose API parity when moving from FA2 to the CuTe/FA4 path.

The new entry points accept the established packed layouts, including GQA/MQA KV with fewer heads, and preserve one packed input gradient through autograd.

## Implementation

A small shared validator checks the packed axis and returns `unbind` views. Each public facade then delegates to the existing dense or varlen CuTe API with the complete CuTe option set.

No attention kernel, scheduler, or backward implementation is duplicated. Autograd joins the view gradients into a contiguous gradient matching the packed input.

The explicit thin functions are intentional public API and cross-family compatibility boundaries; keeping full signatures makes them discoverable and inspectable.

## Validation

RTX 5090 focused suite: 17 passed.

Coverage includes:

- dense and varlen QKV-packed MHA;
- dense and varlen KV-packed GQA;
- causal and non-causal forward/backward numerical equality with unpacked CuTe calls;
- contiguous packed gradients;
- all four APIs under `torch.compile`;
- all four APIs in FakeTensor forward/backward;
- focused invalid-rank and invalid-packed-axis errors.

Ruff, `py_compile`, and whitespace checks pass. On unmodified main, the same test module fails collection because the four public symbols do not exist.

## Compatibility and scope

These are CuTe-native facades: they keep the CuTe option set and `(out, lse)` return contract rather than emulating FA2 dropout or attention-probability returns. Paged KV is forwarded only on architectures where the underlying CuTe implementation supports it. No claim is made that the wrapper itself improves kernel latency.