### PR TITLE
fix: slice backward preprocess predicates per row

### DIFF
--- a/flash_attn/cute/flash_bwd_preprocess.py
+++ b/flash_attn/cute/flash_bwd_preprocess.py
@@ -13,7 +13,6 @@
 # So the main backward kernel is unchanged; we just replace D with D' = D - dLSE here.
 import math
 import operator
-from functools import partial
 from typing import Callable, Type, Optional
 
 import cuda.bindings.driver as cuda
@@ -367,8 +366,6 @@ class FlashAttentionBackwardPreprocess:
             tOpO = None
             if const_expr(self.check_hdim_v_oob):
                 tOpO = copy_utils.predicate_k(tOcO, limit=headdim_v)
-            # Each copy will use the same predicate
-            copy = partial(copy_utils.copy, pred=tOpO)
 
             tOrO = cute.make_rmem_tensor_like(tOgO)
             tOrdO = cute.make_rmem_tensor_like(tOgdO)
@@ -380,8 +377,9 @@ class FlashAttentionBackwardPreprocess:
                 # Instead of using tOcO, we using t0OcO and subtract the offset from the limit.
                 # This is bc the entries of t0OcO are known at compile time.
                 if t0OcO[0, m, 0][0] < seqlen_limit - tOcO[0][0]:
-                    copy(tOgO[None, m, None], tOrO[None, m, None])
-                    copy(tOgdO[None, m, None], tOrdO[None, m, None])
+                    row_predicate = tOpO[None, m, None] if const_expr(tOpO is not None) else None
+                    copy_utils.copy(tOgO[None, m, None], tOrO[None, m, None], pred=row_predicate)
+                    copy_utils.copy(tOgdO[None, m, None], tOrdO[None, m, None], pred=row_predicate)
             # O and dO loads are done; signal that the next kernel can start.
             # Correctness is ensured by griddepcontrol_wait() in bwd_sm90 before it reads our outputs.
             if const_expr(self.use_pdl):


### PR DESCRIPTION
## Summary

Fixes #2852.

The backward preprocess kernel slices `O` and `dO` to one row before each
copy, but reused the unsliced head-dimension predicate. For padded head
dimensions this gives CuTe a predicate with an incompatible shape. The fix
slices the predicate with the same row index before both copies and preserves
the unpredicated path when no head-dimension padding is needed.

## Validation

- `ruff check flash_attn/cute/flash_bwd_preprocess.py`
- `ruff format --check flash_attn/cute/flash_bwd_preprocess.py`
- `py -3 -m py_compile flash_attn/cute/flash_bwd_preprocess.py`
- `git diff --check`

The FA4 GPU/CuTe test suite was not run locally because this Windows machine
does not provide the required CUDA/CuTe runtime; upstream CI should exercise
the SM103 specialization described in the issue.

AI assistance was used for drafting and local validation; I reviewed the
implementation and take responsibility for the submitted changes.
