### PR TITLE
docs: fix FlashAttention interface path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ variable `MAX_JOBS`:
 MAX_JOBS=4 pip install flash-attn --no-build-isolation
 ```
 
-**Interface:** `src/flash_attention_interface.py`
+**Interface:** `flash_attn/flash_attn_interface.py`
 
 ### NVIDIA CUDA Support
 **Requirements:**


### PR DESCRIPTION
## Summary

The README **Interface** line pointed at a path that is not on `main`.

- README (before): `` `src/flash_attention_interface.py` ``
- GitHub API tree on default branch `main` (`ce088ab9ce0fc0434dcd8afa0a791da9fcc3a820`): no `src/flash_attention_interface.py`
- Actual file: `flash_attn/flash_attn_interface.py`

This PR updates that one README path. No other docs or code changes.

## Test plan

- [x] Confirmed `flash_attn/flash_attn_interface.py` exists on `main` via `GET /repos/Dao-AILab/flash-attention/git/trees/main?recursive=1`
- [x] Confirmed `src/flash_attention_interface.py` is absent from that tree
- [x] Diff is a single-line README path correction