### PR TITLE
[MHA] Fix depthwise convolution for cross-attention and GQA

### DIFF
--- a/flash_attn/modules/mha.py
+++ b/flash_attn/modules/mha.py
@@ -461,7 +461,7 @@ class MHA(nn.Module):
             self.Wq = nn.Linear(embed_dim, embed_dim, bias=qkv_proj_bias, **factory_kwargs)
             self.Wkv = nn.Linear(embed_dim, kv_dim, bias=qkv_proj_bias, **factory_kwargs)
         if self.dwconv:
-            if self.num_heads_kv == self.num_heads:
+            if not self.cross_attn and self.num_heads_kv == self.num_heads:
                 self.dwconv_qkv = nn.Conv1d(
                     qkv_dim, qkv_dim, kernel_size=3, padding=2, groups=qkv_dim
                 )
@@ -670,8 +670,6 @@ class MHA(nn.Module):
                 qkv = self.Wqkv(x)
                 q = qkv[..., : self.num_heads * self.head_dim]
                 kv = qkv[..., self.num_heads * self.head_dim :]
-            q = rearrange(q, "... (h d) -> ... h d", d=self.head_dim)
-            kv = rearrange(kv, "... (two hkv d) -> ... two hkv d", two=2, d=self.head_dim)
             if self.dwconv:
                 q = rearrange(
                     self.dwconv_q(rearrange(q, "b s d -> b d s"))[..., :-2], "b d s -> b s d"
@@ -679,6 +677,8 @@ class MHA(nn.Module):
                 kv = rearrange(
                     self.dwconv_kv(rearrange(kv, "b s d -> b d s"))[..., :-2], "b d s -> b s d"
                 ).contiguous()
+            q = rearrange(q, "... (h d) -> ... h d", d=self.head_dim)
+            kv = rearrange(kv, "... (two hkv d) -> ... two hkv d", two=2, d=self.head_dim)
             if (
                 inference_params is None
                 or inference_params.seqlen_offset == 0

--- a/tests/modules/test_mha.py
+++ b/tests/modules/test_mha.py
@@ -1,0 +1,37 @@
+import pytest
+import torch
+
+from flash_attn.modules.mha import MHA
+
+
+@pytest.mark.parametrize(
+    ("cross_attn", "num_heads_kv"),
+    [
+        pytest.param(False, 2, id="gqa-self-attention"),
+        pytest.param(True, 8, id="equal-head-cross-attention"),
+        pytest.param(True, 2, id="gqa-cross-attention"),
+    ],
+)
+def test_mha_dwconv(cross_attn, num_heads_kv):
+    batch_size, query_seqlen, kv_seqlen, embed_dim = 2, 5, 7, 64
+    model = MHA(
+        embed_dim=embed_dim,
+        num_heads=8,
+        num_heads_kv=num_heads_kv,
+        cross_attn=cross_attn,
+        dwconv=True,
+    )
+    x = torch.randn(batch_size, query_seqlen, embed_dim, requires_grad=True)
+    x_kv = torch.randn(batch_size, kv_seqlen, embed_dim, requires_grad=True) if cross_attn else None
+
+    output = model(x, x_kv=x_kv)
+    assert output.shape == x.shape
+
+    output.square().mean().backward()
+    assert torch.isfinite(x.grad).all()
+    if x_kv is not None:
+        assert torch.isfinite(x_kv.grad).all()
+    assert all(
+        parameter.grad is not None and torch.isfinite(parameter.grad).all()
+        for parameter in model.parameters()
+    )


### PR DESCRIPTION
## Summary

- Allocate separate query and key/value depthwise convolutions for cross-attention, including the equal-head case.
- Apply the separate convolutions to the projected 3D tensors before reshaping them into attention heads.
- Add CPU regression coverage for GQA self-attention, equal-head cross-attention, and GQA cross-attention.

## Root cause

The constructor selected `dwconv_qkv` whenever `num_heads_kv == num_heads`, but the cross-attention forward path always uses `dwconv_q` and `dwconv_kv`. Equal-head cross-attention therefore failed with an `AttributeError`.

In the GQA/MQA path, `q` and `kv` were reshaped into 4D and 5D head layouts before the depthwise-convolution code tried to rearrange them as 3D `[batch, sequence, hidden]` tensors. This failed deterministically with an `EinopsError`.

## Impact

`dwconv=True` could not be used with cross-attention or GQA/MQA. The equal-head self-attention fast path is unchanged.

## Validation

- Parameterized CPU forward/backward tests for all three affected configurations: 3 passed.
- Tests check output shape plus finite input and parameter gradients.
- Black formatting, Python syntax compilation, and `git diff --check` pass.

Inference-cache and variable-length paths already reject depthwise convolution explicitly and are outside this change.
