### PR TITLE
Fix broken external links in README and usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,7 +469,7 @@ contribution. Sliding window was used in the [Mistral 7B](https://mistral.ai/new
 
 Implement ALiBi (Press et al., 2021). Thanks to Sanghun Cho from Kakao Brain for this contribution.
 
-Implement deterministic backward pass. Thanks to engineers from [Meituan](www.meituan.com) for this contribution.
+Implement deterministic backward pass. Thanks to engineers from [Meituan](https://www.meituan.com) for this contribution.
 
 ### 2.5: Paged KV cache.
 

--- a/usage.md
+++ b/usage.md
@@ -34,7 +34,7 @@ PR or email us. We'd very much like to hear from you!
 yields the fastest BERT training on cloud instances in MLPerf training 2.0 (June
 2022) and MLPerf training 2.1 (November 2022).
 
-- MLPerf 2.0: [IEEE Spectrum](https://spectrum.ieee.org/mlperf-rankings-2022) and [Forbes](ttps://www.forbes.com/sites/moorinsights/2022/07/12/google-dethrones-nvidia-in-latest-artificial-intelligence-benchmarking-tests/) articles about our submission to the MLPerf 2.0 benchmark using FlashAttention.
+- MLPerf 2.0: [IEEE Spectrum](https://spectrum.ieee.org/mlperf-rankings-2022) and [Forbes](https://www.forbes.com/sites/moorinsights/2022/07/12/google-dethrones-nvidia-in-latest-artificial-intelligence-benchmarking-tests/) articles about our submission to the MLPerf 2.0 benchmark using FlashAttention.
 
 - MLPerf 2.1 -
   collaboration


### PR DESCRIPTION
### What

Two broken external links:

1. `usage.md`: the Forbes link is `ttps://...` (missing `h`), so it points to an invalid URL.
2. `README.md`: the Meituan link is `[Meituan](www.meituan.com)` — a schemeless URL that Markdown renders as a relative link, so it 404s.

Both fixed to proper `https://` URLs.

### Why

Fixes dead links in the docs.

### How I checked

- Verified both URLs resolve with `curl` after the fix.
- Grepped the repo for other `ttps://` or schemeless `www.` links; none remain.