### PR TITLE
docs: point CLAUDE.md SM90 helpers at quack.sm90_utils

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ Tensor layout: `(batch, seqlen, num_heads, head_dim)`, last dim contiguous, 16-b
 
 ### Architecture-Specific Helpers
 
-- `hopper_helpers.py` — SM90 warp-group GEMM, shared memory layout creation, fence/commit/wait.
+- `quack.sm90_utils` — SM90 warp-group GEMM, shared memory layout creation, fence/commit/wait.
 - `blackwell_helpers.py` — SM100 UMMA-based GEMM, PTX-optimized paths, 2CTA support.
 - `mma_sm100_desc.py` — Hardware MMA descriptor enums (formats, saturation, scaling).
 


### PR DESCRIPTION
## Summary

CLAUDE.md still lists `hopper_helpers.py` under Architecture-Specific Helpers. That file is not in the tree on `main`; SM90 warp-group GEMM and shared-memory layout helpers now live in `quack.sm90_utils`.

This updates that one line. No other files are changed.

## Test plan

- [x] Confirmed `flash_attn/cute/hopper_helpers.py` is absent on `main`
- [x] Confirmed SM90 kernels import `quack.sm90_utils` (e.g. `flash_attn/cute/flash_bwd_sm90.py`)
- [x] Diff is a single CLAUDE.md line