### PR TITLE
docs: point training LayerNorm install at Triton ops

### DIFF
--- a/training/README.md
+++ b/training/README.md
@@ -82,10 +82,7 @@ cd ../csrc/rotary && pip install .
 ```
 5. Fused dropout + residual + LayerNorm, adapted from Apex's
 [FastLayerNorm](https://github.com/NVIDIA/apex/tree/master/apex/contrib/layer_norm). We add dropout and residual, and make it work for both pre-norm and post-norm architecture.
-This supports dimensions divisible by 8, up to 6144.
-```sh
-cd ../csrc/layer_norm && pip install .
-```
+Included with `pip install flash-attn` (see `flash_attn/ops/triton/layer_norm.py`); the CUDA path `csrc/layer_norm` is deprecated/unused since 2024-01-05.
 
 ## Training
 


### PR DESCRIPTION
## Summary
`training/README.md` §5 still tells readers to `cd ../csrc/layer_norm && pip install .`, but that CUDA extension has been unused in-tree since 2024-01-05. Training code paths use the Triton LayerNorm in `flash_attn/ops/triton/layer_norm.py` instead.

This updates the LayerNorm bullet to point at the Triton ops (and note the CUDA path is deprecated/unused), matching the style of the nearby fused-kernel bullets.

## Repro (HEAD `17498dad`)
1. Open `training/README.md` §5 LayerNorm — still documents:
   ```sh
   cd ../csrc/layer_norm && pip install .
   ```
2. Open `csrc/layer_norm/README.md` — states the extension is unused since 2024-01-05 and points to `flash_attn/ops/triton/layer_norm.py`.
3. `flash_attn/modules/block.py` and `flash_attn/models/gpt.py` import `layer_norm_fn` / `RMSNorm` from `flash_attn.ops.triton.layer_norm`.

Not covered by open #2834 (xentropy/rotary only) or #2841 (keeps the CUDA install; only bumps the dim note).

## Test plan
- [ ] Diff is limited to `training/README.md` LayerNorm §5
- [ ] Install instruction no longer references `csrc/layer_norm`
- [ ] Points readers at `flash_attn/ops/triton/layer_norm.py` and notes CUDA path unused since 2024-01-05