### PR TITLE
Build CUDA extension with C++20 on PyTorch 2.13+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -309,9 +309,16 @@ if not SKIP_CUDA_BUILD and not IS_ROCM:
     if FORCE_CXX11_ABI:
         torch._C._GLIBCXX_USE_CXX11_ABI = True
 
+    # PyTorch 2.13+ requires C++20 for extensions that include ATen headers
+    # (ATen raises "#error C++20 or later ... required"). Because we pass an
+    # explicit -std flag below, PyTorch's build machinery cannot upgrade the
+    # standard for us, so select it from the installed torch version. Older
+    # torch keeps C++17 to avoid requiring a newer toolchain unnecessarily.
+    cxx_standard = "c++20" if (TORCH_MAJOR, TORCH_MINOR) >= (2, 13) else "c++17"
+
     nvcc_flags = [
     "-O3",
-    "-std=c++17",
+    f"-std={cxx_standard}",
     "-U__CUDA_NO_HALF_OPERATORS__",
     "-U__CUDA_NO_HALF_CONVERSIONS__",
     "-U__CUDA_NO_HALF2_OPERATORS__",
@@ -330,11 +337,11 @@ if not SKIP_CUDA_BUILD and not IS_ROCM:
     # "-DFLASHATTENTION_DISABLE_LOCAL",
     ]
 
-    compiler_c17_flag=["-O3", "-std=c++17"]
+    compiler_cxx_flag = ["-O3", f"-std={cxx_standard}"]
     # Add Windows-specific flags
     if sys.platform == "win32" and os.getenv('DISTUTILS_USE_SDK') == '1':
         nvcc_flags.extend(["-Xcompiler", "/Zc:__cplusplus"])
-        compiler_c17_flag=["-O2", "/std:c++17", "/Zc:__cplusplus"]
+        compiler_cxx_flag = ["-O2", f"/std:{cxx_standard}", "/Zc:__cplusplus"]
 
     # Opt-in: disable building dropout and its dependent headers (ATen philox/RNG
     # headers) from the FA2 build. This flag must be shared across both cxx and nvcc
@@ -446,7 +453,7 @@ if not SKIP_CUDA_BUILD and not IS_ROCM:
                 "csrc/flash_attn/src/flash_fwd_split_align_hdim256_bf16_causal_sm80.cu",
             ],
             extra_compile_args={
-                "cxx": compiler_c17_flag + feature_flags,
+                "cxx": compiler_cxx_flag + feature_flags,
                 "nvcc": append_nvcc_threads(nvcc_flags + cc_flag + feature_flags),
             },
             include_dirs=[


### PR DESCRIPTION
## Summary

The NVIDIA CUDA build hardcodes `-std=c++17` for both the host compiler and NVCC. PyTorch 2.13+ requires **C++20** for any extension that includes ATen headers, so building against torch 2.13/2.14 fails at compile time:

```
#error C++20 or later compatible compiler is required to use ATen
```

Because `setup.py` passes an explicit `-std` flag, PyTorch's `cpp_extension` machinery cannot upgrade the standard for us — the hardcoded C++17 forces the failing standard.

Fixes #2863.

## Change

- Select the C++ standard from the installed torch version: `c++20` for `torch >= 2.13`, `c++17` otherwise. Existing toolchains on older torch are unaffected (no regression).
- Applied to both `nvcc_flags` and the host-compiler flags, including the Windows `/std:` variant, so the two stay in sync.
- Renamed `compiler_c17_flag` → `compiler_cxx_flag` since it is no longer always C++17.

The ROCm/HIP build path already uses C++20, so this only aligns the CUDA path.

No kernel implementation or mathematical behavior is changed — this is a build-configuration fix only.

## Testing

- Verified the version-selection logic maps torch `2.12→c++17`, `2.13→c++20`, `2.14→c++20`, `3.x→c++20`.
- The change is confined to the NVIDIA CUDA branch of `setup.py`; `python -m py_compile setup.py` passes.
- Full end-to-end build against torch 2.14 + CUDA 13.2 / SM120 was reported working by the issue author (#2863); I do not have matching CUDA/GPU hardware to re-run the full compile here, so I validated the setup.py logic rather than the produced binary.

AI assistance was used to prepare this change.
