### PR TITLE
Fix out-of-bounds store in Triton linear kernel_fwd

### DIFF
--- a/flash_attn/ops/triton/linear.py
+++ b/flash_attn/ops/triton/linear.py
@@ -252,7 +252,7 @@ def kernel_fwd(
     # C = C + rm[:, None] * stride_cm + rn[None, :] * stride_cn
     C = C + rm[:, None] * stride_cm + rn[None, :]
     mask = (rm < M)[:, None] & (rn < N)[None, :]
-    tl.store(C, acc)
+    tl.store(C, acc, mask=mask)
 
 
 def triton_linear_act(


### PR DESCRIPTION
Fixes #2789.

## What

`kernel_fwd` builds `mask = (rm < M)[:, None] & (rn < N)[None, :]` on the line directly above its output store and then calls `tl.store(C, acc)` without it. The launch grid rounds up with `cdiv`, so whenever `M` or `N` is not a multiple of the autotuned block sizes the tail tiles write their full `BLOCK_M x BLOCK_N` extent: past the end of the `(M, N)` output, and (for an N-tail overshoot) onto cells owned by neighboring tiles, which also corrupts in-bounds output nondeterministically. This PR passes the already-computed mask, matching `kernel_bwd` in the same file (which has the identical three lines and stores with `mask=mask`) and the upstream matmul this file credits as its source.

The mask is the whole fix: the loads are already safe because `ram`/`rbn` wrap with `% M` / `% N` ("trick to avoid masking on M and N axis"), so tail lanes compute duplicate rows/cols that the mask discards.

## Verification

- [x] Root cause verified by reading `main` @ ce088ab: mask computed and dropped in `kernel_fwd` (`flash_attn/ops/triton/linear.py:254-255`), masked store in `kernel_bwd` (`:525-526`), wrapped loads (`:196-197`).
- [ ] Not executed here: I don't currently have a CUDA box, so I'm relying on the reproduction and `compute-sanitizer` evidence in #2789 (invalid global writes attributed to this store; 0 wrong cells and 0 sanitizer errors with the mask). @truong-v if you still have the setup handy, a confirmation that this branch is clean under the same sanitizer run would close the loop.

## Scope / non-goals

This path is reachable only on triton 2.x (the module imports `triton.ops.matmul_perf_model`, removed in triton >= 3.0) via `triton_linear_act` / `flash_attn/ops/triton/mlp.py`, and tile-aligned shapes hide the bug, which is why tests never see it. The `SAVE_ACT_INPUT` store writes through the wrapped indices (in-bounds by construction) and is not touched here.
