### PR TITLE
docs: mark Hugging Face transformers FlashAttention as integrated

### DIFF
--- a/usage.md
+++ b/usage.md
@@ -10,9 +10,9 @@ PR or email us. We'd very much like to hear from you!
 
 - Pytorch: [integrated](https://github.com/pytorch/pytorch/pull/81434) into core Pytorch in nn.Transformer.
 
-- Huggingface's [transformers](https://github.com/huggingface/transformers) library.
-  [On-going](https://github.com/huggingface/transformers/pull/18439), blogpost
-  coming soon.
+- Huggingface's [transformers](https://github.com/huggingface/transformers) library:
+  [integrated](https://huggingface.co/docs/transformers/perf_infer_gpu_one#attention-backends)
+  (use `attn_implementation="flash_attention_2"`).
 
 - Microsoft's [DeepSpeed](https://github.com/microsoft/DeepSpeed):
   FlashAttention is [integrated](https://github.com/microsoft/DeepSpeed/blob/ec13da6ba7cabc44bb4745a64a208b8580792954/deepspeed/ops/transformer/inference/triton_ops.py) into DeepSpeed's inference engine.


### PR DESCRIPTION
## Summary
`usage.md` still lists Hugging Face `transformers` FlashAttention support as "[On-going](https://github.com/huggingface/transformers/pull/18439), blogpost coming soon." That PR was closed unmerged on 2022-09-10. Transformers has since shipped FlashAttention via `attn_implementation="flash_attention_2"` (see the Attention backends docs).

## Repro
```bash
curl -fsSL https://raw.githubusercontent.com/Dao-AILab/flash-attention/main/usage.md | sed -n '11,16p'
gh api repos/huggingface/transformers/pulls/18439 --jq '{state,merged,closed_at}'
# → state=closed, merged=false, closed_at=2022-09-10T15:02:36Z
```

## Test plan
- [x] Diff only `usage.md`
- [x] Wording aligned with the Pytorch "integrated" bullet
- [x] Left Forbes / PubMedGPT / other adoption links untouched