### PR TITLE
[CuTe] Relax CUTLASS DSL requirement

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ pip install flash-attn-4
 pip install -e "flash_attn/cute[dev]"
 ```
 
-Dependencies: `nvidia-cutlass-dsl>=4.5.2`, `torch`, `einops`, `apache-tvm-ffi`, `quack-kernels>=0.5.0`.
+Dependencies: `nvidia-cutlass-dsl>=4.6.2`, `torch`, `einops`, `apache-tvm-ffi`, `quack-kernels>=0.5.3`.
 
 ## Running Tests
 

--- a/flash_attn/cute/flash_bwd_sm100.py
+++ b/flash_attn/cute/flash_bwd_sm100.py
@@ -3266,10 +3266,8 @@ class FlashAttentionBackwardSm100:
                                 utils.shuffle_sync(tSrdPsum, offset=2 * v),
                                 utils.shuffle_sync(tSrdPsum, offset=2 * v + 1),
                             )
-                        tdPrdP_cur[2 * v], tdPrdP_cur[2 * v + 1] = (
-                            cute.arch.sub_packed_f32x2(
-                                (tdPrdP_cur[2 * v], tdPrdP_cur[2 * v + 1]), dPsum_pair
-                            )
+                        tdPrdP_cur[2 * v], tdPrdP_cur[2 * v + 1] = cute.arch.sub_packed_f32x2(
+                            (tdPrdP_cur[2 * v], tdPrdP_cur[2 * v + 1]), dPsum_pair
                         )
                         tdPrdP_cur[2 * v], tdPrdP_cur[2 * v + 1] = cute.arch.mul_packed_f32x2(
                             (tSrS_cur[2 * v], tSrS_cur[2 * v + 1]),

--- a/flash_attn/cute/pyproject.toml
+++ b/flash_attn/cute/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "nvidia-cutlass-dsl==4.6.0.dev0",
+    "nvidia-cutlass-dsl>=4.6.2",
     "torch",
     "einops",
     "typing_extensions",
@@ -32,7 +32,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-cu13 = ["nvidia-cutlass-dsl[cu13]==4.6.0.dev0"]
+cu13 = ["nvidia-cutlass-dsl[cu13]>=4.6.2"]
 dev = [
     "pytest",
     "pytest-xdist",

--- a/flash_attn/cute/pyproject.toml
+++ b/flash_attn/cute/pyproject.toml
@@ -67,6 +67,7 @@ torch = [
 line-length = 100
 
 [tool.ruff.lint]
+select = ["E4", "E7", "E9", "F"]
 ignore = [
     "E731",  # do not assign a lambda expression, use a def
     "E741",  # Do not use variables named 'I', 'O', or 'l'

--- a/flash_attn/cute/utils.py
+++ b/flash_attn/cute/utils.py
@@ -778,9 +778,7 @@ def ex2_emulation_2(
     xy_rounded = cute.arch.add_packed_f32x2(xy_clamped, (fp32_round_int, fp32_round_int), rnd="rm")
     # The integer floor of x & y are now in the last 8 bits of xy_rounded
     # We want the next 2 ops to round to nearest even. The rounding mode is important.
-    xy_rounded_back = cute.arch.sub_packed_f32x2(
-        xy_rounded, (fp32_round_int, fp32_round_int)
-    )
+    xy_rounded_back = cute.arch.sub_packed_f32x2(xy_rounded, (fp32_round_int, fp32_round_int))
     xy_frac = cute.arch.sub_packed_f32x2(xy_clamped, xy_rounded_back)
     xy_frac_ex2 = evaluate_polynomial_2(*xy_frac, POLY_EX2[poly_degree], loc=loc, ip=ip)
     x_out = combine_int_frac_ex2(xy_rounded[0], xy_frac_ex2[0], loc=loc, ip=ip)

--- a/tools/ci/docker/Dockerfile
+++ b/tools/ci/docker/Dockerfile
@@ -25,9 +25,7 @@ RUN uv pip install --system --break-system-packages --no-cache --pre \
 # The package itself (version 0.0.0 via setuptools-scm fallback) is overwritten at
 # step time by the editable install from the mounted repo.
 COPY flash_attn/cute/ /tmp/fa4/
-# --prerelease=allow: the cutlass-dsl floor is pinned to a dev build (e.g. 4.6.0.dev0), whose
-# cu13 extra pulls transitive pre-release deps (nvidia-cutlass-dsl-libs-base==4.6.0.dev0 …).
-# uv honors the explicit top-level pre-release pin but refuses transitive pre-releases without this.
+# Keep pre-releases enabled so future development-build dependency floors remain resolvable.
 RUN uv pip install --system --break-system-packages --no-cache --prerelease=allow "/tmp/fa4[cu13,dev]"
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
## Human Note
I tested against 4.7 and it works lets try and move this foward 


## Agent note

FA4 still required the 4.6.0 development build after support moved to the released 4.6.2
package and CUTLASS DSL 4.7 compatibility landed in #2787. Replace the exact base and cu13
requirements with a 4.6.2 floor so the resolver can select the version supported by the installed
QuACK release. Keep CI prerelease resolution enabled for future development-build floors and update
the documented dependency versions.

The same SM100 forward, backward, and ex2-emulation checks passed with CUTLASS DSL 4.6.2 and
4.7.0; the 4.7.0 run used QuACK main because its matching release is not on PyPI yet.

## Test Plan

```bash
uv build flash_attn/cute --out-dir agent_space/dist-fa4-pr
```
