### PR TITLE
docs: remove ghost csrc/xentropy and csrc/rotary installs from training README

### DIFF
--- a/training/README.md
+++ b/training/README.md
@@ -73,13 +73,9 @@ cd ../csrc/fused_dense_lib && pip install .
 ```
 3. Optimized cross-entropy loss, adapted from Apex's
 [Xentropy](https://github.com/NVIDIA/apex/tree/master/apex/contrib/xentropy). We make it work for bfloat16 and support in-place backward to save memory.
-```sh
-cd ../csrc/xentropy && pip install .
-```
+Included with `pip install flash-attn` (see `flash_attn/losses/cross_entropy.py`).
 4. Fused rotary embedding:
-```sh
-cd ../csrc/rotary && pip install .
-```
+Included with `pip install flash-attn` (see `flash_attn/layers/rotary.py`).
 5. Fused dropout + residual + LayerNorm, adapted from Apex's
 [FastLayerNorm](https://github.com/NVIDIA/apex/tree/master/apex/contrib/layer_norm). We add dropout and residual, and make it work for both pre-norm and post-norm architecture.
 This supports dimensions divisible by 8, up to 6144.


### PR DESCRIPTION
## Summary

`training/README.md` still tells users to install two CUDA extension directories that are not on `main`.

README (before), under **Model Components**:
```sh
cd ../csrc/xentropy && pip install .
cd ../csrc/rotary && pip install .
```

GitHub API tree on default branch `main` (`ce088ab9ce0fc0434dcd8afa0a791da9fcc3a820`):

- `GET /repos/Dao-AILab/flash-attention/contents/csrc/xentropy` → **404**
- `GET /repos/Dao-AILab/flash-attention/contents/csrc/rotary` → **404**
- `csrc/` top-level dirs on that SHA: `composable_kernel`, `cutlass`, `flash_attn`, `flash_attn_ck`, `fused_dense_lib`, `layer_norm`

Those kernels were removed on main (`Remove old xentropy kernel`, `Remove old rotary kernel`). The current implementations ship with `pip install flash-attn`:

- `flash_attn/losses/cross_entropy.py`
- `flash_attn/layers/rotary.py`

This PR replaces the two ghost `pip install` commands with those paths. `csrc/fused_dense_lib` and `csrc/layer_norm` still exist and are left unchanged.

Docs-only. Not stacked on #2826, #2827, #2828, or #2587.

## Test plan

- [x] Confirmed `csrc/xentropy` and `csrc/rotary` 404 on `main` via Contents API
- [x] Confirmed `flash_attn/losses/cross_entropy.py` and `flash_attn/layers/rotary.py` exist on the recursive tree
- [x] Confirmed `csrc/layer_norm` and `csrc/fused_dense_lib` still exist (install instructions kept)
- [x] Diff is `training/README.md` only