### PR TITLE
[CuTe, SM100] Preserve hd256 output alignment for vectorized stores

### DIFF
--- a/flash_attn/cute/cute_dsl_utils.py
+++ b/flash_attn/cute/cute_dsl_utils.py
@@ -112,22 +112,32 @@ def validate_output_layout(tensor: torch.Tensor, name: str, align_bytes: int) ->
     )
 
 
-def assume_strides_aligned(t):
+def assume_strides_aligned(t, *, canonicalize_singletons=False):
     """Assume all strides except the last are divisible by 128 bits.
 
     Python int strides (e.g., stride=0 from GQA expand) are kept as-is
     since they're static and don't need alignment assumptions.
+    Optionally zero unused dynamic singleton strides before assuming alignment.
     """
     divby = 128 // t.element_type.width
-    strides = tuple(s if isinstance(s, int) else cute.assume(s, divby=divby) for s in t.stride[:-1])
+    strides = tuple(
+        s
+        if isinstance(s, int)
+        else cute.assume(
+            s * cutlass.Int64(t.shape[i] != 1) if canonicalize_singletons else s,
+            divby=divby,
+        )
+        for i, s in enumerate(t.stride[:-1])
+    )
     return (*strides, t.stride[-1])
 
 
-def assume_tensor_aligned(t):
+def assume_tensor_aligned(t, *, canonicalize_singletons=False):
     """Rebuild a tensor with 128-bit aligned stride assumptions. Passes through None."""
     if t is None:
         return None
-    return cute.make_tensor(t.iterator, cute.make_layout(t.shape, stride=assume_strides_aligned(t)))
+    strides = assume_strides_aligned(t, canonicalize_singletons=canonicalize_singletons)
+    return cute.make_tensor(t.iterator, cute.make_layout(t.shape, stride=strides))
 
 
 def to_cute_tensor(t, assumed_align=16, leading_dim=-1, fully_dynamic=False, enable_tvm_ffi=True):

--- a/flash_attn/cute/sm100_hd256_2cta_fmha_forward.py
+++ b/flash_attn/cute/sm100_hd256_2cta_fmha_forward.py
@@ -29,7 +29,13 @@ from flash_attn.cute.mask import (
 )
 from flash_attn.cute.tile_scheduler import SM100_TMEM_CAPACITY_COLUMNS
 from flash_attn.cute.flash_fwd_sm100 import DescaleTensors, _TUNING_CONFIG
-from flash_attn.cute.utils import ex2_emulation_2, as_bshkrd_tensor, AuxData
+from flash_attn.cute.cute_dsl_utils import assume_tensor_aligned
+from flash_attn.cute.utils import (
+    ex2_emulation_2,
+    as_bshkrd_tensor,
+    AuxData,
+    domain_offset_aligned,
+)
 
 
 class BlackwellFusedMultiHeadAttentionForward:
@@ -212,7 +218,18 @@ class BlackwellFusedMultiHeadAttentionForward:
             "SM100 forward with head_dim=256 does not support descale_tensors"
         )
 
-        q_tensor, k_tensor, v_tensor, o_tensor = mQ, mK, mV, mO
+        q_tensor, k_tensor, v_tensor = mQ, mK, mV
+        # Contiguous torch outputs can have arbitrary strides on singleton axes.
+        # Canonicalize those unused strides before asserting their alignment.
+        o_strides = tuple(
+            s if isinstance(s, int) else s * Int64(mO.shape[i] != 1)
+            for i, s in enumerate(mO.stride[:-1])
+        )
+        o_tensor = assume_tensor_aligned(
+            cute.make_tensor(
+                mO.iterator, cute.make_layout(mO.shape, stride=(*o_strides, mO.stride[-1]))
+            )
+        )
         lse_tensor = mLSE
         cum_seqlen_q = mCuSeqlensQ
         cum_seqlen_k = mCuSeqlensK
@@ -1517,7 +1534,8 @@ class BlackwellFusedMultiHeadAttentionForward:
                             Int32(0),
                             ((Int32(0), Int32(0)), Int32(0)),
                         )
