### PR TITLE
docs: point Triton tutorial link at triton-lang/main

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,7 +536,7 @@ train GPT2 on Openwebtext and GPT3 on The Pile.
 ## Triton implementation of FlashAttention
 
 Phil Tillet (OpenAI) has an experimental implementation of FlashAttention in Triton:
-https://github.com/openai/triton/blob/master/python/tutorials/06-fused-attention.py
+https://github.com/triton-lang/triton/blob/main/python/tutorials/06-fused-attention.py
 
 As Triton is a higher-level language than CUDA, it might be easier to understand
 and experiment with. The notations in the Triton implementation are also closer


### PR DESCRIPTION
## Summary

README Triton tutorial URL still pointed at `github.com/openai/triton/.../master/...`, which redirects to `triton-lang/triton` and then to the `main` branch path. Update the link to the current canonical URL.

## Repro

```bash
curl -sI https://github.com/openai/triton/blob/master/python/tutorials/06-fused-attention.py | head -5
# 301 -> triton-lang/triton .../master/...
curl -sI https://github.com/triton-lang/triton/blob/main/python/tutorials/06-fused-attention.py | head -5
# 200
```

Docs-only; no runtime change.