### PR TITLE
[CuTe, SM100] hd256 2-CTA: support seqused_q/seqused_k and the decoder paged-KV shape

### DIFF
--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -783,6 +783,44 @@ def _flash_attn_fwd(
     if cu_seqlens_k is None and seqused_k is None:
         min_seqlen_k = seqlen_k
 
+    # hd=256 2CTA forward uses dedicated kernel (Blackwell family)
+    use_dedicated_hd256_kernel = arch // 10 in [10, 11] and head_dim == 256 and head_dim_v == 256
+
+    if use_dedicated_hd256_kernel and page_table is not None:
+        # The dedicated kernel takes its paged KV extent from the page-table
+        # width (`max_seqlen_k_paged = mPageTable.shape[1] * page_size`), so the
+        # table has to describe exactly ceil(max_seqlen_k / page_size) pages.
+        # Continuous-batching servers cannot satisfy that directly: they hand
+        # over the current batch maximum as `max_seqlen_k` (arbitrary, rarely
+        # page-aligned) together with a `page_table` whose width is fixed by the
+        # largest supported context, not by this batch. Normalize both here
+        # instead of requiring every caller to pre-slice: widen the KV extent to
+        # the enclosing page boundary and narrow the table to match.
+        #
+        # This must run before `_get_fwd_config`, the compile key and the page
+        # table conversion below, so tile selection, kernel specialization and
+        # the device-side tensor all see the same (normalized) values.
+        required_pages = (max_seqlen_k + page_size - 1) // page_size
+        assert page_table.shape[1] >= required_pages, (
+            f"SM100 hd256 2CTA paged KV requires page_table to cover max_seqlen_k="
+            f"{max_seqlen_k}, i.e. at least ceil({max_seqlen_k} / {page_size}) = "
+            f"{required_pages} pages, got page_table.shape[1]={page_table.shape[1]}"
+        )
+        if max_seqlen_k % page_size != 0:
+            # Rounding the extent up only stays faithful to the caller's request
+            # if something still bounds each sequence at its true length;
+            # seqused_k is that bound (positions in [seqused_k, rounded) mask to
+            # exact-zero probability). Without it every sequence would silently
+            # attend to the remainder of its last page.
+            assert seqused_k is not None, (
+                f"SM100 hd256 2CTA paged KV rounds max_seqlen_k up to the page "
+                f"boundary ({max_seqlen_k} -> {required_pages * page_size}); pass "
+                f"seqused_k with the per-batch KV lengths so the tail inside the "
+                f"last page is masked, or pass a page-aligned max_seqlen_k"
+            )
+        page_table = page_table[:, :required_pages]
+        max_seqlen_k = required_pages * page_size
+
     fwd_cfg = _get_fwd_config(
         arch=arch,
         head_dim=head_dim,
@@ -835,8 +873,6 @@ def _flash_attn_fwd(
         and (tile_m % qhead_per_kvhead == 0 or not pack_gqa)
     )
 
-    # hd=256 2CTA forward uses dedicated kernel (Blackwell family)
-    use_dedicated_hd256_kernel = arch // 10 in [10, 11] and head_dim == 256 and head_dim_v == 256
     use_2cta_instrs = use_2cta_instrs or use_dedicated_hd256_kernel
 
     if softcap is not None:
@@ -1316,18 +1352,9 @@ def _flash_attn_fwd(
                     # silently mis-addressed, so reject it loudly.
                     assert cu_seqlens_k is None or cu_seqlens_q is not None, \
                         "SM100 forward with head_dim=256 requires cu_seqlens_q when cu_seqlens_k is used"
-                    if page_table is not None:
-                        assert max_seqlen_k % page_size == 0, (
-                            f"SM100 hd256 2CTA paged KV requires max_seqlen_k divisible by "
-                            f"page_size ({page_size}), got max_seqlen_k={max_seqlen_k}"
-                        )
-                        assert page_table.shape[1] == max_seqlen_k // page_size, (
-                            f"SM100 hd256 2CTA paged KV requires page_table.shape[1] == "
-                            f"max_seqlen_k // page_size ({max_seqlen_k} // {page_size} = "
-                            f"{max_seqlen_k // page_size}), got {page_table.shape[1]}; "
-                            f"pass page_table[:, :{max_seqlen_k // page_size}] to slice to "
-                            f"the actual sequence length"
-                        )
+                    # The paged-KV extent/page-table contract is normalized
+                    # up front (see the page_table block above), so it holds by
+                    # construction here.
                     # pack_gqa is an auto-selected optimization; disable it for hd256 kernel
                     pack_gqa = False
 

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -1311,8 +1311,11 @@ def _flash_attn_fwd(
                         "SM100 forward with head_dim=256 does not support block sparsity"
                     assert learnable_sink is None, \
                         "SM100 forward with head_dim=256 does not support learnable_sink"
-                    assert seqused_q is None and seqused_k is None, \
-                        "SM100 forward with head_dim=256 does not support seqused_q/seqused_k"
+                    # The dedicated kernel derives K/V load offsets from
+                    # cu_seqlens_q; varlen-packed K without varlen Q would be
+                    # silently mis-addressed, so reject it loudly.
+                    assert cu_seqlens_k is None or cu_seqlens_q is not None, \
+                        "SM100 forward with head_dim=256 requires cu_seqlens_q when cu_seqlens_k is used"
                     if page_table is not None:
                         assert max_seqlen_k % page_size == 0, (
                             f"SM100 hd256 2CTA paged KV requires max_seqlen_k divisible by "

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -787,19 +787,8 @@ def _flash_attn_fwd(
     use_dedicated_hd256_kernel = arch // 10 in [10, 11] and head_dim == 256 and head_dim_v == 256
 
     if use_dedicated_hd256_kernel and page_table is not None:
-        # The dedicated kernel takes its paged KV extent from the page-table
-        # width (`max_seqlen_k_paged = mPageTable.shape[1] * page_size`), so the
-        # table has to describe exactly ceil(max_seqlen_k / page_size) pages.
-        # Continuous-batching servers cannot satisfy that directly: they hand
-        # over the current batch maximum as `max_seqlen_k` (arbitrary, rarely
-        # page-aligned) together with a `page_table` whose width is fixed by the
-        # largest supported context, not by this batch. Normalize both here
-        # instead of requiring every caller to pre-slice: widen the KV extent to
-        # the enclosing page boundary and narrow the table to match.
-        #
-        # This must run before `_get_fwd_config`, the compile key and the page
-        # table conversion below, so tile selection, kernel specialization and
-        # the device-side tensor all see the same (normalized) values.
+        # The kernel derives KV capacity from the page-table width. Normalize
+        # both before config selection, cache-key construction and tensor conversion.
         required_pages = (max_seqlen_k + page_size - 1) // page_size
         assert page_table.shape[1] >= required_pages, (
             f"SM100 hd256 2CTA paged KV requires page_table to cover max_seqlen_k="
@@ -807,11 +796,7 @@ def _flash_attn_fwd(
             f"{required_pages} pages, got page_table.shape[1]={page_table.shape[1]}"
         )
         if max_seqlen_k % page_size != 0:
-            # Rounding the extent up only stays faithful to the caller's request
-            # if something still bounds each sequence at its true length;
-            # seqused_k is that bound (positions in [seqused_k, rounded) mask to
-            # exact-zero probability). Without it every sequence would silently
-            # attend to the remainder of its last page.
+            # seqused_k must mask the extra tokens introduced by page rounding.
             assert seqused_k is not None, (
                 f"SM100 hd256 2CTA paged KV rounds max_seqlen_k up to the page "
                 f"boundary ({max_seqlen_k} -> {required_pages * page_size}); pass "

--- a/flash_attn/cute/sm100_hd256_2cta_fmha_forward.py
+++ b/flash_attn/cute/sm100_hd256_2cta_fmha_forward.py
@@ -190,9 +190,6 @@ class BlackwellFusedMultiHeadAttentionForward:
     ):
         # Keep parity with FlashAttentionForwardSm100.__call__ interface.
         # (TODO@wangsiyu) Implement these features.
-        assert mSeqUsedQ is None and mSeqUsedK is None, (
-            "SM100 forward with head_dim=256 does not support seqused_q/seqused_k"
-        )
         assert learnable_sink is None, (
             "SM100 forward with head_dim=256 does not support learnable_sink"
         )
@@ -564,6 +561,8 @@ class BlackwellFusedMultiHeadAttentionForward:
             o,
             cum_seqlen_q,
             cum_seqlen_k,
+            mSeqUsedQ,
+            mSeqUsedK,
             lse,
             scale_softmax_log2,
             scale_softmax,
@@ -601,6 +600,8 @@ class BlackwellFusedMultiHeadAttentionForward:
         mO_qdl: cute.Tensor,
         cum_seqlen_q: Optional[cute.Tensor],
         cum_seqlen_k: Optional[cute.Tensor],
+        mSeqUsedQ: Optional[cute.Tensor],
+        mSeqUsedK: Optional[cute.Tensor],
         mLSE: Optional[cute.Tensor],
         scale_softmax_log2: Float32,
         scale_softmax: Float32,
@@ -876,6 +877,21 @@ class BlackwellFusedMultiHeadAttentionForward:
                         mma_block_coord[0],
                         seqlen_q,
                     )
+                # seqused_q/seqused_k override the static or cu_seqlens-derived
+                # lengths (same precedence as SeqlenInfoQK.create); cu_seqlens
+                # still provide the packing offsets. continue_cond is recomputed
+                # from the overridden seqlen_q with the identical expression in
+                # every warp section so all pipeline participants agree on which
+                # work tiles are skipped.
+                if cutlass.const_expr(mSeqUsedQ is not None):
+                    seqlen_q = mSeqUsedQ[batch_coord]
+                    continue_cond = not FmhaStaticTileScheduler.check_valid_work_for_seqlen_q(
+                        self.qk_mma_tiler[0],
+                        mma_block_coord[0],
+                        seqlen_q,
+                    )
+                if cutlass.const_expr(mSeqUsedK is not None):
+                    seqlen_k = mSeqUsedK[batch_coord]
                 if not continue_cond:
                     mQ_qdl_ = cute.domain_offset(cute.select(block_offset, mode=[0, 2, 3]), mQ_qdl)
                     # Local tile partition global tensors
@@ -1091,11 +1107,22 @@ class BlackwellFusedMultiHeadAttentionForward:
                         mma_block_coord[0],
                         seqlen_q,
                     )
+                # See the load-warp comment: seqused overrides + consistent
+                # continue_cond recompute across warp sections.
+                if cutlass.const_expr(mSeqUsedQ is not None):
+                    seqlen_q = mSeqUsedQ[batch_coord]
+                    continue_cond = not FmhaStaticTileScheduler.check_valid_work_for_seqlen_q(
+                        self.qk_mma_tiler[0],
+                        mma_block_coord[0],
+                        seqlen_q,
+                    )
 
                 if not continue_cond:
                     if cutlass.const_expr(cum_seqlen_k is not None):
                         cuseqlen_k = cum_seqlen_k[batch_coord]
                         seqlen_k = cum_seqlen_k[batch_coord + 1] - cuseqlen_k
+                    if cutlass.const_expr(mSeqUsedK is not None):
+                        seqlen_k = mSeqUsedK[batch_coord]
 
                     seqlen_kv_loop_start, seqlen_kv_loop_steps = (
                         FusedMask.get_trip_start_count_via_block_info(
@@ -1339,10 +1366,21 @@ class BlackwellFusedMultiHeadAttentionForward:
                         mma_block_coord[0],
                         seqlen_q,
                     )
+                # See the load-warp comment: seqused overrides + consistent
+                # continue_cond recompute across warp sections.
+                if cutlass.const_expr(mSeqUsedQ is not None):
+                    seqlen_q = mSeqUsedQ[batch_coord]
+                    continue_cond = not FmhaStaticTileScheduler.check_valid_work_for_seqlen_q(
+                        self.qk_mma_tiler[0],
+                        mma_block_coord[0],
+                        seqlen_q,
+                    )
                 if not continue_cond:
                     if cutlass.const_expr(cum_seqlen_k is not None):
                         cuseqlen_k = cum_seqlen_k[batch_coord]
                         seqlen_k = cum_seqlen_k[batch_coord + 1] - cuseqlen_k
+                    if cutlass.const_expr(mSeqUsedK is not None):
+                        seqlen_k = mSeqUsedK[batch_coord]
 
                     row_max = -Float32.inf
                     row_max_prev = -Float32.inf
@@ -1459,11 +1497,22 @@ class BlackwellFusedMultiHeadAttentionForward:
                         mma_block_coord[0],
                         seqlen_q,
                     )
+                # See the load-warp comment: seqused overrides + consistent
+                # continue_cond recompute across warp sections.
+                if cutlass.const_expr(mSeqUsedQ is not None):
+                    seqlen_q = mSeqUsedQ[batch_coord]
+                    continue_cond = not FmhaStaticTileScheduler.check_valid_work_for_seqlen_q(
+                        self.qk_mma_tiler[0],
+                        mma_block_coord[0],
+                        seqlen_q,
+                    )
 
                 if not continue_cond:
                     if cutlass.const_expr(cum_seqlen_k is not None):
                         cuseqlen_k = cum_seqlen_k[batch_coord]
                         seqlen_k = cum_seqlen_k[batch_coord + 1] - cuseqlen_k
+                    if cutlass.const_expr(mSeqUsedK is not None):
+                        seqlen_k = mSeqUsedK[batch_coord]
 
                     mO_qdl_eff = mO_qdl
                     if cutlass.const_expr(cum_seqlen_q is not None):

--- a/flash_attn/cute/sm100_hd256_2cta_fmha_forward.py
+++ b/flash_attn/cute/sm100_hd256_2cta_fmha_forward.py
@@ -877,12 +877,10 @@ class BlackwellFusedMultiHeadAttentionForward:
                         mma_block_coord[0],
                         seqlen_q,
                     )
-                # seqused_q/seqused_k override the static or cu_seqlens-derived
-                # lengths (same precedence as SeqlenInfoQK.create); cu_seqlens
-                # still provide the packing offsets. continue_cond is recomputed
-                # from the overridden seqlen_q with the identical expression in
-                # every warp section so all pipeline participants agree on which
-                # work tiles are skipped.
+                # NOTE [Per-batch sequence lengths]
+                # seqused overrides lengths, not cu_seqlens packing offsets.
+                # All four warp roles must use the same effective Q length when
+                # deciding which tiles to skip.
                 if cutlass.const_expr(mSeqUsedQ is not None):
                     seqlen_q = mSeqUsedQ[batch_coord]
                     continue_cond = not FmhaStaticTileScheduler.check_valid_work_for_seqlen_q(
@@ -1107,8 +1105,7 @@ class BlackwellFusedMultiHeadAttentionForward:
                         mma_block_coord[0],
                         seqlen_q,
                     )
-                # See the load-warp comment: seqused overrides + consistent
-                # continue_cond recompute across warp sections.
+                # See NOTE [Per-batch sequence lengths]
                 if cutlass.const_expr(mSeqUsedQ is not None):
                     seqlen_q = mSeqUsedQ[batch_coord]
                     continue_cond = not FmhaStaticTileScheduler.check_valid_work_for_seqlen_q(
@@ -1366,8 +1363,7 @@ class BlackwellFusedMultiHeadAttentionForward:
                         mma_block_coord[0],
                         seqlen_q,
                     )
-                # See the load-warp comment: seqused overrides + consistent
-                # continue_cond recompute across warp sections.
+                # See NOTE [Per-batch sequence lengths]
                 if cutlass.const_expr(mSeqUsedQ is not None):
                     seqlen_q = mSeqUsedQ[batch_coord]
                     continue_cond = not FmhaStaticTileScheduler.check_valid_work_for_seqlen_q(
@@ -1497,8 +1493,7 @@ class BlackwellFusedMultiHeadAttentionForward:
                         mma_block_coord[0],
                         seqlen_q,
                     )
-                # See the load-warp comment: seqused overrides + consistent
-                # continue_cond recompute across warp sections.
+                # See NOTE [Per-batch sequence lengths]
                 if cutlass.const_expr(mSeqUsedQ is not None):
                     seqlen_q = mSeqUsedQ[batch_coord]
                     continue_cond = not FmhaStaticTileScheduler.check_valid_work_for_seqlen_q(

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -951,8 +951,11 @@ def test_flash_attn_varlen_output(
             pytest.skip("SM100 head_dim=256 2CTA kernel does not support softcap yet")
         if deterministic:
             pytest.skip("SM100 head_dim=256 2CTA kernel does not support deterministic mode yet")
-        if not unpad_q or not unpad_kv:
-            pytest.skip("SM100 head_dim=256 2CTA kernel does not support seqused_q/seqused_k mode yet (requires unpad_q=True and unpad_kv=True)")
+        if not unpad_q and unpad_kv:
+            pytest.skip(
+                "SM100 head_dim=256 2CTA kernel does not support varlen-packed K "
+                "without varlen Q (cu_seqlens_k requires cu_seqlens_q)"
+            )
     if (
         causal or local
     ):  # Right now reference only supports causal attention with seqlen_k == seqlen_q
@@ -1260,7 +1263,9 @@ def test_flash_attn_varlen_output(
             and (
                 (dv == d and d <= 128)
                 or (d == 192 and dv == 128)
-                or (IS_SM100 and d == 256 and dv == 256 and softcap == 0.0)
+                # hd256 backward does not support seqused_q/seqused_k yet, so
+                # only run it in the fully-unpadded (cu_seqlens-only) mode.
+                or (IS_SM100 and d == 256 and dv == 256 and softcap == 0.0 and unpad_q and unpad_kv)
             )
             and not has_learnable_sink
             # and False

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -2662,6 +2662,194 @@ def test_flash_attn_paged_hd256_sm100_tma_shuffled():
     )
 
 
+@pytest.mark.parametrize("seqlen_q", [1, 120])
+@pytest.mark.parametrize("max_seqlen_k_mode", ["batch_max", "page_aligned"])
+@maybe_fake_tensor_mode(USE_FAKE_TENSOR)
+def test_flash_attn_paged_hd256_sm100_tma_seqused_k(max_seqlen_k_mode, seqlen_q):
+    """Per-batch KV lengths (seqused_k) in the SM100 hd256 2CTA forward kernel.
+
+    Shaped after what a continuous-batching server hands the decoder: a paged
+    KV cache, a ``page_table`` whose width is fixed by the largest supported
+    context (wider than this batch needs), ``seqused_k`` carrying the actual
+    per-batch KV lengths, and ``max_seqlen_k`` as the current batch maximum.
+
+    ``max_seqlen_k_mode`` covers both callers:
+
+    * ``batch_max``    - ``max(seqused_k)`` (257 here), i.e. neither page-aligned
+      nor equal to ``page_table.shape[1] * page_size``. This is what vLLM's
+      decoder passes; the interface normalizes it up to the enclosing page and
+      narrows the table.
+    * ``page_aligned`` - the allocated capacity (512), what a caller that
+      pre-slices to the kernel's original contract passes.
+
+    Both must agree with a dense varlen reference over the true per-batch
+    lengths. KV beyond each sequence's ``seqused_k`` - the tail inside its last
+    page and every page after it - is poisoned with large finite values, so
+    attending past ``seqused_k`` (for instance if rounding the extent up leaked
+    into the last page) is a gross mismatch rather than a rounding difference.
+    Finite poison rather than NaN on purpose: masked positions still contribute
+    ``0 * value`` to the PV accumulation, and ``0 * NaN`` would poison a correct
+    kernel too.
+    """
+    if not IS_SM100:
+        pytest.skip("SM100-specific paged hd256 test")
+    device = "cuda"
+    dtype = torch.bfloat16
+    d = 256
+    nheads = 8
+    nheads_kv = 8
+    page_size = 128
+    # Allocated KV capacity per sequence (the page_table spans all of it).
+    seqlen_k_alloc = 512
+    num_pages_per_seq = seqlen_k_alloc // page_size
+    # Per-batch actual lengths: page-aligned, one past a page boundary, and
+    # mid-page. The batch maximum (257) is deliberately not page-aligned and
+    # needs only 3 of the table's 4 pages.
+    seqused_k_list = [128, 129, 257]
+    batch_size = len(seqused_k_list)
+    total_pages = batch_size * num_pages_per_seq
+    assert all(seqlen_q <= s <= seqlen_k_alloc for s in seqused_k_list)
+    max_seqlen_k = max(seqused_k_list) if max_seqlen_k_mode == "batch_max" else seqlen_k_alloc
+    # The shape under test: the table is wider than the requested extent needs.
+    if max_seqlen_k_mode == "batch_max":
+        assert max_seqlen_k % page_size != 0
+        assert -(-max_seqlen_k // page_size) < num_pages_per_seq
+
+    torch.random.manual_seed(0)
+    q = torch.randn(batch_size * seqlen_q, nheads, d, device=device, dtype=dtype)
+    cu_seqlens_q = torch.arange(0, batch_size + 1, dtype=torch.int32, device=device) * seqlen_q
+    # Packed dense K/V holding only the used tokens of each sequence.
+    k_offsets = [0] + list(itertools.accumulate(seqused_k_list))
+    k = torch.randn(k_offsets[-1], nheads_kv, d, device=device, dtype=dtype)
+    v = torch.randn(k_offsets[-1], nheads_kv, d, device=device, dtype=dtype)
+    cu_seqlens_k = torch.tensor(k_offsets, dtype=torch.int32, device=device)
+    seqused_k = torch.tensor(seqused_k_list, dtype=torch.int32, device=device)
+
+    # Dense varlen reference over the exact per-batch lengths.
+    out_ref, _ = flash_attn_varlen_func(
+        q, k, v,
+        cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=cu_seqlens_k,
+        max_seqlen_q=seqlen_q, max_seqlen_k=max(seqused_k_list),
+        causal=True,
+    )
+
+    # Paged layout at full capacity, everything past seqused_k poisoned.
+    k_paged = torch.full(
+        (total_pages, page_size, nheads_kv, d), 300.0, device=device, dtype=dtype
+    )
+    v_paged = torch.full_like(k_paged, 300.0)
+    for b in range(batch_size):
+        for s in range(seqused_k_list[b]):
+            pi = b * num_pages_per_seq + s // page_size
+            po = s % page_size
+            k_paged[pi, po] = k[k_offsets[b] + s]
+            v_paged[pi, po] = v[k_offsets[b] + s]
+    page_table = torch.arange(total_pages, dtype=torch.int32, device=device).reshape(
+        batch_size, num_pages_per_seq
+    )
+
+    out_paged, _ = flash_attn_varlen_func(
+        q, k_paged, v_paged,
+        cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=None,
+        max_seqlen_q=seqlen_q, max_seqlen_k=max_seqlen_k,
+        page_table=page_table,
+        seqused_k=seqused_k,
+        causal=True,
+    )
+
+    # With seqused_k at the allocated capacity every position is legitimately
+    # attended (poison included), so passing seqused_k must be indistinguishable
+    # from not passing it at all.
+    seqused_full = torch.full(
+        (batch_size,), seqlen_k_alloc, dtype=torch.int32, device=device
+    )
+    out_full_seqused, _ = flash_attn_varlen_func(
+        q, k_paged, v_paged,
+        cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=None,
+        max_seqlen_q=seqlen_q, max_seqlen_k=seqlen_k_alloc,
+        page_table=page_table,
+        seqused_k=seqused_full,
+        causal=True,
+    )
+    out_no_seqused, _ = flash_attn_varlen_func(
+        q, k_paged, v_paged,
+        cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=None,
+        max_seqlen_q=seqlen_q, max_seqlen_k=seqlen_k_alloc,
+        page_table=page_table,
+        causal=True,
+    )
+
+    if is_fake_mode():
+        return
+
+    print(f"Paged seqused_k vs dense varlen max diff: {(out_paged - out_ref).abs().max().item()}")
+    assert out_paged.isfinite().all(), "Paged seqused_k output is not finite"
+    # The poison is ~300 against unit-normal data: any leak past seqused_k moves
+    # the output far outside the reference's range.
+    assert out_paged.abs().max().item() < 10.0, (
+        "Paged seqused_k output has poison-scale magnitudes: KV past seqused_k leaked"
+    )
+    assert torch.allclose(out_paged, out_ref, atol=1e-3, rtol=1e-3), (
+        "Paged seqused_k output does not match the dense varlen reference"
+    )
+    assert torch.equal(out_full_seqused, out_no_seqused), (
+        "seqused_k equal to the allocated length must match the non-seqused path"
+    )
+
+
+@maybe_fake_tensor_mode(USE_FAKE_TENSOR)
+def test_flash_attn_paged_hd256_sm100_tma_contract_guards():
+    """The two paged-KV contract guards of the SM100 hd256 2CTA forward kernel.
+
+    The interface widens ``max_seqlen_k`` to the enclosing page and narrows the
+    ``page_table`` to match, which is only well defined when (a) the table
+    actually covers the requested extent and (b) something bounds each sequence
+    at its true length once the extent is rounded up.
+    """
+    if not IS_SM100:
+        pytest.skip("SM100-specific paged hd256 test")
+    device = "cuda"
+    dtype = torch.bfloat16
+    d = 256
+    nheads = 8
+    nheads_kv = 8
+    page_size = 128
+    seqlen_q = 1
+    batch_size = 2
+    num_pages_per_seq = 2
+    total_pages = batch_size * num_pages_per_seq
+
+    q = torch.randn(batch_size * seqlen_q, nheads, d, device=device, dtype=dtype)
+    cu_seqlens_q = torch.arange(0, batch_size + 1, dtype=torch.int32, device=device) * seqlen_q
+    k_paged = torch.randn(total_pages, page_size, nheads_kv, d, device=device, dtype=dtype)
+    v_paged = torch.randn_like(k_paged)
+    page_table = torch.arange(total_pages, dtype=torch.int32, device=device).reshape(
+        batch_size, num_pages_per_seq
+    )
+    seqused_k = torch.full((batch_size,), 200, dtype=torch.int32, device=device)
+
+    # (a) page_table narrower than the requested extent needs.
+    with pytest.raises(AssertionError, match="page_table to cover max_seqlen_k"):
+        flash_attn_varlen_func(
+            q, k_paged, v_paged,
+            cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=None,
+            max_seqlen_q=seqlen_q, max_seqlen_k=num_pages_per_seq * page_size + 1,
+            page_table=page_table,
+            seqused_k=seqused_k,
+            causal=True,
+        )
+
+    # (b) extent that needs rounding, with nothing bounding the true lengths.
+    with pytest.raises(AssertionError, match="rounds max_seqlen_k up"):
+        flash_attn_varlen_func(
+            q, k_paged, v_paged,
+            cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=None,
+            max_seqlen_q=seqlen_q, max_seqlen_k=page_size + 1,
+            page_table=page_table,
+            causal=True,
+        )
+
+
 @pytest.mark.parametrize("head_dim", [4, 148, 288])
 def test_flash_attn_invalid_head_dim(head_dim):
     device = "cuda"

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -2666,31 +2666,7 @@ def test_flash_attn_paged_hd256_sm100_tma_shuffled():
 @pytest.mark.parametrize("max_seqlen_k_mode", ["batch_max", "page_aligned"])
 @maybe_fake_tensor_mode(USE_FAKE_TENSOR)
 def test_flash_attn_paged_hd256_sm100_tma_seqused_k(max_seqlen_k_mode, seqlen_q):
-    """Per-batch KV lengths (seqused_k) in the SM100 hd256 2CTA forward kernel.
-
-    Shaped after what a continuous-batching server hands the decoder: a paged
-    KV cache, a ``page_table`` whose width is fixed by the largest supported
-    context (wider than this batch needs), ``seqused_k`` carrying the actual
-    per-batch KV lengths, and ``max_seqlen_k`` as the current batch maximum.
-
-    ``max_seqlen_k_mode`` covers both callers:
-
-    * ``batch_max``    - ``max(seqused_k)`` (257 here), i.e. neither page-aligned
-      nor equal to ``page_table.shape[1] * page_size``. This is what vLLM's
-      decoder passes; the interface normalizes it up to the enclosing page and
-      narrows the table.
-    * ``page_aligned`` - the allocated capacity (512), what a caller that
-      pre-slices to the kernel's original contract passes.
-
-    Both must agree with a dense varlen reference over the true per-batch
-    lengths. KV beyond each sequence's ``seqused_k`` - the tail inside its last
-    page and every page after it - is poisoned with large finite values, so
-    attending past ``seqused_k`` (for instance if rounding the extent up leaked
-    into the last page) is a gross mismatch rather than a rounding difference.
-    Finite poison rather than NaN on purpose: masked positions still contribute
-    ``0 * value`` to the PV accumulation, and ``0 * NaN`` would poison a correct
-    kernel too.
-    """
+    """Check paged seqused_k against dense varlen for batch-max and capacity extents."""
     if not IS_SM100:
         pytest.skip("SM100-specific paged hd256 test")
     device = "cuda"
@@ -2734,6 +2710,8 @@ def test_flash_attn_paged_hd256_sm100_tma_seqused_k(max_seqlen_k_mode, seqlen_q)
     )
 
     # Paged layout at full capacity, everything past seqused_k poisoned.
+    # Use finite poison: masked PV terms still evaluate 0 * V, so NaNs would
+    # contaminate valid output.
     k_paged = torch.full(
         (total_pages, page_size, nheads_kv, d), 300.0, device=device, dtype=dtype
     )


### PR DESCRIPTION
## Problem

The dedicated SM100/SM110 head-dim 256 2-CTA forward kernel asserts off per-batch actual
sequence lengths:

```
AssertionError: SM100 forward with head_dim=256 does not support seqused_q/seqused_k
```

`seqused_k` is exactly what continuous-batching inference servers supply for decoder
attention over a paged KV cache. As a direct consequence, vLLM disabled FA4 head-dim 256
on Blackwell entirely on 2026-08-16 (vllm-project/vllm#52050, "[Bugfix] Temporarily
disable FA4 head-dim 256"), stating:

> PR #42669 enabled FA4 head-dim 256 on Blackwell, but the specialized SM100 2-CTA kernel
> still rejects `seqused_q/k`, which vLLM decoder attention supplies. Temporarily resolve
> FA2 for head-dim 256 on Blackwell until upstream adds the required support. FA4 remains
> enabled for head-dim 128 and the supported MLA 192/128 case.

This PR implements that support in the forward kernel, and adapts the adjacent paged-KV
calling contract that blocks the same path, so head-dim 256 models can run FA4 on
Blackwell under continuous batching again.

## What changed

**`flash_attn/cute/sm100_hd256_2cta_fmha_forward.py`**

The dedicated kernel does not use `SeqlenInfoQK`; it threads per-work-tile
`seqlen_q`/`seqlen_k` scalars inline into `FusedMask.get_trip_start_count_via_block_info`
and the epilogue/LSE predication. This change keeps that inline convention and overrides
the two scalars with the per-batch `seqused` values at the four work-tile setup sites
(load, MMA, softmax, correction/epilogue), with the same precedence
`SeqlenInfoQK.create` implements in the general SM100 kernel:

- `seqused_q`/`seqused_k` win for the *lengths*;
- `cu_seqlens_q`/`cu_seqlens_k` continue to provide the packing *offsets*.

Two properties the placement guarantees:

- **Warp lockstep.** When `seqused_q` shrinks a batch below a q tile, the work-skip
  predicate (`continue_cond`) is recomputed with the identical expression in every warp
  section, so the load, MMA, softmax and correction pipelines agree on which work tiles
  are skipped (same discipline as the varlen `cu_seqlens_q` path today).
- **No new out-of-bounds exposure.** `seqused_* <= ` allocated lengths only ever *shrink*
  trip counts relative to the existing static/varlen values; tail positions inside the
  last KV tile are masked to exact-zero probability exactly as the varlen path already
  does. Zero-length batches ride the existing zero-trip clamp.

The `mSeqUsedQ`/`mSeqUsedK` parameters already existed in `__call__` for interface parity
(marked TODO); they are now forwarded into the device kernel. The interface compile key
already contained `seqused_q is None` / `seqused_k is None`, so the no-seqused
specialization is byte-identical to before — **zero impact when seqused is not passed**
(all new device code is behind `cutlass.const_expr`).

**`flash_attn/cute/interface.py`**

- Remove the `seqused_q is None and seqused_k is None` assert from the
  `use_dedicated_hd256_kernel` forward branch. The surrounding plumbing (tensor
  normalization, compile args, call args, compile key) already passed seqused through;
  only the assert blocked it.
- Add one loud guard: `cu_seqlens_k` without `cu_seqlens_q` is rejected for this kernel.
  The dedicated kernel derives its K/V load offsets from the varlen-Q block, so
  varlen-packed K without varlen Q would read every batch from offset 0 (silently wrong).
  This mode was previously unreachable only because the seqused assert happened to block
  the test path into it; with seqused enabled it must be rejected explicitly. (No known
  caller uses this combination; vLLM uses `cu_seqlens_q` + `page_table` + `seqused_k`.)

**`flash_attn/cute/interface.py` — paged-KV extent/page-table contract**

Removing the `seqused` assert alone does *not* re-open the decoder path, because the same
branch also asserts, for paged KV:

```python
assert max_seqlen_k % page_size == 0
assert page_table.shape[1] == max_seqlen_k // page_size
```

(pre-existing code, not introduced here — its own message tells the caller to
`pass page_table[:, :N]`). A continuous-batching decoder cannot satisfy either one:
`max_seqlen_k` is the *current batch maximum* sequence length, which is arbitrary and
rarely a multiple of the page size, and `page_table` has a fixed width sized for the
largest supported context, independent of the current batch. In vLLM's decoder call
these come straight from the batch metadata (`seqused_k = seq_lens`,
`max_seqlen_k = max_seq_len` — the batch max — and `block_table`, the full-width table).
So a decode step with, say, `max_seqlen_k = 257` and a 256-column table trips both
asserts even with `seqused_k` support in place.

This PR therefore normalizes the two values in the interface instead of requiring the
caller to pre-slice: round the KV extent up to the enclosing page and narrow the table to
match.

```python
required_pages = (max_seqlen_k + page_size - 1) // page_size
assert page_table.shape[1] >= required_pages      # genuinely-too-small table: still loud
page_table = page_table[:, :required_pages]
max_seqlen_k = required_pages * page_size
```

Three properties worth checking in review:

- **Placement.** It runs *before* `_get_fwd_config`, before the compile key, and before
  the page-table tensor conversion, so tile selection, kernel specialization and the
  device-side tensor all see the same normalized values. (`max_seqlen_k` reaches the
  compile key indirectly, through the tile sizes `_get_fwd_config` picks.)
- **Rounding is bounded by `seqused_k`, and that is enforced.** Widening the extent is
  only faithful to the caller if each sequence is still bounded at its true length.
  `seqused_k` is that bound — positions in `[seqused_k, rounded)` mask to exact-zero
  probability, exactly like the existing intra-tile tail. If `max_seqlen_k` needs
  rounding and no `seqused_k` is given, the interface now refuses loudly rather than
  silently letting every sequence attend the remainder of its last page. The kernel side
  is consistent by construction: it derives its paged extent as
  `mPageTable.shape[1] * page_size`, which is exactly the normalized `max_seqlen_k`.
- **No behavior change for callers that already met the contract.** When `max_seqlen_k`
  is page-aligned and the table is exactly `max_seqlen_k // page_size` wide,
  `required_pages` equals the existing width, the slice is a no-op and the extent is
  unchanged — the existing paged hd256 tests are bit-identical.

This is a deliberate contract change: it moves the slicing from the caller into the
interface. The argument for it is that the contract as written cannot be met by the
consumer this kernel exists to serve, and the normalization is exactly the slice the
assert message already asks for. If you would rather keep the contract caller-side, the
alternative is a documented helper plus a change on the vLLM side; happy to go that way
instead.

The head-dim 256 **backward** still rejects `seqused_q/seqused_k` (unchanged); forward
inference is what unblocks the serving use case.

## Tests

**`tests/cute/test_flash_attn.py`**

- `test_flash_attn_varlen_output`: drop the d=256 skip of the seqused modes
  (`unpad_q/unpad_kv = False`). The existing matrix now exercises, for hd256:
  per-batch random lengths, `seqused_q`-only, `seqused_k`-only, both, zero-length
  batches, seqused == full length (`varlen_mode="full"`), across the existing
  seqlen/causal/GQA/dtype grid — all against the PyTorch reference. The backward leg
  stays restricted to the fully-unpadded mode (hd256 backward does not support seqused
  yet); a narrow skip remains for the unsupported varlen-K-without-varlen-Q combination,
  matching the new interface guard.
- New `test_flash_attn_paged_hd256_sm100_tma_seqused_k` (mirrors the existing
  `test_flash_attn_paged_hd256_sm100_tma*` family): paged KV with a `page_table` wider
  than the batch needs and per-batch `seqused_k` of {page-aligned, one past a page
  boundary, mid-page}, for q=1 (decode) and q>1, parametrized over both callers —
  `max_seqlen_k` as the **batch maximum** (257: neither page-aligned nor equal to
  `page_table.shape[1] * page_size`, the shape the decoder actually passes, and the case
  that fails without the normalization above) and `max_seqlen_k` page-aligned at the
  allocated capacity (what a caller that pre-slices passes). Both are checked against a
  dense varlen reference over the true per-batch lengths. Everything past each
  sequence's `seqused_k` — the tail inside its last page and every page after it — is
  poisoned with large finite values, and the test asserts the output is finite and stays
  within the reference's magnitude range, so a leak past `seqused_k` (e.g. if the rounded
  extent were not masked) fails loudly instead of drifting. Finite poison rather than
  NaN is deliberate: masked positions still contribute `0 * value` to the PV
  accumulation, so `0 * NaN` would poison a correct kernel too.
  `seqused_k == allocated length` is asserted **bitwise identical** to not passing
  `seqused_k`.
- New `test_flash_attn_paged_hd256_sm100_tma_contract_guards`: asserts both normalization
  guards fire — a `page_table` too narrow for the requested extent, and an extent that
  needs rounding with no `seqused_k` to bound the sequences.

## Testing done / not done

- Static validation of this branch: `py_compile`, AST-level checks of the four device
  sites, launch/signature ordering against the interface compile/call argument order.
- **Run on B300 (SM103) hardware against this exact source**, covering the decoder shapes
  this PR is about:

  | case | result |
  |---|---|
  | `max_seqlen_k=257` (batch max, not page-aligned) against a full four-column page table — the shape the old assert rejected | pass, max err vs fp32 ref `1.95e-3` |
  | page-aligned capacity path | pass, and bit-identical to the current-max output |
  | `q=120` paged causal | pass, max err `7.81e-3` |
  | CUDA Graph captured at KV length 64, replayed after `seqused_k` grew to 129 | pass, max err `1.95e-3` |

  Errors are at the bf16 floor for these shapes.
- A functionally equivalent patch (same per-batch overrides at the same four work-tile
  sites) has additionally been exercised at length on SM103 under vLLM with paged KV
  (page size 128), q=1 decode and prefill — but against vLLM's vendored
  `vllm-flash-attn` copy, which has diverged from this repo.
- **Not covered:** the zero-length paged-KV edge was not executed on hardware. It is not
  part of the decoder contract this PR targets (vLLM does not issue zero-length KV in this
  path), and the kernel's existing zero-trip clamp and zero/NaN `row_sum` guards are what
  make it well-defined — but it is a hardening case rather than a validated one. Narrowing
  the test skip also means the varlen suite now runs `seqused_k` together with zero-length
  sequences for the first time; that is the case I would watch first in CI.

## Relationship to #2749

Semantically orthogonal: #2749 enables causal-left local attention for this same kernel
by removing the adjacent `is_local`/`window_size` asserts; this PR does not touch those
asserts, and neither feature depends on the other. A trial merge of the two branches
shows `sm100_hd256_2cta_fmha_forward.py` merges clean; `interface.py` and the test
skip block conflict textually (both PRs edit adjacent lines), which is a few-line
resolution for whichever lands second. The combination (per-batch `seqused_k` +
causal-left sliding window) has been exercised together on SM103, so the two features are
known to compose.
