### PR TITLE
docs: fix AMD Triton AUTOTUNE default in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,10 +185,15 @@ To run the tests (note: full suite takes hours):
 FLASH_ATTENTION_TRITON_AMD_ENABLE="TRUE" pytest tests/test_flash_attn_triton_amd.py
 ```
 
-The Triton backend uses a default kernel configuration optimized for determinism and reasonable performance across workloads. For peak throughput, enable `FLASH_ATTENTION_TRITON_AMD_AUTOTUNE="TRUE"` to search for optimal settings, which incurs a one-time warmup cost.
+The Triton backend autotunes by default (`FLASH_ATTENTION_TRITON_AMD_AUTOTUNE` defaults to on in the aiter kernels). That searches for optimal settings and incurs a one-time warmup cost. For a fixed deterministic config, disable autotune:
 
-Alternativly, if _not_ autotuning, `FLASH_ATTENTION_FWD_TRITON_AMD_CONFIG_JSON` may be used to set a single triton config overriding the hardcoded defaults for `attn_fwd`. E.g.
 ```sh
+FLASH_ATTENTION_TRITON_AMD_AUTOTUNE=0
+```
+
+When autotune is off, `FLASH_ATTENTION_FWD_TRITON_AMD_CONFIG_JSON` may set a single Triton config overriding the hardcoded defaults for `attn_fwd` (ignored while autotune is on). E.g.
+```sh
+FLASH_ATTENTION_TRITON_AMD_AUTOTUNE=0 \
 FLASH_ATTENTION_FWD_TRITON_AMD_CONFIG_JSON='{"BLOCK_M":128,"BLOCK_N":64,"waves_per_eu":1,"PRE_LOAD_V":false,"num_stages":1,"num_warps":8}'
 ```
 


### PR DESCRIPTION
## Summary

The README **Triton Backend** section said the AMD Triton path uses a fixed deterministic default config and that you enable `FLASH_ATTENTION_TRITON_AMD_AUTOTUNE="TRUE"` for peak throughput.

In the pinned `third_party/aiter` kernels (`aiter/ops/triton/_triton_kernels/flash_attn_triton_amd/utils.py`), `FLASH_ATTENTION_TRITON_AMD_AUTOTUNE` **defaults to on** (`"1"`). `FLASH_ATTENTION_FWD_TRITON_AMD_CONFIG_JSON` is ignored while autotune is enabled.

This updates that paragraph to match: state the real default, show how to disable autotune, and pair `CONFIG_JSON` with `AUTOTUNE=0`.

## Test plan

- [x] Compared README text to aiter `utils.py` at submodule SHA `9bab8388`.
- [x] Confirmed default `os.environ.get(..., "1")` and CONFIG_JSON note "Ignored if ... AUTOTUNE is enabled".
- [x] Diff limited to `README.md`.
