### PR TITLE
Add trainable ALiBi slopes to FA2 CUDA backward

### DIFF
--- a/csrc/flash_attn/flash_api.cpp
+++ b/csrc/flash_attn/flash_api.cpp
@@ -365,6 +365,62 @@ void set_params_alibi(Flash_fwd_params &params, std::optional<at::Tensor> &alibi
 #endif
 }
 
+// Allocate only when the caller requests slope gradients. Distinct key blocks and
+// warps write distinct partials, followed by a deterministic reduction.
+std::tuple<at::Tensor, at::Tensor> set_params_dalibi(
+        Flash_bwd_params &params,
+        const std::optional<at::Tensor> &alibi_slopes,
+        const std::optional<at::Tensor> &dalibi_slopes,
+        const at::Tensor &q,
+        const at::Tensor &k) {
+    params.dalibi_slopes_accum_ptr = nullptr;
+    params.dalibi_slopes_accum_head_stride = 0;
+    params.dalibi_slopes_batched_ptr = nullptr;
+    if (!dalibi_slopes.has_value()) { return {}; }
+    TORCH_CHECK(alibi_slopes.has_value(), "ALiBi slope gradients require ALiBi slopes");
+    TORCH_CHECK(dalibi_slopes->dtype() == torch::kFloat32, "ALiBi slope gradients must have dtype fp32");
+    TORCH_CHECK(dalibi_slopes->device() == q.device(), "ALiBi slope gradients must be on the same device as q");
+    TORCH_CHECK(dalibi_slopes->sizes() == alibi_slopes->sizes(), "ALiBi slope gradients must have the same shape as ALiBi slopes");
+    at::Tensor partials, batched;
+    auto opts = q.options().dtype(at::kFloat);
+    // Zero initialization covers padding, empty sequences, and skipped local tiles.
+    if (params.cu_seqlens_k != nullptr) {
+        // Sequence b starts at floor(cu_seqlens_k[b] / 32) + b. The extra slot
+        // per sequence accommodates rounding without padding every sequence to max K.
+        const int64_t num_slots = k.size(0) / Flash_bwd_params::kAlibiGradMinBlockN + params.b;
+        partials = torch::zeros({params.h, num_slots, Flash_bwd_params::kAlibiGradMaxWarps}, opts);
+        params.dalibi_slopes_accum_head_stride = partials.stride(0);
+        if (dalibi_slopes->dim() == 2) {
+            // Keep zero gradients when max_seqlen_q == 0 skips the backward launch.
+            batched = torch::zeros({params.b, params.h}, opts);
+            params.dalibi_slopes_batched_ptr = batched.data_ptr<float>();
+        }
+    } else {
+        const int num_n_blocks = (params.seqlen_k + Flash_bwd_params::kAlibiGradMinBlockN - 1)
+            / Flash_bwd_params::kAlibiGradMinBlockN;
+        partials = torch::zeros({params.b, params.h, num_n_blocks, Flash_bwd_params::kAlibiGradMaxWarps}, opts);
+        params.dalibi_slopes_accum_head_stride = partials.stride(1);
+    }
+    params.dalibi_slopes_accum_ptr = partials.data_ptr<float>();
+    return {partials, batched};
+}
+
+void reduce_dalibi(const at::Tensor &partials, const at::Tensor &batched,
+                   std::optional<at::Tensor> &dalibi_slopes) {
+    if (!dalibi_slopes.has_value()) { return; }
+    if (batched.defined()) {
+        // The native segmented reduction writes a contiguous temporary so the
+        // caller's output buffer may have any non-overlapping strided layout.
+        dalibi_slopes->copy_(batched);
+    } else if (partials.dim() == 3) {
+        at::sum_out(dalibi_slopes.value(), partials, {1, 2});
+    } else if (dalibi_slopes->dim() == 1) {
+        at::sum_out(dalibi_slopes.value(), partials, {0, 2, 3});
+    } else {
+        at::sum_out(dalibi_slopes.value(), partials, {2, 3});
+    }
+}
+
 std::vector<at::Tensor>
 mha_fwd(at::Tensor &q,         // batch_size x seqlen_q x num_heads x round_multiple(head_size, 8)
         const at::Tensor &k,         // batch_size x seqlen_k x num_heads_k x round_multiple(head_size, 8)
@@ -518,11 +574,11 @@ mha_fwd(at::Tensor &q,         // batch_size x seqlen_q x num_heads x round_mult
 
     set_params_alibi(params, alibi_slopes_, batch_size, num_heads);
 
-    if (seqlen_k > 0) {
+    if (seqlen_q > 0 && seqlen_k > 0) {
         auto stream = at::cuda::getCurrentCUDAStream().stream();
         run_mha_fwd(params, stream);
     } else {
-        // If seqlen_k == 0, then we have an empty tensor. We need to set the output to 0.
+        // Empty Q or K requires no kernel launch and produces zero output.
         out.zero_();
         softmax_lse.fill_(std::numeric_limits<float>::infinity());
     }
@@ -767,11 +823,11 @@ mha_varlen_fwd(at::Tensor &q,  // total_q x num_heads x head_size, total_q := \s
 
     set_params_alibi(params, alibi_slopes_, batch_size, num_heads);
 
-    if (max_seqlen_k > 0) {
+    if (max_seqlen_q > 0 && max_seqlen_k > 0) {
         auto stream = at::cuda::getCurrentCUDAStream().stream();
         run_mha_fwd(params, stream, paged_KV);
     } else {
-        // If seqlen_k == 0, then we have an empty tensor. We need to set the output to 0.
+        // Empty Q or K requires no kernel launch and produces zero output.
         out.zero_();
         softmax_lse.fill_(std::numeric_limits<float>::infinity());
     }
@@ -817,7 +873,8 @@ mha_bwd(const at::Tensor &dout,  // batch_size x seqlen_q x num_heads, x multipl
         const bool deterministic,
         // Retained only for backwards-compat arg positioning; must be None.
         std::optional<at::Tensor> unused_generator_compat,
-        std::optional<at::Tensor> &rng_state) {
+        std::optional<at::Tensor> &rng_state,
+        std::optional<at::Tensor> dalibi_slopes_ = std::nullopt) {
 
     TORCH_CHECK(!unused_generator_compat.has_value(),
                 "flash-attn: the RNG `generator` argument is no longer supported and must be None; "
@@ -988,11 +1045,13 @@ mha_bwd(const at::Tensor &dout,  // batch_size x seqlen_q x num_heads, x multipl
     }
 
     set_params_alibi(params, alibi_slopes_, batch_size, num_heads);
+    auto [dalibi_slopes_accum, dalibi_slopes_batched] = set_params_dalibi(params, alibi_slopes_, dalibi_slopes_, q, k);
 
-    if (seqlen_q > 0) {
+    if (seqlen_q > 0 && seqlen_k > 0) {
         launch(params, stream);
     } else {
-        // If seqlen_q == 0, then we have an empty tensor. We need to set the output to 0.
+        // With empty Q or K all gradients are zero, including dQ when K is empty.
+        dq.zero_();
         dk_expanded.zero_();
         dv_expanded.zero_();
         softmax_d.zero_();
@@ -1004,6 +1063,7 @@ mha_bwd(const at::Tensor &dout,  // batch_size x seqlen_q x num_heads, x multipl
         at::sum_out(dv, at::reshape(dv_expanded, {batch_size, seqlen_k, num_heads_k, num_heads / num_heads_k, head_size}), {3});
     }
 
+    reduce_dalibi(dalibi_slopes_accum, dalibi_slopes_batched, dalibi_slopes_);
     return { dq, dk, dv, softmax_d };
 }
 
@@ -1032,7 +1092,8 @@ mha_varlen_bwd(const at::Tensor &dout,  // total_q x num_heads, x head_size
                const bool deterministic,
                // Retained only for backwards-compat arg positioning; must be None.
                std::optional<at::Tensor> unused_generator_compat,
-               std::optional<at::Tensor> &rng_state) {
+               std::optional<at::Tensor> &rng_state,
+               std::optional<at::Tensor> dalibi_slopes_ = std::nullopt) {
 
     TORCH_CHECK(!unused_generator_compat.has_value(),
                 "flash-attn: the RNG `generator` argument is no longer supported and must be None; "
@@ -1221,11 +1282,13 @@ mha_varlen_bwd(const at::Tensor &dout,  // total_q x num_heads, x head_size
     }
 
     set_params_alibi(params, alibi_slopes_, batch_size, num_heads);
+    auto [dalibi_slopes_accum, dalibi_slopes_batched] = set_params_dalibi(params, alibi_slopes_, dalibi_slopes_, q, k);
 
-    if (max_seqlen_q > 0) {
+    if (max_seqlen_q > 0 && max_seqlen_k > 0) {
         launch(params, stream);
     } else {
-        // If seqlen_q == 0, then we have an empty tensor. We need to set the output to 0.
+        // With empty Q or K all gradients are zero, including dQ when K is empty.
+        dq.zero_();
         dk_expanded.zero_();
         dv_expanded.zero_();
         softmax_d.zero_();
@@ -1237,6 +1300,7 @@ mha_varlen_bwd(const at::Tensor &dout,  // total_q x num_heads, x head_size
         at::sum_out(dv, at::reshape(dv_expanded, {total_k, num_heads_k, num_heads / num_heads_k, head_size}), {2});
     }
 
+    reduce_dalibi(dalibi_slopes_accum, dalibi_slopes_batched, dalibi_slopes_);
     return { dq, dk, dv, softmax_d };
 }
 
@@ -1536,7 +1600,22 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
     m.doc() = "FlashAttention";
     m.def("fwd", &FLASH_NAMESPACE::mha_fwd, "Forward pass");
     m.def("varlen_fwd", &FLASH_NAMESPACE::mha_varlen_fwd, "Forward pass (variable length)");
-    m.def("bwd", &FLASH_NAMESPACE::mha_bwd, "Backward pass");
-    m.def("varlen_bwd", &FLASH_NAMESPACE::mha_varlen_bwd, "Backward pass (variable length)");
+    m.def("bwd", &FLASH_NAMESPACE::mha_bwd, "Backward pass",
+          pybind11::arg("dout"), pybind11::arg("q"), pybind11::arg("k"), pybind11::arg("v"),
+          pybind11::arg("out"), pybind11::arg("softmax_lse"), pybind11::arg("dq"), pybind11::arg("dk"),
+          pybind11::arg("dv"), pybind11::arg("alibi_slopes"), pybind11::arg("p_dropout"),
+          pybind11::arg("softmax_scale"), pybind11::arg("is_causal"), pybind11::arg("window_size_left"),
+          pybind11::arg("window_size_right"), pybind11::arg("softcap"), pybind11::arg("deterministic"),
+          pybind11::arg("unused_generator_compat"), pybind11::arg("rng_state"),
+          pybind11::arg("dalibi_slopes") = pybind11::none());
+    m.def("varlen_bwd", &FLASH_NAMESPACE::mha_varlen_bwd, "Backward pass (variable length)",
+          pybind11::arg("dout"), pybind11::arg("q"), pybind11::arg("k"), pybind11::arg("v"),
+          pybind11::arg("out"), pybind11::arg("softmax_lse"), pybind11::arg("dq"), pybind11::arg("dk"),
+          pybind11::arg("dv"), pybind11::arg("cu_seqlens_q"), pybind11::arg("cu_seqlens_k"),
+          pybind11::arg("alibi_slopes"), pybind11::arg("max_seqlen_q"), pybind11::arg("max_seqlen_k"),
+          pybind11::arg("p_dropout"), pybind11::arg("softmax_scale"), pybind11::arg("zero_tensors"),
+          pybind11::arg("is_causal"), pybind11::arg("window_size_left"), pybind11::arg("window_size_right"),
+          pybind11::arg("softcap"), pybind11::arg("deterministic"), pybind11::arg("unused_generator_compat"),
+          pybind11::arg("rng_state"), pybind11::arg("dalibi_slopes") = pybind11::none());
     m.def("fwd_kvcache", &FLASH_NAMESPACE::mha_fwd_kvcache, "Forward pass, with KV-cache");
 }

--- a/csrc/flash_attn/src/flash.h
+++ b/csrc/flash_attn/src/flash.h
@@ -184,6 +184,15 @@ struct Flash_bwd_params : public Flash_fwd_params {
     // The pointer to the softmax d sum.
     void *__restrict__ dsoftmax_sum;
 
+    // One ALiBi slope-gradient partial per key block and warp. The allocation uses
+    // the smallest supported key block and largest supported number of warps.
+    static constexpr int kAlibiGradMinBlockN = 32;
+    static constexpr int kAlibiGradMaxWarps = 8;
+    float *__restrict__ dalibi_slopes_accum_ptr;
+    index_t dalibi_slopes_accum_head_stride;
+    // Optional contiguous (batch, head) output for the varlen segmented reduction.
+    float *__restrict__ dalibi_slopes_batched_ptr;
+
     bool deterministic;
     index_t dq_accum_split_stride;
 };

--- a/csrc/flash_attn/src/flash_bwd_kernel.h
+++ b/csrc/flash_attn/src/flash_bwd_kernel.h
@@ -77,7 +77,7 @@ make_tiled_copy_C_warpcontiguousN(Copy_Atom<Args...> const& copy_atom,
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-template<typename Kernel_traits, bool Is_dropout, bool Is_causal, bool Is_local, bool Has_alibi, bool Is_even_MN, bool Is_even_K, bool Is_softcap, bool Is_first, bool Is_last, bool Seq_parallel=false, typename Params>
+template<typename Kernel_traits, bool Is_dropout, bool Is_causal, bool Is_local, bool Has_alibi, bool Is_even_MN, bool Is_even_K, bool Is_softcap, bool Is_first, bool Is_last, bool Seq_parallel=false, bool Compute_alibi_grad=false, typename Params>
 inline __device__ void compute_dq_dk_dv_1colblock(const Params &params, const int bidb, const int bidh, const int n_block) {
 
     using Element = typename Kernel_traits::Element;
@@ -453,6 +453,7 @@ inline __device__ void compute_dq_dk_dv_1colblock(const Params &params, const in
 
     const float alibi_slope = !Has_alibi || params.alibi_slopes_ptr == nullptr ? 0.0f : reinterpret_cast<float *>(params.alibi_slopes_ptr)[bidb * params.alibi_slopes_batch_stride + bidh] / params.scale_softmax;
     FLASH_NAMESPACE::Alibi<Is_causal> alibi(alibi_slope, binfo.actual_seqlen_k, binfo.actual_seqlen_q);
+    [[maybe_unused]] float dalibi_slope = 0.0f;
 
     for (; m_block >= m_block_min; --m_block) {
         Tensor acc_s = partition_fragment_C(tiled_mma_sdp, Shape<Int<kBlockM>, Int<kBlockN>>{});  // (MMA=4, MMA_N, MMA_N)
@@ -589,6 +590,21 @@ inline __device__ void compute_dq_dk_dv_1colblock(const Params &params, const in
             #pragma unroll
             for (int ni = 0; ni < size<1>(dS); ++ni) {
                 float scaled_ds = pointwise_mult(scores(mi, ni), dS(mi, ni), dP_sum(mi));
+                if constexpr (Compute_alibi_grad) {
+                    const int row = m_block * kBlockM + get<0>(taccScS_row(mi));
+                    // B/P copies make columns contiguous within each warp;
+                    // use the same column mapping as apply_alibi and masking.
+                    const int col = n_block * kBlockN
+                        + (tidx / 32 / AtomLayoutMS) * MMA_N_SdP * 16
+                        + (tidx % 4) * 2 + (ni / 2) * 8 + ni % 2;
+                    // ALiBi is added after softcapping. Differentiate its bias
+                    // before multiplying by dtanh or the QK softmax scale.
+                    // For causal attention, the forward column-only bias differs
+                    // by a row constant; use the canonical distance here.
+                    if (row < binfo.actual_seqlen_q && col < binfo.actual_seqlen_k) {
+                        dalibi_slope -= scaled_ds * abs(row + binfo.actual_seqlen_k - binfo.actual_seqlen_q - col);
+                    }
+                }
                 if constexpr (Is_softcap) { scaled_ds *= dtanh(mi, ni); }
                 dS(mi, ni) = scaled_ds;
             }
@@ -725,6 +741,24 @@ inline __device__ void compute_dq_dk_dv_1colblock(const Params &params, const in
 
     // Epilogue
 
+    if constexpr (Compute_alibi_grad) {
+        static_assert(kBlockN >= Params::kAlibiGradMinBlockN);
+        static_assert(Kernel_traits::kNThreads <= Params::kAlibiGradMaxWarps * 32);
+        FLASH_NAMESPACE::SumOp<float> sum_op;
+        dalibi_slope = FLASH_NAMESPACE::Allreduce<32>::run(dalibi_slope, sum_op);
+        if (tidx % 32 == 0) {
+            const index_t head_offset = params.cu_seqlens_k == nullptr
+                ? (bidb * params.h + bidh) * params.dalibi_slopes_accum_head_stride
+                : bidh * params.dalibi_slopes_accum_head_stride;
+            const index_t first_slot = params.cu_seqlens_k == nullptr
+                ? 0 : binfo.sum_s_k / Params::kAlibiGradMinBlockN + bidb;
+            const index_t offset = head_offset
+                + (first_slot + n_block) * Params::kAlibiGradMaxWarps + tidx / 32;
+            // The existing dS calculation defers the reciprocal keep probability.
+            params.dalibi_slopes_accum_ptr[offset] = dalibi_slope * params.rp_dropout;
+        }
+    }
+
     if (Is_dropout) {
         #pragma unroll
         for (int i = 0; i < size(acc_dv); ++i) { acc_dv(i) *= params.rp_dropout; }
@@ -823,7 +857,7 @@ inline __device__ void compute_dq_dk_dv(const Params &params) {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-template<typename Kernel_traits, bool Is_dropout, bool Is_causal, bool Is_local, bool Has_alibi, bool Is_even_MN, bool Is_even_K, bool Is_softcap, typename Params>
+template<typename Kernel_traits, bool Is_dropout, bool Is_causal, bool Is_local, bool Has_alibi, bool Is_even_MN, bool Is_even_K, bool Is_softcap, bool Compute_alibi_grad=false, typename Params>
 inline __device__ void compute_dq_dk_dv_seqk_parallel(const Params &params) {
 
     // The block index for the batch.
@@ -833,7 +867,7 @@ inline __device__ void compute_dq_dk_dv_seqk_parallel(const Params &params) {
 
     // If deterministic, each thread block will do atomicAdd to a different dQ_accum buffer.
     for (int n_block = blockIdx.x; n_block < (params.seqlen_k + Kernel_traits::kBlockN - 1) / Kernel_traits::kBlockN; n_block += gridDim.x) {
-        compute_dq_dk_dv_1colblock<Kernel_traits, Is_dropout, Is_causal, Is_local, Has_alibi, Is_even_MN, Is_even_K, Is_softcap, false, false, /*Seq_parallel=*/true>(params, bidb, bidh, n_block);
+        compute_dq_dk_dv_1colblock<Kernel_traits, Is_dropout, Is_causal, Is_local, Has_alibi, Is_even_MN, Is_even_K, Is_softcap, false, false, /*Seq_parallel=*/true, Compute_alibi_grad>(params, bidb, bidh, n_block);
     }
 }
 

--- a/csrc/flash_attn/src/flash_bwd_launch_template.h
+++ b/csrc/flash_attn/src/flash_bwd_launch_template.h
@@ -39,10 +39,10 @@ DEFINE_FLASH_BACKWARD_KERNEL(flash_bwd_dq_dk_dv_loop_kernel, bool Is_dropout, bo
     #endif
 }
 
-DEFINE_FLASH_BACKWARD_KERNEL(flash_bwd_dq_dk_dv_loop_seqk_parallel_kernel, bool Is_dropout, bool Is_causal, bool Is_local, bool Has_alibi, bool Is_even_MN, bool Is_even_K, bool Is_softcap) {
+DEFINE_FLASH_BACKWARD_KERNEL(flash_bwd_dq_dk_dv_loop_seqk_parallel_kernel, bool Is_dropout, bool Is_causal, bool Is_local, bool Has_alibi, bool Is_even_MN, bool Is_even_K, bool Is_softcap, bool Compute_alibi_grad=false) {
     #if defined(ARCH_SUPPORTS_FLASH)
         static_assert(!(Is_causal && Is_local));  // If Is_local is true, Is_causal should be false
-        FLASH_NAMESPACE::compute_dq_dk_dv_seqk_parallel<Kernel_traits, Is_dropout, Is_causal, Is_local, Has_alibi, Is_even_MN, Is_even_K, Is_softcap>(params);
+        FLASH_NAMESPACE::compute_dq_dk_dv_seqk_parallel<Kernel_traits, Is_dropout, Is_causal, Is_local, Has_alibi, Is_even_MN, Is_even_K, Is_softcap, Compute_alibi_grad>(params);
     #else
         FLASH_UNSUPPORTED_ARCH
     #endif
@@ -67,6 +67,37 @@ __global__ void flash_bwd_convert_dq_kernel(const Flash_bwd_params params, const
 template<typename Kernel_traits>
 __global__ void flash_bwd_convert_dkv_kernel(const Flash_bwd_params params) {
     FLASH_NAMESPACE::convert_dKV<Kernel_traits>(params);
+}
+
+// Each CTA owns one (batch, head) segment, with a fixed reduction order and no
+// atomics. Sequence padding was initialized to zero along with the partials.
+template<int kNThreads>
+__global__ void flash_bwd_reduce_dalibi_varlen_kernel(const Flash_bwd_params params) {
+    using index_t = Flash_bwd_params::index_t;
+    constexpr int kNWarps = kNThreads / 32;
+    static_assert(kNThreads % 32 == 0 && kNWarps <= 32);
+    const int tidx = threadIdx.x;
+    const int bidh = blockIdx.x;
+    const int bidb = blockIdx.y;
+    const index_t first_slot = params.cu_seqlens_k[bidb] / Flash_bwd_params::kAlibiGradMinBlockN + bidb;
+    const index_t last_slot = params.cu_seqlens_k[bidb + 1] / Flash_bwd_params::kAlibiGradMinBlockN + bidb + 1;
+    const float *partials = params.dalibi_slopes_accum_ptr
+        + bidh * params.dalibi_slopes_accum_head_stride;
+    float sum = 0.f;
+    for (index_t i = first_slot * Flash_bwd_params::kAlibiGradMaxWarps + tidx;
+         i < last_slot * Flash_bwd_params::kAlibiGradMaxWarps; i += kNThreads) {
+        sum += partials[i];
+    }
+    FLASH_NAMESPACE::SumOp<float> sum_op;
+    sum = FLASH_NAMESPACE::Allreduce<32>::run(sum, sum_op);
+    __shared__ float warp_sums[kNWarps];
+    if (tidx % 32 == 0) { warp_sums[tidx / 32] = sum; }
+    __syncthreads();
+    if (tidx < 32) {
+        sum = tidx < kNWarps ? warp_sums[tidx] : 0.f;
+        sum = FLASH_NAMESPACE::Allreduce<32>::run(sum, sum_op);
+        if (tidx == 0) { params.dalibi_slopes_batched_ptr[bidb * params.h + bidh] = sum; }
+    }
 }
 
 template<typename Kernel_traits, bool Is_dropout, bool Is_causal>
@@ -103,6 +134,11 @@ void run_flash_bwd_seqk_parallel(Flash_bwd_params &params, cudaStream_t stream) 
                         // If head dim > 128, set IsEvenMNConst to false to reduce number of templates
                         // If Is_local, set Is_causal to false
                         auto kernel = &flash_bwd_dq_dk_dv_loop_seqk_parallel_kernel<Kernel_traits, Is_dropout && !Is_softcap, Is_causal, Is_local && !Is_causal, Has_alibi, IsEvenMNConst && IsEvenKConst && !Is_local && !Has_alibi && Kernel_traits::kHeadDim <= 128, IsEvenKConst && !Has_alibi, Is_softcap>;
+                        if constexpr (Has_alibi) {
+                            if (params.dalibi_slopes_accum_ptr != nullptr) {
+                                kernel = &flash_bwd_dq_dk_dv_loop_seqk_parallel_kernel<Kernel_traits, Is_dropout && !Is_softcap, Is_causal, Is_local && !Is_causal, Has_alibi, IsEvenMNConst && IsEvenKConst && !Is_local && !Has_alibi && Kernel_traits::kHeadDim <= 128, IsEvenKConst && !Has_alibi, Is_softcap, /*Compute_alibi_grad=*/true>;
+                            }
+                        }
                         // auto kernel = &flash_bwd_dq_dk_dv_loop_seqk_parallel_kernel<Kernel_traits, false, Is_causal, false, false, true, true>;
                         if (smem_size_dq_dk_dv >= 48 * 1024)  {
                             C10_CUDA_CHECK(cudaFuncSetAttribute(
@@ -123,6 +159,10 @@ void run_flash_bwd_seqk_parallel(Flash_bwd_params &params, cudaStream_t stream) 
     }
     kernel_dq<<<grid_m, Kernel_traits::kNThreads, Kernel_traits::kSmemdQSize, stream>>>(params, !params.deterministic ? 1 : gridDimx);
     C10_CUDA_KERNEL_LAUNCH_CHECK();
+    if (params.dalibi_slopes_batched_ptr != nullptr) {
+        flash_bwd_reduce_dalibi_varlen_kernel<128><<<dim3(params.h, params.b), 128, 0, stream>>>(params);
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
+    }
 }
 
 template<typename Kernel_traits, bool Is_dropout, bool Is_causal>

--- a/flash_attn/flash_attn_interface.py
+++ b/flash_attn/flash_attn_interface.py
@@ -249,7 +249,7 @@ else:
     _wrapped_flash_attn_varlen_forward = _flash_attn_varlen_forward
 
 
-@_torch_custom_op_wrapper("flash_attn::_flash_attn_backward", mutates_args=("dq", "dk", "dv"), device_types="cuda")
+@_torch_custom_op_wrapper("flash_attn::_flash_attn_backward", mutates_args=("dq", "dk", "dv", "dalibi_slopes"), device_types="cuda")
 def _flash_attn_backward(
     dout: torch.Tensor,
     q: torch.Tensor,
@@ -269,8 +269,11 @@ def _flash_attn_backward(
     alibi_slopes: Optional[torch.Tensor],
     deterministic: bool,
     rng_state: Optional[torch.Tensor] = None,
+    dalibi_slopes: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     # dq, dk, dv are allocated by us so they should already be contiguous
+    if dalibi_slopes is not None and torch.version.hip:
+        raise NotImplementedError("ALiBi slope gradients are only supported by the CUDA backend")
     dout, q, k, v, out = [maybe_contiguous(x) for x in (dout, q, k, v, out)]
     (
         dq,
@@ -297,6 +300,7 @@ def _flash_attn_backward(
         deterministic,
         None,  # unused generator slot, kept for backwards-compat arg positioning
         rng_state,
+        *([dalibi_slopes] if dalibi_slopes is not None else []),
     )
     return softmax_d
 
@@ -321,6 +325,7 @@ def _flash_attn_backward_fake(
     alibi_slopes: Optional[torch.Tensor],
     deterministic: bool,
     rng_state: Optional[torch.Tensor] = None,
+    dalibi_slopes: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     dout, q, k, v, out = [maybe_contiguous(x) for x in (dout, q, k, v, out)]
     if dq is None:
@@ -344,7 +349,7 @@ else:
     _wrapped_flash_attn_backward = _flash_attn_backward
 
 
-@_torch_custom_op_wrapper("flash_attn::_flash_attn_varlen_backward", mutates_args=("dq", "dk", "dv"), device_types="cuda")
+@_torch_custom_op_wrapper("flash_attn::_flash_attn_varlen_backward", mutates_args=("dq", "dk", "dv", "dalibi_slopes"), device_types="cuda")
 def _flash_attn_varlen_backward(
     dout: torch.Tensor,
     q: torch.Tensor,
@@ -369,8 +374,11 @@ def _flash_attn_varlen_backward(
     deterministic: bool,
     rng_state: Optional[torch.Tensor] = None,
     zero_tensors: bool = False,
+    dalibi_slopes: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     # dq, dk, dv are allocated by us so they should already be contiguous
+    if dalibi_slopes is not None and torch.version.hip:
+        raise NotImplementedError("ALiBi slope gradients are only supported by the CUDA backend")
     dout, q, k, v, out = [maybe_contiguous(x) for x in (dout, q, k, v, out)]
     (
         dq,
@@ -402,6 +410,7 @@ def _flash_attn_varlen_backward(
         deterministic,
         None,  # unused generator slot, kept for backwards-compat arg positioning
         rng_state,
+        *([dalibi_slopes] if dalibi_slopes is not None else []),
     )
     # if dk.isnan().any() or dk.isnan().any() or dv.isnan().any() or softmax_d.isnan().any():
     #     breakpoint()
@@ -433,6 +442,7 @@ def _flash_attn_varlen_backward_fake(
     deterministic: bool,
     rng_state: Optional[torch.Tensor] = None,
     zero_tensors: bool = False,
+    dalibi_slopes: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     dout, q, k, v, out = [maybe_contiguous(x) for x in (dout, q, k, v, out)]
     batch_size = cu_seqlens_q.numel() - 1
@@ -473,7 +483,10 @@ class FlashAttnQKVPackedFunc(torch.autograd.Function):
         return_softmax,
         is_grad_enabled,
     ):
-        is_grad = is_grad_enabled and qkv.requires_grad
+        is_grad = is_grad_enabled and (
+            qkv.requires_grad
+            or (alibi_slopes is not None and alibi_slopes.requires_grad)
+        )
         if softmax_scale is None:
             softmax_scale = qkv.shape[-1] ** (-0.5)
         q, k, v = qkv[:, :, 0].detach(), qkv[:, :, 1].detach(), qkv[:, :, 2].detach()
@@ -496,20 +509,23 @@ class FlashAttnQKVPackedFunc(torch.autograd.Function):
             return_softmax=return_softmax and dropout_p > 0,
         )
         if is_grad:
-            ctx.save_for_backward(q, k, v, out_padded, softmax_lse, rng_state)
+            ctx.save_for_backward(q, k, v, out_padded, softmax_lse, rng_state, alibi_slopes)
             ctx.dropout_p = dropout_p
             ctx.softmax_scale = softmax_scale
             ctx.causal = causal
             ctx.window_size = window_size
             ctx.softcap = softcap
-            ctx.alibi_slopes = alibi_slopes
             ctx.deterministic = deterministic
         out = out_padded[..., :head_size_og]
         return out if not return_softmax else (out, softmax_lse, S_dmask)
 
     @staticmethod
     def backward(ctx, dout, *args):
-        q, k, v, out, softmax_lse, rng_state = ctx.saved_tensors
+        q, k, v, out, softmax_lse, rng_state, alibi_slopes = ctx.saved_tensors
+        dalibi_slopes = (
+            torch.empty_like(alibi_slopes)
+            if alibi_slopes is not None and alibi_slopes.requires_grad else None
+        )
         qkv_shape = q.shape[:-2] + (3, *q.shape[-2:])
         dqkv = torch.empty(qkv_shape, dtype=q.dtype, device=q.device)
         head_size_og = dout.size(3)
@@ -532,12 +548,13 @@ class FlashAttnQKVPackedFunc(torch.autograd.Function):
             ctx.window_size[0],
             ctx.window_size[1],
             ctx.softcap,
-            ctx.alibi_slopes,
+            alibi_slopes,
             ctx.deterministic,
             rng_state=rng_state,
+            dalibi_slopes=dalibi_slopes,
         )
         dqkv = dqkv[..., : dout.shape[-1]]  # We could have padded the head dimension
-        return dqkv, None, None, None, None, None, None, None, None, None
+        return dqkv, None, None, None, None, None, dalibi_slopes, None, None, None
 
 
 class FlashAttnVarlenQKVPackedFunc(torch.autograd.Function):
@@ -557,7 +574,10 @@ class FlashAttnVarlenQKVPackedFunc(torch.autograd.Function):
         return_softmax,
         is_grad_enabled,
     ):
-        is_grad = is_grad_enabled and qkv.requires_grad
+        is_grad = is_grad_enabled and (
+            qkv.requires_grad
+            or (alibi_slopes is not None and alibi_slopes.requires_grad)
+        )
         if softmax_scale is None:
             softmax_scale = qkv.shape[-1] ** (-0.5)
         q, k, v = qkv[:, 0].detach(), qkv[:, 1].detach(), qkv[:, 2].detach()
@@ -585,21 +605,24 @@ class FlashAttnVarlenQKVPackedFunc(torch.autograd.Function):
             block_table=None,
         )
         if is_grad:
-            ctx.save_for_backward(q, k, v, out_padded, softmax_lse, cu_seqlens, rng_state)
+            ctx.save_for_backward(q, k, v, out_padded, softmax_lse, cu_seqlens, rng_state, alibi_slopes)
             ctx.dropout_p = dropout_p
             ctx.max_seqlen = max_seqlen
             ctx.softmax_scale = softmax_scale
             ctx.causal = causal
             ctx.window_size = window_size
             ctx.softcap = softcap
-            ctx.alibi_slopes = alibi_slopes
             ctx.deterministic = deterministic
         out = out_padded[..., :head_size_og]
         return out if not return_softmax else (out, softmax_lse, S_dmask)
 
     @staticmethod
     def backward(ctx, dout, *args):
-        q, k, v, out, softmax_lse, cu_seqlens, rng_state = ctx.saved_tensors
+        q, k, v, out, softmax_lse, cu_seqlens, rng_state, alibi_slopes = ctx.saved_tensors
+        dalibi_slopes = (
+            torch.empty_like(alibi_slopes)
+            if alibi_slopes is not None and alibi_slopes.requires_grad else None
+        )
         qkv_shape = q.shape[:-2] + (3, *q.shape[-2:])
         dqkv = torch.empty(qkv_shape, dtype=q.dtype, device=q.device)
         head_size_og = dout.size(2)
@@ -626,12 +649,13 @@ class FlashAttnVarlenQKVPackedFunc(torch.autograd.Function):
             ctx.window_size[0],
             ctx.window_size[1],
             ctx.softcap,
-            ctx.alibi_slopes,
+            alibi_slopes,
             ctx.deterministic,
             rng_state=rng_state,
+            dalibi_slopes=dalibi_slopes,
         )
         dqkv = dqkv[..., : dout.shape[-1]]  # We could have padded the head dimension
-        return dqkv, None, None, None, None, None, None, None, None, None, None, None
+        return dqkv, None, None, None, None, None, None, None, dalibi_slopes, None, None, None
 
 
 class FlashAttnKVPackedFunc(torch.autograd.Function):
@@ -650,8 +674,9 @@ class FlashAttnKVPackedFunc(torch.autograd.Function):
         return_softmax,
         is_grad_enabled,
     ):
-        is_grad = is_grad_enabled and any(
-            x.requires_grad for x in [q, kv]
+        is_grad = is_grad_enabled and (
+            any(x.requires_grad for x in [q, kv])
+            or (alibi_slopes is not None and alibi_slopes.requires_grad)
         )
         if softmax_scale is None:
             softmax_scale = q.shape[-1] ** (-0.5)
@@ -675,20 +700,23 @@ class FlashAttnKVPackedFunc(torch.autograd.Function):
             return_softmax=return_softmax and dropout_p > 0,
         )
         if is_grad:
-            ctx.save_for_backward(q, k, v, out_padded, softmax_lse, rng_state)
+            ctx.save_for_backward(q, k, v, out_padded, softmax_lse, rng_state, alibi_slopes)
             ctx.dropout_p = dropout_p
             ctx.softmax_scale = softmax_scale
             ctx.causal = causal
             ctx.window_size = window_size
             ctx.softcap = softcap
-            ctx.alibi_slopes = alibi_slopes
             ctx.deterministic = deterministic
         out = out_padded[..., :head_size_og]
         return out if not return_softmax else (out, softmax_lse, S_dmask)
 
     @staticmethod
     def backward(ctx, dout, *args):
-        q, k, v, out, softmax_lse, rng_state = ctx.saved_tensors
+        q, k, v, out, softmax_lse, rng_state, alibi_slopes = ctx.saved_tensors
+        dalibi_slopes = (
+            torch.empty_like(alibi_slopes)
+            if alibi_slopes is not None and alibi_slopes.requires_grad else None
+        )
         dq = torch.empty_like(q)
         kv_shape = k.shape[:-2] + (2, *k.shape[-2:])
         dkv = torch.empty(kv_shape, dtype=k.dtype, device=k.device)
@@ -712,13 +740,14 @@ class FlashAttnKVPackedFunc(torch.autograd.Function):
             ctx.window_size[0],
             ctx.window_size[1],
             ctx.softcap,
-            ctx.alibi_slopes,
+            alibi_slopes,
             ctx.deterministic,
             rng_state=rng_state,
+            dalibi_slopes=dalibi_slopes,
         )
         dq = dq[..., : dout.shape[-1]]  # We could have padded the head dimension
         dkv = dkv[..., : dout.shape[-1]]
-        return dq, dkv, None, None, None, None, None, None, None, None, None
+        return dq, dkv, None, None, None, None, None, dalibi_slopes, None, None, None
 
 
 class FlashAttnVarlenKVPackedFunc(torch.autograd.Function):
@@ -741,8 +770,9 @@ class FlashAttnVarlenKVPackedFunc(torch.autograd.Function):
         return_softmax,
         is_grad_enabled,
     ):
-        is_grad = is_grad_enabled and any(
-            x.requires_grad for x in [q, kv]
+        is_grad = is_grad_enabled and (
+            any(x.requires_grad for x in [q, kv])
+            or (alibi_slopes is not None and alibi_slopes.requires_grad)
         )
         if softmax_scale is None:
             softmax_scale = q.shape[-1] ** (-0.5)
@@ -772,7 +802,7 @@ class FlashAttnVarlenKVPackedFunc(torch.autograd.Function):
         )
         if is_grad:
             ctx.save_for_backward(
-                q, k, v, out_padded, softmax_lse, cu_seqlens_q, cu_seqlens_k, rng_state
+                q, k, v, out_padded, softmax_lse, cu_seqlens_q, cu_seqlens_k, rng_state, alibi_slopes
             )
             ctx.dropout_p = dropout_p
             ctx.max_seqlen_q = max_seqlen_q
@@ -781,14 +811,17 @@ class FlashAttnVarlenKVPackedFunc(torch.autograd.Function):
             ctx.causal = causal
             ctx.window_size = window_size
             ctx.softcap = softcap
-            ctx.alibi_slopes = alibi_slopes
             ctx.deterministic = deterministic
         out = out_padded[..., :head_size_og]
         return out if not return_softmax else (out, softmax_lse, S_dmask)
 
     @staticmethod
     def backward(ctx, dout, *args):
-        q, k, v, out, softmax_lse, cu_seqlens_q, cu_seqlens_k, rng_state = ctx.saved_tensors
+        q, k, v, out, softmax_lse, cu_seqlens_q, cu_seqlens_k, rng_state, alibi_slopes = ctx.saved_tensors
+        dalibi_slopes = (
+            torch.empty_like(alibi_slopes)
+            if alibi_slopes is not None and alibi_slopes.requires_grad else None
+        )
         dq = torch.empty_like(q)
         kv_shape = k.shape[:-2] + (2, *k.shape[-2:])
         dkv = torch.empty(kv_shape, dtype=k.dtype, device=k.device)
@@ -816,13 +849,14 @@ class FlashAttnVarlenKVPackedFunc(torch.autograd.Function):
             ctx.window_size[0],
             ctx.window_size[1],
             ctx.softcap,
-            ctx.alibi_slopes,
+            alibi_slopes,
             ctx.deterministic,
             rng_state=rng_state,
+            dalibi_slopes=dalibi_slopes,
         )
         dq = dq[..., : dout.shape[-1]]  # We could have padded the head dimension
         dkv = dkv[..., : dout.shape[-1]]
-        return dq, dkv, None, None, None, None, None, None, None, None, None, None, None, None, None
+        return dq, dkv, None, None, None, None, None, None, None, None, None, dalibi_slopes, None, None, None
 
 
 class FlashAttnFunc(torch.autograd.Function):
@@ -842,8 +876,9 @@ class FlashAttnFunc(torch.autograd.Function):
         return_softmax,
         is_grad_enabled,
     ):
-        is_grad = is_grad_enabled and any(
-            x.requires_grad for x in [q, k, v]
+        is_grad = is_grad_enabled and (
+            any(x.requires_grad for x in [q, k, v])
+            or (alibi_slopes is not None and alibi_slopes.requires_grad)
         )
         if softmax_scale is None:
             softmax_scale = q.shape[-1] ** (-0.5)
@@ -866,20 +901,23 @@ class FlashAttnFunc(torch.autograd.Function):
             return_softmax=return_softmax and dropout_p > 0,
         )
         if is_grad:
-            ctx.save_for_backward(q, k, v, out_padded, softmax_lse, rng_state)
+            ctx.save_for_backward(q, k, v, out_padded, softmax_lse, rng_state, alibi_slopes)
             ctx.dropout_p = dropout_p
             ctx.softmax_scale = softmax_scale
             ctx.causal = causal
             ctx.window_size = window_size
             ctx.softcap = softcap
-            ctx.alibi_slopes = alibi_slopes
             ctx.deterministic = deterministic
         out = out_padded[..., :head_size_og]
         return out if not return_softmax else (out, softmax_lse, S_dmask)
 
     @staticmethod
     def backward(ctx, dout, *args):
-        q, k, v, out, softmax_lse, rng_state = ctx.saved_tensors
+        q, k, v, out, softmax_lse, rng_state, alibi_slopes = ctx.saved_tensors
+        dalibi_slopes = (
+            torch.empty_like(alibi_slopes)
+            if alibi_slopes is not None and alibi_slopes.requires_grad else None
+        )
         dq, dk, dv = torch.empty_like(q), torch.empty_like(k), torch.empty_like(v)
         head_size_og = dout.size(3)
         dout_padded = dout
@@ -901,14 +939,15 @@ class FlashAttnFunc(torch.autograd.Function):
             ctx.window_size[0],
             ctx.window_size[1],
             ctx.softcap,
-            ctx.alibi_slopes,
+            alibi_slopes,
             ctx.deterministic,
             rng_state=rng_state,
+            dalibi_slopes=dalibi_slopes,
         )
         dq = dq[..., : dout.shape[-1]]  # We could have padded the head dimension
         dk = dk[..., : dout.shape[-1]]
         dv = dv[..., : dout.shape[-1]]
-        return dq, dk, dv, None, None, None, None, None, None, None, None, None
+        return dq, dk, dv, None, None, None, None, None, dalibi_slopes, None, None, None
 
 
 class FlashAttnVarlenFunc(torch.autograd.Function):
@@ -933,8 +972,9 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
         block_table,
         is_grad_enabled,
     ):
-        is_grad = is_grad_enabled and any(
-            x.requires_grad for x in [q, k, v]
+        is_grad = is_grad_enabled and (
+            any(x.requires_grad for x in [q, k, v])
+            or (alibi_slopes is not None and alibi_slopes.requires_grad)
         )
         if softmax_scale is None:
             softmax_scale = q.shape[-1] ** (-0.5)
@@ -963,7 +1003,7 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
         )
         if is_grad:
             ctx.save_for_backward(
-                q, k, v, out_padded, softmax_lse, cu_seqlens_q, cu_seqlens_k, rng_state
+                q, k, v, out_padded, softmax_lse, cu_seqlens_q, cu_seqlens_k, rng_state, alibi_slopes
             )
             ctx.dropout_p = dropout_p
             ctx.max_seqlen_q = max_seqlen_q
@@ -972,7 +1012,6 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
             ctx.causal = causal
             ctx.window_size = window_size
             ctx.softcap = softcap
-            ctx.alibi_slopes = alibi_slopes
             ctx.deterministic = deterministic
 
         out = out_padded[..., :head_size_og]
@@ -980,7 +1019,11 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, dout, *args):
-        q, k, v, out, softmax_lse, cu_seqlens_q, cu_seqlens_k, rng_state = ctx.saved_tensors
+        q, k, v, out, softmax_lse, cu_seqlens_q, cu_seqlens_k, rng_state, alibi_slopes = ctx.saved_tensors
+        dalibi_slopes = (
+            torch.empty_like(alibi_slopes)
+            if alibi_slopes is not None and alibi_slopes.requires_grad else None
+        )
         dq, dk, dv = torch.empty_like(q), torch.empty_like(k), torch.empty_like(v)
         head_size_og = dout.size(2)
         dout_padded = dout
@@ -1006,14 +1049,15 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
             ctx.window_size[0],
             ctx.window_size[1],
             ctx.softcap,
-            ctx.alibi_slopes,
+            alibi_slopes,
             ctx.deterministic,
             rng_state=rng_state,
+            dalibi_slopes=dalibi_slopes,
         )
         dq = dq[..., : dout.shape[-1]]  # We could have padded the head dimension
         dk = dk[..., : dout.shape[-1]]
         dv = dv[..., : dout.shape[-1]]
-        return dq, dk, dv, None, None, None, None, None, None, None, None, None, None, None, None, None, None
+        return dq, dk, dv, None, None, None, None, None, None, None, None, None, dalibi_slopes, None, None, None, None
 
 
 def flash_attn_qkvpacked_func(
@@ -1047,6 +1091,7 @@ def flash_attn_qkvpacked_func(
         softcap: float. Anything > 0 activates softcapping attention.
         alibi_slopes: (nheads,) or (batch_size, nheads), fp32. A bias of (-alibi_slope * |i - j|) is added to
             the attention score of query i and key j.
+            Receives gradients when requires_grad=True on the CUDA backend.
         deterministic: bool. Whether to use the deterministic implementation of the backward pass,
             which is slightly slower and uses more memory. The forward pass is always deterministic.
         return_attn_probs: bool. Whether to return the attention probabilities. This option is for
@@ -1124,6 +1169,7 @@ def flash_attn_kvpacked_func(
         alibi_slopes: (nheads,) or (batch_size, nheads), fp32. A bias of
             (-alibi_slope * |i + seqlen_k - seqlen_q - j|)
             is added to the attention score of query i and key j.
+            Receives gradients when requires_grad=True on the CUDA backend.
         deterministic: bool. Whether to use the deterministic implementation of the backward pass,
             which is slightly slower and uses more memory. The forward pass is always deterministic.
         return_attn_probs: bool. Whether to return the attention probabilities. This option is for
@@ -1200,6 +1246,7 @@ def flash_attn_func(
         alibi_slopes: (nheads,) or (batch_size, nheads), fp32. A bias of
             (-alibi_slope * |i + seqlen_k - seqlen_q - j|)
             is added to the attention score of query i and key j.
+            Receives gradients when requires_grad=True on the CUDA backend.
         deterministic: bool. Whether to use the deterministic implementation of the backward pass,
             which is slightly slower and uses more memory. The forward pass is always deterministic.
         return_attn_probs: bool. Whether to return the attention probabilities. This option is for
@@ -1266,6 +1313,7 @@ def flash_attn_varlen_qkvpacked_func(
         softcap: float. Anything > 0 activates softcapping attention.
         alibi_slopes: (nheads,) or (batch_size, nheads), fp32. A bias of (-alibi_slope * |i - j|)
             is added to the attention score of query i and key j.
+            Receives gradients when requires_grad=True on the CUDA backend.
         deterministic: bool. Whether to use the deterministic implementation of the backward pass,
             which is slightly slower and uses more memory. The forward pass is always deterministic.
         return_attn_probs: bool. Whether to return the attention probabilities. This option is for
@@ -1355,6 +1403,7 @@ def flash_attn_varlen_kvpacked_func(
         alibi_slopes: (nheads,) or (batch_size, nheads), fp32. A bias of
             (-alibi_slope * |i + seqlen_k - seqlen_q - j|)
             is added to the attention score of query i and key j.
+            Receives gradients when requires_grad=True on the CUDA backend.
         deterministic: bool. Whether to use the deterministic implementation of the backward pass,
             which is slightly slower and uses more memory. The forward pass is always deterministic.
         return_attn_probs: bool. Whether to return the attention probabilities. This option is for
@@ -1447,6 +1496,7 @@ def flash_attn_varlen_func(
         alibi_slopes: (nheads,) or (batch_size, nheads), fp32. A bias of
             (-alibi_slope * |i + seqlen_k - seqlen_q - j|)
             is added to the attention score of query i and key j.
+            Receives gradients when requires_grad=True on the CUDA backend.
         deterministic: bool. Whether to use the deterministic implementation of the backward pass,
             which is slightly slower and uses more memory. The forward pass is always deterministic.
         return_attn_probs: bool. Whether to return the attention probabilities. This option is for

--- a/tests/test_alibi_grad.py
+++ b/tests/test_alibi_grad.py
@@ -1,0 +1,422 @@
+"""Gradient coverage for the existing FA2 ALiBi slopes argument."""
+
+import pytest
+import torch
+
+from flash_attn import (
+    flash_attn_func,
+    flash_attn_kvpacked_func,
+    flash_attn_qkvpacked_func,
+    flash_attn_varlen_func,
+    flash_attn_varlen_kvpacked_func,
+    flash_attn_varlen_qkvpacked_func,
+)
+
+pytestmark = pytest.mark.skipif(
+    torch.version.hip is not None, reason="ALiBi slope gradients require the CUDA backend"
+)
+
+APIS = ("separate", "kvpacked", "qkvpacked", "varlen", "varlen_kvpacked", "varlen_qkvpacked")
+
+
+def _call_attention(api, q, k, v, slopes, q_lengths, k_lengths, **kwargs):
+    kwargs = dict(alibi_slopes=slopes, **kwargs)
+    if not api.startswith("varlen"):
+        if api == "qkvpacked":
+            return flash_attn_qkvpacked_func(torch.stack((q, k, v), dim=2), **kwargs)
+        if api == "kvpacked":
+            return flash_attn_kvpacked_func(q, torch.stack((k, v), dim=2), **kwargs)
+        return flash_attn_func(q, k, v, **kwargs)
+
+    cu_q = torch.tensor([0, *q_lengths], dtype=torch.int32, device=q.device).cumsum(
+        0, dtype=torch.int32
+    )
+    cu_k = torch.tensor([0, *k_lengths], dtype=torch.int32, device=q.device).cumsum(
+        0, dtype=torch.int32
+    )
+    if api == "varlen_qkvpacked":
+        return flash_attn_varlen_qkvpacked_func(
+            torch.stack((q, k, v), dim=1), cu_q, max(q_lengths), **kwargs
+        )
+    args = (cu_q, cu_k, max(q_lengths), max(k_lengths))
+    if api == "varlen_kvpacked":
+        return flash_attn_varlen_kvpacked_func(
+            q, torch.stack((k, v), dim=1), *args, **kwargs
+        )
+    return flash_attn_varlen_func(q, k, v, *args, **kwargs)
+
+
+def _reference_one(
+    q, k, v, slopes, *, softmax_scale=None, causal=False, window_size=(-1, -1),
+    softcap=0.0, dropout_p=0.0, dropout_mask=None,
+):
+    """FP32 oracle, including bottom-right alignment and fully masked rows."""
+    sq, heads, dim = q.shape
+    sk = k.shape[0]
+    if sq == 0 or sk == 0:
+        # Keep every input in the autograd graph, with a zero derivative.
+        return q * 0 + (k.sum() + v.sum() + slopes.sum()) * 0
+    k = k.repeat_interleave(heads // k.shape[1], dim=1)
+    v = v.repeat_interleave(heads // v.shape[1], dim=1)
+    scale = dim ** -0.5 if softmax_scale is None else softmax_scale
+    scores = torch.einsum("qhd,khd->hqk", q * scale, k)
+    if softcap > 0:
+        scores = softcap * torch.tanh(scores / softcap)
+    rows = torch.arange(sq, device=q.device)[:, None] + sk - sq
+    cols = torch.arange(sk, device=q.device)[None, :]
+    # ALiBi is added after softcap, and is not multiplied by softmax_scale.
+    scores = scores - slopes[:, None, None] * (rows - cols).abs()
+    left, right = window_size
+    if causal:
+        right = 0
+    allowed = torch.ones((sq, sk), dtype=torch.bool, device=q.device)
+    if left >= 0:
+        allowed &= cols >= rows - left
+    if right >= 0:
+        allowed &= cols <= rows + right
+    any_key = allowed.any(dim=-1, keepdim=True)
+    scores = scores.masked_fill(~allowed, -torch.inf)
+    # Avoid NaNs in both softmax and its derivative for fully masked rows.
+    scores = torch.where(any_key, scores, torch.zeros_like(scores))
+    probabilities = scores.softmax(dim=-1).masked_fill(~allowed, 0)
+    if dropout_mask is not None:
+        probabilities = probabilities.masked_fill(~dropout_mask, 0)
+    return torch.einsum("hqk,khd->qhd", probabilities, v) / (1 - dropout_p)
+
+
+def _reference(api, q, k, v, slopes, q_lengths, k_lengths, dropout_mask=None, **kwargs):
+    varlen = api.startswith("varlen")
+    q_parts = q.split(q_lengths) if varlen else q.unbind()
+    k_parts = k.split(k_lengths) if varlen else k.unbind()
+    v_parts = v.split(k_lengths) if varlen else v.unbind()
+    outputs = []
+    for batch, (qi, ki, vi) in enumerate(zip(q_parts, k_parts, v_parts)):
+        mask = None if dropout_mask is None else dropout_mask[
+            batch, :, :q_lengths[batch], :k_lengths[batch]
+        ]
+        outputs.append(_reference_one(
+            qi, ki, vi, slopes if slopes.ndim == 1 else slopes[batch],
+            dropout_mask=mask, **kwargs,
+        ))
+    return torch.cat(outputs) if varlen else torch.stack(outputs)
+
+
+def _dropout_mask(api, s_dmask, q_lengths, k_lengths, dim, causal, window_size):
+    # Reuse the established FA2 test helper for the kernel's returned S layout.
+    from test_flash_attn import convert_flash_attn_S_to_softmax
+
+    max_q, max_k = max(q_lengths), max(k_lengths)
+    q_padding = k_padding = None
+    if api.startswith("varlen"):
+        q_padding = torch.arange(max_q, device=s_dmask.device)[None, :] < torch.tensor(
+            q_lengths, device=s_dmask.device
+        )[:, None]
+        k_padding = torch.arange(max_k, device=s_dmask.device)[None, :] < torch.tensor(
+            k_lengths, device=s_dmask.device
+        )[:, None]
+    return convert_flash_attn_S_to_softmax(
+        s_dmask, max_q, max_k, q_padding, k_padding, dim, True,
+        causal=causal, window_size=window_size,
+    ) >= 0
+
+
+def _assert_close(actual, expected, dtype, name):
+    assert torch.isfinite(actual).all(), name
+    error = (actual.float() - expected).abs()
+    if error.numel() == 0:
+        return
+    # Reduction outputs such as dslopes can cross zero; bound both the maximum
+    # and average error by the corresponding FP32 reference magnitude.
+    rtol, atol = (0.01, 0.002) if dtype == torch.float16 else (0.05, 0.01)
+    assert error.max() <= atol + rtol * expected.abs().max(), (
+        name, "max error", error.max().item(), "reference max", expected.abs().max().item()
+    )
+    assert error.mean() <= atol + rtol * expected.abs().mean(), (
+        name, "mean error", error.mean().item(), "reference mean", expected.abs().mean().item()
+    )
+
+
+def _run_case(
+    api, dtype, batched_slopes, *, only_slopes=False, causal=False,
+    window_size=(-1, -1), softcap=0.0, dropout_p=0.0, softmax_scale=None,
+    dim=64, empty=False, deterministic=False, repeats=1,
+):
+    torch.manual_seed(1977)
+    varlen = api.startswith("varlen")
+    qkvpacked = api.endswith("qkvpacked")
+    if empty:
+        assert varlen
+        q_lengths = (0, 7, 19)
+        k_lengths = q_lengths if qkvpacked else (11, 0, 37)
+    elif deterministic:
+        q_lengths = (193, 71, 5) if varlen else (193,) * 3
+        k_lengths = (257, 29, 17) if varlen else (257,) * 3
+    else:
+        q_lengths = (67, 19, 5) if varlen else (67,) * 3
+        k_lengths = (131, 11, 37) if varlen else (131,) * 3
+        if qkvpacked:
+            k_lengths = q_lengths
+    batch, heads = len(q_lengths), 4
+    kv_heads = heads if qkvpacked else 2
+    q_shape = (sum(q_lengths), heads, dim) if varlen else (batch, q_lengths[0], heads, dim)
+    k_shape = (sum(k_lengths), kv_heads, dim) if varlen else (
+        batch, k_lengths[0], kv_heads, dim
+    )
+    q = torch.randn(q_shape, device="cuda", dtype=dtype).requires_grad_(not only_slopes)
+    k = torch.randn(k_shape, device="cuda", dtype=dtype).requires_grad_(not only_slopes)
+    v = torch.randn(k_shape, device="cuda", dtype=dtype).requires_grad_(not only_slopes)
+    # Non-contiguous batch stride is valid when the last dimension is contiguous.
+    slopes = torch.rand(
+        (batch, heads + 2) if batched_slopes else (heads,), device="cuda", dtype=torch.float32
+    ) * 0.05
+    if batched_slopes:
+        slopes = slopes[:, :heads]
+    slopes.requires_grad_()
+    q_ref, k_ref, v_ref, slopes_ref = [
+        x.detach().float().clone().requires_grad_(x.requires_grad) for x in (q, k, v, slopes)
+    ]
+    options = dict(
+        softmax_scale=softmax_scale, causal=causal, window_size=window_size,
+        softcap=softcap, dropout_p=dropout_p,
+    )
+    result = _call_attention(
+        api, q, k, v, slopes, q_lengths, k_lengths,
+        deterministic=deterministic, return_attn_probs=dropout_p > 0, **options,
+    )
+    if dropout_p > 0:
+        out, _, s_dmask = result
+        mask = _dropout_mask(api, s_dmask, q_lengths, k_lengths, dim, causal, window_size)
+    else:
+        out, mask = result, None
+    assert out.requires_grad
+    out_ref = _reference(
+        api, q_ref, k_ref, v_ref, slopes_ref, q_lengths, k_lengths,
+        dropout_mask=mask, **options,
+    )
+    _assert_close(out, out_ref, dtype, "out")
+    dout = torch.randn_like(out)
+    inputs = (slopes,) if only_slopes else (q, k, v, slopes)
+    refs = (slopes_ref,) if only_slopes else (q_ref, k_ref, v_ref, slopes_ref)
+    names = ("dslopes",) if only_slopes else ("dq", "dk", "dv", "dslopes")
+    expected = torch.autograd.grad(out_ref, refs, dout.float())
+    previous = None
+    for iteration in range(repeats):
+        gradients = torch.autograd.grad(out, inputs, dout, retain_graph=iteration + 1 < repeats)
+        assert gradients[-1].dtype == torch.float32
+        assert gradients[-1].shape == slopes.shape
+        for name, actual, ref in zip(names, gradients, expected):
+            _assert_close(actual, ref, dtype, name)
+        if previous is not None:
+            for name, actual, prior in zip(names, gradients, previous):
+                assert torch.equal(actual, prior), name
+        previous = gradients
+    if empty and batched_slopes:
+        # Neither a sequence with no Q nor one with no K contributes to slopes.
+        for batch_idx, (sq, sk) in enumerate(zip(q_lengths, k_lengths)):
+            if sq == 0 or sk == 0:
+                assert torch.count_nonzero(gradients[-1][batch_idx]) == 0
+
+
+@pytest.mark.parametrize("api", APIS)
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("batched_slopes", [False, True], ids=["shared", "batched"])
+def test_alibi_slopes_grad(api, dtype, batched_slopes):
+    _run_case(api, dtype, batched_slopes)
+
+
+@pytest.mark.parametrize(
+    "api,dtype,batched_slopes,only_slopes,causal,window_size,softcap,scale,dim",
+    [
+        pytest.param("separate", torch.float16, False, True, False, (-1, -1), 0.0, 0.37, 32, id="dense-only-slopes-hdim32"),
+        pytest.param("kvpacked", torch.bfloat16, True, True, True, (-1, -1), 0.0, 0.2, 128, id="kvpacked-only-slopes-hdim128"),
+        pytest.param("qkvpacked", torch.float16, False, True, False, (11, 7), 0.0, 0.19, 64, id="qkvpacked-local-only-slopes-hdim64"),
+        pytest.param("varlen", torch.bfloat16, True, True, True, (17, -1), 0.0, 0.25, 32, id="varlen-local-only-slopes-hdim32"),
+        pytest.param("varlen_kvpacked", torch.float16, False, True, False, (-1, 9), 0.0, 0.13, 128, id="varlen-kvpacked-only-slopes-hdim128"),
+        pytest.param("varlen_qkvpacked", torch.bfloat16, True, True, True, (-1, -1), 0.0, 0.35, 64, id="varlen-qkvpacked-only-slopes-hdim64"),
+        pytest.param("separate", torch.float16, True, False, True, (13, 0), 2.5, 0.6, 64, id="dense-local-softcap-hdim64"),
+        pytest.param("varlen", torch.bfloat16, False, False, False, (17, 11), 1.5, 0.4, 64, id="varlen-local-softcap-hdim64"),
+        pytest.param("kvpacked", torch.bfloat16, False, False, False, (-1, -1), 3.0, 0.25, 64, id="kvpacked-softcap-hdim64"),
+        pytest.param("varlen_qkvpacked", torch.float16, True, False, True, (-1, -1), 2.0, 0.3, 64, id="varlen-qkvpacked-softcap-hdim64"),
+    ],
+)
+def test_alibi_slopes_modes(
+    api, dtype, batched_slopes, only_slopes, causal, window_size, softcap, scale, dim
+):
+    _run_case(
+        api, dtype, batched_slopes, only_slopes=only_slopes, causal=causal,
+        window_size=window_size, softcap=softcap, softmax_scale=scale, dim=dim,
+    )
+
+
+@pytest.mark.parametrize("api", APIS[3:])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_alibi_slopes_empty_sequences(api, dtype):
+    _run_case(api, dtype, True, empty=True, causal=True)
+
+
+@pytest.mark.parametrize("api", APIS)
+def test_alibi_slopes_dropout(api):
+    # Softcap + dropout is rejected by the existing FA2 API.
+    _run_case(
+        api, torch.float16, True, dropout_p=0.17, causal=True,
+        window_size=(31, 0), softmax_scale=0.23,
+    )
+
+
+@pytest.mark.parametrize("api", ["separate", "varlen"])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_alibi_slopes_deterministic(api, dtype):
+    _run_case(
+        api, dtype, False, deterministic=True, repeats=3,
+        window_size=(73, 23), softmax_scale=0.2,
+    )
+
+
+
+def _small_inputs(api, *, only_slopes=False, trainable_slopes=True):
+    varlen = api.startswith("varlen")
+    qkvpacked = api.endswith("qkvpacked")
+    q_lengths = (17, 9) if varlen else (17, 17)
+    k_lengths = q_lengths if qkvpacked else ((23, 13) if varlen else (23, 23))
+    heads, dim, batch = 4, 64, len(q_lengths)
+    kv_heads = heads if qkvpacked else 2
+    q_shape = (sum(q_lengths), heads, dim) if varlen else (batch, q_lengths[0], heads, dim)
+    k_shape = (sum(k_lengths), kv_heads, dim) if varlen else (
+        batch, k_lengths[0], kv_heads, dim
+    )
+    q = torch.randn(q_shape, device="cuda", dtype=torch.float16).requires_grad_(not only_slopes)
+    k = torch.randn(k_shape, device="cuda", dtype=torch.float16).requires_grad_(not only_slopes)
+    v = torch.randn(k_shape, device="cuda", dtype=torch.float16).requires_grad_(not only_slopes)
+    slopes = (torch.rand(heads, device="cuda", dtype=torch.float32) * 0.05).requires_grad_(
+        trainable_slopes
+    )
+    return (q, k, v, slopes), q_lengths, k_lengths
+
+
+@pytest.mark.parametrize("api", APIS)
+@pytest.mark.parametrize("trainable_slopes", [False, True], ids=["frozen", "trainable"])
+def test_alibi_saved_slopes_version(api, trainable_slopes):
+    # Even a frozen bias is needed to recompute probabilities during backward.
+    # Mutating it must fail instead of silently using different attention scores.
+    torch.manual_seed(1977)
+    inputs, q_lengths, k_lengths = _small_inputs(api, trainable_slopes=trainable_slopes)
+    q, k, v, slopes = inputs
+    out = _call_attention(api, q, k, v, slopes, q_lengths, k_lengths)
+    with torch.no_grad():
+        slopes.add_(0.01)
+    with pytest.raises(RuntimeError, match="modified by an inplace operation"):
+        torch.autograd.grad(out, q, torch.ones_like(out))
+
+
+@pytest.mark.skipif(
+    not hasattr(torch.library, "custom_op"), reason="FA2 compile support requires PyTorch >= 2.4"
+)
+@pytest.mark.parametrize("api", ["separate", "varlen"])
+@pytest.mark.parametrize("gradient_mode", ["all", "slopes_only", "frozen_slopes"])
+def test_alibi_slopes_compile_fullgraph(api, gradient_mode):
+    # Select with -k compile_fullgraph to run the compiler checks separately.
+    # Training forces AOTAutograd/Inductor to functionalize the optional mutated
+    # backward buffer; a forward-only compile would not exercise that schema.
+    torch.manual_seed(1977)
+    inputs, q_lengths, k_lengths = _small_inputs(
+        api, only_slopes=gradient_mode == "slopes_only",
+        trainable_slopes=gradient_mode != "frozen_slopes",
+    )
+    options = dict(causal=True, softmax_scale=0.23)
+
+    def attention(q, k, v, slopes):
+        return _call_attention(api, q, k, v, slopes, q_lengths, k_lengths, **options)
+
+    torch._dynamo.reset()
+    try:
+        compiled = torch.compile(attention, backend="inductor", fullgraph=True)
+        for _ in range(2):
+            references = tuple(
+                x.detach().float().clone().requires_grad_(x.requires_grad) for x in inputs
+            )
+            out = compiled(*inputs)
+            expected = _reference(api, *references, q_lengths, k_lengths, **options)
+            _assert_close(out, expected, torch.float16, "compiled out")
+            dout = torch.randn_like(out)
+            requested = tuple(x for x in inputs if x.requires_grad)
+            requested_refs = tuple(x for x in references if x.requires_grad)
+            gradients = torch.autograd.grad(out, requested, dout)
+            expected_gradients = torch.autograd.grad(expected, requested_refs, dout.float())
+            names = tuple(
+                name for name, value in zip(("dq", "dk", "dv", "dslopes"), inputs)
+                if value.requires_grad
+            )
+            for name, actual, ref in zip(names, gradients, expected_gradients):
+                _assert_close(actual, ref, torch.float16, "compiled " + name)
+            # Reuse the compiled graph with new bias values and a new dout.
+            with torch.no_grad():
+                inputs[-1].add_(0.01)
+    finally:
+        torch._dynamo.reset()
+
+
+
+@pytest.mark.parametrize("batched_slopes", [False, True], ids=["shared", "batched"])
+def test_alibi_slopes_ragged_memory(batched_slopes):
+    # One long sequence should not pad the slope-gradient workspace for every
+    # short sequence in a packed batch. Compare incremental allocated memory
+    # against the same attention backward with frozen slopes.
+    torch.manual_seed(1977)
+    batch, heads, dim = 1024, 2, 64
+    lengths = [65536] + [64] * (batch - 1)
+    total_k = sum(lengths)
+    q = torch.randn(batch, heads, dim, device="cuda", dtype=torch.float16, requires_grad=True)
+    k = torch.randn(total_k, heads, dim, device="cuda", dtype=torch.float16, requires_grad=True)
+    v = torch.randn_like(k, requires_grad=True)
+    slopes = torch.rand((batch, heads) if batched_slopes else (heads,), device="cuda") * 0.05
+    cu_q = torch.arange(batch + 1, dtype=torch.int32, device="cuda")
+    cu_k = torch.tensor([0, *lengths], dtype=torch.int32, device="cuda").cumsum(0, dtype=torch.int32)
+    dout = torch.randn_like(q)
+
+    def peak_memory(trainable):
+        s = slopes.detach().requires_grad_(trainable)
+        torch.cuda.synchronize()
+        before = torch.cuda.memory_allocated()
+        torch.cuda.reset_peak_memory_stats()
+        out = flash_attn_varlen_func(q, k, v, cu_q, cu_k, 1, max(lengths), alibi_slopes=s)
+        grads = torch.autograd.grad(out, (q, k, v, s) if trainable else (q, k, v), dout)
+        torch.cuda.synchronize()
+        peak = torch.cuda.max_memory_allocated() - before
+        assert all(torch.isfinite(g).all() for g in grads)
+        return peak
+
+    peak_memory(False)
+    peak_memory(True)
+    frozen_peak = peak_memory(False)
+    trainable_peak = peak_memory(True)
+    # A batch-padded FP32 partial buffer alone would use 128 MiB here.
+    assert trainable_peak - frozen_peak < 16 * 1024**2, (frozen_peak, trainable_peak)
+
+
+@pytest.mark.parametrize("api", ["separate", "varlen"])
+@pytest.mark.parametrize("empty_side", ["q", "k"])
+@pytest.mark.parametrize("only_slopes", [False, True], ids=["all-gradients", "slopes-only"])
+def test_alibi_slopes_globally_empty(api, empty_side, only_slopes):
+    # A globally empty side must also work when slopes alone need gradients.
+    # Packed batches with merely one empty segment exercise a different launch.
+    batch, heads, dim = 2, 2, 64
+    q_lengths = (0, 0) if empty_side == "q" else (7, 7)
+    k_lengths = (0, 0) if empty_side == "k" else (11, 11)
+    varlen = api == "varlen"
+    q_shape = (sum(q_lengths), heads, dim) if varlen else (batch, q_lengths[0], heads, dim)
+    k_shape = (sum(k_lengths), heads, dim) if varlen else (batch, k_lengths[0], heads, dim)
+    q = torch.randn(q_shape, device="cuda", dtype=torch.float16).requires_grad_(not only_slopes)
+    k = torch.randn(k_shape, device="cuda", dtype=torch.float16).requires_grad_(not only_slopes)
+    v = torch.randn_like(k, requires_grad=not only_slopes)
+    slopes = torch.full(
+        (batch, heads) if only_slopes else (heads,), 0.01,
+        device="cuda", dtype=torch.float32, requires_grad=True,
+    )
+    out = _call_attention(api, q, k, v, slopes, q_lengths, k_lengths)
+    requested = (slopes,) if only_slopes else (q, k, v, slopes)
+    gradients = torch.autograd.grad(out, requested, torch.ones_like(out))
+    assert torch.count_nonzero(out) == 0
+    assert gradients[-1].shape == slopes.shape
+    assert gradients[-1].dtype == torch.float32
+    for gradient in gradients:
+        assert torch.count_nonzero(gradient) == 0


### PR DESCRIPTION
FA2 currently accepts ALiBi slopes in forward but does not return their gradients. This adds FP32 slope gradients to all six training APIs, including when Q/K/V are frozen, addressing [#1977](https://github.com/Dao-AILab/flash-attention/issues/1977).

The CUDA backward accumulates distance-weighted dS before the softcap derivative, with dropout scaling and fixed-order reduction. Variable-length attention sizes temporary storage by actual key tokens. A separate template specialization keeps gradient computation out of frozen-slopes kernels. The native backward retains its four return values and accepts an optional gradient output buffer. Empty Q/K paths return zero gradients.

Validation on RTX 4090, CUDA 13.0 and PyTorch 2.13.0+cu130: 78 tests pass across d32 (2), d64 (74), and d128 (2). Coverage includes the six APIs, FP16/BF16, GQA, local/causal attention, softcap, dropout, deterministic gradients, saved-tensor version checks, actual Inductor fullgraph training, and ragged-memory bounds. Sixteen additional native boundary probes pass. Exact baseline passes four QKV controls and fails twelve slope-gradient cases because slopes are absent from the autograd graph.

Same-lock CUDA Graph ABBA across six BF16 d64 configurations measures frozen-path differences from −0.049% to +0.343%. These are scoped sm89 native builds using all sixteen CUDA source files per head dimension and a scratch API dispatch restriction; C++20 is used for the installed PyTorch. The full distribution build, other GPU architectures, and ROCm slope gradients are outside this validation.

AI-assisted.
