### PR TITLE
Mask the output store in the Triton linear forward kernel

### DIFF
--- a/flash_attn/ops/triton/linear.py
+++ b/flash_attn/ops/triton/linear.py
@@ -252,7 +252,7 @@ def kernel_fwd(
     # C = C + rm[:, None] * stride_cm + rn[None, :] * stride_cn
     C = C + rm[:, None] * stride_cm + rn[None, :]
     mask = (rm < M)[:, None] & (rn < N)[None, :]
-    tl.store(C, acc)
+    tl.store(C, acc, mask=mask)
 
 
 def triton_linear_act(


### PR DESCRIPTION
Fixes #2789.

`kernel_fwd` in `flash_attn/ops/triton/linear.py` builds the exact bounds mask its output store needs on line 254, then stores without it on line 255:

```python
mask = (rm < M)[:, None] & (rn < N)[None, :]
tl.store(C, acc)
```

The host grid rounds up with `cdiv`, so when `M` or `N` isn't a multiple of the autotuned block sizes, the last tiles write their full `BLOCK_M x BLOCK_N` extent. That runs past the end of the `(M, N)` output, and an N-tail overshoot lands on the next row of the same tensor, so it corrupts cells owned by other tiles too. The in-bounds result then comes out wrong, and nondeterministically. The sibling `kernel_bwd` in the same file has the identical three lines and already stores with `mask=mask` (line 526), so this just brings the forward store in line with it.

The fix is the one line the mask was computed for:

```python
tl.store(C, acc, mask=mask)
```

I didn't touch the `SAVE_ACT_INPUT` store a few lines up: it addresses through `ram`/`rbn`, which are `rm % M` / `rn % N` (the `max_contiguous(multiple_of(...))` "trick to avoid masking" from earlier in the kernel), so it wraps to in-bounds addresses rather than overrunning. It has its own correctness question for the tail, but that's a different issue from the out-of-bounds write here, so I left it alone.

Verified on an RTX 3050 (sm_86), triton 2.3.1 / torch 2.3.1, comparing `triton_linear_act(x, w, activation="id")` against a reference `x @ w.T`:

```
                          before          after
M=512  N=1024 K=256   max_err 0.031     0.031   (tile-aligned, already fine)
M=513  N=1000 K=256   max_err 93.16     0.031
M=500  N=999  K=128   max_err 68.31     0.016
M=1000 N=513  K=256   max_err 97.94     0.062
```

Tile-aligned shapes match either way, which is why the benchmarks never caught this; every non-aligned shape is badly wrong before and correct after. I didn't add a test to the suite because this module imports `triton.ops.matmul_perf_model`, which was removed in triton >= 3.0, so it can't be imported under the triton versions CI runs; a test here would fail to collect. Happy to add one guarded on the triton version if you'd prefer.
