### PR TITLE
[Test] Relax varlen tolerance for bf16 head_dim=256

### DIFF
--- a/tests/cute/test_flash_attn_varlen.py
+++ b/tests/cute/test_flash_attn_varlen.py
@@ -38,6 +38,10 @@ def test_varlen(
         dtype=dtype
     )
 
+    # bf16 (8-bit mantissa) backward dK/dV accumulate over head_dim terms, so the
+    # rounding error grows with D. The fixed 3e-2 tolerance was calibrated for D<=128
+    # and is too tight at D=256, where dK/dV diff reaches ~6e-2 (fp16 is unaffected).
+    atol = rtol = 1e-1 if (dtype == torch.bfloat16 and D == 256) else 3e-2
     ok = check_varlen_vs_torch_flash(
         q, k, v,
         cu_seqlens_q, cu_seqlens_k,
@@ -45,6 +49,8 @@ def test_varlen(
         softmax_scale=softmax_scale,
         causal=causal,
         mha_type=mha_type,
+        atol=atol,
+        rtol=rtol,
     )
     assert ok
 


### PR DESCRIPTION
For bf16 backward, increasing head_dim from 128 to 256 (#2412) increases the reduction length of the dot products involved in computing dP (and consequently dS), which can lead to larger floating-point discrepancies between the FA4 and PyTorch SDPA implementations. These discrepancies can propagate to dK/dV, and are further exposed in MQA/GQA where gradients for shared KV heads require additional accumulation.