### PR TITLE
docs: fix CUTE DSL cubin dump env vars in CLAUDE.md

### DIFF
--- a/AI/DEBUG_METHODOLOGY.md
+++ b/AI/DEBUG_METHODOLOGY.md
@@ -93,7 +93,7 @@ pass/fail across repeated runs; divergence against a reference implementation
 at a specific tensor index.
 
 **Tier 2 — usable, needs corroboration.** PTX (`CUTE_DSL_KEEP_PTX=1`), dumped
-SASS (`CUTE_CUBIN_PATH`), shared-memory layout offsets, `cute.printf` traces.
+SASS (`CUTE_DSL_KEEP_CUBIN=1`), shared-memory layout offsets, `cute.printf` traces.
 Real, but one binary's codegen is not the kernel's semantics.
 
 **Tier 3 — contaminated by definition.** Anything captured *at* a trap:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,13 +111,13 @@ Tensor layout: `(batch, seqlen, num_heads, head_dim)`, last dim contiguous, 16-b
 - `fast_math.py` — exp2 polynomial coefficients, softcap score_mod creation.
 - `utils.py` — Hash functions for compile cache keys, warp reductions, predicates.
 - `cache_utils.py` — JIT compilation cache management.
-- `cute_dsl_utils.py` — Patched `cute.compile` that optionally dumps SASS.
+- `cute_dsl_utils.py` — CuTe DSL helpers and kernel attribute dumps.
 
 ### Compilation & Caching
 
 Kernels are JIT-compiled. Cache key includes dtype, head_dim, causal, mask/score_mod hashes, architecture, block sizes. Caching levels: in-memory LRU + optional disk cache via `get_jit_cache()`.
 
-Env vars: `CUTE_CUBIN_PATH` (dump CUBIN/SASS), `CUTE_DSL_KEEP_PTX=1` (inspect PTX), `CUTE_DSL_PTXAS_PATH` (custom ptxas).
+Env vars: `CUTE_DSL_KEEP_CUBIN=1` (keep CUBIN), `CUTE_DSL_DUMP_DIR` (dump directory), `CUTE_DSL_KEEP_PTX=1` (inspect PTX), `CUTE_DSL_PTXAS_PATH` (custom ptxas).
 
 ## Key Patterns
 


### PR DESCRIPTION
## Summary

`CLAUDE.md` (and `AI/DEBUG_METHODOLOGY.md`) still document ghost `CUTE_CUBIN_PATH` and a patched `cute.compile` that dumps SASS. On `main`, cubin retention is controlled by `CUTE_DSL_KEEP_CUBIN` / `CUTE_DSL_DUMP_DIR` in `flash_attn/cute/cute_dsl_ptxas.py` (see also `AI/SASS_MMA_ANALYSIS.md`).

This updates those docs to the live env var names. Distinct from #2848 (hopper_helpers / `quack.sm90_utils`).

## Repro

```bash
# Ghost (docs only; not referenced by Python on main)
curl -sL https://raw.githubusercontent.com/Dao-AILab/flash-attention/main/CLAUDE.md | grep -n CUTE_CUBIN_PATH
curl -sL https://raw.githubusercontent.com/Dao-AILab/flash-attention/main/AI/DEBUG_METHODOLOGY.md | grep -n CUTE_CUBIN_PATH

# Live vars
curl -sL https://raw.githubusercontent.com/Dao-AILab/flash-attention/main/flash_attn/cute/cute_dsl_ptxas.py | grep -nE 'CUTE_DSL_KEEP_CUBIN|CUTE_DSL_DUMP_DIR'
```

## Test plan

- [x] Confirmed `CUTE_CUBIN_PATH` appears only in CLAUDE.md / DEBUG_METHODOLOGY.md on `main`
- [x] Confirmed `CUTE_DSL_KEEP_CUBIN` / `CUTE_DSL_DUMP_DIR` in `cute_dsl_ptxas.py`
- [x] Confirmed `cute_dsl_utils.py` no longer patches `cute.compile` for SASS dumps
- [x] Diff limited to the two doc files above