-                        mO_qdl_eff = cute.domain_offset(
+                        # Whole-row offsets preserve the output's validated 16-byte alignment.
+                        mO_qdl_eff = domain_offset_aligned(
                             cute.select(block_offset_o, mode=[0, 2, 3]), mO_qdl
                         )
 

--- a/flash_attn/cute/sm100_hd256_2cta_fmha_forward.py
+++ b/flash_attn/cute/sm100_hd256_2cta_fmha_forward.py
@@ -219,17 +219,7 @@ class BlackwellFusedMultiHeadAttentionForward:
         )
 
         q_tensor, k_tensor, v_tensor = mQ, mK, mV
-        # Contiguous torch outputs can have arbitrary strides on singleton axes.
-        # Canonicalize those unused strides before asserting their alignment.
-        o_strides = tuple(
-            s if isinstance(s, int) else s * Int64(mO.shape[i] != 1)
-            for i, s in enumerate(mO.stride[:-1])
-        )
-        o_tensor = assume_tensor_aligned(
-            cute.make_tensor(
-                mO.iterator, cute.make_layout(mO.shape, stride=(*o_strides, mO.stride[-1]))
-            )
-        )
+        o_tensor = assume_tensor_aligned(mO, canonicalize_singletons=True)
         lse_tensor = mLSE
         cum_seqlen_q = mCuSeqlensQ
         cum_seqlen_k = mCuSeqlensK
@@ -1534,7 +1524,6 @@ class BlackwellFusedMultiHeadAttentionForward:
                             Int32(0),
                             ((Int32(0), Int32(0)), Int32(0)),
                         )
-                        # Whole-row offsets preserve the output's validated 16-byte alignment.
                         mO_qdl_eff = domain_offset_aligned(
                             cute.select(block_offset_o, mode=[0, 2, 3]), mO_qdl
                         )

