### PR TITLE
docs: align cute interface cutlass-dsl version comment with pyproject

### DIFF
--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2025, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-# [2025-07-04] Version in Cute-DSL, for Hopper and Blackwell. You'll need install nvidia-cutlass-dsl==4.2.0.
+# [2025-07-04] Version in Cute-DSL, for Hopper and Blackwell. You'll need install nvidia-cutlass-dsl>=4.6.2.
 
 import os
 import math


### PR DESCRIPTION
## Summary
`flash_attn/cute/interface.py` module header still tells readers to install `nvidia-cutlass-dsl==4.2.0`, but `flash_attn/cute/pyproject.toml` depends on `nvidia-cutlass-dsl>=4.6.2`. Align the comment with the package metadata.

## Repro
```bash
sed -n '1,3p' flash_attn/cute/interface.py
# ... You'll need install nvidia-cutlass-dsl==4.2.0.

rg -n 'nvidia-cutlass-dsl' flash_attn/cute/pyproject.toml
# dependencies = [ "nvidia-cutlass-dsl>=4.6.2", ... ]
# cu13 = ["nvidia-cutlass-dsl[cu13]>=4.6.2"]
```

## Fix
Update the comment pin to `nvidia-cutlass-dsl>=4.6.2` (comment-only change).

## Test plan
- [ ] Comment lower bound matches `flash_attn/cute/pyproject.toml`
- [ ] No runtime/code changes
