### PR TITLE
[Triton] Apply the computed bounds mask in kernel_fwd's output store

### DIFF
--- a/flash_attn/ops/triton/linear.py
+++ b/flash_attn/ops/triton/linear.py
@@ -252,7 +252,7 @@ def kernel_fwd(
     # C = C + rm[:, None] * stride_cm + rn[None, :] * stride_cn
     C = C + rm[:, None] * stride_cm + rn[None, :]
     mask = (rm < M)[:, None] & (rn < N)[None, :]
-    tl.store(C, acc)
+    tl.store(C, acc, mask=mask)
 
 
 def triton_linear_act(

--- a/tests/ops/triton/test_linear.py
+++ b/tests/ops/triton/test_linear.py
@@ -1,0 +1,36 @@
+import pytest
+import torch
+
+# flash_attn/ops/triton/linear.py imports triton.ops.matmul_perf_model, which
+# only exists in triton < 3.0
+pytest.importorskip("triton.ops")
+
+from flash_attn.ops.triton.linear import triton_linear_act  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    "M, N, K",
+    [
+        (513, 1000, 256),  # tails on both output axes
+        (5, 17, 9),
+        (512, 1024, 256),  # tile-aligned control
+    ],
+)
+@pytest.mark.parametrize("with_bias", [False, True])
+def test_linear_act_non_tile_aligned(M, N, K, with_bias):
+    """kernel_fwd's output store must respect the (rm < M) & (rn < N) bounds
+    mask: the host grid rounds up with cdiv, so unmasked tail tiles write past
+    the end of the output and onto the next row of it."""
+    torch.manual_seed(0)
+    device = "cuda"
+    x = torch.randn(M, K, device=device, dtype=torch.float16)
+    w = torch.randn(N, K, device=device, dtype=torch.float16)
+    bias = torch.randn(N, device=device, dtype=torch.float16) if with_bias else None
+
+    ref = x.float() @ w.float().t()
+    if bias is not None:
+        ref += bias.float()
+
+    for _ in range(3):  # the in-bounds corruption is a tile race, so repeat
+        out = triton_linear_act(x, w, bias)
+        torch.testing.assert_close(out.float(), ref, atol=1e-1, rtol=1e-2)


### PR DESCRIPTION
Fixes #2789.

`kernel_fwd` in `flash_attn/ops/triton/linear.py` builds the `(rm < M) & (rn < N)` mask on the line above its output store and never passes it, so any launch where M or N is not a multiple of the autotuned block sizes writes whole tail tiles past the end of the output and onto its next row — out-of-bounds writes plus nondeterministic wrong values on in-bounds cells where tiles overlap (6,113–10,358 wrong cells across three identical runs at M=513, N=1000, K=256; invalid global writes under compute-sanitizer, ending in an unspecified launch failure; tile-aligned shapes are clean, which is why tests never saw it). The sibling `kernel_bwd` has the identical three lines and stores with `mask=mask`.

Changes:

- `linear.py`: `tl.store(C, acc)` → `tl.store(C, acc, mask=mask)` — one token, matching `kernel_bwd` line 526.
- New `tests/ops/triton/test_linear.py`: `triton_linear_act` vs `x @ w.T (+bias)` at two non-tile-aligned shapes and an aligned control, three repeats each (the in-bounds corruption is a tile race). Gated with `pytest.importorskip("triton.ops")`, since this module only imports on triton < 3.0 (the same gate that scopes who can hit the bug). The non-aligned cases fail without the fix and all pass with it.

Performance: tile-aligned shapes previously produced identical stores; `do_bench` on `triton_linear_act` at (4096, 4096, 1024) fp16 (L40S, six interleaved runs): 173.7–174.6 us before vs 173.1–174.5 us after — neutral (three outliers from another job on the same GPU excluded, one before and two after). Non-aligned shapes previously computed wrong answers, so there is no meaningful before.

## Environment

- Base commit: a369df7 (main); flash_attn 2.7.4.post1 wheel for the compiled extension + checkout sources for the Triton module
- NVIDIA L40S (sm_89), driver CUDA 12.4
- torch 2.3.1+cu121, triton 2.3.1, Python 3.10
