### PR TITLE
[FA2] Fix varlen GQA fast path with zero-length queries

### DIFF
--- a/csrc/flash_attn/flash_api.cpp
+++ b/csrc/flash_attn/flash_api.cpp
@@ -619,7 +619,7 @@ mha_varlen_fwd(at::Tensor &q,  // total_q x num_heads x head_size, total_q := \s
 
     // Faster to transpose q from (b, 1, (nheads_kv ngroups), d) to (b, ngroups, nheads_kv, d) in this case
     // H/t Daniel Haziza
-    const int seqlenq_ngroups_swapped = max_seqlen_q == 1 && num_heads > num_heads_k && window_size_left < 0 && window_size_right < 0 && p_dropout == 0.f && head_size % 8 == 0 && !alibi_slopes_.has_value();
+    const int seqlenq_ngroups_swapped = max_seqlen_q == 1 && sizes[0] == batch_size && num_heads > num_heads_k && window_size_left < 0 && window_size_right < 0 && p_dropout == 0.f && head_size % 8 == 0 && !alibi_slopes_.has_value();
     const int ngroups = num_heads / num_heads_k;
     if (seqlenq_ngroups_swapped) {
         q = q.reshape({batch_size, num_heads_k, ngroups, head_size}).transpose(1, 2).reshape({batch_size * ngroups, num_heads_k, head_size});

--- a/tests/test_flash_attn.py
+++ b/tests/test_flash_attn.py
@@ -2686,3 +2686,41 @@ def test_flash_attn_generator_arg_must_be_none():
     with pytest.raises(RuntimeError, match=match):
         flash_attn_gpu.varlen_bwd(qf, qf, kf, vf, qf, lse, None, None, None, cu, cu, None,
                                   seqlen, seqlen, 0.0, scale, False, True, -1, -1, 0.0, False, bad, None)
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_flash_attn_varlen_gqa_zero_length_q(dtype):
+    device = "cuda"
+    torch.random.manual_seed(0)
+    batch_size, seqlen_q, seqlen_k = 2, 1, 17
+    nheads, nheads_k, d = 6, 2, 64
+    q = torch.randn(batch_size, seqlen_q, nheads, d, device=device, dtype=dtype)
+    k = torch.randn(batch_size, seqlen_k, nheads_k, d, device=device, dtype=dtype)
+    v = torch.randn(batch_size, seqlen_k, nheads_k, d, device=device, dtype=dtype)
+    # Query lengths [0, 1]: max_seqlen_q == 1 does not imply total_q == batch_size.
+    query_padding_mask = torch.tensor([[False], [True]], device=device)
+    key_padding_mask = query_padding_mask.expand(batch_size, seqlen_k)
+    (
+        q_unpad,
+        k_unpad,
+        v_unpad,
+        cu_seqlens_q,
+        cu_seqlens_k,
+        max_seqlen_q,
+        max_seqlen_k,
+        q,
+        k,
+        v,
+        output_pad_fn,
+        _,
+        _,
+    ) = generate_qkv(q, k, v, query_padding_mask, key_padding_mask)
+
+    out_unpad = flash_attn_varlen_func(
+        q_unpad, k_unpad, v_unpad, cu_seqlens_q, cu_seqlens_k,
+        max_seqlen_q, max_seqlen_k, dropout_p=0.0, causal=False,
+    )
+    out_ref, _ = attention_ref(
+        q, k, v, query_padding_mask=query_padding_mask, key_padding_mask=key_padding_mask,
+    )
+    torch.testing.assert_close(output_pad_fn(out_unpad), out_ref, atol=2e-2, rtol=2e-2)


### PR DESCRIPTION
## Problem

`flash_attn_varlen_func` fails for GQA when `max_seqlen_q == 1` and a query sequence is empty, such as query lengths [0, 1]. See #1619.

## Root cause

The swapped GQA fast path assumes exactly one query token per batch element. For packed varlen input, `max_seqlen_q == 1` permits zero-length sequences and does not imply that the packed query token count equals batch_size.

The fast path therefore attempts to reshape Q using `batch_size`, which fails when `total_q < batch_size`.

## Fix

Require the original packed Q token count, `sizes[0]`, to equal batch_size before enabling the swapped GQA optimization.

Batches containing empty query sequences fall back to the normal varlen GQA path, while ordinary one-token-per-sequence decoding remains eligible for the fast path.

## Tests

Validated on NVIDIA L4 with PyTorch 2.6.0 and CUDA 12.4:

- Upstream `9d61d35` reproduces the expected invalid reshape.
- Patched `[0, 1]` reproducer passes its numerical check.
- New reference-based regression passes for fp16 and bf16: 2 passed.
- Normal `[1, 1]` GQA sanity check passes, confirming the fast path remains valid.

Validation used a temporary d64 forward-only FA2 build to reduce compilation time. The committed regression test was run unchanged; broader suites were not run.