### PR TITLE
docs: drop ghost test_ci_local.sh from tools/ci README

### DIFF
--- a/tools/ci/README.md
+++ b/tools/ci/README.md
@@ -8,7 +8,7 @@ Triggered on every push to `main`.
 - **Pass 1** — compile kernels in parallel via `FakeTensorMode` (no GPU memory needed)
 - **Pass 2** — run tests using cached compiled kernels on real GPU
 
-See `run_fa4_ci.py` for the shared logic used by both CI and `test_ci_local.sh`.
+See `run_fa4_ci.py` for the shared logic used by both CI and local runs.
 
 ## Required GitHub secrets / variables
 
@@ -46,3 +46,4 @@ Tests run inside the Apptainer container. The repo's `flash_attn/__init__.py` im
 1. Register a self-hosted runner on the machine with the desired label (e.g. `h100`).
 2. Add the label to the `gpu` matrix in `.github/workflows/ci.yml`.
 3. Set `CI_WORK_DIR` for the new machine if its scratch path differs.
+


### PR DESCRIPTION
## Summary

`tools/ci/README.md` referenced `test_ci_local.sh`, which is not present on `main` (never landed under `tools/ci/`). Local and CI runs share `run_fa4_ci.py`, so update that sentence to say so without naming a missing script.

## Test plan

- [x] Confirmed `tools/ci/test_ci_local.sh` is absent on `main`
- [x] Confirmed `tools/ci/run_fa4_ci.py` is present
- [x] Diff is a single README line