### PR TITLE
docs: point FA4 CI image update at fa4_image_cu129/cu130

### DIFF
--- a/tools/ci/README.md
+++ b/tools/ci/README.md
@@ -23,7 +23,7 @@ See `run_fa4_ci.py` for the shared logic used by both CI and `test_ci_local.sh`.
 ## Updating the container image
 
 1. Build and push a new image via `tools/ci/docker/build.sh` + `tag_and_push.sh`.
-2. Update `FA4_IMAGE` in `.github/workflows/ci.yml` with the new tag and `sha256` digest.
+2. Update `fa4_image_cu129` and/or `fa4_image_cu130` on the `gpu-test` action call in `.github/workflows/ci.yml` with the new tag and `sha256` digest. The action picks between them from the runner CUDA version and exports `FA4_IMAGE` internally.
 3. The old SIF is automatically deleted from the runner on the next CI run.
 
 ## Expanding test coverage


### PR DESCRIPTION
## Summary

`tools/ci/README.md` still told maintainers to update a top-level `FA4_IMAGE` key in `.github/workflows/ci.yml`. That knob is gone: CI passes `fa4_image_cu129` and `fa4_image_cu130` into `.github/actions/gpu-test`, which selects between them from the runner CUDA version and exports `FA4_IMAGE` only as an internal env var. This updates the image-refresh steps to name the real inputs.

## Repro

```bash
# 1) Stale docs instruction
rg -n 'FA4_IMAGE' tools/ci/README.md
# → Update `FA4_IMAGE` in `.github/workflows/ci.yml` ...

# 2) Actual CI knobs
rg -n 'FA4_IMAGE|fa4_image_cu' .github/workflows/ci.yml .github/actions/gpu-test/action.yml
# ci.yml: fa4_image_cu129 / fa4_image_cu130 only
# action.yml: inputs fa4_image_cu129/cu130; FA4_IMAGE exported internally from CUDA major
```

Docs-only; no workflow or runtime change.

## Test plan

- [ ] Diff limited to `tools/ci/README.md`
- [ ] Image-update step names `fa4_image_cu129` / `fa4_image_cu130`
- [ ] Does not alter the separate `test_ci_local.sh` wording