### PR TITLE
perf(rotary): bypass traceable Triton dispatch in eager mode

### DIFF
--- a/flash_attn/ops/triton/rotary.py
+++ b/flash_attn/ops/triton/rotary.py
@@ -4,6 +4,7 @@
 from typing import Optional, Union
 
 import torch
+from torch.fx.experimental.proxy_tensor import get_proxy_mode
 
 import triton
 import triton.language as tl
@@ -156,7 +157,11 @@ def apply_rotary(
     # Need this, otherwise Triton tries to launch from cuda:0 and we get
     # ValueError: Pointer argument (at 0) cannot be accessed from Triton (cpu tensor?)
     with torch.cuda.device(x.device.index):
-        torch.library.wrap_triton(rotary_kernel)[grid](
+        # Eager execution does not need the traceable higher-order operator. Avoiding it
+        # removes its per-launch dispatch overhead while preserving compile and proxy capture.
+        tracing = torch.compiler.is_compiling() or get_proxy_mode() is not None
+        kernel = torch.library.wrap_triton(rotary_kernel) if tracing else rotary_kernel
+        kernel[grid](
             output,  # data ptrs
             x,
             cos,

--- a/tests/test_rotary.py
+++ b/tests/test_rotary.py
@@ -96,6 +96,43 @@ def test_rotary_emb_func(inplace, interleaved, rotary_fraction, seqlen_offsets_t
     assert torch.allclose(x.grad, x_pt.grad, rtol=rtol, atol=2 * atol)
 
 
+def test_rotary_emb_eager_bypasses_wrap_triton(monkeypatch):
+    device = "cuda"
+    dtype = torch.bfloat16 if is_sm8x else torch.float16
+    x = torch.randn(2, 8, 4, 64, device=device, dtype=dtype)
+    cos, sin = generate_cos_sin(8, 64, device, dtype)
+    expected = apply_rotary_emb_torch(
+        x.float(), cos[:8].float(), sin[:8].float()
+    ).to(dtype)
+
+    def unexpected_wrap_triton(*args, **kwargs):
+        raise AssertionError("eager rotary should launch the Triton kernel directly")
+
+    monkeypatch.setattr(torch.library, "wrap_triton", unexpected_wrap_triton)
+    actual = apply_rotary_emb(x, cos, sin)
+
+    atol = ((expected + 0.3 - 0.3) - expected).abs().max().item()
+    assert torch.allclose(actual, expected, rtol=1e-3, atol=2 * atol)
+
+
+def test_rotary_emb_make_fx_capture():
+    from torch.fx.experimental.proxy_tensor import make_fx
+    from flash_attn.ops.triton.rotary import apply_rotary
+
+    device = "cuda"
+    dtype = torch.bfloat16 if is_sm8x else torch.float16
+    x = torch.randn(2, 8, 4, 64, device=device, dtype=dtype)
+    cos, sin = generate_cos_sin(8, 64, device, dtype)
+    traced = make_fx(lambda x, cos, sin: apply_rotary(x, cos, sin))(
+        x, cos, sin
+    )
+
+    x2 = torch.randn_like(x)
+    expected = apply_rotary(x2, cos, sin)
+    actual = traced(x2, cos, sin)
+    assert torch.equal(actual, expected)
+
+
 @pytest.mark.parametrize(
     "dtype", ([torch.float16] if not is_sm8x else [torch.float16, torch.bfloat16])
 )


### PR DESCRIPTION
## Summary

- launch the raw Triton rotary kernel during ordinary eager execution
- retain `torch.library.wrap_triton` for Dynamo compilation and ProxyTensor capture
- add eager-dispatch and fresh-input `make_fx` regression tests

Fixes #2818.

## Motivation

`torch.library.wrap_triton` is needed to make the Triton mutation visible to
`torch.compile` and proxy tracing, but constructing its higher-order dispatch
path on every eager call adds measurable CPU overhead. The raw Triton launch has
the same output and CUDA kernel while avoiding that host-side cost.

## RTX 3090 SM86 benchmark

BF16, CUDA 13.0, PyTorch 2.13.0+cu130, Triton 3.7.1, fixed seed 20260829,
25 warmups, and 7 synchronized repeats:

| Shape | Iterations / repeat | main median ± stdev | patch median ± stdev | Speedup |
|---|---:|---:|---:|---:|
| `(1, 1, 1, 2)` | 2000 | 148.487 ± 1.155 us | 33.696 ± 0.237 us | 4.407x |
| `(32, 1, 32, 128)` | 1000 | 151.367 ± 1.216 us | 34.651 ± 0.349 us | 4.369x |
| `(8, 1024, 32, 128)` | 100 | 166.144 ± 0.194 us | 164.881 ± 0.124 us | 1.008x |

For the decode case, the profiled CUDA kernel was unchanged within noise
(2.50885 us on main vs 2.51561 us with the patch), and peak allocation was
identical (262,144 bytes). The improvement is host dispatch overhead rather
than a kernel-code speedup.

The main and patched paths produced identical outputs. Their maximum absolute
difference from the BF16 PyTorch reference was also identical: 0 for the tiny
case and 0.03125 for decode and prefill.

An RTX 4090 SM89 corroborating run measured 147.732 us on main and 38.744 us
with the patch for the decode shape (3.813x), with unchanged memory and output.

## Validation

- SM86 CUDA extension source build: 90/90 objects, exit 0
- rotary suite excluding the clean-base-incompatible compilation-count test:
  218 passed, 1 deselected
- eager bypass regression: passed
- fresh-input `make_fx` replay: exact match
- `torch.compile(fullgraph=True)`: exact match
- `torch.export(strict=False)`: exact match
- `py_compile`, `git diff --check`, and exact-base patch check: passed

`test_compilation_count` also fails on the clean base because Triton 3.7.1 no
longer exposes `JITFunction.cache_hook`; this patch does not change that test.

## Coverage

The full source build and test suite ran on SM86. SM89 has benchmark and capture
evidence, but no final source-build/full-suite run. Hopper, Blackwell, ROCm, and
older PyTorch versions were not tested.

## Disclosure

AI assistance was used during development. I reviewed the final diff and
validation evidence and remain responsible for the contribution.
