### PR TITLE
[Cute,Fwd] Fix pack_gqa compute_ptr crd2idx crash on SM80/SM120 (#2444)

### DIFF
--- a/flash_attn/cute/pack_gqa.py
+++ b/flash_attn/cute/pack_gqa.py
@@ -129,6 +129,11 @@ class PackGQA:
         threads_per_row: cutlass.Constexpr[int],
         num_threads: cutlass.Constexpr[int],
     ):
+        # Avoid elem_pointer with a nested coord: MLIR flattens the dynamic
+        # layout type to `(?):(?)` and crd2idx rejects the coord `((h,m),)`.
+        base_ptr = tensor.iterator
+        head_stride = tensor.stride[0][0]
+        seq_stride = tensor.stride[0][1]
         num_ptr_per_thread = cute.ceil_div(cute.size(cRows), threads_per_row)
         tPrPtr = cute.make_rmem_tensor(num_ptr_per_thread, cutlass.Int64)
         for i in cutlass.range_constexpr(num_ptr_per_thread):
@@ -136,7 +141,7 @@ class PackGQA:
             idx = block * self.m_block_size + row
             m_idx = idx // self.qhead_per_kvhead
             h_idx = idx - m_idx * self.qhead_per_kvhead
-            tPrPtr[i] = utils.elem_pointer(tensor, ((h_idx, m_idx),)).toint()
+            tPrPtr[i] = (base_ptr + (h_idx * head_stride + m_idx * seq_stride)).toint()
         return tPrPtr
 
     @cute.jit


### PR DESCRIPTION
## ProblemOn SM80 and SM120 (which subclasses SM80), running `flash_attn_func` with `pack_gqa=True` on the non-TMA Q-load / non-TMA epilogue path fails at compile time with:```ValueError: Operation creation failed:'cute.crd2idx' op unable to compute crd2idx```Reproducer from #2444:```pythonq, k, v = [torch.randn(1, 128, 8, 64, dtype=torch.bfloat16, device='cuda') for _ in range(3)]flash_attn_func(q, k, v, pack_gqa=True)   # crashes on SM80 / SM120```Fixes #2444.## Root causeIn `PackGQA.compute_ptr` (`flash_attn/cute/pack_gqa.py`), the previous code issues:```pythontPrPtr[i] = utils.elem_pointer(tensor, ((h_idx, m_idx),)).toint()````tensor` is a rank-1 view produced by `pack_gqa_layout`, whose mode-0 is a nested composite `((qhead_per_kvhead, seqlen_q),)` with stride `((head_stride, seq_stride),)`.When BOTH inner dims are dynamic (`Int32`, not `Constexpr`) — the case on SM80/SM120 where `qhead_per_kvhead` is not baked in as a constexpr — the CuTe DSL / MLIR layout type erases the nesting to `!cute.layout<"(?):(?{...})">`. The coord passed to `crd2idx` is still nested `((?, ?),)`, and `crd2idx` refuses the rank mismatch, aborting compilation.On SM90 `qhead_per_kvhead` participates in the compile key as a constexpr so the nested shape survives; that is why the crash is architecturally scoped to SM80/SM120 (and to the SM90 case where `pack_gqa=True` and `tile_m % qhead_per_kvhead != 0` force `use_tma_Q=False`, per the reporter).## FixBypass `crd2idx` by computing the flat element offset directly from the strides we already have on the tensor:```pythonbase_ptr    = tensor.iteratorhead_stride = tensor.stride[0][0]seq_stride  = tensor.stride[0][1]...tPrPtr[i] = (base_ptr + (h_idx * head_stride + m_idx * seq_stride)).toint()```This is arithmetically identical to `crd2idx((h_idx, m_idx))` on a layout with stride `((head_stride, seq_stride),)`, and `cute.Pointer + int` is element-scaled just like `elem_pointer`. `.toint()` produces the same byte address in both formulations. The fix matches the approach the reporter of #2444 suggested in the issue.Relation to #2553: that PR mitigates the same crash by defaulting `pack_gqa=False` on SM120 ("Pragmatic mitigation ... until the deeper cuTeDSL issue is fixed"). This PR fixes `compute_ptr` itself so `pack_gqa=True` continues to work on SM80/SM120 — the two are complementary.## Test planHardware: 8× NVIDIA L20X (sm_90), CUDA 13.0, torch 2.9.1+cu130, nvidia-cutlass-dsl 4.4.2.**Path exercised.** We don't have SM80 or SM120 locally so the original crash cannot be reproduced end-to-end on our machine. On SM90 we exercise the same `PackGQA.compute_ptr` code path by forcing `use_tma_Q=False` via `pack_gqa=True` with `qhead_per_kvhead=5` (192 % 5 != 0). Verified with a one-line monkey-patch on `_setup_attributes` and a print inside `compute_ptr`:```use_tma_Q=False tile_m=192 pack_gqa=True qhead_per_kvhead=5[COMPUTE_PTR CALLED] tensor.shape=((5, Int32(?)),),                     stride=((Int64(?), Int64(?)),)```**Correctness vs `F.scaled_dot_product_attention` (fp32 ref), five configs, all within bf16 rounding limit (~2e-3):**```[PASS] non-TMA path (qhead=5, tile_m=192 non-div):  max_diff=2.079e-03[PASS] non-TMA path (qhead=7 with hdim=64):         max_diff=2.083e-03[PASS] TMA GQA path (qhead=3, tile_m=192 div):      max_diff=2.293e-03[PASS] TMA MQA  (qhead=8):                          max_diff=2.293e-03[PASS] Longer seq non-TMA (qhead=5, sq=1024):       max_diff=9.899e-04```**Bit-exact pre-fix vs post-fix**, same seed, same input, non-TMA path:```pre  sum: 537.389954post sum: 537.389954|pre-post| max: 0.0, sum: 0.0bit-exact: True```Same MLIR-visible pointer arithmetic, same values — the fix does not change any numerical result, only the MLIR type path.## Honest limitationOriginal crash reproduction on real SM80 / SM120 is not possible on our hardware. On SM90 we can exercise the `compute_ptr` code path but not force the exact MLIR type-erasure that triggers the reported `ValueError`, because SM90's compile key bakes `qhead_per_kvhead` as constexpr and MLIR keeps the nested shape.A reviewer with SM80 or SM120 hardware can confirm the end-to-end fix with the minimal repro from #2444. Happy to add more shapes / architectures if the maintainers can point me at their existing pack_gqa CI matrix.