### PR TITLE
fix FA2 paged varlen

### DIFF
--- a/csrc/flash_attn/flash_api.cpp
+++ b/csrc/flash_attn/flash_api.cpp
@@ -319,6 +319,8 @@ std::tuple<at::Tensor, at::Tensor> set_params_splitkv(Flash_fwd_params &params, 
     const int head_size_rounded, const float p_dropout,
     const int num_splits, const int num_sm, struct c10::TensorOptions opts) {
 
+    TORCH_CHECK(p_dropout == 0.0f || num_splits <= 1, "num_splits > 1 is not supported with dropout");
+
     // This needs to match with run_mha_fwd_splitkv_dispatch
     const int block_n = head_size <= 64 ? 256 : (head_size <= 128 ? 128 : 64);
     const int num_n_blocks = (max_seqlen_k + block_n - 1) / block_n;
@@ -727,14 +729,11 @@ mha_varlen_fwd(at::Tensor &q,  // total_q x num_heads x head_size, total_q := \s
     params.page_block_size = page_block_size;
     // Keep references to these tensors to extend their lifetime
     at::Tensor softmax_lse_accum, out_accum;
-    if (seqlenq_ngroups_swapped) {
+    if (paged_KV || seqlenq_ngroups_swapped) {
         std::tie(softmax_lse_accum, out_accum) =
             set_params_splitkv(params, batch_size, num_heads, head_size,
                                max_seqlen_k, max_seqlen_q, head_size_rounded,
                                p_dropout, num_splits, get_num_sm(get_current_device()), opts);
-    } else if (paged_KV) {
-        TORCH_CHECK(num_splits <= 1, "num_splits > 1 is not supported for varlen paged KV");
-        params.num_splits = num_splits;
     }
 
     if (leftpad_k_.has_value()) {

--- a/csrc/flash_attn/src/flash_fwd_kernel.h
+++ b/csrc/flash_attn/src/flash_fwd_kernel.h
@@ -1164,7 +1164,14 @@ inline __device__ void combine_attn_seqk_parallel(const Params &params) {
     for (int l = 0; l < kNLsePerThread; ++l) {
         const int row = l * kRowsPerLoadLSE + tidx / kBlockM;
         const int col = tidx % kBlockM;
-        ElementAccum lse = (row < params.num_splits && col < lse_size - bidx * kBlockM) ? gLSEaccum(row, col) : -INFINITY;
+        const index_t lse_idx = row_offset_lse + col;
+        bool valid_lse = row < params.num_splits && lse_idx < lse_size;
+        if (valid_lse && params.cu_seqlens_q != nullptr) {
+            const int batch_idx = lse_idx / (params.h * params.seqlen_q);
+            const int q_row = lse_idx % params.seqlen_q;
+            valid_lse = q_row < params.cu_seqlens_q[batch_idx + 1] - params.cu_seqlens_q[batch_idx];
+        }
+        ElementAccum lse = valid_lse ? gLSEaccum(row, col) : -INFINITY;
         if (row < kMaxSplits) { sLSE[row][col] = lse; }
         // if (bidx == 0 && tidx < 32) { printf("tidx = %d, row = %d, col = %d, lse = %f\n", tidx, row, col, lse); }
     }
@@ -1207,7 +1214,18 @@ inline __device__ void combine_attn_seqk_parallel(const Params &params) {
         if (params.unpadded_lse) {
             const index_t lse_offset = row_offset_lse + tidx / kRowsPerLoadTranspose;
             if (lse_offset < lse_size) {
-                gLSE_unpadded(lse_offset) = lse_logsum;
+                if (params.cu_seqlens_q != nullptr) {
+                    const int batch_idx = lse_offset / (params.h * params.seqlen_q);
+                    const int head_idx = (lse_offset / params.seqlen_q) % params.h;
+                    const int q_row = lse_offset % params.seqlen_q;
+                    const int q_start = params.cu_seqlens_q[batch_idx];
+                    if (q_row < params.cu_seqlens_q[batch_idx + 1] - q_start) {
+                        const index_t lse_addr = head_idx * index_t(params.total_q) + q_start + q_row;
+                        reinterpret_cast<ElementAccum *>(params.softmax_lse_ptr)[lse_addr] = lse_logsum;
+                    }
+                } else {
+                    gLSE_unpadded(lse_offset) = lse_logsum;
+                }
             }
         } else {
             gLSE(tidx / kRowsPerLoadTranspose) = lse_logsum;
@@ -1280,7 +1298,14 @@ inline __device__ void combine_attn_seqk_parallel(const Params &params) {
             const int head_idx = (idx - batch_idx * (params.h * params.seqlen_q)) / params.seqlen_q;
             // The index to the rows of Q
             const int row = idx - batch_idx * (params.h * params.seqlen_q) - head_idx * params.seqlen_q;
-            auto o_ptr = reinterpret_cast<Element *>(params.o_ptr) + batch_idx * params.o_batch_stride
+            if (params.cu_seqlens_q != nullptr) {
+                const int q_start = params.cu_seqlens_q[batch_idx];
+                if (row >= params.cu_seqlens_q[batch_idx + 1] - q_start) { continue; }
+            }
+            const index_t batch_offset = params.cu_seqlens_q == nullptr
+                ? batch_idx * params.o_batch_stride
+                : index_t(params.cu_seqlens_q[batch_idx]) * params.o_row_stride;
+            auto o_ptr = reinterpret_cast<Element *>(params.o_ptr) + batch_offset
                 + head_idx * params.o_head_stride + row * params.o_row_stride;
             #pragma unroll
             for (int k = 0; k < size<2>(rO); ++k) {

--- a/tests/test_flash_attn.py
+++ b/tests/test_flash_attn.py
@@ -2526,12 +2526,16 @@ def test_flash_attn_varlen_deterministic(seqlen_q, seqlen_k, swap_sq_sk, d, caus
 
 
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
-def test_flash_attn_varlen_paged_kv_num_splits(dtype):
-    """Passing num_splits=0 explicitly should be bitwise identical to not passing it (default)."""
-    from flash_attn.flash_attn_interface import _flash_attn_varlen_forward
+@pytest.mark.parametrize(
+    "q_lens,num_heads_k",
+    [((1, 1), 4), ((1, 3), 4), ((0, 3), 4), ((1, 3), 2), ((1, 1), 2)],
+)
+def test_flash_attn_varlen_paged_kv_split(num_heads_k, q_lens, dtype):
+    from flash_attn.flash_attn_interface import flash_attn_gpu
 
     device = "cuda"
-    num_heads, num_heads_k, head_dim = 4, 2, 64
+    torch.random.manual_seed(0)
+    num_heads, head_dim = 4, 64
     page_block_size = 256
     scale = head_dim ** -0.5
 
@@ -2558,29 +2562,64 @@ def test_flash_attn_varlen_paged_kv_num_splits(dtype):
         b=batch_size,
     )
 
-    q = torch.randn(batch_size, num_heads, head_dim, device=device, dtype=dtype)
-    cu_seqlens_q = torch.arange(batch_size + 1, dtype=torch.int32, device=device)
+    q = torch.randn(sum(q_lens), num_heads, head_dim, device=device, dtype=dtype)
+    cu_seqlens_q = F.pad(
+        torch.tensor(q_lens, dtype=torch.int32, device=device).cumsum(0), (1, 0)
+    ).to(torch.int32)
     seqused_k = torch.tensor(kv_lens, dtype=torch.int32, device=device)
-    cu_seqlens_k = torch.nn.functional.pad(seqused_k.cumsum(0), (1, 0)).to(torch.int32)
+    cu_seqlens_k = F.pad(seqused_k.cumsum(0), (1, 0)).to(torch.int32)
 
-    fwd_kwargs = dict(
-        cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=cu_seqlens_k,
-        max_seqlen_q=1, max_seqlen_k=max_seqlen_k,
-        dropout_p=0.0, softmax_scale=scale,
-        causal=False, window_size_left=-1, window_size_right=0,
-        block_table=block_table, seqused_k=seqused_k,
-    )
+    seqlenq_ngroups_swapped = max(q_lens) == 1 and num_heads > num_heads_k
 
-    out_default = _flash_attn_varlen_forward(q, k_cache, v_cache, **fwd_kwargs)[0]
-    out_explicit = _flash_attn_varlen_forward(q, k_cache, v_cache, **fwd_kwargs, num_splits=0)[0]
+    def run_flash_attn(num_splits, dropout_p=0.0):
+        out_buf = None if seqlenq_ngroups_swapped else torch.full_like(q, torch.nan)
+        out, lse = flash_attn_gpu.varlen_fwd(
+            q,
+            k_cache,
+            v_cache,
+            out_buf,
+            cu_seqlens_q,
+            cu_seqlens_k,
+            seqused_k,
+            None,
+            block_table,
+            None,
+            max(q_lens),
+            max_seqlen_k,
+            dropout_p,
+            scale,
+            False,
+            False,
+            -1,
+            -1,
+            0.0,
+            False,
+            None,
+            num_splits,
+        )[:2]
+        if out_buf is not None:
+            assert out.data_ptr() == out_buf.data_ptr()
+            out = out_buf
+        return out, lse
 
-    assert not out_default.isnan().any(), "default num_splits produced NaN"
-    assert torch.equal(out_default, out_explicit), (
-        f"default vs num_splits=0 differ: max diff {(out_default - out_explicit).abs().max().item()}"
-    )
+    out_ref, lse_ref = run_flash_attn(1)
+    if seqlenq_ngroups_swapped:
+        lse_ref_batches = []
+        for batch_idx, kv_len in enumerate(kv_lens):
+            k_ref = k_cache[block_table[batch_idx].long()].flatten(0, 1)[:kv_len]
+            k_ref = repeat(k_ref, "s h d -> s (h g) d", g=num_heads // num_heads_k)
+            scores = torch.einsum("hd,shd->hs", q[batch_idx].float(), k_ref.float()) * scale
+            lse_ref_batches.append(torch.logsumexp(scores, dim=-1))
+        lse_ref = torch.stack(lse_ref_batches, dim=1)
+    atol = 1e-2 if dtype == torch.bfloat16 else 2e-3
+    for num_splits in (0, 2):
+        out, lse = run_flash_attn(num_splits)
+        torch.testing.assert_close(out, out_ref, rtol=atol, atol=atol)
+        torch.testing.assert_close(lse, lse_ref, rtol=1e-5, atol=1e-5)
 
-    with pytest.raises(RuntimeError, match="num_splits > 1 is not supported"):
-        _flash_attn_varlen_forward(q, k_cache, v_cache, **fwd_kwargs, num_splits=2)
+    if dtype == torch.float16 and q_lens == (1, 1) and num_heads_k == num_heads:
+        with pytest.raises(RuntimeError, match="num_splits > 1 is not supported with dropout"):
+            run_flash_attn(2, dropout_p=0.1)
 
 
 @pytest.mark.parametrize("dtype", [torch.float16])


### PR DESCRIPTION
fixes [#194167](https://github.com/pytorch/pytorch/issues/194167) because FA2 split-KV combine doesnt have packed-varlen indexing so use cu_seqlens_q to map padded partial rows into packed output and LSE positions