### PR TITLE
docs: point Triton tutorial link at triton-lang/main in usage.md

### DIFF
--- a/usage.md
+++ b/usage.md
@@ -110,7 +110,7 @@ yields the fastest BERT training on cloud instances in MLPerf training 2.0 (June
 
 ## Different implementations
 
-- [Triton](https://github.com/openai/triton): an [implementation](https://github.com/openai/triton/blob/master/python/tutorials/06-fused-attention.py) of
+- [Triton](https://github.com/triton-lang/triton): an [implementation](https://github.com/triton-lang/triton/blob/main/python/tutorials/06-fused-attention.py) of
   FlashAttention in Triton by Phil Tillet from OpenAI. Triton is a Python-based
   language and compiler for parallel programming.
 


### PR DESCRIPTION
## Summary

`usage.md` still linked the Triton FlashAttention tutorial at the old `openai/triton` `master` path, which redirects and is no longer the canonical location. Point the org link and tutorial URL at `triton-lang/triton` on `main`.

## Repro

```bash
curl -sI https://github.com/openai/triton/blob/master/python/tutorials/06-fused-attention.py | head -5
# 301 -> triton-lang/triton .../master/...
curl -sI https://github.com/triton-lang/triton/blob/main/python/tutorials/06-fused-attention.py | head -5
# 200
```

Docs-only (`usage.md`); no runtime change.

## Test plan

- [x] Confirmed old tutorial URL returns 301
- [x] Confirmed new tutorial URL returns 200
- [x] Diff is `usage.md` only