--- a/tests/cute/test_flash_attn.py
+++ b/tests/cute/test_flash_attn.py
@@ -1029,6 +1029,111 @@ def test_flash_attn_hd256_sm100_noncontiguous_transpose():
     )
 
 
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("paged", [False, True])
+@pytest.mark.parametrize("layout", ["padded", "transposed"])
+@maybe_fake_tensor_mode(USE_FAKE_TENSOR)
+def test_flash_attn_hd256_varlen_output_alignment(dtype, paged, layout):
+    """Preserve aligned strided outputs and guards across a nonzero packed-Q offset."""
+    if not (IS_SM100 or IS_SM110):
+        pytest.skip("SM100/SM110-specific hd256 output alignment test")
+    torch.manual_seed(0)
+    q_lengths, k_lengths = [129, 257], [257, 513]
+    q_offsets, k_offsets = [0, 129, 386], [0, 257, 770]
+    nheads, nheads_kv, d = 4, 2, 256
+    q = torch.randn(q_offsets[-1], nheads, d, device="cuda", dtype=dtype)
+    k = torch.randn(k_offsets[-1], nheads_kv, d, device="cuda", dtype=dtype)
+    v = torch.randn_like(k)
+    cu_q = torch.tensor(q_offsets, device="cuda", dtype=torch.int32)
+    cu_k = torch.tensor(k_offsets, device="cuda", dtype=torch.int32)
+    page_table = seqused_k = None
+    kernel_k, kernel_v = k, v
+    if paged:
+        page_size, pages_per_seq = 128, 5
+        page_table = torch.randperm(10, device="cuda", dtype=torch.int32).reshape(2, 5)
+        seqused_k = torch.tensor(k_lengths, device="cuda", dtype=torch.int32)
+        kernel_k = torch.zeros(10, page_size, nheads_kv, d, device="cuda", dtype=dtype)
+        kernel_v = torch.zeros_like(kernel_k)
+        for b, length in enumerate(k_lengths):
+            padding = (0, 0, 0, 0, 0, pages_per_seq * page_size - length)
+            for source, cache in ((k, kernel_k), (v, kernel_v)):
+                cache[page_table[b].long()] = torch.nn.functional.pad(
+                    source[k_offsets[b]:k_offsets[b + 1]], padding
+                ).reshape(pages_per_seq, page_size, nheads_kv, d)
+        cu_k = None
+
+    # Eight padding elements keep all strides 16-byte aligned without requiring
+    # 128-byte alignment. The leading guard also tests a nonzero storage offset.
+    shape = (q_offsets[-1], nheads, d + 8)
+    if layout == "transposed":
+        shape = (nheads, q_offsets[-1], d + 8)
+    storage = torch.full((math.prod(shape) + 8,), 123.0, device="cuda", dtype=dtype)
+    padded = storage[8:].view(shape)
+    if layout == "transposed":
+        padded = padded.transpose(0, 1)
+    out = padded[..., :d]
+    result = _flash_attn_fwd(
+        q, kernel_k, kernel_v, out=out,
+        cu_seqlens_q=cu_q, cu_seqlens_k=cu_k,
+        max_seqlen_q=max(q_lengths), max_seqlen_k=max(k_lengths),
+        seqused_k=seqused_k, page_table=page_table, causal=True,
+    )[0]
+    if is_fake_mode():
+        return
+
+    assert result.data_ptr() == out.data_ptr()
+    assert not out.is_contiguous()
+    assert torch.equal(storage[:8], torch.full_like(storage[:8], 123.0))
+    assert torch.equal(padded[..., d:], torch.full_like(padded[..., d:], 123.0))
+    assert torch.isfinite(out).all()
+    refs = {}
+    for ref_dtype in (torch.float64, dtype):
+        pieces = []
+        for b, (sq, sk) in enumerate(zip(q_lengths, k_lengths)):
+            mask = torch.arange(sk, device="cuda")[None, :] <= (
+                torch.arange(sq, device="cuda")[:, None] + sk - sq
+            )
+            with torch.nn.attention.sdpa_kernel(torch.nn.attention.SDPBackend.MATH):
+                pieces.append(torch.nn.functional.scaled_dot_product_attention(
+                    q[q_offsets[b]:q_offsets[b + 1]].to(ref_dtype).transpose(0, 1),
+                    k[k_offsets[b]:k_offsets[b + 1]].to(ref_dtype).transpose(0, 1),
+                    v[k_offsets[b]:k_offsets[b + 1]].to(ref_dtype).transpose(0, 1),
+                    attn_mask=mask, enable_gqa=True,
+                ).transpose(0, 1))
+        refs[ref_dtype] = torch.cat(pieces)
+    check_tensor_vs_ref("out", out, refs[torch.float64], refs[dtype], rtol=2)
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("shape", [(1, 129, 4, 256), (2, 1, 4, 256), (2, 129, 1, 256)])
+@maybe_fake_tensor_mode(USE_FAKE_TENSOR)
+def test_flash_attn_hd256_output_singleton_strides(dtype, shape):
+    """Accept arbitrary unused strides without assuming they are aligned."""
+    if not (IS_SM100 or IS_SM110):
+        pytest.skip("SM100/SM110-specific hd256 output alignment test")
+    torch.manual_seed(0)
+    q, k, v = [torch.randn(shape, device="cuda", dtype=dtype) for _ in range(3)]
+    strides = tuple(1 if size == 1 else stride for size, stride in zip(shape, q.stride()))
+    out = torch.empty_strided(shape, strides, device="cuda", dtype=dtype)
+    assert out.is_contiguous()
+    result = _flash_attn_fwd(q, k, v, out=out, causal=True)[0]
+    if is_fake_mode():
+        return
+    assert result.data_ptr() == out.data_ptr()
+    assert out.stride() == strides
+    assert torch.isfinite(out).all()
+    refs = {}
+    with torch.nn.attention.sdpa_kernel(torch.nn.attention.SDPBackend.MATH):
+        for ref_dtype in (torch.float64, dtype):
+            refs[ref_dtype] = torch.nn.functional.scaled_dot_product_attention(
+                q.to(ref_dtype).transpose(1, 2),
+                k.to(ref_dtype).transpose(1, 2),
+                v.to(ref_dtype).transpose(1, 2),
+                is_causal=True,
+            ).transpose(1, 2)
+    check_tensor_vs_ref("out", out, refs[torch.float64], refs[dtype], rtol=2)
+
+
 # @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float8_e4m3fn])
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 @pytest.mark.parametrize("mha_type", ["mha", "mqa", "gqa"])


### PR DESCRIPTION
## Summary

Preserve output alignment through the dedicated SM100/SM110 HD256 forward kernel so its epilogue can use vectorized stores.

The output is already physically aligned, but the kernel loses the compiler's stride/pointer alignment information when creating its view and applying a packed-query offset. In the diagnosed 512-token prefill specialization this scalarized the output stores (`STG.E.U16` instead of `STG.E.128`).

