### PR TITLE
docs: drop dead MosaicML PubMedGPT blog link from usage.md

### DIFF
--- a/usage.md
+++ b/usage.md
@@ -53,7 +53,7 @@ yields the fastest BERT training on cloud instances in MLPerf training 2.0 (June
 
 - [PubMedGPT 2.7B](https://crfm.stanford.edu/2022/12/15/pubmedgpt.html), a
   domain-specific LLM for biomedicine, by Stanford CRFM, trained on
-  [MosaicML](https://www.mosaicml.com/blog/introducing-pubmed-gpt) Cloud. Just
+  MosaicML Cloud. Just
   using FlashAttention nearly halves the total training time.
 
 - Meta's


### PR DESCRIPTION
### What

In the PubMedGPT bullet of `usage.md`, remove the dead MosaicML deep link `https://www.mosaicml.com/blog/introducing-pubmed-gpt` and keep plain-text "MosaicML". The Stanford announcement link in the same bullet is unchanged (see related BioMedLM URL fix).

### Why

That MosaicML URL no longer serves PubMedGPT article content (redirects to a generic Databricks AI research category; guessed Databricks slugs 404).

### How I checked

```bash
SHA=ce088ab9ce0fc0434dcd8afa0a791da9fcc3a820
curl -sI "https://www.mosaicml.com/blog/introducing-pubmed-gpt" | head -n 20
curl -sL "https://www.mosaicml.com/blog/introducing-pubmed-gpt" | rg -i 'pubmed|biomed|flashattention' || true
curl -sL "https://raw.githubusercontent.com/Dao-AILab/flash-attention/$SHA/usage.md" | rg -n 'introducing-pubmed-gpt'
```

Base tip at open: `ce088ab9ce0fc0434dcd8afa0a791da9fcc3a820`.
