### PR TITLE
ROCm: preserve preinstalled Triton for the AITER backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,14 +170,17 @@ The Triton backend kernels are provided by the [aiter](https://github.com/ROCm/a
 To install, first get PyTorch for ROCm from https://pytorch.org/get-started/locally/, then install Flash Attention:
 ```sh
 cd flash-attention
-FLASH_ATTENTION_TRITON_AMD_ENABLE="TRUE" pip install --no-build-isolation .
+AITER_USE_SYSTEM_TRITON="1" FLASH_ATTENTION_TRITON_AMD_ENABLE="TRUE" pip install --no-build-isolation .
 ```
+When Triton is already installed, Flash Attention passes this setting to AITER
+so the existing package is preserved. Set `AITER_USE_SYSTEM_TRITON="0"` to let
+AITER install its recommended Triton build instead.
 
 To use a specific aiter commit (e.g., for testing or development):
 ```sh
 cd flash-attention
 cd third_party/aiter && git fetch origin && git checkout <commit-sha> && cd ../..
-FLASH_ATTENTION_TRITON_AMD_ENABLE="TRUE" pip install --no-build-isolation .
+AITER_USE_SYSTEM_TRITON="1" FLASH_ATTENTION_TRITON_AMD_ENABLE="TRUE" pip install --no-build-isolation .
 ```
 
 To run the tests (note: full suite takes hours):

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ import ast
 import glob
 import shutil
 import tempfile
+from importlib.util import find_spec
 from pathlib import Path
 from typing import Literal, Optional
 from packaging.version import parse, Version
@@ -68,6 +69,15 @@ ROCM_BACKEND: Optional[Literal["triton", "ck"]] = None
 if IS_ROCM:
     ROCM_BACKEND = "triton" if os.getenv("FLASH_ATTENTION_TRITON_AMD_ENABLE", "FALSE") == "TRUE" else "ck"
 NVCC_THREADS = os.getenv("NVCC_THREADS") or "4"
+
+
+def aiter_install_env():
+    env = os.environ.copy()
+    if "AITER_USE_SYSTEM_TRITON" not in env and find_spec("triton") is not None:
+        env["AITER_USE_SYSTEM_TRITON"] = "1"
+        print("[flash-attn] Preserving the installed Triton for AITER")
+    return env
+
 
 @functools.lru_cache(maxsize=None)
 def cuda_archs() -> str:
@@ -265,6 +275,7 @@ if IS_ROCM:
         subprocess.run(
             [sys.executable, "-m", "pip", "install", "--no-build-isolation", "third_party/aiter"],
             check=True,
+            env=aiter_install_env(),
         )
     elif ROCM_BACKEND == "ck":
         if os.path.isdir(".git"):


### PR DESCRIPTION
## Summary

When the AMD Triton backend installs vendored AITER, preserve an already
installed Triton by passing AITER's existing `AITER_USE_SYSTEM_TRITON=1`
contract to the child process.

Explicit `AITER_USE_SYSTEM_TRITON=0` still requests replacement, while a fresh
environment without Triton keeps the normal AITER installation path. Document
both choices in the Triton-backend installation examples.

This complements #2720: that PR skips vendored AITER when a compatible system
AITER is already installed, while this change keeps vendored AITER and
preserves the user's existing Triton.

Fixes #2799.

## Testing

- Network-disabled CPU-only packaging RED/GREEN.
- Installed Triton, explicit replacement, and no-Triton environment matrix.
- Setup syntax, focused lint, and patch checks.