- Use the existing `assume_tensor_aligned` helper for the output view.
- Use the existing `domain_offset_aligned` helper for the cumulative-query row offset.
- First zero dynamic strides on singleton output axes. PyTorch considers tensors with arbitrary unused singleton strides contiguous, so the existing output validator accepts them; asserting divisibility on those raw strides would be incorrect. This normalization changes only the kernel's view, not the caller's tensor, accepted layouts, cache signature, or storage.

Attention math, tiling, pipeline synchronization, and backward kernels are unchanged. No new package dependency.

## Safety and coverage

Adds 14 cases covering FP16/BF16, paged and packed KV, padded/transposed outputs, minimally 16-byte-aligned storage offsets, nonzero cumulative-Q offsets, and singleton batch/sequence/head strides. The tests compare against independent FP64 math attention with low-precision math attention as the error baseline, check finite outputs, and verify that output guards and caller strides are preserved.

For nonsingleton axes, the existing output validator guarantees 16-byte-aligned strides. A cumulative-Q offset moves by whole rows, preserving that alignment. For singleton axes, the normalized stride is zero before the alignment assumption. Static strides receive no new divisibility assumptions.

These are layout-safety tests, not timing assertions; the original implementation is numerically correct on these fixtures too. The performance regression is demonstrated separately below.

## Performance

GPU time per **forward attention call**, in microseconds; lower is better. Speedup is parent time / patched time. Baseline: `0f3fb00d3f34196ca55f30d2f6c5dce0709b4667`.

| Workload | Parent (µs) | Patched (µs) | Speedup |
|---|---:|---:|---:|
| Decode, batch 1, Q=1, KV=512 | 11.45 | 11.03 | 1.04× |
| Decode, batch 1, Q=1, KV=4096 | 40.77 | 40.32 | 1.01× |
| Decode, batch 8, Q=1, KV=4096 | 91.17 | 90.26 | 1.01× |
| Prefill, batch 1, Q=KV=128 | 40.71 | 9.61 | 4.24× |
| Prefill, batch 1, Q=KV=512 | 44.58 | 13.12 | 3.40× |
| Chunked prefill, batch 4, Q=128, KV=4096 | 80.33 | 50.85 | 1.58× |
| Prefill, batch 1, Q=KV=4096 | 245.12 | 116.54 | 2.10× |
| Ragged batch 2, Q=[129,513], KV=[257,1025] | 52.52 | 19.25 | 2.73× |

Measurement contract:
- GB300/SM103, BF16, GQA 16 query heads / 4 KV heads, head dimension 256, causal, 128-token KV pages, packed K/V cache strides, preallocated output, LSE enabled on both sides.
- PyTorch `2.15.0.dev20260909+cu132`, CUTLASS DSL `4.6.2`, Quack `0.6.4`, TVM-FFI `0.1.12`, Triton `3.8.0+gitc01b6774`.
- Same process, GPU, inputs, launch path, and dependencies; separate JIT caches and parent/patched kernel classes. Seed 42, normal-random BF16 inputs, shuffled page mappings.
- CUDA graph containing 32 calls with fixed warm/reused buffers; 25 warmup batches, 100 replay samples, three interleaved rounds (before/after, after/before, before/after), median of round medians. Native clocks/DVFS; telemetry recorded. No locked-clock or cold-DRAM claim.
- Uses Transformer Nuggets' CUDA-graph benchmark helper. Excludes compilation, graph capture, cache updates, model projections, and scheduling. Not an end-to-end model throughput result. Backward performance was not measured because the patch does not touch backward.
- Both implementations passed FP64/low-precision reference checks and produced bitwise-identical outputs for all eight measured workloads.

## Validation

- 14 new output-layout cases passed on GB300.
- 13 existing HD256 layout/paged-KV cases passed.
- Compute Sanitizer memcheck on all seven new BF16 cases: **0 errors**.
- Eight before/after benchmark workloads passed their reference and bitwise-equivalence checks.
- Focused review of the alignment, singleton-stride, and cache-signature contracts found no remaining blocker after the singleton-stride handling was added.
- Repository pre-commit Ruff check/format hooks and `git diff --check` passed.

The full attention suite, SM110 hardware, backward benchmarks, and racecheck were not run. The patch does not address the separate existing NaN-in-unused-V padding behavior.

Targeted new tests:
```bash
pytest -v tests/cute/test_flash_attn.py::test_flash_attn_hd256_varlen_output_alignment tests/cute/test_flash_attn.py::test_flash_attn_hd256_output_singleton_strides
```
