### PR TITLE
publish.yml: trigger the release workflow on tag pushes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,9 +8,9 @@
 name: Build wheels and deploy
 
 on:
-  create:
+  push:
     tags:
-      - v*
+      - 'v*'
 
 jobs:
   setup_release:


### PR DESCRIPTION
Fixes #2769.

## Problem

`publish.yml` triggers on:

```yaml
on:
  create:
    tags:
      - v*
```

The `create` event does not support filters, so the `tags` key is ignored and the workflow runs on every branch creation as well. `setup_release` then runs:

```bash
gh release create ${GITHUB_REF#refs/tags/} ...
```

On a branch the ref is `refs/heads/...`, which does not match the stripped prefix, so the unstripped ref reaches the API and the step fails:

```
pre_receive Sorry, branch or tag names starting with 'refs/' are not allowed.
Published releases must have a valid tag
```

`build_wheels` and `publish_package` both list `setup_release` in `needs`, so they skip.

Checking the workflow's own history, of the last 40 runs **39 failed and one succeeded**, and the single success is the `v2.8.3.post1` tag. Every other run was a branch push.

## Fix

Switch to the `push` trigger, which honors the tag filter.

`publish-fa4.yml` in this repo already uses exactly this form:

```yaml
on:
  push:
    tags:
      - 'fa4-v*'
```

so this brings the older workflow in line with the newer one. `publish.yml` is the only workflow here still on a `create` trigger.

The `${GITHUB_REF#refs/tags/}` expression in `setup_release` is unchanged and continues to work, since a tag push sets `GITHUB_REF` to `refs/tags/<tag>`.

## Note on the matrix

The issue also observes that a tag-triggered run uses the workflow as it existed at that tag, so the matrix added in c04a808 has never run, and no cp310 / cp311 / cp313 wheels exist for torch >= 2.9. This change is what makes the next tag actually run the current matrix. Which versions to publish is a maintainer decision and is not touched here.