### PR TITLE
[FA2, SM89] Add D512 forward and backward

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,15 @@ FlashAttention-2 with CUDA currently supports:
 2. Datatype fp16 and bf16 (bf16 requires Ampere, Ada, or Hopper GPUs).
 3. All head dimensions up to 256. ~~Head dim > 192 backward requires A100/A800 or H100/H800~~. Head dim 256 backward now works on consumer GPUs (if there's no dropout) as of flash-attn 2.5.5.
 
+Head dimension 512 is also supported on SM89 (Ada, including RTX 4090) for
+FP16/BF16 forward and backward. This covers Gemma4-E4B global attention layers.
+The dense and variable-length APIs support MHA, MQA, GQA, causal attention,
+and deterministic backward. D512 requires zero attention dropout and does not
+support local attention, softcap, ALiBi, paged KV, split KV, `leftpad_k`,
+`seqused_k`, or `flash_attn_with_kvcache`. Other head dimensions keep their
+existing feature support. See `tests/test_flash_attn_sm89_d512.py` and
+`benchmarks/benchmark_flash_attention_d512.py` for validation and timing.
+
 ### AMD ROCm Support
 ROCm version has two backends. There is [composable_kernel](https://github.com/ROCm/composable_kernel) (ck) which is the default backend and a [Triton](https://github.com/triton-lang/triton) backend. They provide an implementation of FlashAttention-2.
 

--- a/benchmarks/benchmark_flash_attention_d512.py
+++ b/benchmarks/benchmark_flash_attention_d512.py
@@ -1,0 +1,66 @@
+"""Compare D512 training with PyTorch's memory-efficient SDPA on SM89.
+
+Run from the repository root after building FlashAttention:
+    python benchmarks/benchmark_flash_attention_d512.py
+"""
+import json
+
+import torch
+import torch.nn.functional as F
+from torch.nn.attention import SDPBackend, sdpa_kernel
+
+from flash_attn import flash_attn_func
+
+
+def measure(fn, repeats=20):
+    for _ in range(5):
+        fn()
+    torch.cuda.synchronize()
+    before = torch.cuda.memory_allocated()
+    torch.cuda.reset_peak_memory_stats()
+    start, end = (torch.cuda.Event(enable_timing=True) for _ in range(2))
+    start.record()
+    for _ in range(repeats):
+        fn()
+    end.record()
+    end.synchronize()
+    return {"ms": start.elapsed_time(end) / repeats,
+            "peak_extra_mib": (torch.cuda.max_memory_allocated() - before) / 2**20}
+
+
+def main():
+    assert torch.cuda.get_device_capability() == (8, 9)
+    torch.manual_seed(0)
+    print(json.dumps({"gpu": torch.cuda.get_device_name(), "torch": torch.__version__,
+                      "cuda": torch.version.cuda, "dtype": "bfloat16",
+                      "batch": 1, "heads_q": 8, "heads_kv": 2, "head_dim": 512,
+                      "scale": 1.0, "causal": True}))
+    for n in (512, 2048, 4096, 8192):
+        q = (torch.randn(1, n, 8, 512, device="cuda", dtype=torch.bfloat16) * .2).requires_grad_()
+        k = (torch.randn(1, n, 2, 512, device="cuda", dtype=torch.bfloat16) * .2).requires_grad_()
+        v = torch.randn_like(k).requires_grad_()
+        do = torch.randn_like(q)
+
+        def flash():
+            return flash_attn_func(q, k, v, softmax_scale=1.0, causal=True)
+
+        def sdpa():
+            # The efficient backend needs equal Q/KV head counts. Include both
+            # KV expansion and its backward reduction in the measured call.
+            return F.scaled_dot_product_attention(
+                q.transpose(1, 2), k.repeat_interleave(4, 2).transpose(1, 2),
+                v.repeat_interleave(4, 2).transpose(1, 2),
+                scale=1.0, is_causal=True).transpose(1, 2)
+
+        result = {"seqlen": n}
+        with sdpa_kernel(SDPBackend.EFFICIENT_ATTENTION):
+            for name, fn in (("flash", flash), ("sdpa_efficient", sdpa)):
+                with torch.no_grad():
+                    result[name + "_forward"] = measure(fn)
+                result[name + "_forward_backward"] = measure(
+                    lambda: torch.autograd.grad(fn(), (q, k, v), do))
+        print(json.dumps(result), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/csrc/flash_attn/flash_api.cpp
+++ b/csrc/flash_attn/flash_api.cpp
@@ -259,6 +259,12 @@ void set_params_dgrad(Flash_bwd_params &params,
 }
 
 void run_mha_fwd(Flash_fwd_params &params, cudaStream_t stream, bool force_split_kernel=false) {
+    if (params.d == 512) {
+        TORCH_CHECK(!force_split_kernel && params.num_splits <= 1,
+                    "Head dimension 512 does not support split KV attention");
+        run_mha_fwd_hdim512(params, stream);
+        return;
+    }
     FP16_SWITCH(!params.is_bf16, [&] {
         HEADDIM_SWITCH(params.d, [&] {
             BOOL_SWITCH(params.is_causal, Is_causal, [&] {
@@ -319,6 +325,12 @@ std::tuple<at::Tensor, at::Tensor> set_params_splitkv(Flash_fwd_params &params, 
     const int head_size_rounded, const float p_dropout,
     const int num_splits, const int num_sm, struct c10::TensorOptions opts) {
 
+    if (head_size == 512) {
+        TORCH_CHECK(num_splits <= 1, "Head dimension 512 does not support split KV attention");
+        params.num_splits = 1;
+        return std::make_tuple(at::Tensor(), at::Tensor());
+    }
+
     // This needs to match with run_mha_fwd_splitkv_dispatch
     const int block_n = head_size <= 64 ? 256 : (head_size <= 128 ? 128 : 64);
     const int num_n_blocks = (max_seqlen_k + block_n - 1) / block_n;
@@ -363,6 +375,23 @@ void set_params_alibi(Flash_fwd_params &params, std::optional<at::Tensor> &alibi
         params.alibi_slopes_ptr = nullptr;
     }
 #endif
+}
+
+// D512 uses smaller tiles to fit within Ada's 99 KiB shared-memory limit.
+// Keep its supported feature set explicit before allocating or launching kernels.
+void check_head_dim(const int head_size, const int cc_major, const int cc_minor,
+                    const float p_dropout, const float softcap,
+                    const int window_size_left, const int window_size_right,
+                    const bool is_causal, const bool has_alibi) {
+    TORCH_CHECK(head_size <= 256 || head_size == 512,
+                "FlashAttention supports head dimensions up to 256, or exactly 512 on SM89");
+    if (head_size != 512) { return; }
+    TORCH_CHECK(cc_major == 8 && cc_minor == 9, "Head dimension 512 requires an SM89 GPU");
+    TORCH_CHECK(p_dropout == 0.f, "Head dimension 512 does not support dropout");
+    TORCH_CHECK(softcap == 0.f, "Head dimension 512 does not support softcap");
+    TORCH_CHECK(!has_alibi, "Head dimension 512 does not support ALiBi");
+    TORCH_CHECK(window_size_left < 0 && (is_causal || window_size_right < 0),
+                "Head dimension 512 does not support local attention");
 }
 
 std::vector<at::Tensor>
@@ -413,7 +442,8 @@ mha_fwd(at::Tensor &q,         // batch_size x seqlen_q x num_heads x round_mult
     const int seqlen_k = k.size(1);
     const int num_heads_k = k.size(2);
     TORCH_CHECK(batch_size > 0, "batch size must be positive");
-    TORCH_CHECK(head_size <= 256, "FlashAttention forward only supports head dimension at most 256");
+    check_head_dim(head_size, cc_major, cc_minor, p_dropout, softcap,
+                   window_size_left, window_size_right, is_causal, alibi_slopes_.has_value());
     TORCH_CHECK(head_size % 8 == 0, "query, key, value, and out_ must have a head_size that is a multiple of 8");
     TORCH_CHECK(num_heads % num_heads_k == 0, "Number of heads in key/value must divide number of heads in query");
 
@@ -428,7 +458,7 @@ mha_fwd(at::Tensor &q,         // batch_size x seqlen_q x num_heads x round_mult
 
     // Faster to transpose q from (b, 1, (nheads_kv ngroups), d) to (b, ngroups, nheads_kv, d) in this case
     // H/t Daniel Haziza
-    const int seqlenq_ngroups_swapped = seqlen_q == 1 && num_heads > num_heads_k && window_size_left < 0 && window_size_right < 0 && p_dropout == 0.f && head_size % 8 == 0 && !alibi_slopes_.has_value();
+    const int seqlenq_ngroups_swapped = head_size != 512 && seqlen_q == 1 && num_heads > num_heads_k && window_size_left < 0 && window_size_right < 0 && p_dropout == 0.f && head_size % 8 == 0 && !alibi_slopes_.has_value();
     const int ngroups = num_heads / num_heads_k;
     if (seqlenq_ngroups_swapped) {
         q = q.reshape({batch_size, num_heads_k, ngroups, head_size}).transpose(1, 2);
@@ -604,6 +634,12 @@ mha_varlen_fwd(at::Tensor &q,  // total_q x num_heads x head_size, total_q := \s
     int num_heads = sizes[1];
     const int head_size = sizes[2];
     const int num_heads_k = paged_KV ? k.size(2) : k.size(1);
+    if (head_size == 512) {
+        TORCH_CHECK(!paged_KV, "Head dimension 512 does not support paged KV attention");
+        TORCH_CHECK(!leftpad_k_.has_value(), "Head dimension 512 does not support leftpad_k");
+        TORCH_CHECK(!seqused_k.has_value(), "Head dimension 512 does not support seqused_k");
+        TORCH_CHECK(num_splits <= 1, "Head dimension 512 does not support split KV attention");
+    }
 
     if (softcap > 0.f) { TORCH_CHECK(p_dropout == 0.f, "Softcapping does not support dropout for now"); }
 
@@ -619,7 +655,7 @@ mha_varlen_fwd(at::Tensor &q,  // total_q x num_heads x head_size, total_q := \s
 
     // Faster to transpose q from (b, 1, (nheads_kv ngroups), d) to (b, ngroups, nheads_kv, d) in this case
     // H/t Daniel Haziza
-    const int seqlenq_ngroups_swapped = max_seqlen_q == 1 && num_heads > num_heads_k && window_size_left < 0 && window_size_right < 0 && p_dropout == 0.f && head_size % 8 == 0 && !alibi_slopes_.has_value();
+    const int seqlenq_ngroups_swapped = head_size != 512 && max_seqlen_q == 1 && num_heads > num_heads_k && window_size_left < 0 && window_size_right < 0 && p_dropout == 0.f && head_size % 8 == 0 && !alibi_slopes_.has_value();
     const int ngroups = num_heads / num_heads_k;
     if (seqlenq_ngroups_swapped) {
         q = q.reshape({batch_size, num_heads_k, ngroups, head_size}).transpose(1, 2).reshape({batch_size * ngroups, num_heads_k, head_size});
@@ -631,7 +667,8 @@ mha_varlen_fwd(at::Tensor &q,  // total_q x num_heads x head_size, total_q := \s
     const int total_q = q.sizes()[0];
 
     TORCH_CHECK(batch_size > 0, "batch size must be positive");
-    TORCH_CHECK(head_size <= 256, "FlashAttention forward only supports head dimension at most 256");
+    check_head_dim(head_size, cc_major, cc_minor, p_dropout, softcap,
+                   window_size_left, window_size_right, is_causal, alibi_slopes_.has_value());
     TORCH_CHECK(head_size % 8 == 0, "query, key, value, and out_ must have a head_size that is a multiple of 8");
     TORCH_CHECK(num_heads % num_heads_k == 0, "Number of heads in key/value must divide number of heads in query");
 
@@ -788,6 +825,10 @@ mha_varlen_fwd(at::Tensor &q,  // total_q x num_heads x head_size, total_q := \s
 }
 
 void run_mha_bwd(Flash_bwd_params &params, cudaStream_t stream) {
+    if (params.d == 512) {
+        run_mha_bwd_hdim512(params, stream);
+        return;
+    }
     FP16_SWITCH(!params.is_bf16, [&] {
         HEADDIM_SWITCH(params.d, [&] {
             BOOL_SWITCH(params.is_causal, Is_causal, [&] {
@@ -865,7 +906,8 @@ mha_bwd(const at::Tensor &dout,  // batch_size x seqlen_q x num_heads, x multipl
     const int num_heads_k = k.size(2);
     TORCH_CHECK(batch_size > 0, "batch size must be positive");
     TORCH_CHECK(head_size % 8 == 0, "head_size should be a multiple of 8");
-    TORCH_CHECK(head_size <= 256, "FlashAttention backward only supports head dimension at most 256");
+    check_head_dim(head_size, cc_major, cc_minor, p_dropout, softcap,
+                   window_size_left, window_size_right, is_causal, alibi_slopes_.has_value());
     TORCH_CHECK(num_heads % num_heads_k == 0, "Number of heads in key/value must divide number of heads in query");
 
     auto round_multiple = [](int x, int m) { return (x + m - 1) / m * m; };
@@ -1085,7 +1127,8 @@ mha_varlen_bwd(const at::Tensor &dout,  // total_q x num_heads, x head_size
     const int num_heads_k = k.size(1);
     TORCH_CHECK(batch_size > 0, "batch size must be positive");
     TORCH_CHECK(head_size % 8 == 0, "head_size should be a multiple of 8");
-    TORCH_CHECK(head_size <= 256, "FlashAttention backward only supports head dimension at most 256");
+    check_head_dim(head_size, cc_major, cc_minor, p_dropout, softcap,
+                   window_size_left, window_size_right, is_causal, alibi_slopes_.has_value());
     TORCH_CHECK(num_heads % num_heads_k == 0, "Number of heads in key/value must divide number of heads in query");
     if (softcap > 0.f) { TORCH_CHECK(p_dropout == 0.f, "Softcapping does not support dropout for now"); }
 

--- a/csrc/flash_attn/src/flash.h
+++ b/csrc/flash_attn/src/flash.h
@@ -195,4 +195,7 @@ template<typename T, int Headdim, bool Is_causal> void run_mha_fwd_splitkv_dispa
 
 template<typename T, int Headdim, bool Is_causal> void run_mha_bwd_(Flash_bwd_params &params, cudaStream_t stream);
 
+void run_mha_fwd_hdim512(Flash_fwd_params &params, cudaStream_t stream);
+void run_mha_bwd_hdim512(Flash_bwd_params &params, cudaStream_t stream);
+
 }  // namespace FLASH_NAMESPACE

--- a/csrc/flash_attn/src/flash_bwd_hdim512_sm89.cu
+++ b/csrc/flash_attn/src/flash_bwd_hdim512_sm89.cu
@@ -1,0 +1,47 @@
+#include "flash_bwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template<typename T>
+struct Flash_bwd_d512_traits : Flash_bwd_kernel_traits<512, 16, 32, 2, 1, 1, 1, true, true, T> {
+    // The smaller tile uses 64 threads. Clear dQ accumulators with all 64 threads,
+    // instead of the 256-thread layout used by the existing backward tiles.
+    using GmemTiledCopydQaccum = decltype(make_tiled_copy(
+        Copy_Atom<AutoVectorizingCopyWithAssumedAlignment<128>, float>{},
+        Layout<Shape<_4, _16>, Stride<_16, _1>>{}, Layout<Shape<_1, _4>>{}));
+};
+
+void run_mha_bwd_hdim512(Flash_bwd_params &params, cudaStream_t stream) {
+#ifndef FLASHATTENTION_DISABLE_BACKWARD
+    FP16_SWITCH(!params.is_bf16, [&] {
+        BOOL_SWITCH(params.is_causal, Is_causal, [&] {
+            // A single Q/dO buffer and register-resident V limit shared memory to 96 KiB.
+            using Traits = Flash_bwd_d512_traits<elem_type>;
+            constexpr int smem_size = Traits::kSmemSize1colblock;
+            static_assert(smem_size <= 99 * 1024);
+            dim3 grid_m((params.seqlen_q + Traits::kBlockM - 1) / Traits::kBlockM,
+                        params.b, params.h);
+            int nblocks = (params.seqlen_k + Traits::kBlockN - 1) / Traits::kBlockN;
+            if (params.deterministic) {
+                nblocks = (get_num_sm(get_current_device()) + params.b * params.h - 1)
+                          / (params.b * params.h);
+                flash_bwd_dot_do_o_kernel<false, Traits><<<grid_m, Traits::kNThreads, 0, stream>>>(params);
+            } else {
+                flash_bwd_dot_do_o_kernel<true, Traits><<<grid_m, Traits::kNThreads, 0, stream>>>(params);
+            }
+            C10_CUDA_KERNEL_LAUNCH_CHECK();
+            auto kernel = &flash_bwd_dq_dk_dv_loop_seqk_parallel_kernel<
+                Traits, false, Is_causal, false, false, false, true, false>;
+            C10_CUDA_CHECK(cudaFuncSetAttribute(
+                kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+            kernel<<<dim3(nblocks, params.b, params.h), Traits::kNThreads, smem_size, stream>>>(params);
+            C10_CUDA_KERNEL_LAUNCH_CHECK();
+            flash_bwd_convert_dq_kernel<Traits><<<grid_m, Traits::kNThreads, Traits::kSmemdQSize, stream>>>(
+                params, params.deterministic ? nblocks : 1);
+            C10_CUDA_KERNEL_LAUNCH_CHECK();
+        });
+    });
+#endif
+}
+
+}  // namespace FLASH_NAMESPACE

--- a/csrc/flash_attn/src/flash_bwd_kernel.h
+++ b/csrc/flash_attn/src/flash_bwd_kernel.h
@@ -206,7 +206,14 @@ inline __device__ void compute_dq_dk_dv_1colblock(const Params &params, const in
     Tensor tVsV = gmem_thr_copy_QKV.partition_D(sV);
     Tensor tdQsdQ = gmem_thr_copy_dQ.partition_S(sdQ);    // ((Atom,AtomNum),ATOM_M,ATOM_N)
     Tensor tdQgdQ = gmem_thr_copy_dQ.partition_D(gdQ);
-    Tensor tdQgdQaccum = gmem_thr_copy_dQaccum.partition_D(gdQaccum);
+    Tensor tdQgdQaccum = [&] {
+        if constexpr (kHeadDim == 512 && Seq_parallel) {
+            typename Kernel_traits::TiledMmadQ tiled_mma;
+            return tiled_mma.get_thread_slice(tidx).partition_C(gdQaccum);
+        } else {
+            return gmem_thr_copy_dQaccum.partition_D(gdQaccum);
+        }
+    }();
     // if (cute::thread0()) { print(tdQgdQaccum.layout()); printf("\n"); }
     // __syncthreads();
     // if (blockIdx.x == 0 && blockIdx.y == 0 && blockIdx.z == 0 && tidx < 64) {

--- a/csrc/flash_attn/src/flash_bwd_preprocess_kernel.h
+++ b/csrc/flash_attn/src/flash_bwd_preprocess_kernel.h
@@ -233,7 +233,13 @@ inline __device__ void convert_dQ(const Params &params, const int nsplits) {
 
     Tensor tdQsdQ = gmem_thr_copy_dQ.partition_S(sdQ);    // ((Atom,AtomNum),ATOM_M,ATOM_N)
     Tensor tdQgdQ = gmem_thr_copy_dQ.partition_D(gdQ);
-    Tensor tdQgdQaccum = gmem_thr_copy_dQaccum.partition_S(gdQaccum);
+    Tensor tdQgdQaccum = [&] {
+        if constexpr (kHeadDim == 512) {
+            return tiled_mma_dq.get_thread_slice(tidx).partition_C(gdQaccum);
+        } else {
+            return gmem_thr_copy_dQaccum.partition_S(gdQaccum);
+        }
+    }();
 
     Tensor acc_dq = partition_fragment_C(tiled_mma_dq, Shape<Int<kBlockM>, Int<kHeadDim>>{});  // MMA, MMA_N, MMA_K
     CUTE_STATIC_ASSERT_V(size(acc_dq) == size(tdQgdQaccum));
@@ -241,7 +247,12 @@ inline __device__ void convert_dQ(const Params &params, const int nsplits) {
     Tensor tdQrdQaccum = make_fragment_like(tdQgdQaccum);
     clear(acc_dq);
     for (int s = 0; s < nsplits; ++s) {
-        cute::copy(gmem_tiled_copy_dQaccum, tdQgdQaccum, tdQrdQaccum);
+        if constexpr (kHeadDim == 512) {
+            #pragma unroll
+            for (int i = 0; i < size(acc_dq); ++i) { tdQrdQaccum(i) = tdQgdQaccum(i); }
+        } else {
+            cute::copy(gmem_tiled_copy_dQaccum, tdQgdQaccum, tdQrdQaccum);
+        }
         #pragma unroll
         for (int i = 0; i < size(acc_dq); ++i) { acc_dq(i) += tdQrdQaccum(i); }
         tdQgdQaccum.data() = tdQgdQaccum.data() + params.dq_accum_split_stride;

--- a/csrc/flash_attn/src/flash_fwd_hdim512_sm89.cu
+++ b/csrc/flash_attn/src/flash_fwd_hdim512_sm89.cu
@@ -1,0 +1,24 @@
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+void run_mha_fwd_hdim512(Flash_fwd_params &params, cudaStream_t stream) {
+    FP16_SWITCH(!params.is_bf16, [&] {
+        BOOL_SWITCH(params.is_causal, Is_causal, [&] {
+            // Keeping Q in registers lets Q and K share the same 64 KiB buffer.
+            using Traits = Flash_fwd_kernel_traits<512, 64, 32, 4, true, true, elem_type>;
+            constexpr int smem_size = Traits::kSmemSize;
+            static_assert(smem_size <= 99 * 1024);
+            auto kernel = &flash_fwd_kernel<Traits, false, Is_causal, false, false,
+                                           false, true, false, false>;
+            C10_CUDA_CHECK(cudaFuncSetAttribute(
+                kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+            dim3 grid((params.seqlen_q + Traits::kBlockM - 1) / Traits::kBlockM,
+                      params.b, params.h);
+            kernel<<<grid, Traits::kNThreads, smem_size, stream>>>(params);
+            C10_CUDA_KERNEL_LAUNCH_CHECK();
+        });
+    });
+}
+
+}  // namespace FLASH_NAMESPACE

--- a/setup.py
+++ b/setup.py
@@ -348,6 +348,8 @@ if not SKIP_CUDA_BUILD and not IS_ROCM:
             name="flash_attn_2_cuda",
             sources=[
                 "csrc/flash_attn/flash_api.cpp",
+                "csrc/flash_attn/src/flash_fwd_hdim512_sm89.cu",
+                "csrc/flash_attn/src/flash_bwd_hdim512_sm89.cu",
                 "csrc/flash_attn/src/flash_fwd_hdim32_fp16_sm80.cu",
                 "csrc/flash_attn/src/flash_fwd_hdim32_bf16_sm80.cu",
                 "csrc/flash_attn/src/flash_fwd_hdim64_fp16_sm80.cu",

--- a/tests/test_flash_attn_sm89_d512.py
+++ b/tests/test_flash_attn_sm89_d512.py
@@ -1,0 +1,176 @@
+"""D512 forward and backward on Ada, including the Gemma E4B GQA shape."""
+import pytest
+import torch
+
+from flash_attn import flash_attn_func, flash_attn_varlen_func
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() != (8, 9),
+    reason="D512 kernels require SM89",
+)
+
+
+def reference(q, k, v, causal, scale):
+    """FP64 reference with bottom-right causal alignment and empty-row handling."""
+    sq, sk = q.shape[1], k.shape[1]
+    if sk == 0:
+        return q * 0 + (k.sum() + v.sum()) * 0
+    groups = q.shape[2] // k.shape[2]
+    scores = q.transpose(1, 2) @ k.repeat_interleave(groups, 2).transpose(1, 2).transpose(-1, -2)
+    scores = scores * scale
+    if causal:
+        mask = torch.arange(sk, device=q.device)[None, :] <= (
+            torch.arange(sq, device=q.device)[:, None] + sk - sq
+        )
+        valid = mask.any(-1, keepdim=True)
+        scores = scores.masked_fill(~mask, -torch.inf)
+        scores = torch.where(valid, scores, 0)
+    p = scores.softmax(-1)
+    if causal:
+        p = p.masked_fill(~valid, 0)
+    return (p @ v.repeat_interleave(groups, 2).transpose(1, 2)).transpose(1, 2)
+
+
+def check_result(out, qkv, ref, refs, dtype):
+    do = torch.randn_like(out)
+    actual = (out, *torch.autograd.grad(out, qkv, do, retain_graph=True))
+    expected = (ref, *torch.autograd.grad(ref, refs, do.double()))
+    # Bound both the total error and the worst element relative to the signal.
+    # FP64 computes both the reference output and its gradients.
+    eps = torch.finfo(dtype).eps
+    for a, b in zip(actual, expected):
+        assert torch.isfinite(a).all()
+        diff = (a.double() - b).abs()
+        assert diff.norm() <= 3 * eps * b.norm() + 1e-6
+        assert diff.max() <= 4 * eps * b.abs().max() + 1e-6
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("sq,sk", [(1, 97), (17, 31), (97, 129), (129, 97), (256, 256)])
+@pytest.mark.parametrize("heads_k", [1, 2, 8])
+def test_dense(dtype, causal, sq, sk, heads_k):
+    torch.manual_seed(0)
+    # Slicing also covers non-contiguous batch, sequence and head strides.
+    q = (torch.randn(2, sq, 16, 512, device="cuda", dtype=dtype) * .2)[:, :, ::2].requires_grad_()
+    k = (torch.randn(2, sk, heads_k * 2, 512, device="cuda", dtype=dtype) * .2)[:, :, ::2].requires_grad_()
+    v = torch.randn_like(k).requires_grad_()
+    refs = tuple(x.detach().double().requires_grad_() for x in (q, k, v))
+    out = flash_attn_func(q, k, v, causal=causal, softmax_scale=1.0)
+    ref = reference(*refs, causal, 1.0)
+    check_result(out, (q, k, v), ref, refs, dtype)
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("deterministic", [False, True])
+@pytest.mark.parametrize("lengths", [
+    [(17, 31), (97, 129), (129, 97)],
+    [(0, 0), (1, 97), (0, 31), (1, 1)],
+    [(17, 0), (0, 0), (33, 65)],
+])
+def test_varlen(dtype, causal, deterministic, lengths):
+    torch.manual_seed(1)
+    lq, lk = zip(*lengths)
+    cuq = torch.tensor([0, *lq], device="cuda", dtype=torch.int32).cumsum(0, dtype=torch.int32)
+    cuk = torch.tensor([0, *lk], device="cuda", dtype=torch.int32).cumsum(0, dtype=torch.int32)
+    q = (torch.randn(sum(lq), 8, 512, device="cuda", dtype=dtype) * .2).requires_grad_()
+    k = (torch.randn(sum(lk), 2, 512, device="cuda", dtype=dtype) * .2).requires_grad_()
+    v = torch.randn_like(k).requires_grad_()
+    refs = tuple(x.detach().double().requires_grad_() for x in (q, k, v))
+    out = flash_attn_varlen_func(q, k, v, cuq, cuk, max(lq), max(lk),
+                                causal=causal, softmax_scale=1.0, deterministic=deterministic)
+    qr = refs[0].split(lq)
+    kr, vr = (x.split(lk) for x in refs[1:])
+    ref = torch.cat([reference(a[None], b[None], c[None], causal, 1.0)[0]
+                     for a, b, c in zip(qr, kr, vr)])
+    check_result(out, (q, k, v), ref, refs, dtype)
+    if deterministic:
+        do = torch.randn_like(out)
+        first = torch.autograd.grad(out, (q, k, v), do, retain_graph=True)
+        second = torch.autograd.grad(out, (q, k, v), do)
+        for a, b in zip(first, second):
+            assert torch.equal(a, b)
+
+
+@pytest.mark.parametrize("kwargs, message", [
+    ({"dropout_p": 0.1}, "does not support dropout"),
+    ({"softcap": 30.0}, "does not support softcap"),
+    ({"window_size": (32, 0)}, "does not support local attention"),
+    ({"alibi_slopes": True}, "does not support ALiBi"),
+])
+def test_unsupported_features(kwargs, message):
+    q = torch.randn(1, 64, 2, 512, device="cuda", dtype=torch.float16)
+    kwargs = dict(kwargs)
+    if "alibi_slopes" in kwargs:
+        kwargs["alibi_slopes"] = torch.ones(2, device="cuda")
+    with pytest.raises(RuntimeError, match=message):
+        flash_attn_func(q, q, q, **kwargs)
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("scale", [512**-0.5, 1.0])
+def test_long_sequence(dtype, scale):
+    torch.manual_seed(8)
+    q = torch.randn(1, 1024, 8, 512, device="cuda", dtype=dtype, requires_grad=True)
+    k = torch.randn(1, 1024, 2, 512, device="cuda", dtype=dtype, requires_grad=True)
+    v = torch.randn_like(k, requires_grad=True)
+    refs = tuple(x.detach().double().requires_grad_() for x in (q, k, v))
+    out = flash_attn_func(q, k, v, softmax_scale=scale, causal=True, deterministic=True)
+    ref = reference(*refs, True, scale)
+    check_result(out, (q, k, v), ref, refs, dtype)
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("varlen", [False, True])
+@pytest.mark.parametrize("qkvpacked", [False, True])
+def test_packed(dtype, varlen, qkvpacked):
+    from flash_attn import (flash_attn_kvpacked_func, flash_attn_qkvpacked_func,
+                            flash_attn_varlen_kvpacked_func, flash_attn_varlen_qkvpacked_func)
+
+    torch.manual_seed(2)
+    hk = 8 if qkvpacked else 2
+    q = (torch.randn(1, 50, 8, 512, device="cuda", dtype=dtype) * .2).requires_grad_()
+    k = (torch.randn(1, 50, hk, 512, device="cuda", dtype=dtype) * .2).requires_grad_()
+    v = torch.randn_like(k, requires_grad=True)
+    refs = tuple(x.detach().double().requires_grad_() for x in (q, k, v))
+    packed = torch.stack((q, k, v) if qkvpacked else (k, v), dim=2)
+    if varlen:
+        cu = torch.tensor([0, 17, 50], device="cuda", dtype=torch.int32)
+        if qkvpacked:
+            out = flash_attn_varlen_qkvpacked_func(packed[0], cu, 33, causal=True, softmax_scale=1.0)
+        else:
+            out = flash_attn_varlen_kvpacked_func(q[0], packed[0], cu, cu, 33, 33,
+                                                 causal=True, softmax_scale=1.0)
+        out = out[None]
+        ref = torch.cat([reference(*(x[:, start:end] for x in refs), True, 1.0)
+                         for start, end in [(0, 17), (17, 50)]], dim=1)
+    else:
+        if qkvpacked:
+            out = flash_attn_qkvpacked_func(packed, causal=True, softmax_scale=1.0)
+        else:
+            out = flash_attn_kvpacked_func(q, packed, causal=True, softmax_scale=1.0)
+        ref = reference(*refs, True, 1.0)
+    check_result(out, (q, k, v), ref, refs, dtype)
+
+
+@pytest.mark.parametrize("feature", ["num_splits", "leftpad_k", "seqused_k", "block_table"])
+def test_unsupported_varlen_features(feature):
+    from flash_attn.flash_attn_interface import _flash_attn_varlen_forward
+
+    q = torch.randn(17, 8, 512, device="cuda", dtype=torch.float16)
+    k = torch.randn(31, 2, 512, device="cuda", dtype=torch.float16)
+    cuq = torch.tensor([0, 17], device="cuda", dtype=torch.int32)
+    cuk = torch.tensor([0, 31], device="cuda", dtype=torch.int32)
+    value = 2 if feature == "num_splits" else torch.zeros(1, device="cuda", dtype=torch.int32)
+    if feature == "block_table":
+        k = torch.randn(1, 256, 2, 512, device="cuda", dtype=torch.float16)
+        value = value.reshape(1, 1)
+    with pytest.raises(RuntimeError, match="Head dimension 512 does not support"):
+        _flash_attn_varlen_forward(q, k, k, cuq, cuk, 17, 31, 0.0, 1.0, True, **{feature: value})
+
+
+def test_intermediate_head_dim_rejected():
+    q = torch.randn(1, 17, 2, 384, device="cuda", dtype=torch.float16)
+    with pytest.raises(RuntimeError, match="up to 256, or exactly 512"):
+        flash_attn_func(q, q, q)


### PR DESCRIPTION
Gemma4-E4B global attention uses `head_dim=512`. FA2 currently rejects it on RTX 4090 with `FlashAttention forward only supports head dimension at most 256`.

This adds native CUDA D512 forward and backward for SM89. It supports FP16/BF16, dense and varlen inputs, MHA/MQA/GQA, causal attention, and deterministic backward. The tiles use 64 KiB shared memory for forward and 96 KiB for backward. The D512 dQ accumulator layout follows its 64-thread MMA layout.

D512 requires zero attention dropout. Local attention, softcap, ALiBi, paged/split KV, `leftpad_k`, `seqused_k`, and `flash_attn_with_kvcache` remain unsupported. Existing head dimensions keep their current paths.

Validation on RTX 4090 (48 GB, SM89), PyTorch 2.10.0+cu128, CUDA 12.8:
- Reproduced the original error with the unchanged upstream API.
- 105 new tests and 56 existing regression cases passed.
- Compute Sanitizer: 0 memory errors and 0 race hazards.
- Real Gemma4-E4B global-layer inputs passed FP64 output and gradient checks. LoRA backward with checkpointing and HF cached decoding also ran successfully.

For BF16, batch 1, Q/KV heads 8/2, causal attention, scale 1.0:

| Tokens | FA2 forward + backward | PyTorch efficient SDPA |
| --- | ---: | ---: |
| 512 | 0.56 ms | 0.93 ms |
| 2048 | 5.66 ms | 9.00 ms |
| 4096 | 19.11 ms | 22.92 ms |
| 8192 | 73.35 ms | 69.97 ms |

The benchmark includes SDPA KV expansion and gradient reduction. Forward alone is slower. Training uses less extra memory, but the 8192-token case still needs optimization.

Full-model training parity is not established. In a BF16 LoRA probe, the full-model gradient relative L2 difference was about 0.25 against FP32/FP64 global-attention references. FP32 versus FP64 references also differed by 0.245. Deterministic native repeats matched exactly. These are smoke and kernel accuracy checks, not convergence results.

Run `pytest -q tests/test_flash_attn_sm89_d512.py` and `python benchmarks/benchmark_flash_attention_d512.py` after building.

Related to #2581. This PR covers the FA2 training path; paged-KV support requested there remains open.
