### PR TITLE
[CuTe, SM120] Enable custom score-mod backward

### DIFF
--- a/flash_attn/cute/flash_bwd.py
+++ b/flash_attn/cute/flash_bwd.py
@@ -11,6 +11,7 @@ import cuda.bindings.driver as cuda
 import cutlass
 import cutlass.cute as cute
 from cutlass.cute.nvgpu import cpasync, warp
+from cutlass.cute import FastDivmodDivisor
 from cutlass import Int32
 import cutlass.utils as utils_basic
 
@@ -19,7 +20,7 @@ from flash_attn.cute import ampere_helpers as sm80_utils
 from flash_attn.cute.cute_dsl_utils import assume_tensor_aligned
 from flash_attn.cute import utils
 from flash_attn.cute.mask import AttentionMask
-from flash_attn.cute.softmax import call_score_mod, call_score_mod_bwd
+from flash_attn.cute.softmax import apply_score_mod_inner, apply_score_mod_bwd_inner
 from flash_attn.cute.seqlen_info import SeqlenInfoQK
 from flash_attn.cute.block_info import BlockInfo
 from quack.cute_dsl_utils import ParamsBase
@@ -52,6 +53,7 @@ class FlashAttentionBackwardSm80:
         V_in_regs: bool = False,
         score_mod: cutlass.Constexpr | None = None,
         score_mod_bwd: cutlass.Constexpr | None = None,
