### PR TITLE
[CuTe, SM80] Enable training and fix large-head forward spilling

### DIFF
--- a/flash_attn/cute/flash_bwd.py
+++ b/flash_attn/cute/flash_bwd.py
@@ -52,6 +52,8 @@ class FlashAttentionBackwardSm80:
         V_in_regs: bool = False,
         score_mod: cutlass.Constexpr | None = None,
         score_mod_bwd: cutlass.Constexpr | None = None,
+        mask_mod: cutlass.Constexpr | None = None,
+        mask_seqlen: bool = True,
     ):
         """Initializes the configuration for a flash attention v2 kernel.
 
@@ -100,6 +102,14 @@ class FlashAttentionBackwardSm80:
         self.share_QV_smem = V_in_regs
         self.score_mod = score_mod
         self.score_mod_bwd = score_mod_bwd
+        self.mask_mod = mask_mod
+        self.mask_seqlen = mask_seqlen
+        self.mask_vec_size: cutlass.Constexpr = getattr(mask_mod, "__vec_size__", 1)
+        if self.mask_vec_size > 1:
+            raise ValueError(
+                f"mask_mod vec_size {self.mask_vec_size} not supported on Sm80 "
+                "due to accumulator thread ownership pattern."
+            )
 
     @staticmethod
     def can_implement(
@@ -444,6 +454,9 @@ class FlashAttentionBackwardSm80:
         softmax_scale_log2, _ = utils.compute_softmax_scale_log2(
             softmax_scale, self.score_mod
         )
+        fastdiv_mods = utils.compute_fastdiv_mods(
+            mQ, mK, self.qhead_per_kvhead, self.pack_gqa, aux_data.tensors
+        )
         self.kernel(
             mQ,
             mK,
@@ -482,6 +495,7 @@ class FlashAttentionBackwardSm80:
             tile_sched_params,
             TileScheduler,
             aux_data,
+            fastdiv_mods,
         ).launch(
             grid=grid_dim,
             block=[self.num_threads, 1, 1],
@@ -529,6 +543,7 @@ class FlashAttentionBackwardSm80:
         tile_sched_params: ParamsBase,
         TileScheduler: cutlass.Constexpr[Callable],
         aux_data: AuxData = AuxData(),
+        fastdiv_mods=None,
     ):
         # Thread index, block index
         tidx, _, _ = cute.arch.thread_idx()
@@ -847,7 +862,13 @@ class FlashAttentionBackwardSm80:
                 mask_fn = partial(
                     mask.apply_mask, n_block=n_block, thr_mma=thr_mma_sdp,
                     batch_idx=batch_idx, head_idx=head_idx,
-                    mask_seqlen=True, mask_causal=self.is_causal, mask_local=self.is_local
+                    mask_seqlen=self.mask_seqlen,
+                    mask_causal=self.is_causal,
+                    mask_local=self.is_local,
+                    mask_mod=self.mask_mod, aux_data=aux_data,
+                    fastdiv_mods=(
+                        fastdiv_mods if cutlass.const_expr(self.mask_mod is not None) else None
+                    ),
                 )
                 smem_pipe_read_q = cutlass.Int32(0)
                 smem_pipe_read_do = cutlass.Int32(0)
@@ -923,14 +944,16 @@ class FlashAttentionBackwardSm80:
             smem_copy_params.smem_thr_copy_QdO, smem_copy_params.smem_thr_copy_KV,
             swap_AB=self.SdP_swapAB,
         )
-        acc_S_pre = cute.make_fragment_like(acc_S)
-        acc_S_pre.store(acc_S.load())
+        if cutlass.const_expr(self.score_mod_bwd is not None):
+            acc_S_pre = cute.make_fragment_like(acc_S)
+            acc_S_pre.store(acc_S.load())
         tLSErLSE = cute.make_fragment_like(smem_copy_params.tSsLSEMma[None, 0])
         cute.autovec_copy(
             smem_copy_params.tSsLSEMma[None, smem_pipe_read_q if cutlass.const_expr(self.num_stages_Q > 1) else 0], tLSErLSE
         )
         acc_S_mn = layout_utils.reshape_acc_to_mn(acc_S)
-        acc_S_pre_mn = layout_utils.reshape_acc_to_mn(acc_S_pre)
+        if cutlass.const_expr(self.score_mod_bwd is not None):
+            acc_S_pre_mn = layout_utils.reshape_acc_to_mn(acc_S_pre)
         if cutlass.const_expr(self.score_mod is not None):
             for r in cutlass.range(cute.size(acc_S_mn, mode=[0]), unroll_full=True):
                 acc_S_mn[r, None].store(
@@ -1179,7 +1202,7 @@ class FlashAttentionBackwardSm80:
             if cutlass.const_expr(not seqlen.has_cu_seqlens_k):
                 mdK_cur, mdV_cur = [t[batch_idx, head_idx_kv, None] for t in (mdK, mdV)]
             else:
-                padded_offset_k = seqlen.offset_k + batch_idx * self.n_block_size
+                padded_offset_k = seqlen.padded_offset_k
                 mdK_cur = cute.domain_offset((padded_offset_k * self.head_dim_padded,), mdK[head_idx_kv, None])
                 mdV_cur = cute.domain_offset((padded_offset_k * self.head_dim_v_padded,), mdV[head_idx_kv, None])
 

--- a/flash_attn/cute/flash_fwd.py
+++ b/flash_attn/cute/flash_fwd.py
@@ -791,6 +791,21 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
         work_tile = tile_scheduler.initial_work_tile_info()
         m_block, num_head, batch_size, _ = work_tile.tile_idx
 
+        if const_expr(mCuSeqlensQ is not None or mSeqUsedQ is not None):
+            # The varlen grid is an upper bound and can contain padding CTAs.
+            # CuTe kernels cannot return early on a dynamic predicate, so use
+            # valid coordinates and zero seqlens for those CTAs instead.
+            m_block_safe = Int32(0)
+            num_head_safe = Int32(0)
+            batch_size_safe = Int32(0)
+            if work_tile.is_valid_tile:
+                m_block_safe = m_block
+                num_head_safe = num_head
+                batch_size_safe = batch_size
+            m_block = m_block_safe
+            num_head = num_head_safe
+            batch_size = batch_size_safe
+
         block_info = BlockInfo(
             self.tile_m,
             self.tile_n,
@@ -810,6 +825,34 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
             mSeqUsedQ=mSeqUsedQ,
             mSeqUsedK=mSeqUsedK,
         )
+        if const_expr(mCuSeqlensQ is not None or mSeqUsedQ is not None):
+            seqlen_q_safe = Int32(0)
+            seqlen_k_safe = Int32(0)
+            m_block_offset_safe = Int32(0)
+            block_idx_offset_safe = Int32(0)
+            num_n_blocks_safe = Int32(0)
+            if work_tile.is_valid_tile:
+                seqlen_q_safe = seqlen.seqlen_q
+                seqlen_k_safe = seqlen.seqlen_k
+                m_block_offset_safe = seqlen.m_block_offset
+                block_idx_offset_safe = seqlen.block_idx_offset
+                num_n_blocks_safe = seqlen.num_n_blocks
+            seqlen = SeqlenInfoQK(
+                seqlen.offset_q,
+                seqlen.offset_k,
+                seqlen.padded_offset_q,
+                seqlen.padded_offset_k,
+                seqlen_q_safe,
+                seqlen_k_safe,
+                m_block_offset_safe,
+                block_idx_offset_safe,
+                num_n_blocks_safe,
+                seqlen.has_cu_seqlens_q,
+                seqlen.has_cu_seqlens_k,
+                seqlen.has_seqused_q,
+                seqlen.has_seqused_k,
+                seqlen.has_cu_block_idx_offsets,
+            )
         n_block_min, n_block_max = block_info.get_n_block_min_max(seqlen, m_block)
         # For varlen, wasted grid tiles (where batch_idx >= num_batch) will have
         # seqlen_q=seqlen_k=0 and n_block_max=0.  Clamp to 0 so we don't use a

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -1924,8 +1924,18 @@ def _flash_attn_bwd(
             num_threads = 256
         else:
             AtomLayoutMSdP = 2
-            AtomLayoutNdKV = 4 if n_block_size == 128 else 2
-            AtomLayoutMdQ = 2
+            head_dim_padded = (head_dim + 31) // 32 * 32
+            head_dim_v_padded = (head_dim_v + 31) // 32 * 32
+            # The (2, 4) warp layout has a 64-column N tile, which cannot
+            # partition padded head dimensions such as 96, 160, or 224.
+            # Use (4, 2) in those cases so the N tile is 32 columns.  The
+            # 64-row dQ/dKV tiles remain exactly covered along M.
+            AtomLayoutNdKV = 4 if (
+                n_block_size == 128
+                or head_dim_padded % 64
+                or head_dim_v_padded % 64
+            ) else 2
+            AtomLayoutMdQ = 4 if head_dim_padded % 64 else 2
             num_threads = 256
         V_in_regs = False
         dQ_single_wg = False

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -329,7 +329,11 @@ def _get_fwd_config(
             if head_dim > 64:
                 cfg = FwdConfig(128, 64, True, True)
         elif arch // 10 == 8:
-            cfg = FwdConfig(128, 64, True, True)  # SM80, should tune
+            # M128 at D>128 exhausts the SM80 register file. The additional
+            # dynamic state in varlen then triggers catastrophic local-memory
+            # spilling, while M64 keeps both dense and varlen spill-free.
+            tile_m = 64 if max(head_dim, head_dim_v) > 128 else 128
+            cfg = FwdConfig(tile_m, 64, True, True)
         elif arch // 10 == 9:
             sparse_q = get_sparse_q_block_size(block_sparse_tensors, seqlen_q)
             cfg = _tile_size_fwd_sm90(

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -117,7 +117,12 @@ def _validate_head_dims(head_dim: int, head_dim_v: int, compute_capability: int,
     is_standard_range = 8 <= head_dim <= 128 and 8 <= head_dim_v <= 128
 
     is_sm90_range = 8 <= head_dim <= 256 and 8 <= head_dim_v <= 256
-    if compute_capability == 9:
+    if compute_capability == 8:
+        assert is_sm90_range and head_dim % alignment == 0 and head_dim_v % alignment == 0, (
+            f"(head_dim, head_dim_v)=({head_dim}, {head_dim_v}) is not supported on SM8x. "
+            f"head_dim and head_dim_v must be between 8 and 256 and divisible by {alignment}."
+        )
+    elif compute_capability == 9:
         assert is_sm90_range and head_dim % alignment == 0 and head_dim_v % alignment == 0, (
             f"(head_dim, head_dim_v)=({head_dim}, {head_dim_v}) is not supported on SM90. "
             f"head_dim and head_dim_v must be between 8 and 256 and divisible by {alignment}."
@@ -1851,7 +1856,9 @@ def _flash_attn_bwd(
     aux_scalars = tuple(aux_scalars) if aux_scalars else None
     fake_mode = is_fake_mode()
     arch = _get_device_arch()
-    assert arch // 10 in [9, 10, 11, 12], "Unsupported compute capability. Supported: 9.x, 10.x, 11.x, 12.x"
+    assert arch == 80 or arch // 10 in [9, 10, 11, 12], (
+        "Unsupported compute capability. Supported: 8.0, 9.x, 10.x, 11.x, 12.x"
+    )
     if block_sparse_tensors is not None:
         assert (
             cu_seqlens_q is None
@@ -1885,10 +1892,44 @@ def _flash_attn_bwd(
 
     window_size = [window_size_left, window_size_right]
     causal, local, window_size_left, window_size_right = _resolve_causal_local_window(
-        causal, window_size_left, window_size_right
+        causal, window_size_left, window_size_right, mask_mod
     )
 
-    if arch // 10 == 12:
+    if arch // 10 == 8:
+        # Ampere uses warp-level mma.sync and has 163 KB of shared memory per SM.
+        # D<=64 uses the same 8-warp 128x128 tile shape as FlashAttention-2.
+        # D<=128 uses the original 8-warp 64x128 tile, with dKV warps spread
+        # along N to match Ampere's mma.sync accumulator ownership. Larger
+        # heads use 64-wide KV tiles to stay within SM80 shared memory.
+        max_head_dim = max(head_dim, head_dim_v)
+        m_block_size = 128 if max_head_dim <= 64 else 64
+        n_block_size = 128 if max_head_dim <= 128 else 64
+        num_stages_Q = 2 if max_head_dim <= 128 else 1
+        num_stages_dO = 2 if max_head_dim <= 128 else 1
+        if max_head_dim <= 64 and causal:
+            # Causal D64 traverses fewer Q blocks, so one pipeline stage is faster.
+            num_stages_Q = 1
+            num_stages_dO = 1
+        SdP_swapAB = False
+        dKV_swapAB = False
+        dQ_swapAB = False
+        if max_head_dim <= 64:
+            AtomLayoutMSdP = 4
+            AtomLayoutNdKV = 4
+            AtomLayoutMdQ = 4
+            num_threads = 256
+        else:
+            AtomLayoutMSdP = 2
+            AtomLayoutNdKV = 4 if n_block_size == 128 else 2
+            AtomLayoutMdQ = 2
+            num_threads = 256
+        V_in_regs = False
+        dQ_single_wg = False
+        cluster_size = 1
+        use_2cta_instrs = False
+        assert block_sparse_tensors is None, "Block sparsity backward is not supported on SM80"
+        assert deterministic is False, "Deterministic backward is not supported on SM80"
+    elif arch // 10 == 12:
         # SM120: uses SM80 MMA with 99 KB SMEM, 128 threads (4 warps).
         m_block_size = 64
         n_block_size = 64
@@ -2033,6 +2074,14 @@ def _flash_attn_bwd(
     # default, keeping the key stable with no device sync.
     single_q_block = (not torch.is_tensor(seqlen_q_rounded)) and (seqlen_q_rounded // m_block_size == 1)
     single_k_block = (not torch.is_tensor(seqlen_k_rounded)) and (seqlen_k_rounded // n_block_size == 1)
+    mask_seqlen_sm80 = not (
+        arch == 80
+        and not is_varlen
+        and isinstance(seqlen_q, int)
+        and isinstance(seqlen_k, int)
+        and seqlen_q % m_block_size == 0
+        and seqlen_k % n_block_size == 0
+    )
 
     if cu_seqlens_k is None:
         assert k.shape == (batch_size, seqlen_k, num_head_kv, head_dim)
@@ -2236,9 +2285,9 @@ def _flash_attn_bwd(
         cu_total_m_blocks=cu_total_m_blocks_q,
         fake_mode=fake_mode,
     )
-    # num_threads: SM90 derives from BwdConfig.num_wg, SM120 is set to 128 above,
-    # SM100/SM110 uses default from function signature (384).
-    if arch // 10 not in [9, 12]:
+    # num_threads: SM80/SM120 and SM90 are selected above; SM100/SM110 uses
+    # the default from the function signature (384).
+    if arch // 10 not in [8, 9, 12]:
         num_threads = 384
 
     # Backward kernel: compute dk, dv, dq_accum.
@@ -2313,6 +2362,7 @@ def _flash_attn_bwd(
             AtomLayoutNdKV,
             AtomLayoutMdQ,
             V_in_regs,
+            mask_seqlen_sm80,
             dQ_single_wg,
             deterministic,
             cu_seqlens_q is None,
@@ -2428,6 +2478,8 @@ def _flash_attn_bwd(
                 V_in_regs=V_in_regs,
                 score_mod=score_mod,
                 score_mod_bwd=score_mod_bwd,
+                mask_mod=mask_mod,
+                mask_seqlen=mask_seqlen_sm80 if arch == 80 else True,
             )
         elif arch // 10 == 9:
             fa_bwd_obj = FlashAttentionBackwardSm90(
@@ -2595,6 +2647,12 @@ def _flash_attn_bwd(
             # dQ postprocess: match main kernel's MMA WG count, unless dQ_single_wg
             num_threads_post_dQ = 128 if dQ_single_wg else cfg.num_wg * 128
             num_threads_post_dKV = cfg.num_wg * 128
+        elif arch // 10 == 8:
+            # The SM80 accumulator layout spans all MMA warps from the main
+            # kernel. Reconstruct it with the same thread count; using the
+            # generic 128-thread postprocess silently permutes dQ and GQA dK/dV.
+            num_threads_post_dQ = num_threads
+            num_threads_post_dKV = num_threads
         else:
             num_threads_post_dQ = 128
             num_threads_post_dKV = 128

--- a/flash_attn/cute/mask.py
+++ b/flash_attn/cute/mask.py
@@ -77,6 +77,7 @@ def mask_r2p_lambda(
     X: cute.Tensor,
     mask_gen_fn: cutlass.Constexpr[MaskGenFn],
     rank1: bool = False,
+    use_bitwise_select: bool = False,
 ) -> None:
     """Apply R2P masking with a custom bitmask generator.
 
