### PR TITLE
docs: bump HuggingFace kernels flash-attn2 example to version=2

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ to use Flash Attention 2 and 3 right away.
 from kernels import get_kernel
 
 # FA2
-fa_module = get_kernel("kernels-community/flash-attn2", version=1)
+fa_module = get_kernel("kernels-community/flash-attn2", version=2)
 flash_attn_func = fa_module.flash_attn_func
 
 # FA3


### PR DESCRIPTION
## Summary
The README HuggingFace Kernels snippet pins `kernels-community/flash-attn2` to `version=1`. The current hub card How-to-use (and `kernels benchmark`) documents `version=2`. Leave FA3 at `version=1` to match its hub card.

## Repro
```bash
gh api repos/Dao-AILab/flash-attention/contents/README.md \
  -H 'Accept: application/vnd.github.raw' | nl -ba | sed -n '388,400p'

curl -fsSL https://huggingface.co/kernels-community/flash-attn2/raw/main/README.md | rg -n 'get_kernel|version'
```

## Test plan
- [x] Compared README snippet to the live hub card
- [x] FA3 pin unchanged (`version=1`)
- [x] Single-line README change
