### PR TITLE
[FA3] Fix causal backward aborts when assertions are enabled

### DIFF
--- a/hopper/tile_scheduler.hpp
+++ b/hopper/tile_scheduler.hpp
@@ -399,7 +399,6 @@ public:
         // swizzle. Instead we want to divide by the remainder.
         int const num_hb_remainder = (args.num_head * args.num_batch) % swizzle;
         // printf("num_blocks = %d, num_head = %d, num_batch = %d, size_one_head = %d, ratio = %d, swizzle = %d, num_hb_remainder = %d\n", args.num_blocks, args.num_head, args.num_batch, size_one_head, size_l2 / size_one_head, swizzle, num_hb_remainder);
-        assert(args.tile_count_semaphore != nullptr);
         return {args.num_blocks * args.num_head * args.num_batch,
                 cutlass::FastDivmod(args.num_blocks), cutlass::FastDivmod(args.num_head),
                 cutlass::FastDivmod(swizzle), cutlass::FastDivmod(swizzle * args.num_blocks),


### PR DESCRIPTION
FA3 causal backward aborts when built with assertions enabled (force `-UNDEBUG`) because `SingleTileBwdLPTScheduler::to_underlying_arguments()` asserts that `args.tile_count_semaphore` is non-null.

However:

1. The backward API does not allocate or assign `tile_count_semaphore`.
2. `SingleTileBwdLPTScheduler::Params` does not contain the semaphore.
3. The scheduler implementation never uses the semaphore.

The default build masks the problem because `hopper/setup.py` explicitly adds `-DNDEBUG`.

### Environment

- flash-attention commit: ce088ab9ce0fc0434dcd8afa0a791da9fcc3a820
- Container: nvcr.io/nvidia/pytorch:25.12-py3
- GPU: NVIDIA H20, compute capability 9.0
- PyTorch: 2.10.0a0+b4e4ee81d3.nv25.12
- CUDA: 13.1
- Python: 3.12.3

### Reproducer

Build a fresh checkout with assertions enabled. `NVCC_APPEND_FLAGS=-UNDEBUG` places `-UNDEBUG` after the `-DNDEBUG` added by setup.py:

```bash
cd hopper
NVCC_APPEND_FLAGS=-UNDEBUG python setup.py install
```

Then run the corresponding pytest case:

```
test_flash_attn.py::test_flash_attn_output[256-256-128-False-True-False-0.0-False-False-mha-dtype0]
```

Got:

```
tile_scheduler.hpp:402: static flash::SingleTileBwdLPTScheduler<Varlen, kBlock, SPT>::Params flash::SingleTileBwdLPTScheduler<Varlen, kBlock, SPT>::to_underlying_arguments(const flash::TileSchedulerArguments&) [with bool Varlen = false; int kBlock = 128; bool SPT = false]: Assertion `args.tile_count_semaphore != nullptr' failed.
```

The process aborts with exit code 134.

A non-causal backward invocation succeeds with the same build.

### Fix

Remove only the assertion from `SingleTileBwdLPTScheduler`:

```diff
- assert(args.tile_count_semaphore != nullptr);
```

I rebuilt with assertions still enabled after removing this line. The same pytest case passed.
