### PR TITLE
[CuTe, SM100] Stop the non-causal hdim 128 softmax warps spilling

### DIFF
--- a/flash_attn/cute/flash_fwd_sm100.py
+++ b/flash_attn/cute/flash_fwd_sm100.py
@@ -98,7 +98,7 @@ _LOG2_DTYPE_MAX = {
 }
 
 _TUNING_CONFIG = {
-    (True, False, 128, False): {"ex2_emu_freq": 10, "ex2_emu_start_frg": 1, "num_regs_softmax": 176, "num_regs_correction": 88},
+    (True, False, 128, False): {"ex2_emu_freq": 10, "ex2_emu_start_frg": 1, "num_regs_softmax": 184, "num_regs_correction": 80},
     (False, True, 128, False): {"ex2_emu_freq": 16, "ex2_emu_start_frg": 1, "num_regs_softmax": 192, "num_regs_correction": 72},
     (True, False, 192, False): {"ex2_emu_freq": 16, "ex2_emu_start_frg": 0, "num_regs_softmax": 184, "num_regs_correction": 80},
     (False, True, 192, False): {"ex2_emu_freq": 32, "ex2_emu_start_frg": 1, "num_regs_softmax": 192, "num_regs_correction": 72},


### PR DESCRIPTION
## Summary

Register budget for the non-causal hdim 128 (2-CTA) SM100 forward config. The softmax warps get 176 registers there (the causal, 1-CTA config gets 192), and on current `main` that build spills in the softmax hot loop: 21 `LDL` and 18 `STL` per KV block per warp (ncu `--set full`, SASS view, `launch__registers_per_thread` 128 with `setmaxnreg` redistribution). Moving 8 registers from the correction warps to the softmax warps (176/88 -> 184/80, other warps unchanged at 64) removes every spill.

An earlier revision of this PR also added a scheduling fence after the softmax stats arrive; it was dropped per review since it does not measurably help on `main`.

## Performance

B200, CUDA 13.0 driver 580.159.04, PyTorch 2.11.0+cu130, CUTLASS DSL 4.6.2, GPU clocks locked at 1800 MHz. `flash_attn_func`, bf16, batch 128, 4 heads, hdim 128, median of 20 runs after 5 warm-ups.

| seqlen | causal | main | this PR |
|---|---|---:|---:|
| 4096 | no | 4.344 | 3.433 |
| 2048 | no | 1.027 | 0.813 |
| 4096 | yes | 1.953 | 1.922 |
| 2048 | yes | 0.584 | 0.580 |

The causal config is not touched by this change.

## Test Plan

On a B200 with the two-pass workflow from `CLAUDE.md`, `tests/cute/test_flash_attn.py` filtered to the forward and varlen output tests at hdim 128 without learnable sink or softcap:

```bash
K="(test_flash_attn_output or test_flash_attn_varlen_output) and -False-mha- and not 15.0 and -128-"
FLASH_ATTENTION_FAKE_TENSOR=1 FLASH_ATTENTION_CUTE_DSL_CACHE_ENABLED=1 pytest -n 48 tests/cute/test_flash_attn.py -k "$K"
FLASH_ATTENTION_FAKE_TENSOR=0 FLASH_ATTENTION_CUTE_DSL_CACHE_ENABLED=1 pytest tests/cute/test_flash_attn.py -k "$K"
```

14404 passed, 11612 skipped. A wider run including the learnable-sink cases stops at `test_flash_attn_output[3-3-96-False-1-0.0-False-False-True-mha-dtype0]` on a `dSink` tolerance in the backward, which fails identically on `main` and is unrelated to this change.
