### PR TITLE
[CuTe, SM100] Support varlen block-sparse backward

### DIFF
--- a/flash_attn/cute/block_sparse_utils.py
+++ b/flash_attn/cute/block_sparse_utils.py
@@ -1212,6 +1212,7 @@ def produce_block_sparse_q_loads_bwd_sm100_default(
     # Subtiling factor and bounds
     q_subtile_factor: cutlass.Constexpr = 1,
     m_block_max: int = 0,
+    num_sparse_m_blocks: int | None = None,
     # Optional 2CTA state for hdim <= 128
     use_2cta_instrs: cutlass.Constexpr = False,
     producer_state_Qt=None,
@@ -1231,7 +1232,13 @@ def produce_block_sparse_q_loads_bwd_sm100_default(
         curr_full_idx,
         loop_count,
     ) = get_block_sparse_iteration_info_bwd(
-        blocksparse_tensors, batch_idx, head_idx, n_block, q_subtile_factor, m_block_max
+        blocksparse_tensors,
+        batch_idx,
+        head_idx,
+        n_block,
+        q_subtile_factor,
+        m_block_max,
+        num_sparse_m_blocks,
     )
     # 2 cta peels the first loop for Qt path; so we guard the whole block if loopcount == 0
     if loop_count > Int32(0):
@@ -1403,6 +1410,7 @@ def produce_block_sparse_q_loads_bwd_sm100_2cta_hdim192(
     # Subtiling factor and bounds
     q_subtile_factor: cutlass.Constexpr = 1,
     m_block_max: int = 0,
+    num_sparse_m_blocks: int | None = None,
 ):
     """Produce SM100 backward block-sparse Q/dO loads for the hdim192 2CTA schedule."""
     (
@@ -1412,7 +1420,13 @@ def produce_block_sparse_q_loads_bwd_sm100_2cta_hdim192(
         curr_full_idx,
         loop_count,
     ) = get_block_sparse_iteration_info_bwd(
-        blocksparse_tensors, batch_idx, head_idx, n_block, q_subtile_factor, m_block_max
+        blocksparse_tensors,
+        batch_idx,
+        head_idx,
+        n_block,
+        q_subtile_factor,
+        m_block_max,
+        num_sparse_m_blocks,
     )
 
     if loop_count > Int32(0):

--- a/flash_attn/cute/flash_bwd_sm100.py
+++ b/flash_attn/cute/flash_bwd_sm100.py
@@ -938,9 +938,14 @@ class FlashAttentionBackwardSm100:
         # 2-CTA: 231424 and 1-CTA: 232448
         # print("SMEM: ", self.shared_storage.size_in_bytes())
         if const_expr(self.use_block_sparsity):
-            assert all(x is None for x in (mCuSeqlensQ, mCuSeqlensK, mSeqUsedQ, mSeqUsedK)), (
-                "Variable sequence length is not supported yet for blocksparse in bwd"
-            )
+            is_varlen = any(x is not None for x in (mCuSeqlensQ, mCuSeqlensK, mSeqUsedQ, mSeqUsedK))
+            if const_expr(is_varlen):
+                # Packed varlen metadata is per-physical-KV-tile and per-sequence, so
+                # neither KV subtiling nor 2CTA clustering is supported.
+                assert self.kv_subtile_factor == 1 and not self.use_2cta_instrs, (
+                    "Varlen block-sparse backward requires kv_subtile_factor == 1 "
+                    "and no 2CTA instructions"
+                )
 
         self.kernel(
             tma_tensor_Q,
@@ -1660,6 +1665,9 @@ class FlashAttentionBackwardSm100:
             num_iters = m_block_max - m_block_min
             if const_expr(self.use_block_sparsity):
                 assert blocksparse_tensors is not None
+                num_sparse_m_blocks = cute.ceil_div(
+                    seqlen.seqlen_q, self.tile_m * self.q_subtile_factor
+                )
                 num_iters = get_total_q_block_count_bwd(
                     blocksparse_tensors,
                     batch_idx,
@@ -1667,6 +1675,7 @@ class FlashAttentionBackwardSm100:
                     n_block // self.kv_subtile_factor,
                     q_subtile_factor=self.q_subtile_factor,
                     m_block_max=m_block_max,
+                    num_sparse_m_blocks=num_sparse_m_blocks,
                 )
                 process_tile = num_iters > Int32(0)
 
@@ -2174,6 +2183,9 @@ class FlashAttentionBackwardSm100:
 
             else:
                 assert blocksparse_tensors is not None
+                num_sparse_m_blocks = cute.ceil_div(
+                    seqlen.seqlen_q, self.tile_m * self.q_subtile_factor
+                )
                 if const_expr(self.use_2cta_instrs and self.tile_hdim == 192):
                     assert should_load_Q and should_load_dO
                     assert load_dOt is not None and load_Qt is not None
@@ -2213,6 +2225,7 @@ class FlashAttentionBackwardSm100:
                         self.tma_copy_bytes["V"],
                         q_subtile_factor=self.q_subtile_factor,
                         m_block_max=m_block_max,
+                        num_sparse_m_blocks=num_sparse_m_blocks,
                     )
                 else:
                     (
@@ -2246,6 +2259,7 @@ class FlashAttentionBackwardSm100:
                         should_load_dO,
                         q_subtile_factor=self.q_subtile_factor,
                         m_block_max=m_block_max,
+                        num_sparse_m_blocks=num_sparse_m_blocks,
                         use_2cta_instrs=self.use_2cta_instrs,
                         producer_state_Qt=producer_state_Qt,
                         producer_state_Kt=producer_state_Kt,
@@ -2426,6 +2440,9 @@ class FlashAttentionBackwardSm100:
             )
 
             if const_expr(self.use_block_sparsity):
+                num_sparse_m_blocks = cute.ceil_div(
+                    seqlen.seqlen_q, self.tile_m * self.q_subtile_factor
+                )
                 block_iter_count = get_total_q_block_count_bwd(
                     blocksparse_tensors,
                     batch_idx,
@@ -2433,6 +2450,7 @@ class FlashAttentionBackwardSm100:
                     n_block // self.kv_subtile_factor,
                     q_subtile_factor=self.q_subtile_factor,
                     m_block_max=m_block_max,
+                    num_sparse_m_blocks=num_sparse_m_blocks,
                 )
                 process_tile = block_iter_count > Int32(0)
             else:
@@ -3091,6 +3109,9 @@ class FlashAttentionBackwardSm100:
             )
             if const_expr(self.use_block_sparsity):
                 assert blocksparse_tensors is not None
+                num_sparse_m_blocks = cute.ceil_div(
+                    seqlen.seqlen_q, self.tile_m * self.q_subtile_factor
+                )
                 (
                     curr_q_cnt,
                     curr_q_idx,
@@ -3104,6 +3125,7 @@ class FlashAttentionBackwardSm100:
                     n_block // self.kv_subtile_factor,
                     q_subtile_factor=self.q_subtile_factor,
                     m_block_max=m_block_max,
+                    num_sparse_m_blocks=num_sparse_m_blocks,
                 )
                 process_tile = loop_count > Int32(0)
 
@@ -3673,6 +3695,9 @@ class FlashAttentionBackwardSm100:
             )
             if const_expr(self.use_block_sparsity):
                 assert blocksparse_tensors is not None
