### PR TITLE
docs: update PubMedGPT link to BioMedLM announcement URL

### DIFF
--- a/usage.md
+++ b/usage.md
@@ -51,7 +51,7 @@ yields the fastest BERT training on cloud instances in MLPerf training 2.0 (June
 
 ## Language model training & inference
 
-- [PubMedGPT 2.7B](https://crfm.stanford.edu/2022/12/15/pubmedgpt.html), a
+- [PubMedGPT 2.7B](https://crfm.stanford.edu/2022/12/15/biomedlm.html), a
   domain-specific LLM for biomedicine, by Stanford CRFM, trained on
   [MosaicML](https://www.mosaicml.com/blog/introducing-pubmed-gpt) Cloud. Just
   using FlashAttention nearly halves the total training time.


### PR DESCRIPTION
### What

`usage.md` links PubMedGPT 2.7B to `https://crfm.stanford.edu/2022/12/15/pubmedgpt.html`, which now 404s. Stanford CRFM renamed the model to BioMedLM and moved the announcement to `https://crfm.stanford.edu/2022/12/15/biomedlm.html` (same date; page notes it was previously PubMedGPT).

### Why

Keeps the usage list pointing at a live announcement for this FlashAttention adoption example.

### How I checked

- `HEAD` on `main`: `ce088ab9`
- Old URL: HTTP 404
- New URL: HTTP 200 and states the model was previously known as PubMedGPT
- Distinct from open `usage.md` link fixes that only touch the Forbes `ttps://` scheme / Meituan schemeless URL