### PR TITLE
docs: point training GPT link at Dao-AILab and align LayerNorm dim to 8192

### DIFF
--- a/training/README.md
+++ b/training/README.md
@@ -33,7 +33,7 @@ Non-goals (and other resources):
 ## Model Components
 
 The GPT model is implemented
-[here](https://github.com/HazyResearch/flash-attention/blob/main/flash_attn/models/gpt.py).
+[here](https://github.com/Dao-AILab/flash-attention/blob/main/flash_attn/models/gpt.py).
 And here's an example to construct the GPT3-1.3B model with rotary embedding:
 ```python
 from transformers.models.gpt2.configuration_gpt2 import GPT2Config
@@ -82,7 +82,7 @@ cd ../csrc/rotary && pip install .
 ```
 5. Fused dropout + residual + LayerNorm, adapted from Apex's
 [FastLayerNorm](https://github.com/NVIDIA/apex/tree/master/apex/contrib/layer_norm). We add dropout and residual, and make it work for both pre-norm and post-norm architecture.
-This supports dimensions divisible by 8, up to 6144.
+This supports dimensions divisible by 8, up to 8192.
 ```sh
 cd ../csrc/layer_norm && pip install .
 ```


### PR DESCRIPTION
## Summary
- Point the GPT model example link in `training/README.md` from the old `HazyResearch/flash-attention` org path to `Dao-AILab/flash-attention`.
- Align the fused LayerNorm dimension ceiling (`up to 6144` → `up to 8192`) with `csrc/layer_norm/README.md` and the `ln_*_8192.cu` kernels on `main`.

Does not change the `csrc/xentropy` / `csrc/rotary` install sections (separate open PR).

## Repro
```bash
# Stale org in training README on main
curl -sL https://raw.githubusercontent.com/Dao-AILab/flash-attention/main/training/README.md \
  | grep -n 'HazyResearch/flash-attention'

# LayerNorm ceiling mismatch
curl -sL https://raw.githubusercontent.com/Dao-AILab/flash-attention/main/training/README.md \
  | grep -n 'up to 6144'
curl -sL https://raw.githubusercontent.com/Dao-AILab/flash-attention/main/csrc/layer_norm/README.md \
  | grep -n 'up to 8192'
# Kernels present: ln_fwd_8192.cu / ln_bwd_8192.cu under csrc/layer_norm/
```

## Test plan
- [x] Diff only `training/README.md`
- [x] Hunky vs open training README PR: this only touches the GPT link + LayerNorm dim line