+                num_sparse_m_blocks = cute.ceil_div(
+                    seqlen.seqlen_q, self.tile_m * self.q_subtile_factor
+                )
                 (
                     curr_q_cnt,
                     curr_q_idx,
@@ -3686,6 +3711,7 @@ class FlashAttentionBackwardSm100:
                     n_block_sparse,
                     q_subtile_factor=self.q_subtile_factor,
                     m_block_max=m_block_max,
+                    num_sparse_m_blocks=num_sparse_m_blocks,
                 )
                 process_tile = loop_count > Int32(0)
             if const_expr(self.deterministic and self.use_block_sparsity):

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -1968,9 +1968,9 @@ def _flash_attn_bwd(
         )
     q_subtile_factor = sparse_q // m_block_size if sparse_q is not None else 2
     if is_varlen and use_block_sparsity:
-        if arch // 10 != 9:
+        if arch // 10 not in (9, 10, 11):
             raise NotImplementedError(
-                "Varlen block-sparse backward is supported on SM90 only"
+                "Varlen block-sparse backward is supported on SM90/SM100/SM110 only"
             )
         if deterministic:
             raise NotImplementedError(

--- a/tests/cute/test_mask_mod_varlen.py
+++ b/tests/cute/test_mask_mod_varlen.py
@@ -1110,7 +1110,13 @@ def _assert_varlen_block_sparse_backward_matches_reference(
         )
 
 
-@pytest.mark.skipif(COMPUTE_CAPABILITY != 9, reason="SM90 only")
+# Varlen block-sparse backward is implemented for SM90 and SM100/SM110.
+VARLEN_BWD_SPARSE_SUPPORTED = COMPUTE_CAPABILITY in (9, 10, 11)
+# Sparse forward metadata must match the forward Q tile: 256 on SM100+, 128 on SM90.
+SPARSE_FWD_Q_BLOCK = 256 if COMPUTE_CAPABILITY >= 10 else 128
+
+
+@pytest.mark.skipif(not VARLEN_BWD_SPARSE_SUPPORTED, reason="SM90/SM100/SM110 only")
 @pytest.mark.parametrize(
     "dtype,metadata_heads,mask_name",
     [
@@ -1118,27 +1124,39 @@ def _assert_varlen_block_sparse_backward_matches_reference(
         pytest.param(torch.float16, 1, "mini_causal", id="fp16-broadcast"),
     ],
 )
-def test_varlen_block_sparse_backward_sm90(dtype, metadata_heads, mask_name):
+def test_varlen_block_sparse_backward(dtype, metadata_heads, mask_name):
     _assert_varlen_block_sparse_backward_matches_reference(
         [257, 129],
         [385, 129],
         metadata_heads=metadata_heads,
         dtype=dtype,
         mask_name=mask_name,
+        # Backward-direction (128, 128) metadata does not match the SM100 forward
+        # Q tile of 256, so pair it with a dense mask-mod forward there.
+        use_sparse_forward=COMPUTE_CAPABILITY == 9,
     )
 
 
-@pytest.mark.skipif(COMPUTE_CAPABILITY != 9, reason="SM90 only")
-@pytest.mark.parametrize(
-    "head_dim,block_size,use_sparse_forward",
-    [
+if COMPUTE_CAPABILITY == 9:
+    Q_SUBTILE_CASES = [
         pytest.param(128, (128, 128), True, id="factor-2"),
         # D=96 forward uses tile_n=144, while backward uses tile_n=128. A dense
         # mask-mod forward isolates the packed factor-3 backward metadata path.
         pytest.param(96, (192, 128), False, id="factor-3"),
-    ],
-)
-def test_varlen_block_sparse_backward_q_subtiles_sm90(
+    ]
+else:
+    # SM100 backward uses tile_m=128, so the subtile factors shift by one
+    # relative to SM90 for the same sparse block sizes.
+    Q_SUBTILE_CASES = [
+        pytest.param(128, (128, 128), False, id="factor-1"),
+        pytest.param(128, (256, 128), True, id="factor-2"),
+        pytest.param(64, (384, 128), False, id="factor-3"),
+    ]
+
+
+@pytest.mark.skipif(not VARLEN_BWD_SPARSE_SUPPORTED, reason="SM90/SM100/SM110 only")
+@pytest.mark.parametrize("head_dim,block_size,use_sparse_forward", Q_SUBTILE_CASES)
+def test_varlen_block_sparse_backward_q_subtiles(
     head_dim, block_size, use_sparse_forward
 ):
     # Ragged tails make the last coarse block expand past the effective length,
@@ -1153,16 +1171,23 @@ def test_varlen_block_sparse_backward_q_subtiles_sm90(
     )
 
 
-@pytest.mark.skipif(COMPUTE_CAPABILITY != 9, reason="SM90 only")
+@pytest.mark.skipif(not VARLEN_BWD_SPARSE_SUPPORTED, reason="SM90/SM100/SM110 only")
 @pytest.mark.parametrize("seed", range(9))
-def test_varlen_block_sparse_backward_fuzz_sm90(seed):
+def test_varlen_block_sparse_backward_fuzz(seed):
     """Bounded randomized coverage for packed metadata and ragged tails."""
     rng = random.Random(1000 + seed)
-    q_configs = [
-        (64, (128, 128)),
-        (128, (128, 128)),
-        (96, (192, 128)),
-    ]
+    if COMPUTE_CAPABILITY == 9:
+        q_configs = [
+            (64, (128, 128)),
+            (128, (128, 128)),
+            (96, (192, 128)),
+        ]
+    else:
+        q_configs = [
+            (64, (128, 128)),
+            (128, (256, 128)),
+            (96, (384, 128)),
+        ]
     head_modes = [
         (2, 2, False),
         (4, 2, True),
@@ -1216,9 +1241,76 @@ def test_varlen_block_sparse_backward_fuzz_sm90(seed):
     )
 
 
-@pytest.mark.skipif(COMPUTE_CAPABILITY != 9, reason="SM90 only")
+@pytest.mark.skipif(not VARLEN_BWD_SPARSE_SUPPORTED, reason="SM90/SM100/SM110 only")
+def test_varlen_block_sparse_batch_invariant_fwd():
+    """Permuting packed sequences must not change any sequence's forward bits.
+
+    Per-sequence tile grids are anchored at each sequence's own offset, so the
+    packing order cannot change a sequence's tiling or reduction structure --
+    unlike a fused doc-mask over one packed sequence, where blocks straddle
+    unaligned document boundaries. The contract is forward-only; backward runs
+    as part of the flow but gradients are not part of the bitwise contract
+    (dQ cross-KV-tile accumulation is atomic and order-dependent).
+    """
+    torch.manual_seed(42)
+    device = "cuda"
+    dtype = torch.bfloat16
+    seqlens = [257, 129, 385, 300]
+    permutation = [2, 0, 3, 1]
+    num_heads = 2
+    head_dim = 64
+    window = 256
+    mask_mod_cute, mask_mod_flex = get_mask_pair(
+        "sliding_window", seqlen_q=max(seqlens), seqlen_k=max(seqlens), window_size=window
+    )
+    docs = [
+        tuple(
+            torch.randn(seqlen, num_heads, head_dim, device=device, dtype=dtype)
+            for _ in range(4)
+        )
+        for seqlen in seqlens
+    ]
+
+    def run(order):
+        lens = [seqlens[i] for i in order]
+        q, k, v, dout = (
+            torch.cat([docs[i][j] for i in order]).requires_grad_(j < 3)
+            for j in range(4)
+        )
+        cu_seqlens = torch.tensor(
+            [0, *torch.tensor(lens).cumsum(0).tolist()], device=device, dtype=torch.int32
+        )
+        sparse_fwd, sparse_bwd = _make_varlen_block_sparse_pair(
+            mask_mod_flex, lens, lens, 1, (128, 128), device
+        )
+        out, _ = flash_attn_varlen_func(
+            q, k, v,
+            cu_seqlens_q=cu_seqlens,
+            cu_seqlens_k=cu_seqlens,
+            max_seqlen_q=max(lens),
+            max_seqlen_k=max(lens),
+            mask_mod=mask_mod_cute,
+            # (128, 128) forward metadata does not match the SM100 forward tile.
+            block_sparse_tensors=sparse_fwd if COMPUTE_CAPABILITY == 9 else None,
+            block_sparse_tensors_bwd=sparse_bwd,
+        )
+        torch.autograd.grad(out, (q, k, v), dout)
+        per_doc = {}
+        for pos, i in enumerate(order):
+            per_doc[i] = out[cu_seqlens[pos] : cu_seqlens[pos + 1]].detach()
+        return per_doc
+
+    base = run(list(range(len(seqlens))))
+    permuted = run(permutation)
+    for i in base:
+        assert torch.equal(permuted[i], base[i]), (
+            f"sequence {i} out is not bitwise equal after permuting the packing order"
+        )
+
+
+@pytest.mark.skipif(not VARLEN_BWD_SPARSE_SUPPORTED, reason="SM90/SM100/SM110 only")
 @pytest.mark.parametrize("score_case", ["times_two", "aux_buffers"])
-def test_varlen_block_sparse_backward_score_mod_and_sink_sm90(score_case):
+def test_varlen_block_sparse_backward_score_mod_and_sink(score_case):
     """Block-sparse packed indexing composes with score backward and sink gradients."""
     torch.manual_seed(42)
     device = "cuda"
@@ -1227,7 +1319,7 @@ def test_varlen_block_sparse_backward_score_mod_and_sink_sm90(score_case):
     seqlens_k = [385, 129]
     num_heads = 2
     head_dim = 64
-    block_size = (128, 128)
+    block_size = (SPARSE_FWD_Q_BLOCK, 128)
     q, k, v, cu_seqlens_q, cu_seqlens_k = setup_varlen_tensors(
         seqlens_q, seqlens_k, num_heads, num_heads, head_dim, dtype
     )


### PR DESCRIPTION
Stacked PRs:
 * #2795
 * __->__#2794
 * #2759


--- --- ---

[CuTe, SM100] Support varlen block-sparse backward


### Human note

Adding in Blackwell support as well; perf is dece and forsure a bump over document mask + mask_mod

# Agent Notes

Port of the SM90 varlen block-sparse backward (#2759) to the SM100 kernel. The interface plumbing
(packed 2D metadata with cu_total_n_blocks / cu_block_idx_offsets, normalize + compile/call args) is
shared with SM90, so the SM100 kernel only needed the sequence-local metadata addressing: each warp
role (relay, load, mma, compute, dQaccum reduce) computes num_sparse_m_blocks =
ceil_div(seqlen.seqlen_q, tile_m * q_subtile_factor) in its block-sparse branch and threads it into
get_block_sparse_iteration_info_bwd, which selects the packed layout when the count tensors are 2D.
The two SM100 producer helpers in block_sparse_utils.py gain the same pass-through parameter.

The kernel's varlen+blocksparse rejection assert is replaced with a compile-time guard requiring
kv_subtile_factor == 1 and no 2CTA: packed varlen metadata is per-physical-KV-tile and per-sequence,
and the interface already normalizes varlen sparse metadata to that shape (2CTA is disabled because
kv_subtile_factor == 1 fails block_sparse_bwd_supports_2cta). Deterministic mode stays rejected at
the interface, matching SM90. The guard must sit under const_expr(is_varlen); a plain Python `if`
gets traced by the DSL and fired for fixed-length kv-subtile kernels.

Tests drop the SM90-only skip and parametrize per arch: SM100 backward uses tile_m=128, so the same
sparse block sizes shift the Q-subtile factor by one, and sparse-forward metadata needs a 256-row Q
block to match the SM100 forward tile.

## Performance

Doc-packed causal-SWA on B200 (16 rows x 8192 tokens packed into one cu_seqlens, bf16, H=8, D=128).
All arms verified numerically equal; CUDA-graph replay timing (host overhead excluded), TFLOP/s on
pattern-exact logical FLOPs. Docs U[2048,8192), window 2048 (201M attended pairs):

| arm                                       | fwd us | fwd TF/s | bwd us | bwd TF/s |
|-------------------------------------------|--------|----------|--------|----------|
| varlen + SWA mask_mod + packed sparse     |   1253 |      658 |   3436 |      600 |
| varlen + native window_size (no metadata) |   1053 |      783 |   3153 |      654 |
| flex_attention BACKEND=FLASH (doc-mask∘SWA) |  1502 |      549 |   4603 |      448 |
| flex_attention BACKEND=TRITON             |   2111 |      391 |   8788 |      235 |

The varlen sparse path is 1.20x fwd / 1.34x bwd over the fused doc-mask flex-flash flow (block
counts are nearly identical between the two; the gap is doc_ids-gather masking on partial blocks vs
arithmetic-only SWA with document structure carried by cu_seqlens), and 2.6x bwd over flex-triton.
FA4's built-in local attention remains the ceiling for this exact pattern (1.19x fwd / 1.09x bwd
over the sparse path); the sparse path's value is arbitrary flex-style masks.

## Test Plan

On a B200 (SM100):

```bash
cd tests/cute
pytest test_mask_mod_varlen.py -k "test_varlen_block_sparse_backward"  # 16 passed
pytest test_mask_mod.py -n 30 -k "bwd or backward"  # 74 passed, 13 skipped (no regressions)
```