### PR TITLE
Fix 'Accomodate' typo in comments

### DIFF
--- a/flash_attn/cute/flash_bwd_sm90.py
+++ b/flash_attn/cute/flash_bwd_sm90.py
@@ -218,7 +218,7 @@ class FlashAttentionBackwardSm90:
             ]
         ]
         wg_d_dQ = self.num_wg_dQ // self.AtomLayoutMdQ
-        # Accomodate both K and K.T
+        # Accommodate both K and K.T
         self.sK_layout = sm90_utils.make_smem_layout(
             self.dtype,
             LayoutEnum.ROW_MAJOR,
@@ -230,7 +230,7 @@ class FlashAttentionBackwardSm90:
         self.sV_layout = sm90_utils.make_smem_layout(
             self.dtype, LayoutEnum.ROW_MAJOR, (self.tile_n, self.tile_hdimv), None
         )
-        # Accomodate both S and S.T
+        # Accommodate both S and S.T
         wg_n_SdP = self.num_wg_mma // self.AtomLayoutMSdP
         wg_n_dKV = self.AtomLayoutNdKV
         self.sPdS_layout = sm90_utils.make_smem_layout(


### PR DESCRIPTION
### What

Fix the spelling of 'Accomodate' -> 'Accommodate' in two comments in `flash_attn/cute/flash_bwd_sm90.py` (lines 221 and 233).

### Why

Typo in comments.

### How I checked

- `grep -n 'Accomodate' flash_attn/cute/flash_bwd_sm90.py` shows both occurrences, all fixed.