### PR TITLE
Optimize SM100 FP8 softmax conversion with packed E4M3x4

### DIFF
--- a/flash_attn/cute/flash_fwd_sm100.py
+++ b/flash_attn/cute/flash_fwd_sm100.py
@@ -2520,6 +2520,7 @@ class FlashAttentionForwardSm100:
             tSrP_r2t,
             ex2_emu_freq=self.ex2_emu_freq,
             ex2_emu_start_frg=self.ex2_emu_start_frg,
+            converted_f32=tSrP_r2t_f32,
         )
         # Sequence barrier arrive
         if const_expr(self.s0_s1_barrier):

--- a/flash_attn/cute/softmax.py
+++ b/flash_attn/cute/softmax.py
@@ -8,12 +8,44 @@ from dataclasses import dataclass
 import cutlass
 import cutlass.cute as cute
 from cutlass import Float32, Boolean
+from cutlass.cutlass_dsl import T as _fa4_T, dsl_user_op as _fa4_dsl_user_op
+from cutlass._mlir.dialects import llvm as _fa4_llvm
 
 from quack import layout_utils
 import flash_attn.cute.utils as utils
 from quack.cute_dsl_utils import ParamsBase
 from flash_attn.cute.seqlen_info import SeqlenInfoQK
 from flash_attn.cute.utils import AuxData
+
+# The standard elementwise f32 -> e4m3 conversion emits a PRMT to pack each
+# group of four bytes.  Expressing the conversion as two e4m3x2 operations
+# lets ptxas fold that packing into F2FP's merge operand.
+_FA4_PACK4 = True
+
+
+@_fa4_dsl_user_op
+def _fa4_cvt_e4m3x4(e0, e1, e2, e3, *, loc=None, ip=None):
+    """Return four packed e4m3 values in the bit pattern of one Float32."""
+    out = _fa4_llvm.inline_asm(
+        _fa4_T.f32(),
+        [
+            Float32(e0).ir_value(loc=loc, ip=ip),
+            Float32(e1).ir_value(loc=loc, ip=ip),
+            Float32(e2).ir_value(loc=loc, ip=ip),
+            Float32(e3).ir_value(loc=loc, ip=ip),
+        ],
+        "{\n\t"
+        ".reg .b16 lo, hi;\n\t"
+        "cvt.rn.satfinite.e4m3x2.f32 lo, $2, $1;\n\t"
+        "cvt.rn.satfinite.e4m3x2.f32 hi, $4, $3;\n\t"
+        "mov.b32 $0, {lo, hi};\n\t"
+        "}\n",
+        "=f,f,f,f,f",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=_fa4_llvm.AsmDialect.AD_ATT,
+    )
+    return Float32(out)
 
 
 @cute.jit
@@ -365,6 +397,7 @@ class SoftmaxSm100(Softmax):
         ex2_emu_freq: cutlass.Constexpr[int] = 0,
         ex2_emu_res: cutlass.Constexpr[int] = 4,
         ex2_emu_start_frg: cutlass.Constexpr[int] = 0,
+        converted_f32: cute.Tensor = None,
     ):
         assert cute.size(acc_S_row.shape) % 2 == 0, "acc_S_row must have an even number of elements"
         frg_tile = 32
@@ -374,6 +407,11 @@ class SoftmaxSm100(Softmax):
         acc_S_row_frg = cute.logical_divide(acc_S_row, cute.make_layout(frg_tile))
         acc_S_row_converted_frg = cute.logical_divide(
             acc_S_row_converted, cute.make_layout(frg_tile)
+        )
+        pack4 = cutlass.const_expr(
+            _FA4_PACK4
+            and converted_f32 is not None
+            and acc_S_row_converted.element_type is cutlass.Float8E4M3FN
         )
         for j in cutlass.range_constexpr(frg_cnt):
             for k in cutlass.range_constexpr(0, cute.size(acc_S_row_frg, mode=[0]), 2):
@@ -397,9 +435,19 @@ class SoftmaxSm100(Softmax):
                         acc_S_row_frg[k, j], acc_S_row_frg[k + 1, j] = utils.ex2_emulation_2(
                             acc_S_row_frg[k, j], acc_S_row_frg[k + 1, j]
                         )