+        has_aux_tensors: cutlass.Constexpr = False,
     ):
         """Initializes the configuration for a flash attention v2 kernel.
 
@@ -100,6 +102,16 @@ class FlashAttentionBackwardSm80:
         self.share_QV_smem = V_in_regs
         self.score_mod = score_mod
         self.score_mod_bwd = score_mod_bwd
+        self.has_aux_tensors = has_aux_tensors
+        self.score_vec_size: cutlass.Constexpr = getattr(
+            score_mod, "__vec_size__", 1 if cutlass.const_expr(has_aux_tensors) else 2
+        )
+        if self.score_vec_size > 2:
+            raise ValueError(
+                f"score_mod vec_size {self.score_vec_size} not supported on Sm80/120 "
+                "due to accumulator thread ownership pattern."
+            )
+        self.qk_acc_dtype = cutlass.Float32
 
     @staticmethod
     def can_implement(
@@ -444,6 +456,14 @@ class FlashAttentionBackwardSm80:
         softmax_scale_log2, _ = utils.compute_softmax_scale_log2(
             softmax_scale, self.score_mod
         )
+        fastdiv_mods = None
+        if cutlass.const_expr(aux_data.tensors is not None):
+            seqlen_q = mQ.shape[1] if cutlass.const_expr(mCuSeqlensQ is None) else mQ.shape[0]
+            seqlen_k = mK.shape[1] if cutlass.const_expr(mCuSeqlensK is None) else mK.shape[0]
+            fastdiv_mods = (
+                FastDivmodDivisor(seqlen_q),
+                FastDivmodDivisor(seqlen_k),
+            )
         self.kernel(
             mQ,
             mK,
@@ -482,6 +502,7 @@ class FlashAttentionBackwardSm80:
             tile_sched_params,
             TileScheduler,
             aux_data,
+            fastdiv_mods,
         ).launch(
             grid=grid_dim,
             block=[self.num_threads, 1, 1],
@@ -529,6 +550,7 @@ class FlashAttentionBackwardSm80:
         tile_sched_params: ParamsBase,
         TileScheduler: cutlass.Constexpr[Callable],
         aux_data: AuxData = AuxData(),
+        fastdiv_mods=None,
     ):
         # Thread index, block index
         tidx, _, _ = cute.arch.thread_idx()
@@ -550,6 +572,25 @@ class FlashAttentionBackwardSm80:
                 tile_m=self.m_block_size,
                 tile_n=self.n_block_size,
             )
+
+            recompute_fastdiv_mods_q = cutlass.const_expr(
+                aux_data.tensors is not None
+                and (seqlen.has_cu_seqlens_q or seqlen.has_seqused_q)
+            )
+            recompute_fastdiv_mods_k = cutlass.const_expr(
+                aux_data.tensors is not None
+                and (seqlen.has_cu_seqlens_k or seqlen.has_seqused_k)
+            )
+            if cutlass.const_expr(fastdiv_mods is not None):
+                seqlen_q_divmod, seqlen_k_divmod = fastdiv_mods
+                fastdiv_mods = (
+                    seqlen_q_divmod
+                    if not recompute_fastdiv_mods_q
+                    else FastDivmodDivisor(seqlen.seqlen_q),
+                    seqlen_k_divmod
+                    if not recompute_fastdiv_mods_k
+                    else FastDivmodDivisor(seqlen.seqlen_k),
+                )
 
             block_info = BlockInfo(
                 self.m_block_size,
@@ -797,7 +838,12 @@ class FlashAttentionBackwardSm80:
                 m_block_max=m_block_max,
                 softmax_scale=softmax_scale,
                 softmax_scale_log2=softmax_scale_log2,
+                batch_idx=batch_idx,
+                head_idx=head_idx,
+                n_block=n_block,
+                seqlen=seqlen,
                 aux_data=aux_data,
+                fastdiv_mods=fastdiv_mods,
             )
 
             if m_block_min < m_block_max:
@@ -879,6 +925,100 @@ class FlashAttentionBackwardSm80:
             )
 
     @cute.jit
+    def apply_score_mod(
+        self,
+        acc_S: cute.Tensor,
+        thr_mma_sdp: cute.ThrMma,
+        batch_idx,
+        head_idx,
+        m_block,
+        n_block,
+        softmax_scale,
+        seqlen_info: SeqlenInfoQK,
+        aux_data: AuxData = AuxData(),
+        fastdiv_mods=None,
+    ):
+        cS = cute.make_identity_tensor(
+            (self.n_block_size, self.m_block_size)
+            if self.SdP_swapAB
+            else (self.m_block_size, self.n_block_size)
+        )
+        cS = cute.domain_offset(
+            (n_block * self.n_block_size, m_block * self.m_block_size)
+            if self.SdP_swapAB
+            else (m_block * self.m_block_size, n_block * self.n_block_size),
+            cS,
+        )
+        tScS = thr_mma_sdp.partition_C(cS)
+
+        apply_score_mod_inner(
+            acc_S,
+            tScS,
+            self.score_mod,
+            batch_idx,
+            head_idx,
+            softmax_scale,
+            self.score_vec_size,
+            self.qk_acc_dtype,
+            aux_data,
+            fastdiv_mods,
+            seqlen_info,
+            constant_q_idx=None,
+            qhead_per_kvhead=(
+                self.qhead_per_kvhead if cutlass.const_expr(self.pack_gqa) else 1
+            ),
+            transpose_indices=self.SdP_swapAB,
+        )
+
+    @cute.jit
+    def apply_score_mod_bwd(
+        self,
+        grad_tensor: cute.Tensor,
+        score_tensor: cute.Tensor,
+        thr_mma_sdp: cute.ThrMma,
+        batch_idx,
+        head_idx,
+        m_block,
+        n_block,
+        softmax_scale,
+        seqlen_info: SeqlenInfoQK,
+        aux_data: AuxData = AuxData(),
+        fastdiv_mods=None,
+    ):
+        cS = cute.make_identity_tensor(
+            (self.n_block_size, self.m_block_size)
+            if self.SdP_swapAB
+            else (self.m_block_size, self.n_block_size)
+        )
+        cS = cute.domain_offset(
+            (n_block * self.n_block_size, m_block * self.m_block_size)
+            if self.SdP_swapAB
+            else (m_block * self.m_block_size, n_block * self.n_block_size),
+            cS,
+        )
+        tScS = thr_mma_sdp.partition_C(cS)
+
+        apply_score_mod_bwd_inner(
+            grad_tensor,
+            score_tensor,
+            tScS,
+            self.score_mod_bwd,
+            batch_idx,
+            head_idx,
+            softmax_scale,
+            self.score_vec_size,
+            self.qk_acc_dtype,
+            aux_data,
+            fastdiv_mods,
+            seqlen_info,
+            constant_q_idx=None,
+            qhead_per_kvhead=(
+                self.qhead_per_kvhead if cutlass.const_expr(self.pack_gqa) else 1
+            ),
+            transpose_indices=self.SdP_swapAB,
+        )
+
+    @cute.jit
     def compute_one_m_block(
         self,
         m_block: cutlass.Int32,
@@ -894,7 +1034,12 @@ class FlashAttentionBackwardSm80:
         m_block_max: cutlass.Int32,
         softmax_scale: cutlass.Float32,
         softmax_scale_log2: cutlass.Float32,
+        batch_idx: cutlass.Int32,
+        head_idx: cutlass.Int32,
+        n_block: cutlass.Int32,
+        seqlen: SeqlenInfoQK,
         aux_data: AuxData = AuxData(),
+        fastdiv_mods=None,
         mask_fn: Optional[Callable] = None,
     ):
         def load_Q_next():
@@ -932,19 +1077,18 @@ class FlashAttentionBackwardSm80:
         acc_S_mn = layout_utils.reshape_acc_to_mn(acc_S)
         acc_S_pre_mn = layout_utils.reshape_acc_to_mn(acc_S_pre)
         if cutlass.const_expr(self.score_mod is not None):
-            for r in cutlass.range(cute.size(acc_S_mn, mode=[0]), unroll_full=True):
-                acc_S_mn[r, None].store(
-                    call_score_mod(
-                        self.score_mod,
-                        acc_S_mn[r, None].load() * softmax_scale,
-                        0,
-                        0,
-                        0,
-                        0,
-                        None,
-                        aux_data,
-                    )
-                )
+            self.apply_score_mod(
+                acc_S,
+                mma_params.thr_mma_sdp,
+                batch_idx,
+                head_idx,
+                m_block,
+                n_block,
+                softmax_scale,
+                seqlen,
+                aux_data,
+                fastdiv_mods,
+            )
         if cutlass.const_expr(mask_fn is not None):
             mask_fn(acc_S, m_block=m_block)
         bidx = 0
@@ -977,19 +1121,21 @@ class FlashAttentionBackwardSm80:
         assert cute.size(acc_dP_mn, mode=[0]) == cute.size(tLSErdPsum)
         for r in cutlass.range(cute.size(acc_dP_mn, mode=[0]), unroll_full=True):
             grad_val = acc_S_mn[r, None].load() * (acc_dP_mn[r, None].load() - tLSErdPsum[r])
-            if cutlass.const_expr(self.score_mod_bwd is not None):
-                grad_val = call_score_mod_bwd(
-                    self.score_mod_bwd,
-                    grad_val,
-                    acc_S_pre_mn[r, None].load() * softmax_scale,
-                    0,
-                    0,
-                    0,
-                    0,
-                    None,
-                    aux_data,
-                )
             acc_dP_mn[r, None].store(grad_val)
+        if cutlass.const_expr(self.score_mod_bwd is not None):
+            self.apply_score_mod_bwd(
+                acc_dP,
+                acc_S_pre,
+                mma_params.thr_mma_sdp,
+                batch_idx,
+                head_idx,
+                m_block,
+                n_block,
+                softmax_scale,
+                seqlen,
+                aux_data,
+                fastdiv_mods,
+            )
         # if cute.arch.thread_idx()[0] == 0 and cute.arch.block_idx()[0] == bidx: cute.print_tensor(acc_dP_mn)
         rP = cute.make_fragment_like(acc_S, self.dtype)
         rP.store(acc_S.load().to(self.dtype))

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -1910,7 +1910,6 @@ def _flash_attn_bwd(
         use_2cta_instrs = False
         num_threads = 128
         assert not (block_sparse_tensors is not None), "Block sparsity backward not supported on SM 12.0"
-        assert score_mod is None and score_mod_bwd is None, "score_mod backward not supported on SM 12.0"
         assert mask_mod is None, "mask_mod backward not supported on SM 12.0"
         assert deterministic is False, "deterministic backward not supported on SM 12.0"
     elif arch // 10 == 9:
@@ -2428,6 +2427,7 @@ def _flash_attn_bwd(
                 V_in_regs=V_in_regs,
                 score_mod=score_mod,
                 score_mod_bwd=score_mod_bwd,
+                has_aux_tensors=aux_tensors is not None,
             )
         elif arch // 10 == 9:
             fa_bwd_obj = FlashAttentionBackwardSm90(

--- a/tests/cute/test_score_mod.py
+++ b/tests/cute/test_score_mod.py
@@ -1,4 +1,5 @@
 import math
+import os
 
 import pytest
 import torch
@@ -15,6 +16,7 @@ from flash_attn.cute.interface import (
     _tile_size_bwd_sm90,
 )
 from flash_attn.cute.block_sparsity import BlockSparseTensorsTorch
+from flash_attn.cute.testing import is_fake_mode, maybe_fake_tensor_mode
 
 COMPUTE_CAPABILITY = torch.cuda.get_device_capability()[0]
 
@@ -883,6 +885,142 @@ def run_flex_reference_bwd(q, k, v, eager_score_mod, grad_out, dtype=None):
     dq, dk, dv = torch.autograd.grad(out, (q, k, v), grad_out)
 
     return out, dq, dk, dv
+
+
+def run_eager_attention_reference_bwd(q, k, v, eager_score_mod, grad_out, dtype):
+    """Dense PyTorch reference that does not depend on a fused GPU kernel."""
+    q = q.to(dtype).detach().requires_grad_(True)
+    k = k.to(dtype).detach().requires_grad_(True)
+    v = v.to(dtype).detach().requires_grad_(True)
+    grad_out = grad_out.to(dtype)
+
+    qhead_per_kvhead = q.shape[1] // k.shape[1]
+    k_for_scores = k.repeat_interleave(qhead_per_kvhead, dim=1)
+    v_for_out = v.repeat_interleave(qhead_per_kvhead, dim=1)
+    scores = torch.matmul(q, k_for_scores.transpose(-2, -1)) * (q.shape[-1] ** -0.5)
+    batch_idx = torch.arange(q.shape[0], device=q.device).view(-1, 1, 1, 1)
+    head_idx = torch.arange(q.shape[1], device=q.device).view(1, -1, 1, 1)
+    q_idx = torch.arange(q.shape[2], device=q.device).view(1, 1, -1, 1)
+    kv_idx = torch.arange(k.shape[2], device=q.device).view(1, 1, 1, -1)
+    scores = eager_score_mod(scores, batch_idx, head_idx, q_idx, kv_idx)
+    out = torch.matmul(torch.softmax(scores, dim=-1), v_for_out)
+    dq, dk, dv = torch.autograd.grad(out, (q, k, v), grad_out)
+    return out, dq, dk, dv
+
+
+@pytest.mark.skipif(COMPUTE_CAPABILITY != 12, reason="SM120-only score_mod backward coverage")
+@pytest.mark.parametrize(
+    "dim,dtype,seqlen_q,seqlen_kv,score_mod_triple,uses_aux,num_kv_heads",
+    [
+        pytest.param(
+            64,
+            torch.bfloat16,
+            65,
+            97,
+            (score_mod_5, score_mod_bwd_5, times_two_eager),
+            False,
+            4,
+            id="times-two-bf16-d64",
+        ),
+        pytest.param(
+            64,
+            torch.float16,
+            113,
+            203,
+            (score_mod_3, score_mod_bwd_3, relative_bias_eager),
+            False,
+            4,
+            id="relative-bias-fp16-d64",
+        ),
+        pytest.param(
+            128,
+            torch.bfloat16,
+            64,
+            96,
+            (score_mod_squared, score_mod_bwd_squared, score_squared_eager),
+            False,
+            4,
+            id="squared-bf16-d128",
+        ),
+        pytest.param(
+            128,
+            torch.float16,
+            97,
+            65,
+            (score_mod_11, score_mod_bwd_identity, dual_buffer_bias),
+            True,
+            4,
+            id="dual-buffer-fp16-d128",
+        ),
+        pytest.param(
+            64,
+            torch.bfloat16,
+            129,
+            97,
+            (score_mod_11, score_mod_bwd_identity, dual_buffer_bias),
+            True,
+            1,
+            id="dual-buffer-gqa-bf16-d64",
+        ),
+    ],
+)
+@maybe_fake_tensor_mode(int(os.getenv("FLASH_ATTENTION_FAKE_TENSOR", 0)) == 1)
+def test_sm120_score_mod_backward(
+    dim, dtype, seqlen_q, seqlen_kv, score_mod_triple, uses_aux, num_kv_heads
+):
+    """Exercise value-, position-, and aux-dependent score gradients on SM120."""
+    torch.random.manual_seed(42)
+    cute_fwd, cute_bwd, eager_mod = score_mod_triple
+    q, k, v = create_tensors(
+        batch_size=2,
+        seqlen_q=seqlen_q,
+        seqlen_kv=seqlen_kv,
+        num_heads=4,
+        dim=dim,
+        dtype=dtype,
+    )
+    k = k[:, :num_kv_heads].clone()
+    v = v[:, :num_kv_heads].clone()
+
+    aux_tensors = None
+    if uses_aux:
+        head_bias = torch.randn(q.shape[1], device="cuda", dtype=dtype) * 0.2
+        pos_bias = torch.arange(seqlen_q, device="cuda", dtype=dtype) * 0.01
+        aux_tensors = [head_bias, pos_bias]
+        eager_mod = eager_mod(head_bias, pos_bias)
+
+    _, grad_out, dq_cute, dk_cute, dv_cute = run_cute_flash_bwd(
+        q,
+        k,
+        v,
+        cute_fwd,
+        cute_bwd,
+        aux_tensors=aux_tensors,
+        pack_gqa=num_kv_heads != q.shape[1],
+    )
+    if is_fake_mode():
+        return
+    _, dq_ref_fp32, dk_ref_fp32, dv_ref_fp32 = run_eager_attention_reference_bwd(
+        q, k, v, eager_mod, grad_out, torch.float32
+    )
+    _, dq_pt, dk_pt, dv_pt = run_eager_attention_reference_bwd(
+        q, k, v, eager_mod, grad_out, dtype
+    )
+
+    for name, cute_grad, ref_fp32, pt_grad in (
+        ("dQ", dq_cute, dq_ref_fp32, dq_pt),
+        ("dK", dk_cute, dk_ref_fp32, dk_pt),
+        ("dV", dv_cute, dv_ref_fp32, dv_pt),
+    ):
+        assert not torch.isnan(cute_grad).any(), f"{name} contains NaN"
+        atol = 2 * (ref_fp32 + 0.3 - 0.3 - ref_fp32).abs().max().item() + 1e-3
+        ref = ref_fp32.to(dtype)
+        pt_error = (pt_grad - ref).abs().max().item()
+        cute_error = (cute_grad - ref).abs().max().item()
+        assert cute_error <= 3 * pt_error + atol, (
+            f"{name} CuTE error {cute_error:.2e} exceeds "
+            f"3x PyTorch error {pt_error:.2e} + {atol:.2e}"
+        )
 
 
 @pytest.mark.skipif(COMPUTE_CAPABILITY != 9, reason="SM90-only test")

--- a/tests/cute/test_score_mod_varlen.py
+++ b/tests/cute/test_score_mod_varlen.py
@@ -86,6 +86,7 @@ from score_mod_definitions import (
 
 IS_SM90 = torch.cuda.get_device_capability()[0] == 9
 IS_SM100 = torch.cuda.get_device_capability()[0] == 10
+IS_SM120 = torch.cuda.get_device_capability()[0] == 12
 
 # =============================================================================
 # Test pairs
@@ -1350,6 +1351,67 @@ def _check_grad(name, cute_grad, ref_fp32, pt_grad, dtype, rtol=3, extra=1e-3):
     assert cute_err <= rtol * pt_err + atol, (
         f"{name} CuTE err {cute_err:.2e} exceeds {rtol}*PT err {pt_err:.2e} + {atol:.2e}"
     )
+
+
+@pytest.mark.skipif(not IS_SM120, reason="SM120-only score_mod backward coverage")
+@pytest.mark.parametrize("use_autograd", [True, False])
+def test_sm120_varlen_score_mod_backward(use_autograd):
+    """Cover logical head and query-position aux reads for varlen attention."""
+    torch.random.manual_seed(42)
+    dtype = torch.bfloat16
+    dim = 64
+    seqlens_q = [65, 17, 129]
+    seqlens_k = [65, 17, 129]
+    num_q_heads = 4
+    num_kv_heads = 4
+
+    q = torch.randn(sum(seqlens_q), num_q_heads, dim, device="cuda", dtype=dtype)
+    k = torch.randn(sum(seqlens_k), num_kv_heads, dim, device="cuda", dtype=dtype)
+    v = torch.randn_like(k)
+    cu_seqlens_q = torch.tensor(
+        [0] + list(torch.tensor(seqlens_q).cumsum(0).tolist()),
+        device="cuda",
+        dtype=torch.int32,
+    )
+    cu_seqlens_k = torch.tensor(
+        [0] + list(torch.tensor(seqlens_k).cumsum(0).tolist()),
+        device="cuda",
+        dtype=torch.int32,
+    )
+    head_bias = torch.randn(num_q_heads, device="cuda", dtype=dtype) * 0.2
+    pos_bias = torch.arange(max(seqlens_q), device="cuda", dtype=dtype) * 0.01
+    aux_tensors = [head_bias, pos_bias]
+    eager_score_mod = dual_buffer_factory(head_bias, pos_bias)
+
+    _, grad_out, dq_cute, dk_cute, dv_cute = run_cute_flash_bwd_varlen(
+        q,
+        k,
+        v,
+        score_mod_dual_buffer,
+        score_mod_bwd_dual_buffer,
+        cu_seqlens_q,
+        cu_seqlens_k,
+        aux_tensors=aux_tensors,
+        pack_gqa=False,
+        use_autograd=use_autograd,
+    )
+    _, dq_ref_fp32, dk_ref_fp32, dv_ref_fp32 = run_flex_varlen_ref_bwd(
+        q,
+        k,
+        v,
+        cu_seqlens_q,
+        cu_seqlens_k,
+        eager_score_mod,
+        grad_out,
+        dtype=torch.float32,
+    )
+    _, dq_pt, dk_pt, dv_pt = run_flex_varlen_ref_bwd(
+        q, k, v, cu_seqlens_q, cu_seqlens_k, eager_score_mod, grad_out, dtype=dtype
+    )
+
+    _check_grad("dQ", dq_cute, dq_ref_fp32, dq_pt, dtype)
+    _check_grad("dK", dk_cute, dk_ref_fp32, dk_pt, dtype)
+    _check_grad("dV", dv_cute, dv_ref_fp32, dv_pt, dtype)
 
 
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])


### PR DESCRIPTION
## Summary

Enable custom `score_mod` / `score_mod_bwd` in the CuTe SM120 backward path for:

- dense MHA and GQA;
- dense score modifiers with scalar, position, batch/head, or auxiliary-tensor dependence;
- varlen MHA with per-sequence auxiliary indexing;
- BF16/FP16 and D64/D128 configurations covered by the existing SM120 kernel.

## Problem

The public forward path already accepts custom score modification on SM120, but backward rejects it unconditionally:

```text
score_mod backward not supported on SM 12.0
```

Simply removing that assertion would be incorrect. The inherited SM80-era backward code calls the modifier with batch, head, query, and key coordinates all hardcoded to zero. Value-only modifiers can appear to work, while relative-position, per-head, per-batch, and auxiliary-buffer modifiers silently compute wrong gradients.

## Implementation

The SM120/SM80-era kernel now follows the reviewed SM90/SM100 structure:

- build the real coordinate tensor from the MMA tile and scheduler coordinates;
- use shared `apply_score_mod_inner` and `apply_score_mod_bwd_inner` helpers;
- pass logical batch/head/Q/K indices and sequence metadata;
- use static fast-divisors for dense auxiliary buffers and rebuild divisors from each actual varlen sequence;
- include aux presence in the compile-time kernel configuration.

When no score modifier or aux tensor is present, the new branches and coordinate work are removed by `constexpr` specialization.

The forward and backward helper methods remain separate intentionally: they mirror the corresponding JIT boundaries in SM90/SM100 and keep cross-architecture code shapes grepable.

## Validation

RTX 5090 / SM120:

- unmodified main: 4/4 representative dense, aux, GQA, and varlen cases fail at the explicit SM120 assertion;
- new dense SM120 matrix: 5/5 passed (BF16/FP16, D64/D128, nonlinear, relative-position, aux, and GQA);
- new varlen MHA autograd/direct cases: 2/2 passed;
- FakeTensor compile coverage: 5/5 passed;
- existing dense score-mod regression subset: 6/6 passed;
- existing dense PackGQA score-mod subset: 2/2 passed;
- ordinary no-mod backward: 2/2 passed;
- softcap backward: 1/1 passed;
- independent varlen dual-buffer and global-aux checks pass;
- `py_compile`, fatal Ruff checks, and `git diff --check` pass.

D128 numerical checks use an eager FP32 PyTorch reference because the compiled FlexAttention reference itself requests 115200 bytes of shared memory, above the RTX 5090 limit of 101376 bytes.

## No-mod performance

BF16, B=2, S=2048, H=8, D=64 backward, five blocks of 100 launches:

- unmodified main median: 0.3485 ms;
- patch median: 0.3483 ms.

The 0.06% difference is measurement noise, consistent with compile-time elimination of the new modifier path.

## Scope and known upstream limits

Varlen GQA is not claimed: the existing SM120 no-score-mod varlen GQA path already hits a CUDA illegal access on current main. A separate order-dependent SM120 forward/JIT-cache failure can also appear when certain varlen auxiliary forward tests share one process; the same cases pass independently and the fault occurs in `_flash_attn_fwd`, before this backward change.

`mask_mod`, block sparsity, deterministic backward, and those pre-existing varlen-forward issues remain explicitly out of scope. `IS_SM120` added in tests is an architecture fixture constant, not production dispatch data.