### PR TITLE
docs: align NVIDIA CUDA requirement with setup.py (11.7+)

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ MAX_JOBS=4 pip install flash-attn --no-build-isolation
 
 ### NVIDIA CUDA Support
 **Requirements:**
-- CUDA 12.0 and above.
+- CUDA 11.7 and above.
 
 We recommend the
 [Pytorch](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/pytorch)


### PR DESCRIPTION
## Summary

The README **NVIDIA CUDA Support** requirement did not match the compile gate in root `setup.py`.

README (before), under `## Installation and features` / `### NVIDIA CUDA Support`:
```
- CUDA 12.0 and above.
```

Root `setup.py` (FA2 CUDA build):
```python
if bare_metal_version < Version("11.7"):
    raise RuntimeError(
        "FlashAttention is only supported on CUDA 11.7 and above.  "
        "Note: make sure nvcc has a supported version by running nvcc -V."
    )
```

This is a global install requirement for NVIDIA CUDA / FlashAttention-2, not the FA3/hopper/cute path. FA3 remains documented separately (`Requirements: H100 / H800 GPU, CUDA >= 12.3.`) and `hopper/setup.py` still gates at 12.3.

This PR updates that one README bullet to `CUDA 11.7 and above.` to match `setup.py`. No other docs or code changes. Not stacked on #2826 or #2587.

## Test plan

- [x] Confirmed README CUDA 12.0 line is under NVIDIA CUDA Support, not FA3/hopper/cute
- [x] Confirmed root `setup.py` raises only when `bare_metal_version < 11.7`
- [x] Confirmed FA3 README and `hopper/setup.py` still say CUDA 12.3+
- [x] Diff is a single-line README version correction