-            acc_S_row_converted_frg[None, j].store(
-                acc_S_row_frg[None, j].load().to(acc_S_row_converted.element_type)
-            )
+            if cutlass.const_expr(pack4):
+                for word in cutlass.range_constexpr(frg_tile // 4):
+                    k = word * 4
+                    converted_f32[j * (frg_tile // 4) + word] = _fa4_cvt_e4m3x4(
+                        acc_S_row_frg[k, j],
+                        acc_S_row_frg[k + 1, j],
+                        acc_S_row_frg[k + 2, j],
+                        acc_S_row_frg[k + 3, j],
+                    )
+            else:
+                acc_S_row_converted_frg[None, j].store(
+                    acc_S_row_frg[None, j].load().to(acc_S_row_converted.element_type)
+                )
 
     @cute.jit
     def scale_apply_exp2_convert(


### PR DESCRIPTION
# Optimize SM100 FP8 softmax conversion with packed E4M3x4

## Motivation

This PR follows up on [#2701](https://github.com/Dao-AILab/flash-attention/issues/2701), where I reported low TC/FMA/XU utilization for FA4 FP8 inference on B300. The discussion established that FP8 substantially shortens GEMM while the mostly precision-independent softmax path remains, making softmax co-critical. Further improvement therefore needs to reduce or restructure work on the softmax critical path.

Inspecting the generated SASS identified one concrete source of avoidable work: the generic FP32-to-E4M3 conversion emits extra permutation instructions when packing the converted probabilities. This PR removes that packing overhead.

## Summary

This change reduces packing overhead in the SM100 FP8 forward softmax path. The generic elementwise `f32 -> e4m3` lowering emits extra `PRMT` instructions when packing four FP8 values. Instead, this patch converts four values with two `cvt.rn.satfinite.e4m3x2.f32` instructions and combines both 16-bit results into one 32-bit word. This lets `ptxas` fold the packing into the `F2FP` merge operand.

The optimized path is selected at compile time only for standard SM100-family forward kernels using FP8 E4M3. E5M2, BF16/FP16, MLA, and call sites without the FP32 output overlay keep the existing conversion path.

## Implementation

- Add a small DSL inline-PTX helper that returns four packed E4M3 values in one 32-bit word.
- Pass the existing FP32 overlay of the converted fragment from `flash_fwd_sm100.py` to the softmax conversion routine.
- Store one packed word per four values when the E4M3 compile-time gate is true; otherwise retain the original elementwise conversion.

## Correctness and generated code

- Native and packed outputs are bit-identical with no NaNs across the full B200 non-causal and causal matrix: 7 sequence lengths x 3 head dimensions.
- E5M2 and BF16 fallback paths compile and run successfully.
- FP8 versus dequantized FP32 SDPA cosine similarity is 0.99973 non-causal and 0.99983 causal.
- The two existing FP8 paged-decode regression tests pass.

| GPU | Variant | PRMT | F2FP | CUBIN size |
|---|---|---:|---:|---:|
| B200 / SM100 | baseline | 72 | 256 | 104288 B |
| B200 / SM100 | packed | **8** | 256 | **102976 B** |
| B300 / SM103 | baseline | 72 | 256 | - |
| B300 / SM103 | packed | **8** | 256 | - |

The packed path removes 64 `PRMT` instructions without increasing the number of FP8 conversions or introducing local-memory loads/stores.

## Performance

Positive speedup means the packed path is faster. Representative shape: FP8 E4M3, `b=2, s=16384, h=16, d=128`.

| GPU | Mode | Baseline | Packed | Speedup |
|---|---|---:|---:|---:|
| B200 | non-causal | 3.7984 ms | 3.6081 ms | **+5.0%** |
| B200 | causal | 1.8982 ms | 1.7197 ms | **+9.4%** |
| B300 | non-causal | 2.5789 ms | 2.3613 ms | **+8.4%** |
| B300 | causal | 1.4398 ms | 1.3150 ms | **+8.7%** |

The following tables contain all measured `s x hd` points. Each value is the speedup of PACK4 over the baseline.

### B200 non-causal

| s \ hd | 64 | 96 | 128 |
|---|---:|---:|---:|
| 1024 | +0.1% | +0.6% | +0.9% |
| 2048 | +5.3% | +6.7% | +4.4% |
| 4096 | +5.5% | +7.3% | +4.3% |
| 8192 | +5.7% | +8.0% | +5.0% |
| 16384 | +5.6% | +7.8% | +5.0% |
| 32768 | +5.6% | +7.1% | +5.1% |
| 131072 | +5.7% | +5.4% | +5.8% |

### B200 causal

| s \ hd | 64 | 96 | 128 |
|---|---:|---:|---:|
| 1024 | +0.6% | +0.4% | -0.2% |
| 2048 | +2.2% | +6.2% | +8.0% |
| 4096 | +2.7% | +8.4% | +7.6% |
| 8192 | +3.3% | +7.2% | +9.1% |
| 16384 | +3.5% | +7.3% | +9.4% |
| 32768 | +3.8% | +6.6% | +9.1% |
| 131072 | +4.4% | +5.5% | +7.6% |

### B300 non-causal

| s \ hd | 64 | 96 | 128 |
|---|---:|---:|---:|
| 1024 | -6.3% | +2.0% | +4.8% |
| 2048 | +0.6% | +1.0% | +1.1% |
| 4096 | -1.9% | +3.8% | +6.5% |
| 8192 | -3.4% | +2.5% | +7.7% |
| 16384 | -3.5% | +3.3% | +8.6% |
| 32768 | -3.6% | +3.1% | +8.7% |
| 131072 | -2.0% | +3.0% | +9.1% |

### B300 causal

| s \ hd | 64 | 96 | 128 |
|---|---:|---:|---:|
| 1024 | +1.4% | -0.5% | +2.1% |
| 2048 | +2.7% | +1.0% | +2.1% |
| 4096 | +0.9% | +1.8% | +7.4% |
| 8192 | +1.9% | +1.6% | +6.1% |
| 16384 | +2.4% | +2.5% | +8.3% |
| 32768 | +2.8% | +2.5% | +9.1% |
| 131072 | +2.9% | +2.7% | +10.0% |

Short-sequence points (`s <= 2048`) have 0.03-0.08 ms absolute latency and are too noisy to use as the main performance evidence. B200 short-sequence outliers were retested with 15 interleaved paired A/B rounds and alternating measurement order; B300 outliers were checked with eight repeated measurements. The tables above use the final retested values.

## NCU profile

Nsight Compute 2025.3.1, main `FlashAttentionForwardSm100` kernel only, FP8 E4M3, non-causal, `b=2, s=16384, h=16, d=128`.

| Pipe | B200 baseline | B200 packed | B300 baseline | B300 packed |
|---|---:|---:|---:|---:|
| Tensor | 34.9% | 36.8% | 54.8% | 60.0% |
| XU/SFU (exp) | 57.3% | 60.3% | 55.2% | 60.5% |
| FMA | 33.8% | 35.4% | 28.6% | 31.3% |
| ALU | 29.0% | **26.1%** | 40.8% | **37.2%** |
| Issue | 43.8% | 43.4% | 54.5% | 56.0% |
| SM busy | 97.3% | 97.2% | 60.0% | 68.4% |
| Occupancy | 23.4% | 23.4% | 23.4% | 23.4% |

The ALU reduction on both GPUs matches the removal of `PRMT`. Tensor and XU/SFU utilization increase while occupancy remains unchanged, indicating that the optimization removes conversion/packing work without changing resource occupancy.

## Scope and caveats

- Active for standard SM100/SM103/SM110 forward kernels with FP8 E4M3.
- E5M2, BF16/FP16, MLA, and SM90 use the original path.
- The wall-clock benefit depends on FP8 softmax conversion being on the critical path. The B300 results above use the optimized, softmax-bound configuration.
- B300 non-causal `d=64` regresses by 2-4%, while B200 `d=64` and B300 causal `d=64` improve. No head-dimension gate is added because the result is architecture- and mode-dependent.
