### PR TITLE
docs: point assert_dsl_floor rebake hint at fa4_image_cu129/cu130

### DIFF
--- a/tools/ci/assert_dsl_floor.py
+++ b/tools/ci/assert_dsl_floor.py
@@ -61,8 +61,9 @@ def main(pyproject_path: str) -> int:
             print(f"  - {line}", file=sys.stderr)
         print(
             "\nThe SIF was likely baked before a floor bump. Rebake the image "
-            "(tools/ci/docker/build.sh + tag_and_push.sh) and update the digest in "
-            ".github/workflows/ci.yml.",
+            "(tools/ci/docker/build.sh + tag_and_push.sh) and update "
+            "`fa4_image_cu129` and/or `fa4_image_cu130` on the `gpu-test` action "
+            "call in `.github/workflows/ci.yml`.",
             file=sys.stderr,
         )
         return 1


### PR DESCRIPTION
## Summary

`tools/ci/assert_dsl_floor.py` still told maintainers to "update the digest in `.github/workflows/ci.yml`" after a SIF rebake. That knob is gone: CI passes `fa4_image_cu129` and `fa4_image_cu130` into `.github/actions/gpu-test`, which selects between them from the runner CUDA version and exports `FA4_IMAGE` only as an internal env var. This updates the rebake failure hint to name the real inputs (sibling of the `tools/ci/README.md` image-refresh wording).

## Repro

```bash
rg -n 'update the digest in' tools/ci/assert_dsl_floor.py
# → update the digest in .github/workflows/ci.yml

rg -n 'FA4_IMAGE|fa4_image_cu' .github/workflows/ci.yml .github/actions/gpu-test/action.yml
# ci.yml: fa4_image_cu129 / fa4_image_cu130 only
# action.yml: inputs fa4_image_cu129/cu130; FA4_IMAGE exported internally
```

Docs/helptext-only; no workflow or runtime change.

## Test plan

- [ ] Diff limited to `tools/ci/assert_dsl_floor.py`
- [ ] Failure hint names `fa4_image_cu129` / `fa4_image_cu130` on the `gpu-test` action call
- [ ] Does not touch `tools/ci/README.md`