@@ -91,24 +92,32 @@ def mask_r2p_lambda(
         mask = mask_gen_fn(s)
         # This needs to be range_constexpr, o/w the compiler can't generate the R2P instruction
         for i in cutlass.range_constexpr(min(CHUNK_SIZE, ncol - s * CHUNK_SIZE)):
-            in_bound = cutlass.Boolean(mask & (Uint32(1) << i))
             c = s * CHUNK_SIZE + i
-            if const_expr(rank1):
-                X[c] = X[c] if in_bound else -Float32.inf
+            if const_expr(use_bitwise_select):
+                if const_expr(rank1):
+                    X[c] = utils.mask_f32_by_u32_bit(X[c], mask, i)
+                else:
+                    for r in cutlass.range_constexpr(cute.size(X.shape[0])):
+                        X[r, c] = utils.mask_f32_by_u32_bit(X[r, c], mask, i)
             else:
-                for r in cutlass.range_constexpr(cute.size(X.shape[0])):
-                    X[r, c] = X[r, c] if in_bound else -Float32.inf
+                in_bound = cutlass.Boolean(mask & (Uint32(1) << i))
+                if const_expr(rank1):
+                    X[c] = X[c] if in_bound else -Float32.inf
+                else:
+                    for r in cutlass.range_constexpr(cute.size(X.shape[0])):
+                        X[r, c] = X[r, c] if in_bound else -Float32.inf
 
 
 @cute.jit
-def sm90_col_to_r2p_idx(col_limit: Int32) -> Int32:
-    """Transform SM90 MMA column coordinate to R2P element index.
+def col_to_r2p_idx(col_limit: Int32, col_stride: int) -> Int32:
+    """Transform an MMA column coordinate to its R2P element index.
 
-    SM90 MMA accumulator column indices are non-contiguous: 0, 1, 8, 9, 16, 17, ...
-    Element indices are contiguous: 0, 1, 2, 3, 4, 5, ...
-    This converts a column-space threshold to element-space for r2p_bitmask_below/above.
+    Each MMA accumulator thread owns adjacent column pairs separated by
+    ``col_stride``: 0, 1, col_stride, col_stride + 1, ...  Element indices are
+    contiguous: 0, 1, 2, 3, ...  This converts a column-space threshold to
+    element-space for r2p_bitmask_below/above.
     """
-    return col_limit // 8 * 2 + min(col_limit % 8, 2)
+    return col_limit // col_stride * 2 + min(col_limit % col_stride, 2)
 
 
 @cute.jit
@@ -202,6 +211,14 @@ class AttentionMask:
         ROW = 0 if const_expr(not self.swap_AB) else 1
         COL = 1 if const_expr(not self.swap_AB) else 0
         thr_col_offset = tScS_mn[0][COL]
+        use_bitwise_r2p = False
+        if const_expr(not self.swap_AB):
+            # MMA accumulator columns are pairs whose stride depends on the thread
+            # layout. Infer it from the compile-time identity coordinates instead of
+            # assuming the SM90 value (8). SM80 can use a stride of 32 when MMA
+            # warps are partitioned along N.
+            r2p_col_stride = t0ScS_mn[0, 2][COL] - t0ScS_mn[0, 0][COL]
+            use_bitwise_r2p = const_expr(r2p_col_stride != 8)
         # To handle edge cases of completely masked out rows where n_block_max = 0,
         # we treat negative n_blocks as 0th n_block
         # TODO: find more transparent solution
@@ -210,16 +227,24 @@ class AttentionMask:
         seqlenk_col_limit = self.seqlen_k - n_block * self.tile_n - thr_col_offset
         if const_expr(not mask_causal and not mask_local and mask_mod is None):
             if const_expr(mask_seqlen):
-                r2p = const_expr(not self.swap_AB)
-                if const_expr(not r2p):
-                    # traverse column index.
-                    for c in cutlass.range(cute.size(tScS_mn.shape[1]), unroll_full=True):
-                        oob = t0ScS_mn[0, c][COL] >= seqlenk_col_limit
-                        for r in cutlass.range(cute.size(tScS_mn.shape[0]), unroll_full=True):
-                            acc_S_mn[r, c] = -Float32.inf if oob else acc_S_mn[r, c]
-                else:
-                    seqlenk_col_limit_r2p = sm90_col_to_r2p_idx(seqlenk_col_limit)
-                    mask_r2p_lambda(acc_S_mn, lambda s: r2p_bitmask_below(seqlenk_col_limit_r2p, s))
+                # Full KV tiles need no elementwise masking. This is the common
+                # dense case and avoids executing an all-ones R2P mask for every
+                # score tile.
+                if (n_block + 1) * self.tile_n > self.seqlen_k:
+                    r2p = const_expr(not self.swap_AB)
+                    if const_expr(not r2p):
+                        # traverse column index.
+                        for c in cutlass.range(cute.size(tScS_mn.shape[1]), unroll_full=True):
+                            oob = t0ScS_mn[0, c][COL] >= seqlenk_col_limit
+                            for r in cutlass.range(cute.size(tScS_mn.shape[0]), unroll_full=True):
+                                acc_S_mn[r, c] = -Float32.inf if oob else acc_S_mn[r, c]
+                    else:
+                        seqlenk_col_limit_r2p = col_to_r2p_idx(seqlenk_col_limit, r2p_col_stride)
+                        mask_r2p_lambda(
+                            acc_S_mn,
+                            lambda s: r2p_bitmask_below(seqlenk_col_limit_r2p, s),
+                            use_bitwise_select=use_bitwise_r2p,
+                        )
 
         elif const_expr(
             not mask_causal and not mask_local and mask_mod is not None
@@ -322,11 +347,12 @@ class AttentionMask:
                                     else acc_S_mn[r, c]
                                 )
                         else:
-                            col_limit_r2p = sm90_col_to_r2p_idx(col_limit_right)
+                            col_limit_r2p = col_to_r2p_idx(col_limit_right, r2p_col_stride)
                             mask_r2p_lambda(
                                 acc_S_mn[r, None],
                                 lambda s: r2p_bitmask_below(col_limit_r2p, s),
                                 rank1=True,
+                                use_bitwise_select=use_bitwise_r2p,
                             )
                 else:  # Local
                     local_row_offset_right = (
@@ -365,15 +391,20 @@ class AttentionMask:
                                 if col_idx >= col_limit_right or col_idx < col_limit_left:
                                     acc_S_mn[r, c] = -Float32.inf
                         else:
-                            col_limit_right_r2p = sm90_col_to_r2p_idx(col_limit_right)
-                            col_limit_left_r2p = sm90_col_to_r2p_idx(col_limit_left)
+                            col_limit_right_r2p = col_to_r2p_idx(col_limit_right, r2p_col_stride)
+                            col_limit_left_r2p = col_to_r2p_idx(col_limit_left, r2p_col_stride)
 
                             def mask_gen_fn(s: int) -> Uint32:
                                 return r2p_bitmask_below(
                                     col_limit_right_r2p, s
                                 ) & r2p_bitmask_above(col_limit_left_r2p, s)
 
-                            mask_r2p_lambda(acc_S_mn[r, None], mask_gen_fn, rank1=True)
+                            mask_r2p_lambda(
+                                acc_S_mn[r, None],
+                                mask_gen_fn,
+                                rank1=True,
+                                use_bitwise_select=use_bitwise_r2p,
+                            )
             else:  # swap_AB
                 assert self.qhead_per_kvhead_packgqa == 1
                 thr_row_offset = tScS_mn[0][ROW]

--- a/flash_attn/cute/utils.py
+++ b/flash_attn/cute/utils.py
@@ -612,6 +612,44 @@ def shr_u32(val: cutlass.Uint32, shift: cutlass.Uint32, *, loc=None, ip=None) ->
     )
 
 
+@dsl_user_op
+def mask_f32_by_u32_bit(
+    value: cutlass.Float32,
+    bitmask: cutlass.Uint32,
+    bit_index: int,
+    *,
+    loc=None,
+    ip=None,
+) -> cutlass.Float32:
+    """Keep ``value`` when ``bit_index`` is set, otherwise return negative infinity.
+
+    Extract and sign-extend the bit inside the inline assembly so unrolled mask
+    applications do not keep a separate scalar or predicate live per element.
+    """
+    assert 0 <= bit_index < 32
+    return cutlass.Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [
+                cutlass.Float32(value).ir_value(loc=loc, ip=ip),
+                cutlass.Uint32(bitmask).ir_value(loc=loc, ip=ip),
+            ],
+            "{\n\t"
+            ".reg .b32 keep_mask, value_bits;\n\t"
+            f"bfe.s32 keep_mask, $2, {bit_index}, 1;\n\t"
+            "mov.b32 value_bits, $1;\n\t"
+            # F(a, b, c) = c ? b : a; immLut = 0xd8.
+            "lop3.b32 value_bits, 0xff800000, value_bits, keep_mask, 0xd8;\n\t"
+            "mov.b32 $0, value_bits;\n\t"
+            "}\n",
+            "=f,f,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
 @cute.jit
 def warp_prefix_sum(val: cutlass.Int32, lane: Optional[cutlass.Int32] = None) -> cutlass.Int32:
     if const_expr(lane is None):

--- a/tests/cute/test_flash_attn_sm80.py
+++ b/tests/cute/test_flash_attn_sm80.py
@@ -5,6 +5,7 @@ import pytest
 import torch
 
 from flash_attn.cute import flash_attn_func, flash_attn_varlen_func
+from flash_attn.cute.interface import _get_fwd_config
 
 pytestmark = pytest.mark.skipif(
     not torch.cuda.is_available() or torch.cuda.get_device_capability() != (8, 0),
@@ -19,6 +20,32 @@ DTYPES = [
 MODES = ["mha", "gqa", "mqa"]
 LAYOUTS = ["dense", "varlen"]
 HEAD_DIMS = [64, 128]
+
+
+@pytest.mark.parametrize(
+    ("head_dim", "expected_tile_m"),
+    [(128, 128), (192, 64), (256, 64)],
+)
+def test_sm80_forward_tile_avoids_large_head_spills(head_dim, expected_tile_m):
+    config = _get_fwd_config(
+        arch=80,
+        head_dim=head_dim,
+        head_dim_v=head_dim,
+        max_seqlen_q=480,
+        max_seqlen_k=480,
+        num_head_kv=2,
+        qhead_per_kvhead=4,
+        pack_gqa=True,
+        batch_size=8,
+        causal=True,
+        local=False,
+        window_size_left=None,
+        window_size_right=None,
+        num_splits=1,
+        device=torch.device("cuda"),
+    )
+    assert config.m_block_size == expected_tile_m
+    assert config.n_block_size == 64
 
 
 def causal_mask_mod(batch_idx, head_idx, q_idx, kv_idx, seqlen_info, aux_tensors):
@@ -214,7 +241,7 @@ def _check_case(dtype, mode, layout, head_dim, mask_kind, lengths=None):
         + (0 if dtype == torch.float16 else 100)
         + MODES.index(mode) * 10
         + LAYOUTS.index(layout) * 3
-        + HEAD_DIMS.index(head_dim)
+        + (HEAD_DIMS.index(head_dim) if head_dim in HEAD_DIMS else head_dim)
     )
     inputs, dout, q_lengths, k_lengths = _make_inputs(
         dtype, mode, layout, head_dim, seed, lengths
@@ -303,4 +330,17 @@ def test_sm80_dense_even_tiles(head_dim, mask_kind):
         head_dim,
         mask_kind,
         lengths=((256, 256), (256, 256)),
+    )
+
+
+@pytest.mark.parametrize("layout", LAYOUTS)
+def test_sm80_hd256_forward_backward_smoke(layout):
+    lengths = ((96, 96), (96, 96)) if layout == "dense" else ((96, 80), (96, 80))
+    _check_case(
+        torch.bfloat16,
+        "gqa",
+        layout,
+        256,
+        "causal",
+        lengths=lengths,
     )

--- a/tests/cute/test_flash_attn_sm80.py
+++ b/tests/cute/test_flash_attn_sm80.py
@@ -344,3 +344,17 @@ def test_sm80_hd256_forward_backward_smoke(layout):
         "causal",
         lengths=lengths,
     )
+
+
+@pytest.mark.parametrize("head_dim", [72, 144, 200])
+@pytest.mark.parametrize("layout", LAYOUTS)
+def test_sm80_padded_head_dim_not_divisible_by_64(head_dim, layout):
+    lengths = ((256, 256), (256, 256)) if layout == "dense" else ((96, 80), (96, 80))
+    _check_case(
+        torch.bfloat16,
+        "mha",
+        layout,
+        head_dim,
+        "none",
+        lengths=lengths,
+    )

--- a/tests/cute/test_flash_attn_sm80.py
+++ b/tests/cute/test_flash_attn_sm80.py
@@ -1,0 +1,306 @@
+import json
+import math
+
+import pytest
+import torch
+
+from flash_attn.cute import flash_attn_func, flash_attn_varlen_func
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() != (8, 0),
+    reason="SM80 backward coverage",
+)
+
+
+DTYPES = [
+    pytest.param(torch.float16, id="fp16"),
+    pytest.param(torch.bfloat16, id="bf16"),
+]
+MODES = ["mha", "gqa", "mqa"]
+LAYOUTS = ["dense", "varlen"]
+HEAD_DIMS = [64, 128]
+
+
+def causal_mask_mod(batch_idx, head_idx, q_idx, kv_idx, seqlen_info, aux_tensors):
+    return kv_idx <= q_idx + seqlen_info.seqlen_k - seqlen_info.seqlen_q
+
+
+def parallel_chunks_mask_mod(
+    batch_idx, head_idx, q_idx, kv_idx, seqlen_info, aux_tensors
+):
+    prefix_len = seqlen_info.seqlen_k - seqlen_info.seqlen_q
+    chunk_size = seqlen_info.seqlen_q // 4
+    suffix_kv_idx = kv_idx - prefix_len
+    return (kv_idx < prefix_len) | (
+        (suffix_kv_idx >= 0) & ((q_idx // chunk_size) == (suffix_kv_idx // chunk_size))
+    )
+
+
+MASK_MODS = {
+    "causal_mask_mod": causal_mask_mod,
+    "parallel_chunks": parallel_chunks_mask_mod,
+}
+
+
+def _lengths(layout):
+    if layout == "dense":
+        return (128, 128), (257, 257)
+    return (128, 96), (257, 193)
+
+
+def _head_counts(mode):
+    return 8, {"mha": 8, "gqa": 2, "mqa": 1}[mode]
+
+
+def _make_inputs(dtype, mode, layout, head_dim, seed, lengths=None):
+    torch.manual_seed(seed)
+    q_lengths, k_lengths = _lengths(layout) if lengths is None else lengths
+    num_heads, num_kv_heads = _head_counts(mode)
+    if layout == "dense":
+        q_shape = (len(q_lengths), q_lengths[0], num_heads, head_dim)
+        kv_shape = (len(k_lengths), k_lengths[0], num_kv_heads, head_dim)
+    else:
+        q_shape = (sum(q_lengths), num_heads, head_dim)
+        kv_shape = (sum(k_lengths), num_kv_heads, head_dim)
+    q = torch.randn(q_shape, device="cuda", dtype=dtype)
+    k = torch.randn(kv_shape, device="cuda", dtype=dtype)
+    v = torch.randn(kv_shape, device="cuda", dtype=dtype)
+    dout = torch.randn(q_shape, device="cuda", dtype=dtype)
+    return (q, k, v), dout, q_lengths, k_lengths
+
+
+def _visible_mask(q_len, k_len, mask_kind, device):
+    if mask_kind == "none":
+        return None
+    q_idx = torch.arange(q_len, device=device)
+    kv_idx = torch.arange(k_len, device=device)
+    prefix_len = k_len - q_len
+    if mask_kind in ("causal", "causal_mask_mod"):
+        return kv_idx[None, :] <= q_idx[:, None] + prefix_len
+    if mask_kind == "parallel_chunks":
+        chunk_size = q_len // 4
+        suffix_kv_idx = kv_idx - prefix_len
+        return (kv_idx[None, :] < prefix_len) | (
+            (suffix_kv_idx[None, :] >= 0)
+            & ((q_idx[:, None] // chunk_size) == (suffix_kv_idx[None, :] // chunk_size))
+        )
+    raise ValueError(f"Unknown mask kind: {mask_kind}")
+
+
+def _reference_forward(q, k, v, layout, q_lengths, k_lengths, mask_kind):
+    num_heads = q.shape[-2]
+    num_kv_heads = k.shape[-2]
+    repeat_factor = num_heads // num_kv_heads
+    outputs = []
+    q_offset = 0
+    kv_offset = 0
+    for batch_idx, (q_len, k_len) in enumerate(zip(q_lengths, k_lengths)):
+        if layout == "dense":
+            q_seq, k_seq, v_seq = q[batch_idx], k[batch_idx], v[batch_idx]
+        else:
+            q_seq = q[q_offset : q_offset + q_len]
+            k_seq = k[kv_offset : kv_offset + k_len]
+            v_seq = v[kv_offset : kv_offset + k_len]
+        q_bhsd = q_seq.transpose(0, 1)
+        k_bhsd = k_seq.transpose(0, 1).repeat_interleave(repeat_factor, dim=0)
+        v_bhsd = v_seq.transpose(0, 1).repeat_interleave(repeat_factor, dim=0)
+        visible = _visible_mask(q_len, k_len, mask_kind, q.device)
+        softmax_scale = 1.0 / math.sqrt(q.shape[-1])
+        if q.dtype == torch.float32:
+            scores = torch.einsum("hqd,hkd->hqk", q_bhsd * softmax_scale, k_bhsd)
+        else:
+            # Match the same-dtype reference used by the other architecture tests:
+            # avoid upcasting and reorder the scale multiplication relative to FP32.
+            scores = torch.einsum("hqd,hkd->hqk", q_bhsd, k_bhsd * softmax_scale)
+        if visible is not None:
+            scores = scores.masked_fill(~visible[None], float("-inf"))
+        attention = torch.softmax(scores, dim=-1).to(v_bhsd.dtype)
+        out = torch.einsum("hqk,hkd->qhd", attention, v_bhsd)
+        outputs.append(out)
+        q_offset += q_len
+        kv_offset += k_len
+    return torch.stack(outputs) if layout == "dense" else torch.cat(outputs)
+
+
+def _run_reference(inputs, dout, layout, q_lengths, k_lengths, mask_kind, dtype):
+    q, k, v = [tensor.detach().to(dtype).requires_grad_() for tensor in inputs]
+    out = _reference_forward(q, k, v, layout, q_lengths, k_lengths, mask_kind)
+    grads = torch.autograd.grad(out, (q, k, v), dout.to(dtype))
+    return out.detach(), tuple(grad.detach() for grad in grads)
+
+
+def _run_flash(
+    inputs,
+    dout,
+    layout,
+    q_lengths,
+    k_lengths,
+    mask_kind,
+):
+    q, k, v = [tensor.detach().requires_grad_() for tensor in inputs]
+    mask_mod = MASK_MODS.get(mask_kind)
+    kwargs = {
+        "softmax_scale": 1.0 / math.sqrt(q.shape[-1]),
+        "causal": mask_kind == "causal",
+        "mask_mod": mask_mod,
+        "pack_gqa": None,
+        "return_lse": True,
+    }
+    if layout == "dense":
+        out, _ = flash_attn_func(q, k, v, **kwargs)
+    else:
+        cu_seqlens_q = torch.tensor(
+            [0, *torch.tensor(q_lengths).cumsum(0).tolist()],
+            device="cuda",
+            dtype=torch.int32,
+        )
+        cu_seqlens_k = torch.tensor(
+            [0, *torch.tensor(k_lengths).cumsum(0).tolist()],
+            device="cuda",
+            dtype=torch.int32,
+        )
+        out, _ = flash_attn_varlen_func(
+            q,
+            k,
+            v,
+            cu_seqlens_q=cu_seqlens_q,
+            cu_seqlens_k=cu_seqlens_k,
+            max_seqlen_q=max(q_lengths),
+            max_seqlen_k=max(k_lengths),
+            **kwargs,
+        )
+    grads = torch.autograd.grad(out, (q, k, v), dout)
+    return out.detach(), tuple(grad.detach() for grad in grads)
+
+
+def _max_abs(tensor):
+    return tensor.float().abs().max().item()
+
+
+def _assert_numeric_error(name, actual, ref_dtype, ref_fp32, dtype):
+    assert torch.isfinite(actual).all(), f"{name} contains NaN or Inf"
+    ref_quantized = ref_fp32.to(dtype)
+    pytorch_error = _max_abs(ref_dtype - ref_quantized)
+    kernel_error = _max_abs(actual - ref_quantized)
+    rounding_atol = 2 * _max_abs(ref_fp32 + 0.3 - 0.3 - ref_fp32)
+    atol_floor = 1e-5
+    limit = 2 * pytorch_error + max(atol_floor, rounding_atol)
+    assert kernel_error <= limit, (
+        f"{name} kernel error {kernel_error:.3e} exceeds "
+        f"2 * PyTorch error {pytorch_error:.3e} + atol "
+        f"{max(atol_floor, rounding_atol):.3e}"
+    )
+    return {
+        "kernel_error": kernel_error,
+        "pytorch_error": pytorch_error,
+        "limit": limit,
+    }
+
+
+def _assert_stable(name, first, second, dtype):
+    assert torch.isfinite(second).all(), f"repeated {name} contains NaN or Inf"
+    drift = _max_abs(first - second)
+    scale = max(1.0, _max_abs(first), _max_abs(second))
+    limit = 4 * torch.finfo(dtype).eps * scale
+    assert drift <= limit, (
+        f"repeated {name} drift {drift:.3e} exceeds stability limit {limit:.3e}"
+    )
+    return drift
+
+
+def _check_case(dtype, mode, layout, head_dim, mask_kind, lengths=None):
+    seed = (
+        1000
+        + (0 if dtype == torch.float16 else 100)
+        + MODES.index(mode) * 10
+        + LAYOUTS.index(layout) * 3
+        + HEAD_DIMS.index(head_dim)
+    )
+    inputs, dout, q_lengths, k_lengths = _make_inputs(
+        dtype, mode, layout, head_dim, seed, lengths
+    )
+    actual_out, actual_grads = _run_flash(
+        inputs, dout, layout, q_lengths, k_lengths, mask_kind
+    )
+    repeated_out, repeated_grads = _run_flash(
+        inputs, dout, layout, q_lengths, k_lengths, mask_kind
+    )
+    ref_out, ref_grads = _run_reference(
+        inputs, dout, layout, q_lengths, k_lengths, mask_kind, dtype
+    )
+    ref_out_fp32, ref_grads_fp32 = _run_reference(
+        inputs, dout, layout, q_lengths, k_lengths, mask_kind, torch.float32
+    )
+
+    tensors = {
+        "out": (actual_out, repeated_out, ref_out, ref_out_fp32),
+        "dq": (actual_grads[0], repeated_grads[0], ref_grads[0], ref_grads_fp32[0]),
+        "dk": (actual_grads[1], repeated_grads[1], ref_grads[1], ref_grads_fp32[1]),
+        "dv": (actual_grads[2], repeated_grads[2], ref_grads[2], ref_grads_fp32[2]),
+    }
+    errors = {}
+    drift = {}
+    for name, (actual, repeated, ref_dtype, ref_fp32) in tensors.items():
+        errors[name] = _assert_numeric_error(name, actual, ref_dtype, ref_fp32, dtype)
+        drift[name] = _assert_stable(name, actual, repeated, dtype)
+    print(
+        "\nSM80_MATRIX "
+        + json.dumps(
+            {
+                "dtype": str(dtype).removeprefix("torch."),
+                "mode": mode,
+                "layout": layout,
+                "mask": mask_kind,
+                "head_dim": head_dim,
+                "errors": errors,
+                "repeat_max_abs_drift": drift,
+            },
+            sort_keys=True,
+        )
+    )
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("mode", MODES)
+@pytest.mark.parametrize("layout", LAYOUTS)
+@pytest.mark.parametrize("mask_kind", ["none", "causal"])
+@pytest.mark.parametrize("head_dim", HEAD_DIMS)
+def test_sm80_backward_matrix(dtype, mode, layout, mask_kind, head_dim):
+    _check_case(dtype, mode, layout, head_dim, mask_kind)
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("mode", MODES)
+@pytest.mark.parametrize("layout", LAYOUTS)
+@pytest.mark.parametrize("mask_kind", list(MASK_MODS))
+@pytest.mark.parametrize("head_dim", HEAD_DIMS)
+def test_sm80_mask_mod_backward_matrix(dtype, mode, layout, mask_kind, head_dim):
+    _check_case(dtype, mode, layout, head_dim, mask_kind)
+
+
+@pytest.mark.parametrize("mask_kind", ["none", "causal"])
+def test_sm80_r2p_warp_n_partition_tail(mask_kind):
+    # D=128 partitions the 8 MMA warps along N, so each thread's accumulator
+    # columns are 0, 1, 32, 33, ... . A 16-column tail distinguishes the
+    # layout-derived R2P stride from the SM90 stride of 8.
+    _check_case(
+        torch.bfloat16,
+        "mha",
+        "dense",
+        128,
+        mask_kind,
+        lengths=((64, 64), (80, 80)),
+    )
+
+
+@pytest.mark.parametrize("mask_kind", ["none", "causal"])
+@pytest.mark.parametrize("head_dim", HEAD_DIMS)
+def test_sm80_dense_even_tiles(head_dim, mask_kind):
+    _check_case(
+        torch.bfloat16,
+        "gqa",
+        "dense",
+        head_dim,
+        mask_kind,
+        lengths=((256, 256), (256, 256)),
+    )

--- a/tests/cute/test_flash_attn_varlen.py
+++ b/tests/cute/test_flash_attn_varlen.py
@@ -48,6 +48,108 @@ def test_varlen(
     )
     assert ok
 
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability()[0] == 12,
+    reason="mask_mod backward is not supported on this device",
+)
+@pytest.mark.parametrize("num_kv_heads", [8, 4])
+@pytest.mark.parametrize("mask_kind", ["plain", "causal", "parallel_chunks"])
+def test_varlen_mask_mod_backward(num_kv_heads, mask_kind):
+    """Exercise masked MHA/GQA backward with unequal packed Q/K lengths."""
+    mask_seed = {"plain": 0, "causal": 1, "parallel_chunks": 2}[mask_kind]
+    torch.manual_seed(1234 + mask_seed)
+    q_lengths = (128, 96)
+    prefix_lengths = (257, 193)
+    kv_lengths = tuple(prefix + q for prefix, q in zip(prefix_lengths, q_lengths))
+    num_query_heads, headdim = 8, 128
+
+    cu_seqlens_q = torch.tensor(
+        [0, q_lengths[0], sum(q_lengths)], device="cuda", dtype=torch.int32
+    )
+    cu_seqlens_k = torch.tensor(
+        [0, kv_lengths[0], sum(kv_lengths)], device="cuda", dtype=torch.int32
+    )
+    inputs = [
+        torch.randn(total, nheads, headdim, device="cuda", dtype=torch.bfloat16)
+        for total, nheads in (
+            (sum(q_lengths), num_query_heads),
+            (sum(kv_lengths), num_kv_heads),
+            (sum(kv_lengths), num_kv_heads),
+        )
+    ]
+    actual_inputs = [tensor.clone().requires_grad_() for tensor in inputs]
+    reference_inputs = [tensor.float().requires_grad_() for tensor in inputs]
+
+    def mask_mod(batch_idx, head_idx, q_idx, kv_idx, seqlen_info, aux_tensors):
+        prefix_len = seqlen_info.seqlen_k - seqlen_info.seqlen_q
+        chunk_size = seqlen_info.seqlen_q // 4
+        suffix_kv_idx = kv_idx - prefix_len
+        return (kv_idx < prefix_len) | (
+            (suffix_kv_idx >= 0)
+            & ((q_idx // chunk_size) == (suffix_kv_idx // chunk_size))
+        )
+
+    custom_mask = mask_mod if mask_kind == "parallel_chunks" else None
+
+    actual, _ = flash_attn_varlen_func(
+        *actual_inputs,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        max_seqlen_q=max(q_lengths),
+        max_seqlen_k=max(kv_lengths),
+        softmax_scale=headdim**-0.5,
+        causal=mask_kind == "causal",
+        mask_mod=custom_mask,
+        return_lse=True,
+    )
+
+    reference_outputs = []
+    q_offset = kv_offset = 0
+    for q_len, kv_len in zip(q_lengths, kv_lengths):
+        q, k, v = (
+            reference_inputs[0][q_offset : q_offset + q_len],
+            reference_inputs[1][kv_offset : kv_offset + kv_len],
+            reference_inputs[2][kv_offset : kv_offset + kv_len],
+        )
+        k, v = (
+            tensor.repeat_interleave(num_query_heads // num_kv_heads, dim=1)
+            for tensor in (k, v)
+        )
+        scores = torch.einsum("qhd,khd->hqk", q, k) * headdim**-0.5
+        prefix_len = kv_len - q_len
+        q_idx = torch.arange(q_len, device="cuda")
+        kv_idx = torch.arange(kv_len, device="cuda")
+        if mask_kind == "causal":
+            visible = kv_idx[None] <= q_idx[:, None] + prefix_len
+            scores = scores.masked_fill(~visible[None], float("-inf"))
+        elif mask_kind == "parallel_chunks":
+            chunk_size = q_len // 4
+            visible = (kv_idx[None] < prefix_len) | (
+                (q_idx[:, None] // chunk_size)
+                == ((kv_idx[None] - prefix_len).clamp_min(0) // chunk_size)
+            )
+            scores = scores.masked_fill(~visible[None], float("-inf"))
+        reference_outputs.append(
+            torch.einsum("hqk,khd->qhd", torch.softmax(scores, dim=-1), v)
+        )
+        q_offset += q_len
+        kv_offset += kv_len
+    reference = torch.cat(reference_outputs, dim=0)
+
+    grad_out = torch.randn_like(actual)
+    actual.backward(grad_out)
+    reference.backward(grad_out.float())
+
+    torch.testing.assert_close(actual.float(), reference, rtol=3e-2, atol=5e-2)
+    for actual_input, reference_input in zip(actual_inputs, reference_inputs):
+        assert actual_input.grad is not None and reference_input.grad is not None
+        assert torch.isfinite(actual_input.grad).all()
+        torch.testing.assert_close(
+            actual_input.grad.float(), reference_input.grad, rtol=3e-2, atol=5e-2
+        )
+
+
 def check_varlen_vs_torch_flash(
     q, k, v,
     cu_seqlens_q=None,


### PR DESCRIPTION
## What changed

- enable the existing CuTe SM80 backward implementation in the public FA4 dispatch
- select Ampere-specific tile, pipeline, MMA-warp, and postprocess layouts through head dimension 256
- propagate scalar `mask_mod` and varlen metadata through SM80 backward
- derive R2P column mapping from the MMA accumulator layout and handle invalid varlen padding CTAs safely
- use an M64 x N64 forward tile on SM80 when either head dimension exceeds 128, avoiding large-head register spilling
- add SM80 forward/backward coverage for MHA, GQA, MQA, dense, varlen, causal, custom-mask, and D256 cases

## Why

FA4 already contained an SM80 backward kernel and varlen scheduler scaffolding, but the public backward path rejected SM80 and could select non-SM80 configuration defaults. The SM80 kernel also did not receive `mask_mod`, and varlen padded offsets plus postprocess thread-layout mismatches could produce incorrect gradients.

The previous SM80 forward heuristic selected M128 x N64 for all supported head dimensions. At D192/D256, M128 exhausts the SM80 register budget. The dense specialization spills 2,456 bytes of stack per thread, while the additional dynamic state in varlen causes 11,304 bytes of stack per thread and a large local-memory instruction expansion. M64 x N64 keeps both specializations spill-free without changing the total attention work.

## Impact

This patch enables SM80 training for the existing dense and packed-varlen forward paths, including scalar custom masks, and removes the large-head forward spill cliff. Architecture selection for SM90, SM100/110, and SM120 is preserved.

SM80 block-sparse backward, deterministic backward, and vectorized `mask_mod` remain explicitly unsupported.

## Validation

- full SM80 correctness suite on A800, CUDA 12.8: 107 passed
- generic MHA/GQA/MQA matrix: dense and varlen, causal and non-causal, FP16 and BF16, D64/D128
- D256 dense and varlen causal GQA forward/backward smokes: passed
- varlen custom-mask backward: passed
- R2P/tail regressions: passed
- eager and `torch.compile(fullgraph=False)` public-API integration checks: passed

### SM80 large-head kernel resources

BF16 causal GQA, Q/KV heads 8/2, batch 8, sequence length 480, D256:

| Forward specialization | Registers | Stack/thread | SASS instructions | Local loads | Local stores |
|---|---:|---:|---:|---:|---:|
| Dense M128 x N64 | 255 | 2,456 B | 10,822 | 1,116 | 1,019 |
| Varlen M128 x N64 | 32 | 11,304 B | 34,623 | 11,469 | 8,721 |
| Dense M64 x N64 | 246 | 0 B | 3,534 | 0 | 0 |
| Varlen M64 x N64 | 255 | 0 B | 4,299 | 0 | 0 |

M64 uses half as many HMMA instructions per CTA and about twice as many useful Q tiles, leaving total tensor-core work unchanged.

### A800 large-head performance

Public FA4 APIs, PyTorch 2.8, CUDA 12.8, BF16, causal GQA, Q/KV heads 8/2, batch 8, sequence length 480. Times are medians after warm-up; lower is better.

| D | Layout | Metric | M128 x N64 | M64 x N64 | Speedup |
|---:|---|---|---:|---:|---:|
| 256 | Dense | Forward | 0.435 ms | 0.173 ms | 2.52x |
| 256 | Varlen | Forward | 3.604 ms | 0.184 ms | 19.57x |
| 256 | Dense | Forward + backward | 0.921 ms | 0.723 ms | 1.27x |
| 256 | Varlen | Forward + backward | 3.958 ms | 0.780 ms | 5.07x |
| 192 | Dense | Forward | 0.197 ms | 0.121 ms | 1.63x |
| 192 | Varlen | Forward | 2.240 ms | 0.133 ms | 16.84x |

M64 and M128 outputs were bitwise identical in the D192/D256 comparisons.

## A800 backward performance

Standalone backward was measured on A800 (SM80) with PyTorch 2.8, CUDA 12.8, BF16, batch size 4, three warm-up iterations, 10 repetitions, and medians over 5 rounds. Dense sequences have length 2048; varlen sequences have lengths 2048, 1792, 1536, and 1280. Lower is better.

| Attention | Heads (Q/KV) | Mask | Layout | D | FA2 | FA4 | FA4 latency reduction |
|---|---:|---|---|---:|---:|---:|---:|
| MHA | 8/8 | None | Dense | 64 | 0.554 ms | 0.523 ms | 5.5% |
| MHA | 8/8 | Causal | Varlen | 128 | 0.494 ms | 0.492 ms | 0.5% |
| GQA | 8/2 | Causal | Dense | 128 | 0.708 ms | 0.685 ms | 3.2% |
| GQA | 8/2 | None | Varlen | 64 | 0.423 ms | 0.409 ms | 3.4% |
| MQA | 8/1 | None | Dense | 128 | 1.045 ms | 0.978 ms | 6.4% |
| MQA | 8/1 | Causal | Varlen | 64 | 0.299 ms | 0.273 ms | 8.7% |

The full 48-case standalone-backward matrix covers FP16 and BF16, MHA/GQA/MQA, dense and varlen layouts, causal and non-causal attention, and head dimensions 64 and 128. FA4 had lower backward latency in all 48 cases, with a 4.42% geometric-mean speedup and a 0.36% minimum speedup over FA2.

Arbitrary scalar `mask_mod` is not included in the FA2 comparison because the FA2 public API does not support it; SM80 scalar `mask_mod` is covered by the correctness tests above.
