### PR TITLE
feat: support per-head rotary frequencies

### DIFF
--- a/flash_attn/layers/rotary.py
+++ b/flash_attn/layers/rotary.py
@@ -104,7 +104,8 @@ def apply_rotary_emb(
     Arguments:
         x: (batch_size, seqlen, nheads, headdim) if cu_seqlens is None
             else (total_seqlen, nheads, headdim)
-        cos, sin: (seqlen_rotary, rotary_dim / 2)
+        cos, sin: (seqlen_rotary, rotary_dim / 2) or
+            (seqlen_rotary, nheads, rotary_dim / 2)
         interleaved: if True, rotate pairs of even and odd dimensions (GPT-J style) instead
             of 1st half and 2nd half (GPT-NeoX style).
         inplace: if True, apply rotary embedding in-place.
@@ -146,7 +147,7 @@ def _apply_rotary_emb_qkv(
         conjugate=conjugate,
         seqlen_offsets=seqlen_offsets
     )
-    if cos_k is None and sin_k is None and qkv.is_contiguous():
+    if cos_k is None and sin_k is None and cos.ndim == 2 and qkv.is_contiguous():
         # Call 1 kernel instead of 2 kernels
         # We need qkv to be contiguous so that when we reshape to combine (3, nheads)
         # dimensions, we get the same tensor
@@ -248,8 +249,11 @@ def apply_rotary_emb_qkv_(
         qkv: (batch_size, seqlen, 3, nheads, headdim) or (batch_size, seqlen, num_heads_q + 2 * num_heads_k, headdim).
             If qkv has shape (batch_size, seqlen, num_heads_q + 2 * num_heads_k, headdim) (e.g. MQA / GQA),
             then num_heads_q must be provided.
-        cos, sin: (seqlen, rotary_dim / 2)
-        cos_k, sin_k: (seqlen, rotary_dim / 2), optional
+        cos, sin: (seqlen, rotary_dim / 2) or
+            (seqlen, num_heads_q, rotary_dim / 2)
+        cos_k, sin_k: (seqlen, rotary_dim / 2) or
+            (seqlen, num_heads_k, rotary_dim / 2), optional. When cos and sin are
+            per-head, cos_k and sin_k must be provided for MQA / GQA.
         interleaved: if True, rotate pairs of even and odd dimensions (GPT-J style) instead of
             1st half and 2nd half (GPT-NeoX style).
         seqlen_offsets: (batch_size,) or int. Each sequence in Q and K is shifted by this amount.
@@ -315,7 +319,8 @@ def apply_rotary_emb_kv_(
     """
     Arguments:
         kv: (batch_size, seqlen, 2, nheads, headdim)
-        cos, sin: (seqlen, rotary_dim / 2)
+        cos, sin: (seqlen, rotary_dim / 2) or
+            (seqlen, nheads, rotary_dim / 2)
         interleaved: if True, rotate pairs of even and odd dimensions (GPT-J style) instead of
             1st half and 2nd half (GPT-NeoX style).
         seqlen_offsets: (batch_size,) or int. Each sequence in Q and K is shifted by this amount.

--- a/flash_attn/ops/triton/rotary.py
+++ b/flash_attn/ops/triton/rotary.py
@@ -38,6 +38,7 @@ def rotary_kernel(
     IS_VARLEN: tl.constexpr,
     INTERLEAVED: tl.constexpr,
     CONJUGATE: tl.constexpr,
+    IS_PER_HEAD: tl.constexpr,
     BLOCK_H: tl.constexpr,
     BLOCK_M: tl.constexpr,
 ):
@@ -67,9 +68,26 @@ def rotary_kernel(
         rm_cs = rm + tl.load(SEQLEN_OFFSETS + pid_batch)
 
     rk_half = tl.arange(0, BLOCK_K // 2)
-    COS = COS + (rm_cs[:, None] * ROTARY_DIM_HALF + rk_half[None, :])
-    SIN = SIN + (rm_cs[:, None] * ROTARY_DIM_HALF + rk_half[None, :])
-    mask_cs = (rm_cs[:, None] < seqlen_ro) & (rk_half[None, :] < ROTARY_DIM_HALF)
+    if IS_PER_HEAD:
+        COS = COS + (
+            rh[:, None, None] * ROTARY_DIM_HALF
+            + rm_cs[None, :, None] * nheads * ROTARY_DIM_HALF
+            + rk_half[None, None, :]
+        )
+        SIN = SIN + (
+            rh[:, None, None] * ROTARY_DIM_HALF
+            + rm_cs[None, :, None] * nheads * ROTARY_DIM_HALF
+            + rk_half[None, None, :]
+        )
+        mask_cs = (
+            (rh[:, None, None] < nheads)
+            & (rm_cs[None, :, None] < seqlen_ro)
+            & (rk_half[None, None, :] < ROTARY_DIM_HALF)
+        )
+    else:
+        COS = COS + (rm_cs[:, None] * ROTARY_DIM_HALF + rk_half[None, :])
+        SIN = SIN + (rm_cs[:, None] * ROTARY_DIM_HALF + rk_half[None, :])
+        mask_cs = (rm_cs[:, None] < seqlen_ro) & (rk_half[None, :] < ROTARY_DIM_HALF)
     cos = tl.load(COS, mask=mask_cs, other=1.0).to(tl.float32)
     sin = tl.load(SIN, mask=mask_cs, other=0.0).to(tl.float32)
     if CONJUGATE:
@@ -114,8 +132,8 @@ def apply_rotary(
     Arguments:
         x: (batch, seqlen, nheads, headdim) if cu_seqlens is None
             else (total_seqlen, nheads, headdim).
-        cos: (seqlen_ro, rotary_dim / 2)
-        sin: (seqlen_ro, rotary_dim / 2)
+        cos: (seqlen_ro, rotary_dim / 2) or (seqlen_ro, nheads, rotary_dim / 2)
+        sin: (seqlen_ro, rotary_dim / 2) or (seqlen_ro, nheads, rotary_dim / 2)
         seqlen_offsets: integer or integer tensor of size (batch,)
         cu_seqlens: (batch + 1,) or None
         max_seqlen: int
@@ -131,8 +149,17 @@ def apply_rotary(
         batch_p_1 = cu_seqlens.shape[0]
         batch = batch_p_1 - 1
         seqlen = max_seqlen
-    seqlen_ro, rotary_dim = cos.shape
+    assert cos.ndim in (2, 3), (
+        "cos and sin must have shape (seqlen_ro, rotary_dim / 2) or "
+        "(seqlen_ro, nheads, rotary_dim / 2)"
+    )
     assert sin.shape == cos.shape
+    is_per_head = cos.ndim == 3
+    if is_per_head:
+        seqlen_ro, nheads_ro, rotary_dim = cos.shape
+        assert nheads_ro == nheads, "The number of rotary heads must match the input"
+    else:
+        seqlen_ro, rotary_dim = cos.shape
     rotary_dim *= 2
     assert rotary_dim <= headdim, "rotary_dim must be <= headdim"
     assert headdim <= 256, "Only support headdim <= 256"
@@ -179,6 +206,7 @@ def apply_rotary(
             is_varlen,
             interleaved,
             conjugate,
+            is_per_head,
             BLOCK_M=BLOCK_M,
             BLOCK_H=2,
         )

--- a/tests/test_rotary.py
+++ b/tests/test_rotary.py
@@ -171,6 +171,98 @@ def test_rotary_emb_qkv(interleaved, rotary_fraction, seqlen_offsets_type, gqa, 
 @pytest.mark.parametrize(
     "dtype", ([torch.float16] if not is_sm8x else [torch.float16, torch.bfloat16])
 )
+@pytest.mark.parametrize("gqa", [False, True])
+@pytest.mark.parametrize("interleaved", [False, True])
+def test_rotary_emb_qkv_per_head(interleaved, gqa, dtype):
+    """Each Q/K head can use a distinct set of rotary frequencies."""
+    rtol = 1e-3
+    batch_size = 4
+    seqlen = 63
+    nheads_q = 6
+    nheads_k = 3 if gqa else nheads_q
+    headdim = 64
+    rotary_dim = 32
+    device = "cuda"
+    torch.manual_seed(42)
+
+    if not gqa:
+        qkv = torch.randn(
+            batch_size,
+            seqlen,
+            3,
+            nheads_q,
+            headdim,
+            dtype=dtype,
+            device=device,
+            requires_grad=True,
+        )
+    else:
+        qkv = torch.randn(
+            batch_size,
+            seqlen,
+            nheads_q + 2 * nheads_k,
+            headdim,
+            dtype=dtype,
+            device=device,
+            requires_grad=True,
+        )
+    qkv_pt = qkv.detach().clone().requires_grad_()
+    angles_q = torch.rand(seqlen, nheads_q, rotary_dim // 2, device=device) * 2 * math.pi
+    angles_k = torch.rand(seqlen, nheads_k, rotary_dim // 2, device=device) * 2 * math.pi
+    cos_q, sin_q = angles_q.cos().to(dtype=dtype), angles_q.sin().to(dtype=dtype)
+    cos_k, sin_k = angles_k.cos().to(dtype=dtype), angles_k.sin().to(dtype=dtype)
+
+    out = apply_rotary_emb_qkv_(
+        qkv,
+        cos_q,
+        sin_q,
+        cos_k=None if not gqa else cos_k,
+        sin_k=None if not gqa else sin_k,
+        interleaved=interleaved,
+        num_heads_q=None if not gqa else nheads_q,
+    )
+
+    def apply_rotary_per_head_torch(x, cos, sin):
+        x_rotary = x[..., :rotary_dim].float()
+        if interleaved:
+            x1, x2 = x_rotary[..., ::2], x_rotary[..., 1::2]
+            x_half = torch.stack((-x2, x1), dim=-1).flatten(-2)
+            cos = cos.repeat_interleave(2, dim=-1)
+            sin = sin.repeat_interleave(2, dim=-1)
+        else:
+            x1, x2 = x_rotary.chunk(2, dim=-1)
+            x_half = torch.cat((-x2, x1), dim=-1)
+            cos = torch.cat((cos, cos), dim=-1)
+            sin = torch.cat((sin, sin), dim=-1)
+        x_rotary = x_rotary * cos[None].float() + x_half * sin[None].float()
+        return torch.cat((x_rotary.to(dtype=dtype), x[..., rotary_dim:]), dim=-1)
+
+    if not gqa:
+        q_pt, k_pt, v_pt = qkv_pt.unbind(2)
+        cos_k, sin_k = cos_q, sin_q
+    else:
+        q_pt, k_pt, v_pt = qkv_pt.split([nheads_q, nheads_k, nheads_k], dim=2)
+    q_pt = apply_rotary_per_head_torch(q_pt, cos_q, sin_q)
+    k_pt = apply_rotary_per_head_torch(k_pt, cos_k, sin_k)
+    out_pt = (
+        torch.stack((q_pt, k_pt, v_pt), dim=2)
+        if not gqa
+        else torch.cat((q_pt, k_pt, v_pt), dim=2)
+    )
+
+    g = torch.randn_like(out)
+    g_pt = g.clone()  # Since inplace=True, backward modifies the gradient inplace
+    out.backward(g)
+    out_pt.backward(g_pt)
+    atol = ((out_pt + 0.3 - 0.3) - out_pt).abs().max().item()
+    assert torch.allclose(out, out_pt, rtol=rtol, atol=2 * atol)
+    atol = ((qkv_pt.grad + 0.3 - 0.3) - qkv_pt.grad).abs().max().item()
+    assert torch.allclose(qkv.grad, qkv_pt.grad, rtol=rtol, atol=2 * atol)
+
+
+@pytest.mark.parametrize(
+    "dtype", ([torch.float16] if not is_sm8x else [torch.float16, torch.bfloat16])
+)
 # @pytest.mark.parametrize('dtype', ([torch.float16]))
 @pytest.mark.parametrize("seqlen_offsets_type", [0, int, torch.Tensor])
 # @pytest.mark.parametrize("seqlen_offsets_type", [0])


### PR DESCRIPTION
## Summary

- accept per-head rotary cosine and sine tables with shape `(seqlen, nheads, rotary_dim / 2)`
- preserve the existing shared-table Q/K fast path and support distinct Q/K head counts for GQA
- add FP16/BF16 forward and backward coverage for standard QKV and GQA layouts

Fixes #578.

## Testing

- `CUDA_VISIBLE_DEVICES=0 python -m pytest -q tests/test_rotary.py -k per_head -x` — 8 passed
- `CUDA_VISIBLE_DEVICES=1 python -m pytest -q tests/test_rotary.py -k per_head -x` — 8 passed
- `CUDA_VISIBLE_DEVICES=0 python -m pytest -q tests/test_rotary.py` — 224 passed, 1 failed; the failure is the pre-existing `test_compilation_count` incompatibility with Triton 3.7.1 and reproduces on the clean base
- `python -m py_compile flash_attn/ops/triton/rotary.py flash_attn/layers/rotary.py tests/test_rotary.py`
- `git diff --check`
