### PR TITLE
docs: fix broken Forbes URL scheme in usage.md

### DIFF
--- a/usage.md
+++ b/usage.md
@@ -34,7 +34,7 @@ PR or email us. We'd very much like to hear from you!
 yields the fastest BERT training on cloud instances in MLPerf training 2.0 (June
 2022) and MLPerf training 2.1 (November 2022).
 
-- MLPerf 2.0: [IEEE Spectrum](https://spectrum.ieee.org/mlperf-rankings-2022) and [Forbes](ttps://www.forbes.com/sites/moorinsights/2022/07/12/google-dethrones-nvidia-in-latest-artificial-intelligence-benchmarking-tests/) articles about our submission to the MLPerf 2.0 benchmark using FlashAttention.
+- MLPerf 2.0: [IEEE Spectrum](https://spectrum.ieee.org/mlperf-rankings-2022) and [Forbes](https://www.forbes.com/sites/moorinsights/2022/07/12/google-dethrones-nvidia-in-latest-artificial-intelligence-benchmarking-tests/) articles about our submission to the MLPerf 2.0 benchmark using FlashAttention.
 
 - MLPerf 2.1 -
   collaboration


### PR DESCRIPTION
## Summary

`usage.md` links the MLPerf 2.0 Forbes article with `ttps://...` (missing the leading `h`), so the markdown link is not a valid URL.

This changes that one href to `https://www.forbes.com/...`.

## Test plan

- [x] Confirmed `usage.md` on `main` contains `ttps://www.forbes.com/...`
- [x] Diff is a single-character scheme fix in `usage.md`
- [x] Corrected URL resolves