### PR TITLE
Fix flash_attn.cute.__version__ metadata lookup (fa4 -> flash-attn-4)

### DIFF
--- a/flash_attn/cute/__init__.py
+++ b/flash_attn/cute/__init__.py
@@ -3,7 +3,7 @@
 from importlib.metadata import PackageNotFoundError, version
 
 try:
-    __version__ = version("fa4")
+    __version__ = version("flash-attn-4")
 except PackageNotFoundError:
     __version__ = "0.0.0"
 


### PR DESCRIPTION
## Summary
- Docs still claimed a fixed **4 GiB / 4GB / 0** default for `VLLM_CPU_KVCACHE_SPACE`.
- Code: unset returns `None`; when set, maps to `kv_cache_memory_bytes` in GiB; when unset, the CPU worker auto-sizes KV cache from NUMA memory using `--gpu-memory-utilization` (default 0.9).
- Update `conserving_memory.md`, CPU install FAQ/env list, and the stale `envs.py` comment (no runtime logic change).

## Repro
```bash
# Docs (stale on main)
curl -sL https://raw.githubusercontent.com/vllm-project/vllm/main/docs/configuration/conserving_memory.md | rg -n 'VLLM_CPU_KVCACHE_SPACE|4 GiB'
curl -sL https://raw.githubusercontent.com/vllm-project/vllm/main/docs/getting_started/installation/cpu.md | rg -n 'VLLM_CPU_KVCACHE_SPACE|4GB by default|Default value is'

# Code (actual)
curl -sL https://raw.githubusercontent.com/vllm-project/vllm/main/vllm/envs.py | rg -n -A6 'VLLM_CPU_KVCACHE_SPACE'
curl -sL https://raw.githubusercontent.com/vllm-project/vllm/main/vllm/platforms/cpu.py | rg -n -A5 'VLLM_CPU_KVCACHE_SPACE'
curl -sL https://raw.githubusercontent.com/vllm-project/vllm/main/vllm/v1/worker/cpu_worker.py | rg -n -A8 'gpu_memory_utilization|requested_cpu_memory|kv_cache_memory_bytes'
```

## Test plan
- [ ] Confirm docs no longer claim 4 GiB / 4GB / 0 as the unset default
- [ ] Confirm `envs.py` comment matches None-when-unset behavior
- [ ] No runtime logic changes
