### PR TITLE
Declare test requirements so tests/test_flash_attn.py can collect

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,6 +556,7 @@ dtype, sequence length, causal / non-causal).
 
 To run the tests:
 ```sh
+pip install -r tests/requirements.txt
 pytest -q -s tests/test_flash_attn.py
 ```
 ## When you encounter issues

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,5 @@
+# Requirements for running the tests in this directory, in addition to the
+# flash-attn package itself. torch is intentionally not listed: install the
+# build matching your CUDA/ROCm setup as described in the README.
+einops
+pytest


### PR DESCRIPTION
Fixes #2811. Same symptom as #961.

## Root cause

The documented test command in the README (`## Tests` section):

```sh
pytest -q -s tests/test_flash_attn.py
```

fails during collection in a source checkout with `ModuleNotFoundError: No module named 'einops'` at `tests/test_flash_attn.py:6`. The test file imports einops at module level, and its reference implementation genuinely uses `rearrange`/`repeat` throughout, so the import cannot reasonably be made lazy or optional. einops is declared only as an `install_requires` of the flash-attn package itself; nothing in the repo declares prerequisites for running the tests from a checkout, and the README's test instructions name no install step (CI sidesteps this by running the FA4 `tests/cute/` suite inside prebuilt Docker images).

## Fix

Add `tests/requirements.txt` declaring the test-time requirements beyond the flash-attn package itself (`einops`, `pytest`), and reference it from the README's test instructions. `torch` is intentionally not listed so `pip install -r` cannot replace a CUDA/ROCm-specific torch build — the same reasoning setup.py already applies when excluding torch from the ROCm `install_requires`.

## Verification

Red/green in a fresh venv (CPU torch 2.13.0, no einops installed): collection fails with the exact error from the issue at `tests/test_flash_attn.py:6`; after `pip install -r tests/requirements.txt`, collection clears einops. Disclosure: on this GPU-less box collection then stops at the compiled `flash_attn_2_cuda` extension, which is expected for any source checkout without the built extension — full collection/execution was not run here.