### PR TITLE
docs: align CLAUDE.md public API key params with flash_attn_func

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ Two entry points exported from `flash_attn/cute/__init__.py`:
 - `flash_attn_func(q, k, v, ...)` — standard attention
 - `flash_attn_varlen_func(q, k, v, cu_seqlens_q, cu_seqlens_k, ...)` — variable-length
 
-Key parameters: `causal`, `window_size_left/right`, `softmax_scale`, `softcap`, `score_mod`, `mask_mod`, `block_sparse_tensors`, `num_splits`, `pack_gqa`, `m_block_size`, `n_block_size`, `num_threads`.
+Key parameters: `causal`, `window_size` (tuple of left/right), `softmax_scale`, `softcap`, `score_mod`, `mask_mod`, `block_sparse_tensors`, `num_splits`, `pack_gqa`, `learnable_sink`, `return_lse`, `deterministic`. Tile knobs such as `m_block_size` / `n_block_size` / `num_threads` are internal to `_flash_attn_fwd` / `_flash_attn_bwd`, not public entry-point arguments.
 
 Tensor layout: `(batch, seqlen, num_heads, head_dim)`, last dim contiguous, 16-byte aligned.
 


### PR DESCRIPTION
## Summary

`CLAUDE.md` **Public API** listed key parameters that do not match the exported `flash_attn_func` / `flash_attn_varlen_func` signatures in `flash_attn/cute/interface.py`:

- Documented `window_size_left/right`, but the public entry points take a `window_size` tuple (left/right are only used inside `_flash_attn_fwd` / `_flash_attn_bwd`).
- Documented `m_block_size` / `n_block_size` / `num_threads` as if they were public entry-point args; those tile knobs are internal.

Also list real public knobs that agents commonly need (`learnable_sink`, `return_lse`, `deterministic`).

Docs-only; does not edit the `AGENTS.md` symlink.

## Repro

```bash
# Public signatures use window_size, not window_size_left/right:
rg -n 'def flash_attn_func|def flash_attn_varlen_func|window_size' flash_attn/cute/interface.py | head -40

# CLAUDE.md on main still says window_size_left/right + m_block_size as key params:
rg -n 'Key parameters' CLAUDE.md
```

## Test plan

- [x] Compared against `flash_attn_func` / `flash_attn_varlen_func` on `main`
- [x] Confirmed `window_size` is unpacked to left/right only inside `FlashAttnFunc.forward`
- [x] Confirmed `m_block_size` / `n_block_size` / `num_threads` are not parameters of the public entry points
- [x] Did not modify `AGENTS.md` (git symlink → `CLAUDE.md`)