### PR TITLE
docs: fix Meituan URL scheme in README Features section

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,7 +469,7 @@ contribution. Sliding window was used in the [Mistral 7B](https://mistral.ai/new
 
 Implement ALiBi (Press et al., 2021). Thanks to Sanghun Cho from Kakao Brain for this contribution.
 
-Implement deterministic backward pass. Thanks to engineers from [Meituan](www.meituan.com) for this contribution.
+Implement deterministic backward pass. Thanks to engineers from [Meituan](https://www.meituan.com) for this contribution.
 
 ### 2.5: Paged KV cache.
 


### PR DESCRIPTION
## Summary
- Fix `[Meituan](www.meituan.com)` → `https://www.meituan.com` in README Features §2.4 so the Markdown link is absolute instead of a broken relative GitHub path.

## Verification
- Without a scheme, GitHub resolves the link under the repo (`.../blob/main/www.meituan.com`) → 404.
- `https://www.meituan.com` returns 200.