### PR TITLE
docs: remove ghost csrc/xentropy and csrc/rotary installs from training README

### DIFF
--- a/training/README.md
+++ b/training/README.md
@@ -73,13 +73,9 @@ cd ../csrc/fused_dense_lib && pip install .
 ```
 3. Optimized cross-entropy loss, adapted from Apex's
 [Xentropy](https://github.com/NVIDIA/apex/tree/master/apex/contrib/xentropy). We make it work for bfloat16 and support in-place backward to save memory.
-```sh
-cd ../csrc/xentropy && pip install .
-```
+Included with `pip install flash-attn` (see `flash_attn/losses/cross_entropy.py`).
 4. Fused rotary embedding:
-```sh
-cd ../csrc/rotary && pip install .
-```
+Included with `pip install flash-attn` (see `flash_attn/layers/rotary.py`).
 5. Fused dropout + residual + LayerNorm, adapted from Apex's
 [FastLayerNorm](https://github.com/NVIDIA/apex/tree/master/apex/contrib/layer_norm). We add dropout and residual, and make it work for both pre-norm and post-norm architecture.
 This supports dimensions divisible by 8, up to 6144.


### PR DESCRIPTION
## Summary

`training/README.md` still tells users to `cd ../csrc/xentropy && pip install .` and `cd ../csrc/rotary && pip install .`, but those directories are gone from the tree.

Cross-entropy and fused rotary are already shipped with `pip install flash-attn` (`flash_attn/losses/cross_entropy.py`, `flash_attn/layers/rotary.py`). This PR replaces the two dead install commands with pointers to those modules. `csrc/fused_dense_lib` and `csrc/layer_norm` installs are unchanged.

## Test plan

- [x] Confirmed `csrc/xentropy` and `csrc/rotary` 404 on main
- [x] Confirmed `flash_attn/losses/cross_entropy.py` and `flash_attn/layers/rotary.py` exist
- [x] Diff only touches `training/README.md`
