### PR TITLE
[CuTe] Speed up scalar SM100 mask compilation

### DIFF
--- a/flash_attn/cute/mask.py
+++ b/flash_attn/cute/mask.py
@@ -452,7 +452,7 @@ class AttentionMask:
         batch_idx_ssa = utils.scalar_to_ssa(batch_idx, cutlass.Int32)
         ncol = const_expr(cute.size(tScS_t2r.shape))
 
-        for i in cutlass.range_constexpr(ncol):
+        for i in cutlass.range(ncol, unroll_full=True):
             row_coord = tScS_t2r[i][0] if not self.swap_AB else tScS_t2r[i][1]
             col_coord = tScS_t2r[i][1] if not self.swap_AB else tScS_t2r[i][0]
             global_row = row_coord + m_block * self.tile_m


### PR DESCRIPTION
## Human Note

Easy win and removes a bunch of warn spam

## Agent note

Use a fully unrolled dynamic CuTeDSL range for the 128-element scalar SM100 mask-mod loop.
The previous static Python expansion emits a `DSLOptimizationWarning` and spends substantially
more time in cold compilation. The loop index supports dynamic fragment access, so this keeps
the same fully unrolled execution while avoiding the slow frontend expansion.

The current PyTorch nightly normally selects the vectorized mask path for the VSA workload. The
scalar path was forced with `FlexFlashConfig(mask_mod_vec_size=1)` to exercise this loop directly.

## Performance

Measured on an NVIDIA B200 with PyTorch `2.15.0.dev20260819+cu132` and CUTLASS DSL `4.6.2`.
Each cold compile used fresh Inductor and Triton cache directories with the FA4 persistent cache
disabled.

| Measurement | Baseline | This PR | Change |
|---|---:|---:|---:|
| VSA Flex/Flash cold first-call mean, 3 runs | 11.02 s | 7.58 s | -31.2% |
| CUDA-graph steady-state latency | 15.23 us | 15.17 us | within noise |

The optimization warning is also eliminated.

## Test Plan

Run from the attention-gym checkout against this editable FA4 checkout:

```bash
pytest test/test_vsa.py::test_vsa_flex_flash_backend_sm100_matches_reference test/test_vsa.py::test_vsa_flex_flash_backend_sm100_masks_partial_kv_subblocks
pytest -p agent_space.force_scalar_flex_flash test/test_vsa.py::test_vsa_flex_flash_backend_sm100_matches_reference test/test_vsa.py::test_vsa_flex_flash_backend_sm100_masks_partial_kv_subblocks
```

The first command validated the nightly's normal vectorized path. The second used a local pytest
plugin that forced `FlexFlashConfig(mask_mod_vec_size=1)` and validated the changed scalar path.
Pre-commit Ruff check and format hooks also passed.
