### PR TITLE
Fix GeLUFunction.backward returning a tuple instead of unpacked gradients

### DIFF
--- a/flash_attn/ops/activations.py
+++ b/flash_attn/ops/activations.py
@@ -44,8 +44,8 @@ class GeLUFunction(torch.autograd.Function):
     @staticmethod
     def backward(ctx, grad_output):
         input, bias = ctx.saved_tensors
-        tmp = bias_gelu_back(grad_output, input, bias)
-        return tmp, tmp
+        grad_input, grad_bias = bias_gelu_back(grad_output, input, bias)
+        return grad_input, grad_bias
 
 
 bias_gelu_impl = GeLUFunction.apply

--- a/tests/ops/test_activations.py
+++ b/tests/ops/test_activations.py
@@ -1,0 +1,24 @@
+import torch
+import torch.nn.functional as F
+
+from flash_attn.ops.activations import bias_gelu_impl
+
+
+def test_bias_gelu_backward():
+    torch.manual_seed(0)
+    x = torch.randn(4, 8, requires_grad=True)
+    bias = torch.randn(8, requires_grad=True)
+    x_ref = x.detach().clone().requires_grad_()
+    bias_ref = bias.detach().clone().requires_grad_()
+
+    out = bias_gelu_impl(x, bias)
+    out_ref = F.gelu(x_ref + bias_ref, approximate="tanh")
+    assert torch.allclose(out, out_ref, atol=1e-6)
+
+    g = torch.randn_like(out)
+    out.backward(g)
+    out_ref.backward(g)
+    assert x.grad.shape == x.shape
+    assert bias.grad.shape == bias.shape
+    assert torch.allclose(x.grad, x_ref.grad, atol=1e-6)
+    assert torch.allclose(bias.grad, bias_ref.grad, atol=1e-6)


### PR DESCRIPTION
`bias_gelu_back` returns a pair `(grad_input, grad_bias)`, but `GeLUFunction.backward` still returns the whole tuple twice:

```python
tmp = bias_gelu_back(grad_output, input, bias)
return tmp, tmp
```

so any backward pass through `bias_gelu_impl` fails with `RuntimeError: expected Variable or None (got tuple)`. The helper originally returned a single tensor (the Megatron/mlcommons version this file was copied from, see the header comment); when it was extended to also return the summed bias gradient, the autograd `Function` wasn't updated to unpack the pair. Same class of bug as #1337 (swiglu backward return type).

Repro (CPU is enough):

```python
import torch
from flash_attn.ops.activations import bias_gelu_impl

x = torch.randn(4, 8, requires_grad=True)
b = torch.randn(8, requires_grad=True)
bias_gelu_impl(x, b).sum().backward()
# RuntimeError: expected Variable or None (got tuple)
```

This PR unpacks the tuple and returns the two gradients, and adds a CPU test (`tests/ops/test_activations.py`) checking that backward runs and that both gradients match the autograd reference of `F.gelu(x + bias, approximate="tanh")` (max abs diff at fp32 rounding level, ~1e-6).

Test output: the new test fails with the RuntimeError above before the fix and passes after.