### PR TITLE
docs: fix FlashAttention interface path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ variable `MAX_JOBS`:
 MAX_JOBS=4 pip install flash-attn --no-build-isolation
 ```
 
-**Interface:** `src/flash_attention_interface.py`
+**Interface:** `flash_attn/flash_attn_interface.py`
 
 ### NVIDIA CUDA Support
 **Requirements:**


### PR DESCRIPTION
## Summary

The README **Interface** line pointed at `src/flash_attention_interface.py`, which is not in the tree on `main`. The file that exists is `flash_attn/flash_attn_interface.py`.

This updates that one path. No other files are changed.

## Test plan

- [x] Confirmed `flash_attn/flash_attn_interface.py` is present on `main`
- [x] Confirmed `src/flash_attention_interface.py` is absent
- [x] Diff is a single README line